### PR TITLE
feat(control-plane): add advanced.privileged to cloud API, runner, and SDKs

### DIFF
--- a/apps/api/src/box/dto/box.dto.spec.ts
+++ b/apps/api/src/box/dto/box.dto.spec.ts
@@ -17,5 +17,21 @@ describe('BoxDto public identity', () => {
 
     expect(dto.id).toBe(box.id)
     expect((dto as any).boxId).toBeUndefined()
+    expect(dto.privileged).toBe(false)
+    expect(dto.capabilities).toEqual({ add: [], drop: [] })
+  })
+
+  it('reads back a stored privileged box', () => {
+    const box = new Box('us', 'dind')
+    box.organizationId = '057963b2-60ca-4356-81fc-11503e15f249'
+    box.osUser = 'boxlite'
+    // The shape box.service.ts persists for a privileged create.
+    box.privileged = true
+    box.capabilities = { add: ['ALL'], drop: [] }
+
+    const dto = BoxDto.fromBox(box, 'https://proxy.boxlite.dev/toolbox')
+
+    expect(dto.privileged).toBe(true)
+    expect(dto.capabilities).toEqual({ add: ['ALL'], drop: [] })
   })
 })

--- a/apps/api/src/box/dto/box.dto.ts
+++ b/apps/api/src/box/dto/box.dto.ts
@@ -10,6 +10,12 @@ import { IsEnum, IsOptional } from 'class-validator'
 import { Box } from '../entities/box.entity'
 import { BoxDesiredState } from '../enums/box-desired-state.enum'
 import { BoxClass } from '../enums/box-class.enum'
+import { resolveBoxAdvancedOptions } from '../utils/advanced-options.util'
+
+export interface BoxCapabilities {
+  add: string[]
+  drop: string[]
+}
 
 @ApiSchema({ name: 'BoxVolume' })
 export class BoxVolume {
@@ -92,6 +98,18 @@ export class BoxDto {
     example: '192.168.1.0/16,10.0.0.0/24',
   })
   networkAllowList?: string
+
+  @ApiProperty({
+    description: 'Whether Docker-style privileged mode is enabled for the box',
+    example: false,
+  })
+  privileged: boolean
+
+  @ApiProperty({
+    description: 'Linux capabilities added to or removed from the box processes',
+    example: { add: ['SYS_ADMIN'], drop: [] },
+  })
+  capabilities: BoxCapabilities
 
   @ApiProperty({
     description: 'The target environment for the box',
@@ -253,6 +271,13 @@ export class BoxDto {
   toolboxProxyUrl: string
 
   static fromBox(box: Box, toolboxProxyUrl: string): BoxDto {
+    // A stored row is not a request: it already holds the canonical shape, so
+    // resolve it instead of re-running the request-time conflict rule.
+    const advanced = resolveBoxAdvancedOptions({
+      privileged: box.privileged,
+      capabilities: box.capabilities,
+    })
+
     return {
       id: box.id,
       organizationId: box.organizationId,
@@ -268,6 +293,8 @@ export class BoxDto {
       public: box.public,
       networkBlockAll: box.networkBlockAll,
       networkAllowList: box.networkAllowList,
+      privileged: advanced.privileged,
+      capabilities: advanced.capabilities,
       labels: box.labels,
       volumes: box.volumes,
       state: this.getBoxState(box),

--- a/apps/api/src/box/dto/box.dto.ts
+++ b/apps/api/src/box/dto/box.dto.ts
@@ -17,6 +17,28 @@ export interface BoxCapabilities {
   drop: string[]
 }
 
+// A plain `interface` has no runtime representation for Nest's Swagger
+// plugin to introspect, so `@ApiProperty({ type: BoxCapabilities })` below
+// would fall back to an untyped object in the generated spec (and, from
+// there, an untyped map/object in every generated client). This decorated
+// class gives it one, the same way BoxVolume does for `volumes`.
+@ApiSchema({ name: 'BoxCapabilities' })
+export class BoxCapabilitiesDto implements BoxCapabilities {
+  @ApiProperty({
+    description: 'Linux capabilities added to the default container capability set',
+    type: [String],
+    example: ['SYS_ADMIN'],
+  })
+  add: string[]
+
+  @ApiProperty({
+    description: 'Linux capabilities removed from the container capability set',
+    type: [String],
+    example: [],
+  })
+  drop: string[]
+}
+
 @ApiSchema({ name: 'BoxVolume' })
 export class BoxVolume {
   @ApiProperty({
@@ -107,7 +129,7 @@ export class BoxDto {
 
   @ApiProperty({
     description: 'Linux capabilities added to or removed from the box processes',
-    example: { add: ['SYS_ADMIN'], drop: [] },
+    type: BoxCapabilitiesDto,
   })
   capabilities: BoxCapabilities
 

--- a/apps/api/src/box/dto/create-box.dto.ts
+++ b/apps/api/src/box/dto/create-box.dto.ts
@@ -7,10 +7,14 @@
 import { IsEnum, IsObject, IsOptional, IsString, IsNumber, IsBoolean, IsArray, IsInt, Min } from 'class-validator'
 import { ApiPropertyOptional, ApiSchema } from '@nestjs/swagger'
 import { BoxClass } from '../enums/box-class.enum'
-import { BoxVolume } from './box.dto'
+import { BoxCapabilities, BoxVolume } from './box.dto'
 
 @ApiSchema({ name: 'CreateBox' })
 export class CreateBoxDto {
+  privileged?: boolean
+
+  capabilities?: BoxCapabilities
+
   @ApiPropertyOptional({
     description: 'The name of the box. If not provided, the box ID will be used as the name',
     example: 'MyBox',

--- a/apps/api/src/box/entities/box.entity.ts
+++ b/apps/api/src/box/entities/box.entity.ts
@@ -8,7 +8,7 @@ import { Column, CreateDateColumn, Entity, Index, PrimaryColumn, OneToOne, Uniqu
 import { BoxState } from '../enums/box-state.enum'
 import { BoxDesiredState } from '../enums/box-desired-state.enum'
 import { BoxClass } from '../enums/box-class.enum'
-import { BoxVolume } from '../dto/box.dto'
+import { BoxCapabilities, BoxVolume } from '../dto/box.dto'
 import { nanoid } from 'nanoid'
 import { BoxLastActivity } from './box-last-activity.entity'
 import { BOX_ID_LENGTH, BOX_ID_REGEX, generateBoxId } from '../utils/box-id.util'
@@ -116,6 +116,12 @@ export class Box {
 
   @Column({ nullable: true })
   networkAllowList?: string
+
+  @Column({ default: false, type: 'boolean' })
+  privileged = false
+
+  @Column({ type: 'jsonb', default: { add: [], drop: [] } })
+  capabilities: BoxCapabilities = { add: [], drop: [] }
 
   @Column('jsonb', { nullable: true })
   labels: { [key: string]: string }

--- a/apps/api/src/box/runner-adapter/runnerAdapter.v0.ts
+++ b/apps/api/src/box/runner-adapter/runnerAdapter.v0.ts
@@ -261,6 +261,8 @@ export class RunnerAdapterV0 implements RunnerAdapter {
       env: box.env,
       networkBlockAll: box.networkBlockAll,
       networkAllowList: box.networkAllowList,
+      privileged: box.privileged,
+      capabilities: box.capabilities,
       metadata,
       authToken: box.authToken,
       organizationId: box.organizationId,
@@ -330,6 +332,8 @@ export class RunnerAdapterV0 implements RunnerAdapter {
       })),
       networkBlockAll: box.networkBlockAll,
       networkAllowList: box.networkAllowList,
+      privileged: box.privileged,
+      capabilities: box.capabilities,
       errorReason: box.errorReason,
     }
     await this.boxApiClient.recover(box.id, recoverBoxDTO)

--- a/apps/api/src/box/runner-adapter/runnerAdapter.v2.ts
+++ b/apps/api/src/box/runner-adapter/runnerAdapter.v2.ts
@@ -134,6 +134,8 @@ export class RunnerAdapterV2 implements RunnerAdapter {
       })),
       networkBlockAll: box.networkBlockAll,
       networkAllowList: box.networkAllowList,
+      privileged: box.privileged,
+      capabilities: box.capabilities,
       metadata,
       authToken: box.authToken,
       organizationId: box.organizationId,

--- a/apps/api/src/box/services/box.service.ts
+++ b/apps/api/src/box/services/box.service.ts
@@ -41,6 +41,7 @@ import { WarmPool } from '../entities/warm-pool.entity'
 import { BoxDto, BoxVolume } from '../dto/box.dto'
 import { RunnerAdapterFactory } from '../runner-adapter/runnerAdapter'
 import { validateNetworkAllowList } from '../utils/network-validation.util'
+import { normalizeBoxAdvancedOptions } from '../utils/advanced-options.util'
 import { VolumeService } from './volume.service'
 import { PaginatedList } from '../../common/interfaces/paginated-list.interface'
 import {
@@ -227,6 +228,12 @@ export class BoxService {
         createBoxDto.networkBlockAll !== undefined ||
         createBoxDto.networkAllowList !== undefined ||
         organization.boxLimitedNetworkEgress
+      const advanced = normalizeBoxAdvancedOptions({
+        privileged: createBoxDto.privileged,
+        capabilities: createBoxDto.capabilities,
+      })
+      const hasAdvancedOptions =
+        advanced.privileged || advanced.capabilities.add.length > 0 || advanced.capabilities.drop.length > 0
 
       this.organizationService.assertOrganizationIsNotSuspended(organization)
 
@@ -241,7 +248,7 @@ export class BoxService {
       if (createBoxDto.volumes && createBoxDto.volumes.length > 0) {
         const volumeIdOrNames = createBoxDto.volumes.map((v) => v.volumeId)
         await this.volumeService.validateVolumes(organization.id, volumeIdOrNames)
-      } else if (image && !requiresFreshBoxForNetworkPolicy) {
+      } else if (image && !requiresFreshBoxForNetworkPolicy && !hasAdvancedOptions) {
         //  No volumes requested — try to claim a pre-warmed box matching this image/spec
         //  before creating a fresh one.
         const skipWarmPool = (await this.redis.exists(`warm-pool:skip:${image}`)) === 1
@@ -284,6 +291,8 @@ export class BoxService {
       box.disk = disk
 
       box.public = createBoxDto.public ?? true
+      box.privileged = advanced.privileged
+      box.capabilities = advanced.capabilities
 
       if (createBoxDto.networkBlockAll !== undefined) {
         box.networkBlockAll = createBoxDto.networkBlockAll

--- a/apps/api/src/box/utils/advanced-options.util.spec.ts
+++ b/apps/api/src/box/utils/advanced-options.util.spec.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BadRequestError } from '../../exceptions/bad-request.exception'
+import { normalizeBoxAdvancedOptions } from './advanced-options.util'
+
+describe('normalizeBoxAdvancedOptions', () => {
+  it('rejects privileged mode combined with explicit capabilities', () => {
+    expect(() =>
+      normalizeBoxAdvancedOptions({
+        privileged: true,
+        capabilities: { add: ['SYS_ADMIN'], drop: ['NET_RAW'] },
+      }),
+    ).toThrow(BadRequestError)
+  })
+
+  it('normalizes privileged mode without explicit capabilities', () => {
+    expect(normalizeBoxAdvancedOptions({ privileged: true })).toEqual({
+      privileged: true,
+      capabilities: { add: ['ALL'], drop: [] },
+    })
+  })
+
+  it('accepts the canonical privileged shape it produces, so normalizing twice is safe', () => {
+    const normalized = normalizeBoxAdvancedOptions({ privileged: true })
+
+    expect(normalizeBoxAdvancedOptions(normalized)).toEqual(normalized)
+  })
+
+  it('accepts a privileged request that already carries the canonical cap_add=ALL', () => {
+    expect(
+      normalizeBoxAdvancedOptions({
+        privileged: true,
+        capabilities: { add: ['ALL'], drop: [] },
+      }),
+    ).toEqual({ privileged: true, capabilities: { add: ['ALL'], drop: [] } })
+  })
+
+  it('canonicalizes capability spelling and removes semantic duplicates', () => {
+    expect(
+      normalizeBoxAdvancedOptions({
+        capabilities: { add: ['cap_net_admin', 'NET_ADMIN'], drop: ['CAP_NET_RAW'] },
+      }),
+    ).toEqual({ privileged: false, capabilities: { add: ['NET_ADMIN'], drop: ['NET_RAW'] } })
+  })
+
+  it('accepts well-formed capability names for guest-side support validation', () => {
+    expect(normalizeBoxAdvancedOptions({ capabilities: { add: ['FUTURE_KERNEL_CAPABILITY'] } })).toEqual({
+      privileged: false,
+      capabilities: { add: ['FUTURE_KERNEL_CAPABILITY'], drop: [] },
+    })
+  })
+
+  it('rejects malformed capability names', () => {
+    expect(() => normalizeBoxAdvancedOptions({ capabilities: { add: ['NET-ADMIN'] } })).toThrow(BadRequestError)
+  })
+})

--- a/apps/api/src/box/utils/advanced-options.util.ts
+++ b/apps/api/src/box/utils/advanced-options.util.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BadRequestError } from '../../exceptions/bad-request.exception'
+import type { BoxCapabilities } from '../dto/box.dto'
+
+export type BoxAdvancedOptionsInput = {
+  privileged?: boolean
+  capabilities?: Partial<BoxCapabilities>
+}
+
+export type NormalizedBoxAdvancedOptions = {
+  privileged: boolean
+  capabilities: BoxCapabilities
+}
+
+// Validate the portable spelling here, but leave kernel support checks to the
+// guest. Linux can add capabilities independently of an API release.
+const LINUX_CAPABILITY_NAME = /^[A-Z][A-Z0-9_]*$/
+
+/** Return the canonical, unprefixed capability spelling used on the wire. */
+export function canonicalizeLinuxCapability(value: string): string {
+  const normalized = value.toUpperCase()
+  const name = normalized.startsWith('CAP_') ? normalized.slice(4) : normalized
+
+  if (!LINUX_CAPABILITY_NAME.test(name)) {
+    throw new BadRequestError(`Malformed Linux capability '${value}'`)
+  }
+
+  return name
+}
+
+export function isValidLinuxCapabilityName(value: unknown): boolean {
+  if (typeof value !== 'string') {
+    return false
+  }
+
+  try {
+    canonicalizeLinuxCapability(value)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function normalizeCapabilityList(values: string[] | undefined): string[] {
+  return [...new Set((values ?? []).map(canonicalizeLinuxCapability))]
+}
+
+/** Whether a policy is exactly the shape privileged mode expands to. */
+function isPrivilegedCapabilityShape(capabilities: Partial<BoxCapabilities> | undefined): boolean {
+  const add = capabilities?.add ?? []
+  const drop = capabilities?.drop ?? []
+
+  return drop.length === 0 && add.length === 1 && canonicalizeLinuxCapability(add[0]) === 'ALL'
+}
+
+/**
+ * Expand the advanced-options contract without applying the request-time
+ * conflict rule. Idempotent, so it is safe on an already-normalized value —
+ * notably a row read back from storage, which is not a request and must not
+ * be rejected like one.
+ */
+export function resolveBoxAdvancedOptions(input: BoxAdvancedOptionsInput = {}): NormalizedBoxAdvancedOptions {
+  if (input.privileged) {
+    return {
+      privileged: true,
+      capabilities: { add: ['ALL'], drop: [] },
+    }
+  }
+
+  return {
+    privileged: false,
+    capabilities: {
+      add: normalizeCapabilityList(input.capabilities?.add),
+      drop: normalizeCapabilityList(input.capabilities?.drop),
+    },
+  }
+}
+
+/**
+ * Validate and normalize the one public advanced-options contract, at a
+ * request boundary. Privileged mode is a separate shape from capability
+ * overrides and cannot be combined with them — except for the canonical
+ * `add: ["ALL"]` policy privileged mode itself expands to. Every first-party
+ * client serializes that policy alongside `privileged` (see
+ * `CreateBoxRequest::from_options`), so rejecting it would reject every
+ * privileged create the SDKs and CLI make. Mirrors the host-side carve-out in
+ * `ContainerCapabilities::is_privileged_capability_shape`.
+ */
+export function normalizeBoxAdvancedOptions(input: BoxAdvancedOptionsInput = {}): NormalizedBoxAdvancedOptions {
+  if (input.privileged !== undefined && typeof input.privileged !== 'boolean') {
+    throw new BadRequestError('privileged must be a boolean')
+  }
+
+  if (input.privileged) {
+    const hasOverrides = (input.capabilities?.add?.length ?? 0) > 0 || (input.capabilities?.drop?.length ?? 0) > 0
+
+    if (hasOverrides && !isPrivilegedCapabilityShape(input.capabilities)) {
+      throw new BadRequestError('privileged mode cannot be combined with cap_add or cap_drop')
+    }
+  }
+
+  return resolveBoxAdvancedOptions(input)
+}

--- a/apps/api/src/boxlite-rest/boxlite-config.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-config.controller.ts
@@ -16,6 +16,8 @@ export class BoxliteConfigController {
   getConfig() {
     return {
       capabilities: {
+        linux_capabilities_enabled: true,
+        privileged_enabled: true,
         snapshots_enabled: false,
         clone_enabled: false,
         export_enabled: false,

--- a/apps/api/src/boxlite-rest/dto/create-box.dto.spec.ts
+++ b/apps/api/src/boxlite-rest/dto/create-box.dto.spec.ts
@@ -70,6 +70,38 @@ describe('CreateBoxDto lifecycle policy', () => {
   })
 })
 
+describe('CreateBoxDto advanced options', () => {
+  it('accepts privileged and capability options', async () => {
+    const errors = await validate(
+      plainToInstance(CreateBoxDto, {
+        advanced: { privileged: true },
+      }),
+    )
+
+    expect(errors).toHaveLength(0)
+  })
+
+  it('rejects a non-boolean privileged option', async () => {
+    const errors = await validate(plainToInstance(CreateBoxDto, { advanced: { privileged: 'true' } }))
+
+    expect(JSON.stringify(errors)).toContain('isBoolean')
+  })
+
+  it('accepts a well-formed capability name for guest-side support validation', async () => {
+    const errors = await validate(
+      plainToInstance(CreateBoxDto, { advanced: { capabilities: { add: ['FUTURE_KERNEL_CAPABILITY'] } } }),
+    )
+
+    expect(errors).toHaveLength(0)
+  })
+
+  it('rejects a malformed Linux capability name', async () => {
+    const errors = await validate(plainToInstance(CreateBoxDto, { advanced: { capabilities: { add: ['NET-ADMIN'] } } }))
+
+    expect(JSON.stringify(errors)).toContain('well-formed Linux capability')
+  })
+})
+
 describe('CreateBoxDto network validation', () => {
   it('accepts supported allow_net entry types', async () => {
     const errors = await validate(

--- a/apps/api/src/boxlite-rest/dto/create-box.dto.ts
+++ b/apps/api/src/boxlite-rest/dto/create-box.dto.ts
@@ -25,6 +25,7 @@ import {
   ValidatorConstraintInterface,
 } from 'class-validator'
 import { isValidNetworkAllowEntry, MAX_NETWORK_ALLOW_LIST_ENTRIES } from '../../box/utils/network-validation.util'
+import { isValidLinuxCapabilityName } from '../../box/utils/advanced-options.util'
 
 const logger = new Logger('CreateBoxDto')
 
@@ -51,6 +52,17 @@ class HasVolumeSourceConstraint implements ValidatorConstraintInterface {
 
   defaultMessage(): string {
     return 'volume requires source (or the deprecated host_path)'
+  }
+}
+
+@ValidatorConstraint({ name: 'isLinuxCapabilityName', async: false })
+class IsLinuxCapabilityNameConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown): boolean {
+    return isValidLinuxCapabilityName(value)
+  }
+
+  defaultMessage(): string {
+    return 'each capability must be a well-formed Linux capability name'
   }
 }
 
@@ -177,7 +189,37 @@ export class VolumeSpecDto {
   read_only?: false
 }
 
+export class CreateBoxCapabilitiesDto {
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  @Validate(IsLinuxCapabilityNameConstraint, { each: true })
+  add?: string[]
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  @Validate(IsLinuxCapabilityNameConstraint, { each: true })
+  drop?: string[]
+}
+
+export class CreateBoxAdvancedOptionsDto {
+  @IsOptional()
+  @IsBoolean()
+  privileged?: boolean
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => CreateBoxCapabilitiesDto)
+  capabilities?: CreateBoxCapabilitiesDto
+}
+
 export class CreateBoxDto {
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => CreateBoxAdvancedOptionsDto)
+  advanced?: CreateBoxAdvancedOptionsDto
+
   @IsOptional()
   @IsString()
   name?: string

--- a/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.spec.ts
+++ b/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.spec.ts
@@ -86,6 +86,46 @@ describe('BoxLite lifecycle policy mapper', () => {
     ).toThrow('volume source must use the volume:// scheme')
   })
 
+  it('maps advanced privileged options into the control-plane DTO', () => {
+    const mapped = createBoxToCreateBox({ advanced: { privileged: true } })
+
+    expect(mapped.privileged).toBe(true)
+    expect(mapped.capabilities).toEqual({ add: ['ALL'], drop: [] })
+  })
+
+  it('accepts the canonical privileged body the first-party clients send', () => {
+    // CreateBoxRequest::from_options always serializes capabilities next to
+    // privileged, so this is the body every SDK and the CLI put on the wire.
+    const mapped = createBoxToCreateBox({
+      advanced: { privileged: true, capabilities: { add: ['ALL'], drop: [] } },
+    })
+
+    expect(mapped.privileged).toBe(true)
+    expect(mapped.capabilities).toEqual({ add: ['ALL'], drop: [] })
+  })
+
+  it('rejects privileged capability overrides at the REST boundary', () => {
+    expect(() =>
+      createBoxToCreateBox({
+        advanced: {
+          privileged: true,
+          capabilities: { add: ['SYS_ADMIN'], drop: ['NET_RAW'] },
+        },
+      }),
+    ).toThrow('cannot be combined')
+  })
+
+  it('canonicalizes capability names when privileged mode is disabled', () => {
+    const mapped = createBoxToCreateBox({
+      advanced: {
+        capabilities: { add: ['cap_net_admin', 'NET_ADMIN'], drop: ['CAP_NET_RAW'] },
+      },
+    })
+
+    expect(mapped.privileged).toBe(false)
+    expect(mapped.capabilities).toEqual({ add: ['NET_ADMIN'], drop: ['NET_RAW'] })
+  })
+
   it('returns the effective second-based policy', () => {
     const response = boxToBoxResponse({
       id: 'box-1',

--- a/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.ts
+++ b/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.ts
@@ -15,6 +15,7 @@ import {
 import { BoxResponseDto } from '../dto/box-response.dto'
 import { CreateBoxDto as RestCreateBoxDto } from '../dto/create-box.dto'
 import { CreateBoxDto } from '../../box/dto/create-box.dto'
+import { normalizeBoxAdvancedOptions } from '../../box/utils/advanced-options.util'
 
 export function boxToBoxResponse(box: BoxDto): BoxResponseDto {
   return {
@@ -50,6 +51,9 @@ export function createBoxToCreateBox(dto: RestCreateBoxDto, target?: string): Cr
     volumeId: resolveVolumeId(volume),
     mountPath: volume.guest_path,
   }))
+  const advanced = normalizeBoxAdvancedOptions(dto.advanced)
+  createDto.privileged = advanced.privileged
+  createDto.capabilities = advanced.capabilities
   if (dto.network) {
     const allowNet = dto.network.outbound?.allow_net?.map((entry) => entry.trim()).filter(Boolean)
     createDto.networkBlockAll = dto.network.outbound?.mode === 'disabled'

--- a/apps/api/src/migrations/pre-deploy/1785819202000-add-box-advanced-options-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1785819202000-add-box-advanced-options-migration.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddBoxAdvancedOptions1785819202000 implements MigrationInterface {
+  name = 'AddBoxAdvancedOptions1785819202000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "box" ADD "privileged" boolean NOT NULL DEFAULT false`)
+    await queryRunner.query(`ALTER TABLE "box" ADD "capabilities" jsonb NOT NULL DEFAULT '{"add":[],"drop":[]}'`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "box" DROP COLUMN "capabilities"`)
+    await queryRunner.query(`ALTER TABLE "box" DROP COLUMN "privileged"`)
+  }
+}

--- a/apps/dashboard/src/mocks/fixtures.ts
+++ b/apps/dashboard/src/mocks/fixtures.ts
@@ -111,6 +111,8 @@ function buildBox(overrides: Partial<Box> & Pick<Box, 'id' | 'name' | 'state'>):
     labels: {},
     public: false,
     networkBlockAll: false,
+    privileged: false,
+    capabilities: { add: [], drop: [] },
     target: 'mock',
     image: 'ghcr.io/boxlite-ai/boxlite-agent-base:mock',
     cpu: 1,

--- a/apps/e2e/README.md
+++ b/apps/e2e/README.md
@@ -184,6 +184,7 @@ apps/e2e/
     ├── test_path_verification.py    # Meta-test: prove SDK→API→Runner path
     ├── test_lifecycle.py            # Box create / get_info / remove
     ├── test_exec_*.py               # Exec stdout, attach, timeout
+    ├── test_privileged_options.py   # REST capability and privileged shape
     ├── test_copy_roundtrip.py       # Copy in/out
     ├── test_cli_entry.py            # CLI smoke (run, exec, whoami)
     ├── test_cli_detach_recovery.py  # CLI detach + reattach

--- a/apps/e2e/cases/test_privileged_options.py
+++ b/apps/e2e/cases/test_privileged_options.py
@@ -1,0 +1,98 @@
+"""REST regression coverage for Docker-style privileged options."""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import boxlite
+import pytest
+
+from conftest import drain
+
+
+async def _read_privilege_state(box) -> dict[str, bool]:
+    script = r"""
+import json
+
+status = {}
+with open('/proc/self/status', encoding='ascii') as stream:
+    for line in stream:
+        if ':' in line:
+            key, value = line.split(':', 1)
+            status[key] = value.strip()
+
+last_cap = int(open('/proc/sys/kernel/cap_last_cap', encoding='ascii').read())
+effective = int(status['CapEff'], 16)
+required = (1 << (last_cap + 1)) - 1
+sysctl_path = '/proc/sys/net/ipv4/ip_forward'
+sysctl_writable = False
+try:
+    with open(sysctl_path, 'r+', encoding='ascii') as stream:
+        value = stream.read()
+        stream.seek(0)
+        stream.write(value)
+        stream.flush()
+    sysctl_writable = True
+except OSError:
+    pass
+cgroup_writable = False
+with open('/proc/self/mountinfo', encoding='ascii') as stream:
+    for line in stream:
+        fields = line.split(' - ', 1)[0].split()
+        if len(fields) > 5 and fields[4] == '/sys/fs/cgroup':
+            cgroup_writable = 'rw' in fields[5].split(',')
+            break
+
+print(json.dumps({
+    'all_capabilities': (effective & required) == required,
+    'sysctl_writable': sysctl_writable,
+    'cgroup_writable': cgroup_writable,
+}))
+"""
+    execution = await box.exec('python3', ['-c', script])
+    stdout, stderr = await drain(execution)
+    result = await asyncio.wait_for(execution.wait(), timeout=30)
+    assert result.exit_code == 0, f'privileged probe failed: {stderr}'
+    return json.loads(stdout)
+
+
+@pytest.mark.asyncio
+async def test_rest_privileged_shape_and_capability_shape_are_distinct(rt, image):
+    """PR 646 must normalize privileged mode without conflating cap_add=ALL."""
+    privileged = await rt.create(
+        boxlite.BoxOptions(
+            image=image,
+            auto_remove=True,
+            advanced=boxlite.AdvancedBoxOptions(privileged=True),
+        )
+    )
+    capabilities_only = await rt.create(
+        boxlite.BoxOptions(
+            image=image,
+            auto_remove=True,
+            advanced=boxlite.AdvancedBoxOptions(
+                capabilities=boxlite.ContainerCapabilities(add=['ALL']),
+            ),
+        )
+    )
+
+    try:
+        privileged_state = await _read_privilege_state(privileged)
+        capabilities_state = await _read_privilege_state(capabilities_only)
+
+        assert privileged_state == {
+            'all_capabilities': True,
+            'sysctl_writable': True,
+            'cgroup_writable': True,
+        }
+        assert capabilities_state == {
+            'all_capabilities': True,
+            'sysctl_writable': False,
+            'cgroup_writable': False,
+        }
+    finally:
+        await asyncio.gather(
+            rt.remove(privileged.id, force=True),
+            rt.remove(capabilities_only.id, force=True),
+            return_exceptions=True,
+        )

--- a/apps/libs/api-client-go/api/openapi.yaml
+++ b/apps/libs/api-client-go/api/openapi.yaml
@@ -5200,6 +5200,11 @@ components:
         public: false
         networkBlockAll: false
         networkAllowList: "192.168.1.0/16,10.0.0.0/24"
+        privileged: false
+        capabilities:
+          add:
+          - SYS_ADMIN
+          drop: []
         target: local
         image: boxlite/base
         cpu: 2
@@ -5270,6 +5275,17 @@ components:
             the box
           example: "192.168.1.0/16,10.0.0.0/24"
           type: string
+        privileged:
+          description: Whether Docker-style privileged mode is enabled for the box
+          example: false
+          type: boolean
+        capabilities:
+          description: Linux capabilities added to or removed from the box processes
+          example:
+            add:
+            - SYS_ADMIN
+            drop: []
+          type: object
         target:
           description: The target environment for the box
           example: local
@@ -5359,6 +5375,7 @@ components:
           example: https://proxy.app.boxlite.io/toolbox
           type: string
       required:
+      - capabilities
       - cpu
       - disk
       - env
@@ -5369,6 +5386,7 @@ components:
       - name
       - networkBlockAll
       - organizationId
+      - privileged
       - public
       - target
       - toolboxProxyUrl
@@ -5388,6 +5406,11 @@ components:
           public: false
           networkBlockAll: false
           networkAllowList: "192.168.1.0/16,10.0.0.0/24"
+          privileged: false
+          capabilities:
+            add:
+            - SYS_ADMIN
+            drop: []
           target: local
           image: boxlite/base
           cpu: 2
@@ -5425,6 +5448,11 @@ components:
           public: false
           networkBlockAll: false
           networkAllowList: "192.168.1.0/16,10.0.0.0/24"
+          privileged: false
+          capabilities:
+            add:
+            - SYS_ADMIN
+            drop: []
           target: local
           image: boxlite/base
           cpu: 2

--- a/apps/libs/api-client-go/model_box.go
+++ b/apps/libs/api-client-go/model_box.go
@@ -39,6 +39,10 @@ type Box struct {
 	NetworkBlockAll bool `json:"networkBlockAll"`
 	// Comma-separated list of allowed CIDR network addresses for the box
 	NetworkAllowList *string `json:"networkAllowList,omitempty"`
+	// Whether Docker-style privileged mode is enabled for the box
+	Privileged bool `json:"privileged"`
+	// Linux capabilities added to or removed from the box processes
+	Capabilities map[string]interface{} `json:"capabilities"`
 	// The target environment for the box
 	Target string `json:"target"`
 	// The image used for the box
@@ -89,7 +93,7 @@ type _Box Box
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewBox(id string, organizationId string, name string, user string, env map[string]string, labels map[string]string, public bool, networkBlockAll bool, target string, cpu float32, gpu float32, memory float32, disk float32, toolboxProxyUrl string) *Box {
+func NewBox(id string, organizationId string, name string, user string, env map[string]string, labels map[string]string, public bool, networkBlockAll bool, privileged bool, capabilities map[string]interface{}, target string, cpu float32, gpu float32, memory float32, disk float32, toolboxProxyUrl string) *Box {
 	this := Box{}
 	this.Id = id
 	this.OrganizationId = organizationId
@@ -99,6 +103,8 @@ func NewBox(id string, organizationId string, name string, user string, env map[
 	this.Labels = labels
 	this.Public = public
 	this.NetworkBlockAll = networkBlockAll
+	this.Privileged = privileged
+	this.Capabilities = capabilities
 	this.Target = target
 	this.Cpu = cpu
 	this.Gpu = gpu
@@ -338,6 +344,54 @@ func (o *Box) HasNetworkAllowList() bool {
 // SetNetworkAllowList gets a reference to the given string and assigns it to the NetworkAllowList field.
 func (o *Box) SetNetworkAllowList(v string) {
 	o.NetworkAllowList = &v
+}
+
+// GetPrivileged returns the Privileged field value
+func (o *Box) GetPrivileged() bool {
+	if o == nil {
+		var ret bool
+		return ret
+	}
+
+	return o.Privileged
+}
+
+// GetPrivilegedOk returns a tuple with the Privileged field value
+// and a boolean to check if the value has been set.
+func (o *Box) GetPrivilegedOk() (*bool, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.Privileged, true
+}
+
+// SetPrivileged sets field value
+func (o *Box) SetPrivileged(v bool) {
+	o.Privileged = v
+}
+
+// GetCapabilities returns the Capabilities field value
+func (o *Box) GetCapabilities() map[string]interface{} {
+	if o == nil {
+		var ret map[string]interface{}
+		return ret
+	}
+
+	return o.Capabilities
+}
+
+// GetCapabilitiesOk returns a tuple with the Capabilities field value
+// and a boolean to check if the value has been set.
+func (o *Box) GetCapabilitiesOk() (map[string]interface{}, bool) {
+	if o == nil {
+		return map[string]interface{}{}, false
+	}
+	return o.Capabilities, true
+}
+
+// SetCapabilities sets field value
+func (o *Box) SetCapabilities(v map[string]interface{}) {
+	o.Capabilities = v
 }
 
 // GetTarget returns the Target field value
@@ -956,6 +1010,8 @@ func (o Box) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.NetworkAllowList) {
 		toSerialize["networkAllowList"] = o.NetworkAllowList
 	}
+	toSerialize["privileged"] = o.Privileged
+	toSerialize["capabilities"] = o.Capabilities
 	toSerialize["target"] = o.Target
 	if !IsNil(o.Image) {
 		toSerialize["image"] = o.Image
@@ -1025,6 +1081,8 @@ func (o *Box) UnmarshalJSON(data []byte) (err error) {
 		"labels",
 		"public",
 		"networkBlockAll",
+		"privileged",
+		"capabilities",
 		"target",
 		"cpu",
 		"gpu",
@@ -1069,6 +1127,8 @@ func (o *Box) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "public")
 		delete(additionalProperties, "networkBlockAll")
 		delete(additionalProperties, "networkAllowList")
+		delete(additionalProperties, "privileged")
+		delete(additionalProperties, "capabilities")
 		delete(additionalProperties, "target")
 		delete(additionalProperties, "image")
 		delete(additionalProperties, "cpu")

--- a/apps/libs/api-client/src/docs/Box.md
+++ b/apps/libs/api-client/src/docs/Box.md
@@ -14,6 +14,8 @@ Name | Type | Description | Notes
 **_public** | **boolean** | Whether the box http preview is public | [default to undefined]
 **networkBlockAll** | **boolean** | Whether to block all network access for the box | [default to undefined]
 **networkAllowList** | **string** | Comma-separated list of allowed CIDR network addresses for the box | [optional] [default to undefined]
+**privileged** | **boolean** | Whether Docker-style privileged mode is enabled for the box | [default to undefined]
+**capabilities** | **object** | Linux capabilities added to or removed from the box processes | [default to undefined]
 **target** | **string** | The target environment for the box | [default to undefined]
 **image** | **string** | The image used for the box | [optional] [default to undefined]
 **cpu** | **number** | The CPU quota for the box | [default to undefined]
@@ -50,6 +52,8 @@ const instance: Box = {
     _public,
     networkBlockAll,
     networkAllowList,
+    privileged,
+    capabilities,
     target,
     image,
     cpu,

--- a/apps/libs/api-client/src/models/box.ts
+++ b/apps/libs/api-client/src/models/box.ts
@@ -61,6 +61,14 @@ export interface Box {
      */
     'networkAllowList'?: string;
     /**
+     * Whether Docker-style privileged mode is enabled for the box
+     */
+    'privileged': boolean;
+    /**
+     * Linux capabilities added to or removed from the box processes
+     */
+    'capabilities': object;
+    /**
      * The target environment for the box
      */
     'target': string;

--- a/apps/libs/runner-api-client/src/.openapi-generator/FILES
+++ b/apps/libs/runner-api-client/src/.openapi-generator/FILES
@@ -40,6 +40,7 @@ docs/UpdateNetworkSettingsDTO.md
 git_push.sh
 index.ts
 models/box-info-response.ts
+models/capabilities-dto.ts
 models/build-snapshot-request-dto.ts
 models/create-backup-dto.ts
 models/create-box-dto.ts

--- a/apps/libs/runner-api-client/src/docs/CapabilitiesDTO.md
+++ b/apps/libs/runner-api-client/src/docs/CapabilitiesDTO.md
@@ -1,0 +1,11 @@
+# CapabilitiesDTO
+
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**add** | **Array&lt;string&gt;** |  | [optional] [default to undefined]
+**drop** | **Array&lt;string&gt;** |  | [optional] [default to undefined]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/apps/libs/runner-api-client/src/models/capabilities-dto.ts
+++ b/apps/libs/runner-api-client/src/models/capabilities-dto.ts
@@ -1,0 +1,12 @@
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * BoxLite Runner API
+ *
+ * This file is generated from runner/pkg/api/docs/swagger.json.
+ */
+
+export interface CapabilitiesDTO {
+    'add'?: Array<string>;
+    'drop'?: Array<string>;
+}

--- a/apps/libs/runner-api-client/src/models/create-box-dto.ts
+++ b/apps/libs/runner-api-client/src/models/create-box-dto.ts
@@ -19,6 +19,9 @@ import type { DtoVolumeDTO } from './dto-volume-dto';
 // May contain unused imports in some cases
 // @ts-ignore
 import type { RegistryDTO } from './registry-dto';
+// May contain unused imports in some cases
+// @ts-ignore
+import type { CapabilitiesDTO } from './capabilities-dto';
 
 export interface CreateBoxDTO {
     'authToken'?: string;
@@ -32,6 +35,8 @@ export interface CreateBoxDTO {
     'metadata'?: { [key: string]: string; };
     'networkAllowList'?: string;
     'networkBlockAll'?: boolean;
+    'privileged'?: boolean;
+    'capabilities'?: CapabilitiesDTO;
     /**
      * Nullable for backward compatibility
      */
@@ -45,4 +50,3 @@ export interface CreateBoxDTO {
     'storageQuota'?: number;
     'volumes'?: Array<DtoVolumeDTO>;
 }
-

--- a/apps/libs/runner-api-client/src/models/index.ts
+++ b/apps/libs/runner-api-client/src/models/index.ts
@@ -1,4 +1,5 @@
 export * from './box-info-response';
+export * from './capabilities-dto';
 export * from './build-snapshot-request-dto';
 export * from './create-backup-dto';
 export * from './create-box-dto';

--- a/apps/libs/runner-api-client/src/models/recover-box-dto.ts
+++ b/apps/libs/runner-api-client/src/models/recover-box-dto.ts
@@ -16,6 +16,7 @@
 // May contain unused imports in some cases
 // @ts-ignore
 import type { DtoVolumeDTO } from './dto-volume-dto';
+import type { CapabilitiesDTO } from './capabilities-dto';
 
 export interface RecoverBoxDTO {
     'backupErrorReason'?: string;
@@ -27,9 +28,10 @@ export interface RecoverBoxDTO {
     'memoryQuota'?: number;
     'networkAllowList'?: string;
     'networkBlockAll'?: boolean;
+    'privileged'?: boolean;
+    'capabilities'?: CapabilitiesDTO;
     'osUser': string;
     'snapshot'?: string;
     'storageQuota'?: number;
     'volumes'?: Array<DtoVolumeDTO>;
 }
-

--- a/apps/runner/pkg/api/docs/docs.go
+++ b/apps/runner/pkg/api/docs/docs.go
@@ -1156,6 +1156,23 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "CapabilitiesDTO": {
+            "type": "object",
+            "properties": {
+                "add": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "drop": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "BoxInfoResponse": {
             "type": "object",
             "properties": {
@@ -1239,6 +1256,9 @@ const docTemplate = `{
                 "authToken": {
                     "type": "string"
                 },
+                "capabilities": {
+                    "$ref": "#/definitions/CapabilitiesDTO"
+                },
                 "cpuQuota": {
                     "type": "integer",
                     "minimum": 1
@@ -1279,6 +1299,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "networkBlockAll": {
+                    "type": "boolean"
+                },
+                "privileged": {
                     "type": "boolean"
                 },
                 "organizationId": {
@@ -1418,6 +1441,9 @@ const docTemplate = `{
                 "backupErrorReason": {
                     "type": "string"
                 },
+                "capabilities": {
+                    "$ref": "#/definitions/CapabilitiesDTO"
+                },
                 "cpuQuota": {
                     "type": "integer",
                     "minimum": 1
@@ -1446,6 +1472,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "networkBlockAll": {
+                    "type": "boolean"
+                },
+                "privileged": {
                     "type": "boolean"
                 },
                 "osUser": {

--- a/apps/runner/pkg/api/docs/swagger.json
+++ b/apps/runner/pkg/api/docs/swagger.json
@@ -1078,6 +1078,23 @@
     }
   },
   "definitions": {
+    "CapabilitiesDTO": {
+      "type": "object",
+      "properties": {
+        "add": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "drop": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "BoxInfoResponse": {
       "type": "object",
       "properties": {
@@ -1151,6 +1168,9 @@
         "authToken": {
           "type": "string"
         },
+        "capabilities": {
+          "$ref": "#/definitions/CapabilitiesDTO"
+        },
         "cpuQuota": {
           "type": "integer",
           "minimum": 1
@@ -1191,6 +1211,9 @@
           "type": "string"
         },
         "networkBlockAll": {
+          "type": "boolean"
+        },
+        "privileged": {
           "type": "boolean"
         },
         "organizationId": {
@@ -1316,6 +1339,9 @@
         "backupErrorReason": {
           "type": "string"
         },
+        "capabilities": {
+          "$ref": "#/definitions/CapabilitiesDTO"
+        },
         "cpuQuota": {
           "type": "integer",
           "minimum": 1
@@ -1344,6 +1370,9 @@
           "type": "string"
         },
         "networkBlockAll": {
+          "type": "boolean"
+        },
+        "privileged": {
           "type": "boolean"
         },
         "osUser": {

--- a/apps/runner/pkg/api/docs/swagger.yaml
+++ b/apps/runner/pkg/api/docs/swagger.yaml
@@ -12,6 +12,17 @@ definitions:
       state:
         $ref: '#/definitions/enums.BoxState'
     type: object
+  CapabilitiesDTO:
+    properties:
+      add:
+        items:
+          type: string
+        type: array
+      drop:
+        items:
+          type: string
+        type: array
+    type: object
   BuildSnapshotRequestDTO:
     properties:
       context:
@@ -51,6 +62,8 @@ definitions:
     properties:
       authToken:
         type: string
+      capabilities:
+        $ref: '#/definitions/CapabilitiesDTO'
       cpuQuota:
         minimum: 1
         type: integer
@@ -79,6 +92,8 @@ definitions:
       networkAllowList:
         type: string
       networkBlockAll:
+        type: boolean
+      privileged:
         type: boolean
       organizationId:
         description: Nullable for backward compatibility
@@ -175,6 +190,8 @@ definitions:
     properties:
       backupErrorReason:
         type: string
+      capabilities:
+        $ref: '#/definitions/CapabilitiesDTO'
       cpuQuota:
         minimum: 1
         type: integer
@@ -195,6 +212,8 @@ definitions:
       networkAllowList:
         type: string
       networkBlockAll:
+        type: boolean
+      privileged:
         type: boolean
       osUser:
         type: string

--- a/apps/runner/pkg/api/dto/box.go
+++ b/apps/runner/pkg/api/dto/box.go
@@ -19,6 +19,8 @@ type CreateBoxDTO struct {
 	Volumes          []VolumeDTO       `json:"volumes,omitempty"`
 	NetworkBlockAll  *bool             `json:"networkBlockAll,omitempty"`
 	NetworkAllowList *string           `json:"networkAllowList,omitempty"`
+	Privileged       *bool             `json:"privileged,omitempty"`
+	Capabilities     *CapabilitiesDTO  `json:"capabilities,omitempty"`
 	Metadata         map[string]string `json:"metadata,omitempty"`
 	AuthToken        *string           `json:"authToken,omitempty"`
 	OtelEndpoint     *string           `json:"otelEndpoint,omitempty"`
@@ -28,6 +30,11 @@ type CreateBoxDTO struct {
 	OrganizationId *string `json:"organizationId,omitempty"`
 	RegionId       *string `json:"regionId,omitempty"`
 } //	@name	CreateBoxDTO
+
+type CapabilitiesDTO struct {
+	Add  []string `json:"add,omitempty"`
+	Drop []string `json:"drop,omitempty"`
+} //	@name	CapabilitiesDTO
 
 type UpdateNetworkSettingsDTO struct {
 	NetworkBlockAll    *bool   `json:"networkBlockAll,omitempty"`
@@ -46,6 +53,8 @@ type RecoverBoxDTO struct {
 	Volumes          []VolumeDTO       `json:"volumes,omitempty"`
 	NetworkBlockAll  *bool             `json:"networkBlockAll,omitempty"`
 	NetworkAllowList *string           `json:"networkAllowList,omitempty"`
+	Privileged       *bool             `json:"privileged,omitempty"`
+	Capabilities     *CapabilitiesDTO  `json:"capabilities,omitempty"`
 	ErrorReason      string            `json:"errorReason" validate:"required"`
 } //	@name	RecoverBoxDTO
 

--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -77,6 +77,33 @@ func networkSpec(blockAll *bool, allowList *string) boxlite.NetworkSpec {
 	return spec
 }
 
+func advancedOptions(boxDto dto.CreateBoxDTO) (*boxlite.AdvancedBoxOptions, error) {
+	privileged := boxDto.Privileged != nil && *boxDto.Privileged
+	hasCapabilities := boxDto.Capabilities != nil &&
+		(len(boxDto.Capabilities.Add) > 0 || len(boxDto.Capabilities.Drop) > 0)
+	if !privileged && !hasCapabilities {
+		return nil, nil
+	}
+
+	advanced, err := boxlite.NewAdvancedBoxOptions()
+	if err != nil {
+		return nil, err
+	}
+	if hasCapabilities {
+		if err := advanced.SetCapabilities(boxlite.ContainerCapabilities{
+			Add:  append([]string(nil), boxDto.Capabilities.Add...),
+			Drop: append([]string(nil), boxDto.Capabilities.Drop...),
+		}); err != nil {
+			advanced.Close()
+			return nil, err
+		}
+	}
+	if privileged {
+		advanced.SetPrivileged(true)
+	}
+	return advanced, nil
+}
+
 func boxRuntimeEnv(ctx context.Context, boxDto dto.CreateBoxDTO) map[string]string {
 	env := map[string]string{
 		"BOXLITE_BOX_ID": boxDto.Id,
@@ -232,6 +259,14 @@ func (c *Client) Create(ctx context.Context, boxDto dto.CreateBoxDTO) (string, s
 		boxlite.WithMemory(memoryMiB),
 		boxlite.WithAutoRemove(false),
 		boxlite.WithDetach(true),
+	}
+	advanced, err := advancedOptions(boxDto)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid advanced box options: %w", err)
+	}
+	if advanced != nil {
+		defer advanced.Close()
+		opts = append(opts, boxlite.WithAdvancedOptions(advanced))
 	}
 	if boxDto.StorageQuota > 0 {
 		opts = append(opts, boxlite.WithDiskSize(int(boxDto.StorageQuota)))

--- a/apps/runner/pkg/boxlite/stubs.go
+++ b/apps/runner/pkg/boxlite/stubs.go
@@ -31,6 +31,8 @@ func (c *Client) RecoverBox(ctx context.Context, boxId string, recoverDto dto.Re
 		NetworkBlockAll:  recoverDto.NetworkBlockAll,
 		NetworkAllowList: recoverDto.NetworkAllowList,
 		FromVolumeId:     recoverDto.FromVolumeId,
+		Privileged:       recoverDto.Privileged,
+		Capabilities:     recoverDto.Capabilities,
 	}
 
 	_, _, err := c.Create(ctx, createDto)

--- a/docs/reference/nodejs/README.md
+++ b/docs/reference/nodejs/README.md
@@ -107,7 +107,7 @@ Configuration options for creating a box.
 | `network` | `NetworkSpec` | `{ mode: "enabled" }` | Structured network configuration |
 | `ports` | `JsPortSpec[]` | `[]` | Local TCP port mappings; omit `hostPort` for automatic allocation |
 | `secrets` | `Secret[]` | `[]` | Outbound HTTP(S) secret substitution rules |
-| `advanced` | `AdvancedBoxOptions` | `{}` | Expert-only options, including `capabilities.add` and `capabilities.drop` |
+| `advanced` | `AdvancedBoxOptions` | `{}` | Expert-only options, including capability policy and `privileged` |
 | `autoRemove` | `boolean` | `false` | Auto cleanup when stopped |
 | `detach` | `boolean` | `false` | Survive parent process exit |
 
@@ -124,6 +124,13 @@ const options = {
   },
 };
 ```
+
+Set `advanced.privileged: true` for Docker-style DinD behavior. This
+normalizes the capability policy to `add: ["ALL"]`, clears drops, and enables
+the complete guest-level privileged shape: writable guest `/sys`, guest
+cgroups, and guest devices. `add: ["ALL"]` without `privileged: true` keeps the
+ordinary guest shape. Do not combine `privileged: true` with capability
+overrides; the request is rejected.
 
 #### `NetworkSpec`
 
@@ -396,6 +403,7 @@ interface SimpleBoxOptions {
       add?: string[];     // Add Linux capabilities
       drop?: string[];    // Remove Linux capabilities
     };
+    privileged?: boolean; // Enable the complete guest-level privileged shape
   };
 }
 ```

--- a/docs/reference/python/README.md
+++ b/docs/reference/python/README.md
@@ -134,7 +134,7 @@ Configuration options for creating a box.
 | `network` | `NetworkSpec \| None` | `None` | Structured network configuration. Omit for default enabled networking. |
 | `ports` | `List[Tuple \| Dict]` | `[]` | Local TCP forwarding; omit `host_port` in a dict for automatic allocation |
 | `secrets` | `List[Secret]` | `[]` | Outbound HTTP(S) secret substitution rules |
-| `advanced` | `AdvancedBoxOptions \| None` | `None` | Expert-only options, including `capabilities.add` and `capabilities.drop` |
+| `advanced` | `AdvancedBoxOptions \| None` | `None` | Expert-only options, including capability policy and `privileged` |
 | `auto_remove` | `bool` | `True` | Auto cleanup when stopped |
 | `detach` | `bool` | `False` | Survive parent process exit |
 
@@ -153,6 +153,14 @@ options = BoxOptions(
     ),
 )
 ```
+
+Set `AdvancedBoxOptions(privileged=True)` for Docker-style DinD behavior. This
+normalizes the capability policy to `add=["ALL"]`, clears drops, and enables
+the complete guest-level privileged shape: writable guest `/sys`, guest
+cgroups, and guest devices. `capabilities.add=["ALL"]` without
+`privileged=True` grants the capabilities but keeps the ordinary guest shape.
+Do not combine `privileged=True` with capability overrides; the request is
+rejected.
 
 #### `NetworkSpec`
 

--- a/sdks/c/README.md
+++ b/sdks/c/README.md
@@ -226,7 +226,12 @@ int main() {
         return 1;
     }
     // Docker-style privileged mode enables the complete guest-level shape.
-    boxlite_advanced_options_set_privileged(advanced, 1);
+    if (boxlite_advanced_options_set_privileged(advanced, 1) != Ok) {
+        boxlite_advanced_options_free(advanced);
+        boxlite_options_free(opts);
+        boxlite_runtime_free(runtime);
+        return 1;
+    }
     boxlite_options_set_advanced(opts, advanced);
     boxlite_advanced_options_free(advanced);
 

--- a/sdks/c/README.md
+++ b/sdks/c/README.md
@@ -225,15 +225,8 @@ int main() {
         boxlite_runtime_free(runtime);
         return 1;
     }
-    const char* cap_add[] = {"NET_ADMIN"};
-    const char* cap_drop[] = {"NET_RAW"};
-    if (boxlite_advanced_options_set_capabilities_add(advanced, cap_add, 1) != Ok ||
-        boxlite_advanced_options_set_capabilities_drop(advanced, cap_drop, 1) != Ok) {
-        fprintf(stderr, "Invalid Linux capability list\n");
-        boxlite_advanced_options_free(advanced);
-        boxlite_options_free(opts);
-        return 1;
-    }
+    // Docker-style privileged mode enables the complete guest-level shape.
+    boxlite_advanced_options_set_privileged(advanced, 1);
     boxlite_options_set_advanced(opts, advanced);
     boxlite_advanced_options_free(advanced);
 

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -487,7 +487,14 @@ void boxlite_advanced_options_set_security_enabled(CAdvancedBoxOptions *opts, in
 // Toggle Docker-style privileged mode. Enabling it also normalizes the
 // capability policy to `ALL` with no drops; the guest still receives the
 // privileged shape and capabilities as separate fields.
-void boxlite_advanced_options_set_privileged(CAdvancedBoxOptions *opts, int enabled);
+//
+// Enabling over an explicit, non-canonical capability override already set
+// via `boxlite_advanced_options_set_capabilities_add`/`_drop` fails closed
+// with `InvalidArgument` instead of silently keeping the override — the same
+// conflict those two functions themselves reject when called in the other
+// order (privileged first, then a conflicting override).
+enum BoxliteErrorCode boxlite_advanced_options_set_privileged(CAdvancedBoxOptions *opts,
+                                                              int enabled);
 
 // Replace the capabilities added to BoxLite's Docker-compatible baseline.
 //

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -484,6 +484,11 @@ void boxlite_advanced_options_free(CAdvancedBoxOptions *opts);
 // genuinely can't sandbox). Null `opts` is a no-op.
 void boxlite_advanced_options_set_security_enabled(CAdvancedBoxOptions *opts, int enabled);
 
+// Toggle Docker-style privileged mode. Enabling it also normalizes the
+// capability policy to `ALL` with no drops; the guest still receives the
+// privileged shape and capabilities as separate fields.
+void boxlite_advanced_options_set_privileged(CAdvancedBoxOptions *opts, int enabled);
+
 // Replace the capabilities added to BoxLite's Docker-compatible baseline.
 //
 // A zero count clears the list. Negative counts, null handles, null arrays
@@ -849,7 +854,7 @@ void boxlite_options_set_auto_resume_enabled(CBoxliteOptions *opts, int val);
 
 void boxlite_options_set_detach(CBoxliteOptions *opts, int val);
 
-// Apply a `CAdvancedBoxOptions` (capabilities, security, mount isolation, health check) to a
+// Apply a `CAdvancedBoxOptions` (privileged mode, capabilities, security, mount isolation, health check) to a
 // `CBoxliteOptions`. Clones the advanced configuration into the box options —
 // the caller retains ownership of `advanced_opts` and is responsible for
 // freeing it via `boxlite_advanced_options_free`.
@@ -859,7 +864,8 @@ void boxlite_options_set_detach(CBoxliteOptions *opts, int val);
 // build the `CAdvancedBoxOptions` handle via `boxlite_advanced_options_new`,
 // toggle the sandbox with `boxlite_advanced_options_set_security_enabled`,
 // then apply it here.
-void boxlite_options_set_advanced(CBoxliteOptions *opts, const CAdvancedBoxOptions *advanced_opts);
+void boxlite_options_set_advanced(CBoxliteOptions *opts,
+                                  const CAdvancedBoxOptions *advanced_opts);
 
 void boxlite_options_set_entrypoint(CBoxliteOptions *opts, const char *const *args, int argc);
 

--- a/sdks/c/src/advanced_options.rs
+++ b/sdks/c/src/advanced_options.rs
@@ -83,17 +83,33 @@ pub unsafe extern "C" fn boxlite_advanced_options_set_security_enabled(
 /// Toggle Docker-style privileged mode. Enabling it also normalizes the
 /// capability policy to `ALL` with no drops; the guest still receives the
 /// privileged shape and capabilities as separate fields.
+///
+/// Enabling over an explicit, non-canonical capability override already set
+/// via `boxlite_advanced_options_set_capabilities_add`/`_drop` fails closed
+/// with `InvalidArgument` instead of silently keeping the override — the same
+/// conflict those two functions themselves reject when called in the other
+/// order (privileged first, then a conflicting override).
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_advanced_options_set_privileged(
     opts: *mut CAdvancedBoxOptions,
     enabled: c_int,
-) {
-    if opts.is_null() {
-        return;
+) -> BoxliteErrorCode {
+    let Some(handle) = (unsafe { opts.as_mut() }) else {
+        return BoxliteErrorCode::InvalidArgument;
+    };
+    let enabled = enabled != 0;
+    if enabled {
+        // Probe on a clone rather than flipping the real flag first: cheap
+        // (a couple of string vecs), and the handle never passes through a
+        // transiently-inconsistent state a concurrent reader could observe.
+        let mut probe = handle.options.clone();
+        probe.privileged = true;
+        if probe.validate_privileged_capability_conflict().is_err() {
+            return BoxliteErrorCode::InvalidArgument;
+        }
     }
-    unsafe {
-        (*opts).options.set_privileged(enabled != 0);
-    }
+    handle.options.set_privileged(enabled);
+    BoxliteErrorCode::Ok
 }
 
 /// Replace the capabilities added to BoxLite's Docker-compatible baseline.
@@ -132,7 +148,7 @@ fn set_capability_list(
     handle: *mut CAdvancedBoxOptions,
     capabilities: *const *const c_char,
     count: c_int,
-    assign: impl FnOnce(&mut AdvancedBoxOptions, Vec<String>),
+    assign: impl Fn(&mut AdvancedBoxOptions, Vec<String>),
 ) -> BoxliteErrorCode {
     let Some(handle) = (unsafe { handle.as_mut() }) else {
         return BoxliteErrorCode::InvalidArgument;
@@ -140,15 +156,26 @@ fn set_capability_list(
 
     match parse_capability_array(capabilities, count) {
         Ok(values) => {
-            if handle.options.privileged && !values.is_empty() {
-                // Preserve a fail-closed marker if the caller ignores the
-                // return code. Privileged mode and explicit capability
-                // overrides are mutually exclusive.
-                assign(
-                    &mut handle.options,
-                    vec![INVALID_CAPABILITY_INPUT.to_string()],
-                );
-                return BoxliteErrorCode::InvalidArgument;
+            if handle.options.privileged {
+                // Probe on a clone: whether this conflicts with privileged
+                // mode depends on the *resulting* shape (add=["ALL"], empty
+                // drop is not a conflict — it is what privileged mode itself
+                // installs), not on whether this one field is merely
+                // non-empty, so it can't be decided without applying it
+                // first. `validate_privileged_capability_conflict` is the
+                // core's own rule for that shape; reuse it instead of a
+                // second copy of the condition.
+                let mut probe = handle.options.clone();
+                assign(&mut probe, values.clone());
+                if probe.validate_privileged_capability_conflict().is_err() {
+                    // Preserve a fail-closed marker if the caller ignores the
+                    // return code.
+                    assign(
+                        &mut handle.options,
+                        vec![INVALID_CAPABILITY_INPUT.to_string()],
+                    );
+                    return BoxliteErrorCode::InvalidArgument;
+                }
             }
             assign(&mut handle.options, values);
             BoxliteErrorCode::Ok

--- a/sdks/c/src/advanced_options.rs
+++ b/sdks/c/src/advanced_options.rs
@@ -1,7 +1,8 @@
 //! C ABI for `boxlite::runtime::advanced_options::AdvancedBoxOptions`.
 //!
 //! Mirrors the core model: advanced knobs (capabilities, security, mount
-//! isolation, health check) live under `BoxOptions.advanced`, never directly on the box. Build a
+//! privileged mode, capabilities, security, mount isolation, health check) live under
+//! `BoxOptions.advanced`, never directly on the box. Build a
 //! `CAdvancedBoxOptions` handle via `boxlite_advanced_options_new`, toggle the
 //! sandbox with `boxlite_advanced_options_set_security_enabled`, then apply it
 //! to a `CBoxliteOptions` via `boxlite_options_set_advanced`.
@@ -79,6 +80,22 @@ pub unsafe extern "C" fn boxlite_advanced_options_set_security_enabled(
     }
 }
 
+/// Toggle Docker-style privileged mode. Enabling it also normalizes the
+/// capability policy to `ALL` with no drops; the guest still receives the
+/// privileged shape and capabilities as separate fields.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_advanced_options_set_privileged(
+    opts: *mut CAdvancedBoxOptions,
+    enabled: c_int,
+) {
+    if opts.is_null() {
+        return;
+    }
+    unsafe {
+        (*opts).options.set_privileged(enabled != 0);
+    }
+}
+
 /// Replace the capabilities added to BoxLite's Docker-compatible baseline.
 ///
 /// A zero count clears the list. Negative counts, null handles, null arrays
@@ -123,6 +140,16 @@ fn set_capability_list(
 
     match parse_capability_array(capabilities, count) {
         Ok(values) => {
+            if handle.options.privileged && !values.is_empty() {
+                // Preserve a fail-closed marker if the caller ignores the
+                // return code. Privileged mode and explicit capability
+                // overrides are mutually exclusive.
+                assign(
+                    &mut handle.options,
+                    vec![INVALID_CAPABILITY_INPUT.to_string()],
+                );
+                return BoxliteErrorCode::InvalidArgument;
+            }
             assign(&mut handle.options, values);
             BoxliteErrorCode::Ok
         }

--- a/sdks/c/src/options.rs
+++ b/sdks/c/src/options.rs
@@ -197,7 +197,7 @@ pub unsafe extern "C" fn boxlite_options_set_detach(opts: *mut CBoxliteOptions, 
     options_set_detach(opts, val)
 }
 
-/// Apply a `CAdvancedBoxOptions` (capabilities, security, mount isolation, health check) to a
+/// Apply a `CAdvancedBoxOptions` (privileged mode, capabilities, security, mount isolation, health check) to a
 /// `CBoxliteOptions`. Clones the advanced configuration into the box options —
 /// the caller retains ownership of `advanced_opts` and is responsible for
 /// freeing it via `boxlite_advanced_options_free`.

--- a/sdks/c/src/tests.rs
+++ b/sdks/c/src/tests.rs
@@ -110,6 +110,46 @@ fn test_error_code_mapping() {
 }
 
 #[test]
+fn privileged_normalizes_capabilities() {
+    let mut advanced: *mut CAdvancedBoxOptions = ptr::null_mut();
+    let mut error = FFIError::default();
+    let code = unsafe { boxlite_advanced_options_new(&mut advanced, &mut error as *mut _) };
+    assert_eq!(code, BoxliteErrorCode::Ok);
+
+    unsafe { boxlite_advanced_options_set_privileged(advanced, 1) };
+    let options = unsafe { &(*advanced).options };
+    assert!(options.privileged);
+    assert_eq!(options.capabilities.add, ["ALL"]);
+    assert!(options.capabilities.drop.is_empty());
+
+    unsafe { boxlite_advanced_options_free(advanced) };
+}
+
+/// Disabling must withdraw the policy enabling installed, or the caller ends up
+/// with a non-privileged box that still holds every capability.
+#[test]
+fn disabling_privileged_withdraws_the_capability_shape() {
+    let mut advanced: *mut CAdvancedBoxOptions = ptr::null_mut();
+    let mut error = FFIError::default();
+    let code = unsafe { boxlite_advanced_options_new(&mut advanced, &mut error as *mut _) };
+    assert_eq!(code, BoxliteErrorCode::Ok);
+
+    unsafe { boxlite_advanced_options_set_privileged(advanced, 1) };
+    unsafe { boxlite_advanced_options_set_privileged(advanced, 0) };
+
+    let options = unsafe { &(*advanced).options };
+    assert!(!options.privileged);
+    assert!(
+        options.capabilities.add.is_empty(),
+        "cap_add must not survive disabling privileged mode: {:?}",
+        options.capabilities.add
+    );
+    assert!(options.capabilities.drop.is_empty());
+
+    unsafe { boxlite_advanced_options_free(advanced) };
+}
+
+#[test]
 fn test_error_struct_creation() {
     let err = BoxliteError::NotFound("box123".into());
     let mut c_err = error_to_c_error(err);

--- a/sdks/c/src/tests.rs
+++ b/sdks/c/src/tests.rs
@@ -116,7 +116,8 @@ fn privileged_normalizes_capabilities() {
     let code = unsafe { boxlite_advanced_options_new(&mut advanced, &mut error as *mut _) };
     assert_eq!(code, BoxliteErrorCode::Ok);
 
-    unsafe { boxlite_advanced_options_set_privileged(advanced, 1) };
+    let set_code = unsafe { boxlite_advanced_options_set_privileged(advanced, 1) };
+    assert_eq!(set_code, BoxliteErrorCode::Ok);
     let options = unsafe { &(*advanced).options };
     assert!(options.privileged);
     assert_eq!(options.capabilities.add, ["ALL"]);
@@ -134,8 +135,14 @@ fn disabling_privileged_withdraws_the_capability_shape() {
     let code = unsafe { boxlite_advanced_options_new(&mut advanced, &mut error as *mut _) };
     assert_eq!(code, BoxliteErrorCode::Ok);
 
-    unsafe { boxlite_advanced_options_set_privileged(advanced, 1) };
-    unsafe { boxlite_advanced_options_set_privileged(advanced, 0) };
+    assert_eq!(
+        unsafe { boxlite_advanced_options_set_privileged(advanced, 1) },
+        BoxliteErrorCode::Ok
+    );
+    assert_eq!(
+        unsafe { boxlite_advanced_options_set_privileged(advanced, 0) },
+        BoxliteErrorCode::Ok
+    );
 
     let options = unsafe { &(*advanced).options };
     assert!(!options.privileged);
@@ -145,6 +152,66 @@ fn disabling_privileged_withdraws_the_capability_shape() {
         options.capabilities.add
     );
     assert!(options.capabilities.drop.is_empty());
+
+    unsafe { boxlite_advanced_options_free(advanced) };
+}
+
+/// The conflict `set_capabilities_add`/`_drop` reject when privileged is
+/// already set must also be rejected in the opposite order: an explicit
+/// override set first must not be silently kept once privileged is enabled.
+#[test]
+fn set_privileged_rejects_existing_capability_override() {
+    let mut advanced: *mut CAdvancedBoxOptions = ptr::null_mut();
+    let mut error = FFIError::default();
+    let code = unsafe { boxlite_advanced_options_new(&mut advanced, &mut error as *mut _) };
+    assert_eq!(code, BoxliteErrorCode::Ok);
+
+    let cap_add = [CString::new("NET_ADMIN").unwrap()];
+    let cap_add_ptrs: Vec<*const std::os::raw::c_char> =
+        cap_add.iter().map(|cap| cap.as_ptr()).collect();
+    let add_code = unsafe {
+        boxlite_advanced_options_set_capabilities_add(
+            advanced,
+            cap_add_ptrs.as_ptr(),
+            cap_add_ptrs.len() as c_int,
+        )
+    };
+    assert_eq!(add_code, BoxliteErrorCode::Ok);
+
+    let set_code = unsafe { boxlite_advanced_options_set_privileged(advanced, 1) };
+    assert_eq!(set_code, BoxliteErrorCode::InvalidArgument);
+    let options = unsafe { &(*advanced).options };
+    assert!(
+        !options.privileged,
+        "privileged must not be recorded as enabled after a rejected call"
+    );
+
+    unsafe { boxlite_advanced_options_free(advanced) };
+}
+
+/// The canonical add=["ALL"] shape is not a conflict in either order: it is
+/// exactly what `set_privileged(true)` itself installs.
+#[test]
+fn set_privileged_allows_canonical_shape_already_set() {
+    let mut advanced: *mut CAdvancedBoxOptions = ptr::null_mut();
+    let mut error = FFIError::default();
+    let code = unsafe { boxlite_advanced_options_new(&mut advanced, &mut error as *mut _) };
+    assert_eq!(code, BoxliteErrorCode::Ok);
+
+    let cap_add = [CString::new("ALL").unwrap()];
+    let cap_add_ptrs: Vec<*const std::os::raw::c_char> =
+        cap_add.iter().map(|cap| cap.as_ptr()).collect();
+    let add_code = unsafe {
+        boxlite_advanced_options_set_capabilities_add(
+            advanced,
+            cap_add_ptrs.as_ptr(),
+            cap_add_ptrs.len() as c_int,
+        )
+    };
+    assert_eq!(add_code, BoxliteErrorCode::Ok);
+
+    let set_code = unsafe { boxlite_advanced_options_set_privileged(advanced, 1) };
+    assert_eq!(set_code, BoxliteErrorCode::Ok);
 
     unsafe { boxlite_advanced_options_free(advanced) };
 }

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -128,10 +128,7 @@ for _, image := range cached {
   advanced, err := boxlite.NewAdvancedBoxOptions()
   if err != nil { log.Fatal(err) }
   defer advanced.Close()
-  if err := advanced.SetCapabilities(boxlite.ContainerCapabilities{
-      Add: []string{"NET_ADMIN"},
-      Drop: []string{"NET_RAW"},
-  }); err != nil { log.Fatal(err) }
+  advanced.SetPrivileged(true) // DinD: complete guest-level privileged shape
   box, err := runtime.Create(ctx, "alpine:latest", boxlite.WithAdvancedOptions(advanced))
   ```
 

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -128,7 +128,7 @@ for _, image := range cached {
   advanced, err := boxlite.NewAdvancedBoxOptions()
   if err != nil { log.Fatal(err) }
   defer advanced.Close()
-  advanced.SetPrivileged(true) // DinD: complete guest-level privileged shape
+  if err := advanced.SetPrivileged(true); err != nil { log.Fatal(err) } // DinD: complete guest-level privileged shape
   box, err := runtime.Create(ctx, "alpine:latest", boxlite.WithAdvancedOptions(advanced))
   ```
 

--- a/sdks/go/advanced_options.go
+++ b/sdks/go/advanced_options.go
@@ -63,10 +63,19 @@ func (a *AdvancedBoxOptions) SetSecurityEnabled(enabled bool) {
 }
 
 // SetPrivileged enables Docker-style privileged mode. Enabling it also
-// normalizes the capability policy to cap_add=["ALL"] and an empty cap_drop.
-func (a *AdvancedBoxOptions) SetPrivileged(enabled bool) {
+// normalizes the capability policy to cap_add=["ALL"] and an empty cap_drop,
+// unless an explicit, non-canonical policy was already set via
+// SetCapabilities — then it returns an error, the same conflict
+// SetCapabilities itself rejects when called in the other order (privileged
+// first, then a conflicting override). Without this check here, calling the
+// two setters in reverse order silently kept whatever policy was set first.
+func (a *AdvancedBoxOptions) SetPrivileged(enabled bool) error {
 	if a == nil || a.handle == nil {
-		return
+		return fmt.Errorf("boxlite: advanced options handle is closed")
+	}
+	if enabled && (len(a.capabilities.Add) > 0 || len(a.capabilities.Drop) > 0) &&
+		!isPrivilegedCapabilityShape(a.capabilities) {
+		return fmt.Errorf("boxlite: privileged mode cannot be combined with cap_add or cap_drop")
 	}
 	C.boxlite_advanced_options_set_privileged(a.handle, boolToCInt(enabled))
 	a.privileged = enabled
@@ -74,11 +83,21 @@ func (a *AdvancedBoxOptions) SetPrivileged(enabled bool) {
 		if len(a.capabilities.Add) == 0 && len(a.capabilities.Drop) == 0 {
 			a.capabilities = ContainerCapabilities{Add: []string{"ALL"}}
 		}
-	} else if len(a.capabilities.Drop) == 0 && len(a.capabilities.Add) == 1 && a.capabilities.Add[0] == "ALL" {
+	} else if isPrivilegedCapabilityShape(a.capabilities) {
 		// Mirror the withdrawal the native handle just performed, so the Go
 		// view does not keep reporting ALL for a non-privileged box.
 		a.capabilities = ContainerCapabilities{}
 	}
+	return nil
+}
+
+// isPrivilegedCapabilityShape reports whether capabilities is exactly the
+// canonical shape SetPrivileged(true) installs (add=["ALL"], drop=[]) —
+// mirroring the core `ContainerCapabilities::is_privileged_capability_shape`
+// this Go type sends over the wire. That shape is not a conflict: it is what
+// SetPrivileged itself would produce, whichever order the two setters ran in.
+func isPrivilegedCapabilityShape(c ContainerCapabilities) bool {
+	return len(c.Drop) == 0 && len(c.Add) == 1 && c.Add[0] == "ALL"
 }
 
 // SetCapabilities replaces advanced.capabilities for subsequently created
@@ -88,7 +107,8 @@ func (a *AdvancedBoxOptions) SetCapabilities(capabilities ContainerCapabilities)
 	if a == nil || a.handle == nil {
 		return fmt.Errorf("boxlite: advanced options handle is closed")
 	}
-	if a.privileged && (len(capabilities.Add) > 0 || len(capabilities.Drop) > 0) {
+	if a.privileged && (len(capabilities.Add) > 0 || len(capabilities.Drop) > 0) &&
+		!isPrivilegedCapabilityShape(capabilities) {
 		return fmt.Errorf("boxlite: privileged mode cannot be combined with cap_add or cap_drop")
 	}
 	if err := validateCapabilities("advanced.capabilities.add", capabilities.Add); err != nil {

--- a/sdks/go/advanced_options.go
+++ b/sdks/go/advanced_options.go
@@ -34,6 +34,7 @@ type ContainerCapabilities struct {
 type AdvancedBoxOptions struct {
 	handle       *C.CAdvancedBoxOptions
 	capabilities ContainerCapabilities
+	privileged   bool
 }
 
 // NewAdvancedBoxOptions allocates an advanced-options handle initialized to
@@ -61,12 +62,34 @@ func (a *AdvancedBoxOptions) SetSecurityEnabled(enabled bool) {
 	C.boxlite_advanced_options_set_security_enabled(a.handle, boolToCInt(enabled))
 }
 
+// SetPrivileged enables Docker-style privileged mode. Enabling it also
+// normalizes the capability policy to cap_add=["ALL"] and an empty cap_drop.
+func (a *AdvancedBoxOptions) SetPrivileged(enabled bool) {
+	if a == nil || a.handle == nil {
+		return
+	}
+	C.boxlite_advanced_options_set_privileged(a.handle, boolToCInt(enabled))
+	a.privileged = enabled
+	if enabled {
+		if len(a.capabilities.Add) == 0 && len(a.capabilities.Drop) == 0 {
+			a.capabilities = ContainerCapabilities{Add: []string{"ALL"}}
+		}
+	} else if len(a.capabilities.Drop) == 0 && len(a.capabilities.Add) == 1 && a.capabilities.Add[0] == "ALL" {
+		// Mirror the withdrawal the native handle just performed, so the Go
+		// view does not keep reporting ALL for a non-privileged box.
+		a.capabilities = ContainerCapabilities{}
+	}
+}
+
 // SetCapabilities replaces advanced.capabilities for subsequently created
 // boxes. The input slices are copied; callers may safely reuse or mutate them
 // after this method returns.
 func (a *AdvancedBoxOptions) SetCapabilities(capabilities ContainerCapabilities) error {
 	if a == nil || a.handle == nil {
 		return fmt.Errorf("boxlite: advanced options handle is closed")
+	}
+	if a.privileged && (len(capabilities.Add) > 0 || len(capabilities.Drop) > 0) {
+		return fmt.Errorf("boxlite: privileged mode cannot be combined with cap_add or cap_drop")
 	}
 	if err := validateCapabilities("advanced.capabilities.add", capabilities.Add); err != nil {
 		return err

--- a/sdks/go/boxlite_test.go
+++ b/sdks/go/boxlite_test.go
@@ -311,7 +311,9 @@ func TestAdvancedOptionsSetPrivilegedNormalizesCapabilities(t *testing.T) {
 	}
 	defer advanced.Close()
 
-	advanced.SetPrivileged(true)
+	if err := advanced.SetPrivileged(true); err != nil {
+		t.Fatalf("SetPrivileged(true): %v", err)
+	}
 	if !advanced.privileged {
 		t.Fatal("privileged should be enabled")
 	}
@@ -336,9 +338,53 @@ func TestAdvancedOptionsRejectsPrivilegedCapabilityOverrides(t *testing.T) {
 	}
 	defer advanced.Close()
 
-	advanced.SetPrivileged(true)
+	if err := advanced.SetPrivileged(true); err != nil {
+		t.Fatalf("SetPrivileged(true): %v", err)
+	}
 	if err := advanced.SetCapabilities(ContainerCapabilities{Drop: []string{"ALL"}}); err == nil {
 		t.Fatal("privileged mode must reject cap-drop overrides")
+	}
+}
+
+// The same conflict SetCapabilities rejects when privileged is already set
+// must also be rejected in the opposite order — a caller who sets an explicit
+// capability override first and then enables privileged mode must not have
+// their override silently kept alongside a privileged flag that contradicts it.
+func TestAdvancedOptionsSetPrivilegedRejectsExistingCapabilityOverride(t *testing.T) {
+	advanced, err := NewAdvancedBoxOptions()
+	if err != nil {
+		t.Fatalf("NewAdvancedBoxOptions: %v", err)
+	}
+	defer advanced.Close()
+
+	if err := advanced.SetCapabilities(ContainerCapabilities{Add: []string{"NET_ADMIN"}}); err != nil {
+		t.Fatalf("SetCapabilities: %v", err)
+	}
+	if err := advanced.SetPrivileged(true); err == nil {
+		t.Fatal("enabling privileged mode over an explicit capability override must be rejected")
+	}
+	if advanced.privileged {
+		t.Fatal("privileged must not be recorded as enabled after a rejected SetPrivileged call")
+	}
+}
+
+// The canonical add=["ALL"] shape is not a conflict in either order: it is
+// exactly what SetPrivileged(true) itself installs.
+func TestAdvancedOptionsSetPrivilegedAllowsCanonicalShapeInEitherOrder(t *testing.T) {
+	advanced, err := NewAdvancedBoxOptions()
+	if err != nil {
+		t.Fatalf("NewAdvancedBoxOptions: %v", err)
+	}
+	defer advanced.Close()
+
+	if err := advanced.SetCapabilities(ContainerCapabilities{Add: []string{"ALL"}}); err != nil {
+		t.Fatalf("SetCapabilities(ALL): %v", err)
+	}
+	if err := advanced.SetPrivileged(true); err != nil {
+		t.Fatalf("SetPrivileged(true) over an already-canonical shape: %v", err)
+	}
+	if err := advanced.SetCapabilities(ContainerCapabilities{Add: []string{"ALL"}}); err != nil {
+		t.Fatalf("re-affirming the canonical shape while privileged: %v", err)
 	}
 }
 
@@ -351,8 +397,12 @@ func TestAdvancedOptionsSetPrivilegedFalseWithdrawsCapabilities(t *testing.T) {
 	}
 	defer advanced.Close()
 
-	advanced.SetPrivileged(true)
-	advanced.SetPrivileged(false)
+	if err := advanced.SetPrivileged(true); err != nil {
+		t.Fatalf("SetPrivileged(true): %v", err)
+	}
+	if err := advanced.SetPrivileged(false); err != nil {
+		t.Fatalf("SetPrivileged(false): %v", err)
+	}
 
 	if advanced.privileged {
 		t.Fatal("privileged should be disabled")

--- a/sdks/go/boxlite_test.go
+++ b/sdks/go/boxlite_test.go
@@ -304,6 +304,67 @@ func TestAdvancedOptionsSetCapabilitiesDeepCopies(t *testing.T) {
 	}
 }
 
+func TestAdvancedOptionsSetPrivilegedNormalizesCapabilities(t *testing.T) {
+	advanced, err := NewAdvancedBoxOptions()
+	if err != nil {
+		t.Fatalf("NewAdvancedBoxOptions: %v", err)
+	}
+	defer advanced.Close()
+
+	advanced.SetPrivileged(true)
+	if !advanced.privileged {
+		t.Fatal("privileged should be enabled")
+	}
+	if !reflect.DeepEqual(advanced.capabilities.Add, []string{"ALL"}) {
+		t.Fatalf("advanced.capabilities.add: got %v, want [ALL]", advanced.capabilities.Add)
+	}
+	if len(advanced.capabilities.Drop) != 0 {
+		t.Fatalf("advanced.capabilities.drop: got %v, want empty", advanced.capabilities.Drop)
+	}
+
+	cfg := &boxConfig{}
+	WithAdvancedOptions(advanced)(cfg)
+	if err := buildAndFreeCOptions("docker:dind", cfg); err != nil {
+		t.Fatalf("privileged advanced options must apply cleanly: %v", err)
+	}
+}
+
+func TestAdvancedOptionsRejectsPrivilegedCapabilityOverrides(t *testing.T) {
+	advanced, err := NewAdvancedBoxOptions()
+	if err != nil {
+		t.Fatalf("NewAdvancedBoxOptions: %v", err)
+	}
+	defer advanced.Close()
+
+	advanced.SetPrivileged(true)
+	if err := advanced.SetCapabilities(ContainerCapabilities{Drop: []string{"ALL"}}); err == nil {
+		t.Fatal("privileged mode must reject cap-drop overrides")
+	}
+}
+
+// Disabling must withdraw what enabling installed, or the Go view keeps
+// reporting ALL for a box that is no longer privileged.
+func TestAdvancedOptionsSetPrivilegedFalseWithdrawsCapabilities(t *testing.T) {
+	advanced, err := NewAdvancedBoxOptions()
+	if err != nil {
+		t.Fatalf("NewAdvancedBoxOptions: %v", err)
+	}
+	defer advanced.Close()
+
+	advanced.SetPrivileged(true)
+	advanced.SetPrivileged(false)
+
+	if advanced.privileged {
+		t.Fatal("privileged should be disabled")
+	}
+	if len(advanced.capabilities.Add) != 0 {
+		t.Fatalf("cap_add must not survive disabling privileged mode: got %v", advanced.capabilities.Add)
+	}
+	if len(advanced.capabilities.Drop) != 0 {
+		t.Fatalf("advanced.capabilities.drop: got %v, want empty", advanced.capabilities.Drop)
+	}
+}
+
 func TestSetCapabilitiesRejectsEmbeddedNUL(t *testing.T) {
 	advanced, err := NewAdvancedBoxOptions()
 	if err != nil {

--- a/sdks/node/README.md
+++ b/sdks/node/README.md
@@ -183,10 +183,7 @@ const box = new SimpleBox({
     allowNet: ['api.openai.com'],
   },
   advanced: {
-    capabilities: {
-      add: ['NET_ADMIN'],
-      drop: ['NET_RAW'],
-    },
+    privileged: true, // DinD: complete guest-level privileged shape
   },
   env: { FOO: 'bar' },
   volumes: [

--- a/sdks/node/lib/native-contracts.ts
+++ b/sdks/node/lib/native-contracts.ts
@@ -150,6 +150,7 @@ export interface JsContainerCapabilities {
 
 export interface JsAdvancedBoxOptions {
   capabilities?: JsContainerCapabilities;
+  privileged?: boolean;
 }
 
 export interface JsBoxOptions {

--- a/sdks/node/lib/simplebox.ts
+++ b/sdks/node/lib/simplebox.ts
@@ -280,6 +280,8 @@ export interface ContainerCapabilities {
 
 export interface AdvancedBoxOptions {
   capabilities?: ContainerCapabilities;
+  /** Request Docker-style privileged mode for DinD. */
+  privileged?: boolean;
 }
 
 /** Box-scoped network operations for a SimpleBox. */
@@ -451,6 +453,7 @@ export class SimpleBox {
                   drop: [...(options.advanced.capabilities.drop ?? [])],
                 }
               : undefined,
+            privileged: options.advanced.privileged,
           }
         : undefined,
       security,

--- a/sdks/node/src/advanced_options.rs
+++ b/sdks/node/src/advanced_options.rs
@@ -115,6 +115,9 @@ impl From<JsContainerCapabilities> for ContainerCapabilities {
 #[derive(Clone, Debug)]
 pub struct JsAdvancedBoxOptions {
     pub capabilities: Option<JsContainerCapabilities>,
+
+    /// Request Docker-style privileged mode for DinD.
+    pub privileged: Option<bool>,
 }
 
 #[cfg(test)]

--- a/sdks/node/src/options.rs
+++ b/sdks/node/src/options.rs
@@ -454,10 +454,14 @@ impl TryFrom<JsBoxOptions> for BoxOptions {
             .unwrap_or_default();
 
         let health_check = js_opts.health_check.map(HealthCheckOptions::from);
-        let capabilities = js_opts
+        let (capabilities, privileged) = js_opts
             .advanced
-            .and_then(|advanced| advanced.capabilities)
-            .map(Into::into)
+            .map(|advanced| {
+                (
+                    advanced.capabilities.map(Into::into).unwrap_or_default(),
+                    advanced.privileged.unwrap_or(false),
+                )
+            })
             .unwrap_or_default();
         let secrets = js_opts
             .secrets
@@ -473,7 +477,7 @@ impl TryFrom<JsBoxOptions> for BoxOptions {
             })
             .collect();
 
-        Ok(BoxOptions {
+        let mut options = BoxOptions {
             cpus: js_opts.cpus,
             memory_mib: js_opts.memory_mib,
             disk_size_gb: js_opts.disk_size_gb.map(|v| v as u64),
@@ -486,6 +490,7 @@ impl TryFrom<JsBoxOptions> for BoxOptions {
             auto_remove,
             advanced: AdvancedBoxOptions {
                 capabilities,
+                privileged,
                 security,
                 health_check,
                 ..Default::default()
@@ -502,7 +507,10 @@ impl TryFrom<JsBoxOptions> for BoxOptions {
             // do until they grow `attach()` (see sdk-run-semantics-api.md).
             tty: false,
             secrets,
-        })
+        };
+        options.advanced.validate_privileged_capability_conflict()?;
+        options.normalize_privileged();
+        Ok(options)
     }
 }
 
@@ -839,6 +847,7 @@ mod tests {
                 add: Some(vec!["NET_ADMIN".into(), "SYS_PTRACE".into()]),
                 drop: Some(vec!["MKNOD".into(), "NET_RAW".into()]),
             }),
+            privileged: None,
         });
         let with_capabilities = BoxOptions::try_from(with_capabilities).unwrap();
         assert_eq!(
@@ -849,6 +858,28 @@ mod tests {
             with_capabilities.advanced.capabilities.drop,
             ["MKNOD", "NET_RAW"]
         );
+
+        let mut with_privileged = js.clone();
+        with_privileged.advanced = Some(JsAdvancedBoxOptions {
+            capabilities: None,
+            privileged: Some(true),
+        });
+        let with_privileged = BoxOptions::try_from(with_privileged).unwrap();
+        assert!(with_privileged.advanced.privileged);
+        assert_eq!(with_privileged.advanced.capabilities.add, ["ALL"]);
+        assert!(with_privileged.advanced.capabilities.drop.is_empty());
+
+        let mut conflicting_privileged = js.clone();
+        conflicting_privileged.advanced = Some(JsAdvancedBoxOptions {
+            capabilities: Some(JsContainerCapabilities {
+                add: None,
+                drop: Some(vec!["ALL".into()]),
+            }),
+            privileged: Some(true),
+        });
+        let error = BoxOptions::try_from(conflicting_privileged)
+            .expect_err("privileged capability overrides must be rejected");
+        assert!(error.to_string().contains("cannot be combined"));
 
         let opts = BoxOptions::try_from(js).unwrap();
         assert!(!opts.auto_remove);

--- a/sdks/node/src/options.rs
+++ b/sdks/node/src/options.rs
@@ -509,7 +509,7 @@ impl TryFrom<JsBoxOptions> for BoxOptions {
             secrets,
         };
         options.advanced.validate_privileged_capability_conflict()?;
-        options.normalize_privileged();
+        options.advanced.normalize_privileged();
         Ok(options)
     }
 }

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -250,6 +250,7 @@ Configuration options for creating a box.
 - `advanced: AdvancedBoxOptions | None` - Expert-only container options
   - `capabilities.add: List[str]` - Capabilities added to BoxLite's baseline
   - `capabilities.drop: List[str]` - Capabilities removed from the resulting set
+  - `privileged: bool` - Docker-style privileged mode; enables the complete guest-level privileged shape
 - `auto_remove: bool` - Auto cleanup after stop (default: True)
 
 `NetworkSpec` uses:

--- a/sdks/python/src/advanced_options.rs
+++ b/sdks/python/src/advanced_options.rs
@@ -310,21 +310,27 @@ pub struct PyAdvancedBoxOptions {
     /// Linux capability policy for the container process.
     #[pyo3(get, set)]
     pub capabilities: PyContainerCapabilities,
+
+    /// Request Docker-style privileged mode for DinD.
+    #[pyo3(get, set)]
+    pub privileged: bool,
 }
 
 #[pymethods]
 impl PyAdvancedBoxOptions {
     #[new]
-    #[pyo3(signature = (security=None, health_check=None, capabilities=None))]
+    #[pyo3(signature = (security=None, health_check=None, capabilities=None, privileged=false))]
     fn new(
         security: Option<PySecurityOptions>,
         health_check: Option<PyHealthCheckOptions>,
         capabilities: Option<PyContainerCapabilities>,
+        privileged: bool,
     ) -> Self {
         Self {
             security,
             health_check,
             capabilities: capabilities.unwrap_or_default(),
+            privileged,
         }
     }
 }

--- a/sdks/python/src/options.rs
+++ b/sdks/python/src/options.rs
@@ -569,7 +569,7 @@ impl TryFrom<PyBoxOptions> for BoxOptions {
         }
 
         opts.advanced.validate_privileged_capability_conflict()?;
-        opts.normalize_privileged();
+        opts.advanced.normalize_privileged();
 
         // Convert Python secrets to Rust secrets
         opts.secrets = py_opts

--- a/sdks/python/src/options.rs
+++ b/sdks/python/src/options.rs
@@ -565,7 +565,11 @@ impl TryFrom<PyBoxOptions> for BoxOptions {
                 opts.advanced.health_check = Some(HealthCheckOptions::from(health_check));
             }
             opts.advanced.capabilities = advanced.capabilities.into();
+            opts.advanced.privileged = advanced.privileged;
         }
+
+        opts.advanced.validate_privileged_capability_conflict()?;
+        opts.normalize_privileged();
 
         // Convert Python secrets to Rust secrets
         opts.secrets = py_opts

--- a/sdks/python/tests/test_options.py
+++ b/sdks/python/tests/test_options.py
@@ -57,6 +57,32 @@ class TestBoxOptionsDefaults:
         assert not hasattr(opts, "cap_add")
         assert not hasattr(opts, "cap_drop")
 
+    def test_privileged_is_carried_verbatim_by_the_python_binding(self):
+        # The Python objects are carriers: the ["ALL"] expansion and the
+        # conflict check both run in the Rust core when the options are
+        # converted at create time. Asserting the expansion here would assert
+        # something the binding never does.
+        advanced = boxlite.AdvancedBoxOptions(
+            capabilities=boxlite.ContainerCapabilities(drop=["NET_RAW"]),
+            privileged=True,
+        )
+        opts = boxlite.BoxOptions(image="docker:dind", advanced=advanced)
+
+        assert opts.advanced.privileged is True
+        assert opts.advanced.capabilities.add == []
+        assert opts.advanced.capabilities.drop == ["NET_RAW"]
+
+    async def test_privileged_rejects_capability_overrides(self, runtime):
+        advanced = boxlite.AdvancedBoxOptions(
+            capabilities=boxlite.ContainerCapabilities(drop=["ALL"]),
+            privileged=True,
+        )
+
+        with pytest.raises(Exception, match="cannot be combined"):
+            await runtime.create(
+                boxlite.BoxOptions(image="docker:dind", advanced=advanced)
+            )
+
     def test_explicit_auto_remove_true(self):
         """Test setting auto_remove=True explicitly."""
         opts = boxlite.BoxOptions(image="alpine:latest", auto_remove=True)

--- a/src/boxlite/src/runtime/advanced_options.rs
+++ b/src/boxlite/src/runtime/advanced_options.rs
@@ -735,7 +735,12 @@ impl AdvancedBoxOptions {
     /// The canonical `add=["ALL"]` shape is allowed for persisted and FFI
     /// options that have already been normalized. Other explicit overrides
     /// must not be silently discarded by privileged mode.
-    pub(crate) fn validate_privileged_capability_conflict(
+    ///
+    /// `pub`, not `pub(crate)`: the Node/Python FFI bindings construct
+    /// `AdvancedBoxOptions` directly from a plain options object rather than
+    /// through `set_privileged`, so they call this and `normalize_privileged`
+    /// themselves to get the same guarantee that setter gives in-crate.
+    pub fn validate_privileged_capability_conflict(
         &self,
     ) -> boxlite_shared::errors::BoxliteResult<()> {
         if self.privileged
@@ -772,7 +777,10 @@ impl AdvancedBoxOptions {
     /// `validate_privileged_capability_conflict` before this method; a
     /// conflicting explicit override is deliberately left untouched so it
     /// cannot be silently discarded.
-    pub(crate) fn normalize_privileged(&mut self) {
+    ///
+    /// `pub` for the same FFI-binding reason as
+    /// `validate_privileged_capability_conflict`.
+    pub fn normalize_privileged(&mut self) {
         if self.privileged
             && (self.capabilities.is_empty() || self.capabilities.is_privileged_capability_shape())
         {


### PR DESCRIPTION
Split out of #646 to keep that PR to the guest/core/CLI feature itself (84 files was too large for one review). This is the downstream plumbing that consumes the core `AdvancedBoxOptions.privileged` field #646 adds:

- NestJS control-plane: DTO, entity, migration, service, REST mapper, config controller
- Go runner: forwarding `privileged`/`capabilities` through `CreateBoxDTO`/`RecoverBoxDTO`
- Generated API clients (Go, TS, runner-api-client)
- SDK bindings: C, Go, Node, Python

Includes the e2e regression test (`test_privileged_options.py`) and the Node/Python SDK reference docs — both exercise/document this control-plane layer specifically (the e2e case drives the full SDK → apps/api → apps/runner → guest chain, so it has nothing to test without this PR's server-side changes).

Depends on #646 conceptually (needs `AdvancedBoxOptions.privileged` to exist), but is code-independent — nothing here blocks #646 from merging first or vice versa.

Test plan:
- [x] Verified working-tree diff against `main` touches only these 52 files; no accidental changes to guest/core/CLI content (spot-checked via `git diff origin/main` on representative files)
- [ ] CI (will run on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added privileged mode and Linux capability controls for creating and recovering boxes.
  * Added support across REST, C, Go, Node.js, and Python SDKs.
  * Box responses now include privileged status and capability settings.
* **Bug Fixes**
  * Added validation, normalization, deduplication, and conflict detection for advanced security options.
* **Documentation**
  * Updated API references, SDK guides, and examples.
* **Tests**
  * Added coverage for validation, normalization, API behavior, and privileged environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->