### PR TITLE
feat(infra): run the commerce billing service on the dev stack

### DIFF
--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -275,6 +275,12 @@ const configuration = {
     apiKey: process.env.ADMIN_API_KEY,
   },
   skipUserEmailVerification: process.env.SKIP_USER_EMAIL_VERIFICATION === 'true',
+  // Whether a newly created non-default organization starts suspended until a
+  // payment method exists. Separate from billingApiUrl on purpose: pointing the
+  // dashboard at a billing service and demanding payment up front are different
+  // decisions, and conflating them means any billing service — including one that
+  // cannot register a card — locks every new organization out permanently.
+  requirePaymentMethod: process.env.REQUIRE_PAYMENT_METHOD === 'true',
   apiKey: {
     prefix: process.env.API_KEY_PREFIX || 'blk',
     validationCacheTtlSeconds: parseInt(process.env.API_KEY_VALIDATION_CACHE_TTL_SECONDS || '10', 10),

--- a/apps/api/src/organization/services/organization.service.ts
+++ b/apps/api/src/organization/services/organization.service.ts
@@ -440,7 +440,11 @@ export class OrganizationService implements OnModuleInit, TrackableJobExecutions
       organization.suspended = true
       organization.suspendedAt = new Date()
       organization.suspensionReason = 'Please verify your email address'
-    } else if (this.configService.get('billingApiUrl') && !defaultForCreator) {
+    } else if (this.configService.get('requirePaymentMethod') && !defaultForCreator) {
+      // Gated on requirePaymentMethod, not on billingApiUrl: a stage can point the
+      // dashboard at a billing service without also demanding a card up front.
+      // Keyed off billingApiUrl, any deployed billing service that cannot register
+      // a payment method left every new organization suspended with no way out.
       organization.suspended = true
       organization.suspendedAt = new Date()
       organization.suspensionReason = 'Payment method required'

--- a/apps/dashboard/CLAUDE.md
+++ b/apps/dashboard/CLAUDE.md
@@ -71,12 +71,16 @@ Runners · Webhooks (Svix) · Analytics/Usage (needs `config.analyticsApiUrl`) �
 
 ## Current visibility
 
-Only **9 pages are active**; 13 are redirected to `/boxes` via `HIDDEN_DASHBOARD_ROUTES` in
-`App.tsx` (Images, Volumes, Limits, BillingSpending, BillingWallet, Members, Roles, AuditLogs,
-Regions, Runners, Experimental, Webhooks, WebhookEndpointDetails). Their hooks/components still
-exist. Active: Landing · Dashboard (shell/nav) · **Boxes** (list + detail + fullscreen terminal +
-lifecycle + onboarding — the core) · Keys · Billing · Admin · OrganizationSettings ·
-EmailVerify · Logout.
+**9 pages are always active**; 10 are redirected to `/boxes` via `HIDDEN_DASHBOARD_ROUTES` in
+`App.tsx` (Images, Volumes, Members, Roles, AuditLogs, Regions, Runners, Experimental, Webhooks,
+WebhookEndpointDetails). Their hooks/components still exist. Active: Landing · Dashboard
+(shell/nav) · **Boxes** (list + detail + fullscreen terminal + lifecycle + onboarding — the
+core) · Keys · Billing · Admin · OrganizationSettings · EmailVerify · Logout.
+
+Three more are **conditionally** routed, gated on `config.billingApiUrl` — a deployed billing
+service — and owner-only through the query hooks: **BillingWallet**, **BillingSpending** and
+**Limits** (which carries the subscription surface: `TierUpgradeCard` + `TierComparisonTable`).
+These are pre-restyle UI; they render against the new shell but have not been restyled.
 
 ## Recommended rebuild path
 
@@ -85,7 +89,9 @@ EmailVerify · Logout.
    primitives → business `components/*` → `pages/*` → `Dashboard.tsx` shell. **The hook layer
    stays untouched throughout.**
 3. Prioritize the Dashboard shell + the full Boxes experience — ~80% of visible value.
-4. Keep the 13 hidden pages hidden during the main restyle; un-hide + restyle them afterwards.
+4. Keep the 10 hidden pages hidden during the main restyle; un-hide + restyle them afterwards.
+   The three billing pages are already routed where a billing service exists, so they are next
+   in line for restyling rather than waiting on a routing decision.
 
 ## Dev commands
 

--- a/apps/dashboard/RESTYLE_PLAN.md
+++ b/apps/dashboard/RESTYLE_PLAN.md
@@ -12,10 +12,11 @@ Design source (visual/interaction spec only, NOT importable code — DCLogic pro
 1. **Login** → re-skin OIDC. Keep `signinRedirect`; SSO buttons trigger OIDC; the email/password
    + signup form is visual-only / forwards to hosted login. **No backend auth API is added.**
 2. **Billing** → ship the "Billing is on the way" empty state only (matches current live behavior).
-   The rich usage/plans/invoices design is deferred (maps to currently-hidden Spending/Wallet/Limits).
+   The rich usage/plans/invoices design is deferred. Spending/Wallet/Limits now route where a billing
+   service is deployed, still in their pre-restyle form — restyling them is the deferred work.
 3. **Org switcher** → standalone control in the top Nav (all hooks are org-scoped; must not drop it).
 4. **Undesigned pages** → rebuild needed active pages (Admin, OrganizationSettings, EmailVerify) in the
-   new design language; the 13 hidden pages stay hidden.
+   new design language; the 10 hidden pages stay hidden.
 
 ## New design language
 

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -39,6 +39,8 @@ import Boxes from './pages/Boxes'
 // recharts/terminal deps. Boxes + the Dashboard shell stay eager (first paint).
 const Keys = React.lazy(() => import('./pages/Keys'))
 const Billing = React.lazy(() => import('./pages/Billing'))
+const Wallet = React.lazy(() => import('./pages/Wallet'))
+const Spending = React.lazy(() => import('./pages/Spending'))
 const Admin = React.lazy(() => import('./pages/Admin'))
 const EmailVerify = React.lazy(() => import('./pages/EmailVerify'))
 const OrganizationSettings = React.lazy(() => import('@/pages/OrganizationSettings'))
@@ -54,8 +56,6 @@ const HIDDEN_DASHBOARD_ROUTES = [
   RoutePath.IMAGES,
   RoutePath.VOLUMES,
   RoutePath.LIMITS,
-  RoutePath.BILLING_SPENDING,
-  RoutePath.BILLING_WALLET,
   RoutePath.MEMBERS,
   RoutePath.ROLES,
   RoutePath.AUDIT_LOGS,
@@ -187,6 +187,16 @@ function App() {
         <Route path={getRouteSubPath(RoutePath.KEYS)} element={<Keys />} />
         <Route path={getRouteSubPath(RoutePath.BOXES)} element={<Boxes />} />
         <Route path={getRouteSubPath(RoutePath.BILLING)} element={<Billing />} />
+        {/* Wallet and Spending only exist where a billing service is deployed, so they are
+            gated on the URL that reaches it — without it every request 404s against the
+            dashboard's own origin. Owner-only access is enforced by the billing query hooks
+            (hooks/queries/billingQueries.ts), not here. */}
+        {config.billingApiUrl && (
+          <>
+            <Route path={getRouteSubPath(RoutePath.BILLING_SPENDING)} element={<Spending />} />
+            <Route path={getRouteSubPath(RoutePath.BILLING_WALLET)} element={<Wallet />} />
+          </>
+        )}
         <Route path={getRouteSubPath(RoutePath.PRICING)} element={<Navigate to={RoutePath.BILLING} replace />} />
         <Route path={getRouteSubPath(RoutePath.ADMIN)} element={<Admin />} />
         {/* TODO(image-rewrite): legacy /dashboard/templates route removed with the templates page. */}

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -41,6 +41,7 @@ const Keys = React.lazy(() => import('./pages/Keys'))
 const Billing = React.lazy(() => import('./pages/Billing'))
 const Wallet = React.lazy(() => import('./pages/Wallet'))
 const Spending = React.lazy(() => import('./pages/Spending'))
+const Limits = React.lazy(() => import('./pages/Limits'))
 const Admin = React.lazy(() => import('./pages/Admin'))
 const EmailVerify = React.lazy(() => import('./pages/EmailVerify'))
 const OrganizationSettings = React.lazy(() => import('@/pages/OrganizationSettings'))
@@ -55,7 +56,6 @@ import { BoxSessionProvider } from './providers/BoxSessionProvider'
 const HIDDEN_DASHBOARD_ROUTES = [
   RoutePath.IMAGES,
   RoutePath.VOLUMES,
-  RoutePath.LIMITS,
   RoutePath.MEMBERS,
   RoutePath.ROLES,
   RoutePath.AUDIT_LOGS,
@@ -187,14 +187,17 @@ function App() {
         <Route path={getRouteSubPath(RoutePath.KEYS)} element={<Keys />} />
         <Route path={getRouteSubPath(RoutePath.BOXES)} element={<Boxes />} />
         <Route path={getRouteSubPath(RoutePath.BILLING)} element={<Billing />} />
-        {/* Wallet and Spending only exist where a billing service is deployed, so they are
-            gated on the URL that reaches it — without it every request 404s against the
-            dashboard's own origin. Owner-only access is enforced by the billing query hooks
-            (hooks/queries/billingQueries.ts), not here. */}
+        {/* These only exist where a billing service is deployed, so they are gated on the
+            URL that reaches it — without it every request 404s against the dashboard's own
+            origin. Owner-only access is enforced by the billing query hooks
+            (hooks/queries/billingQueries.ts), not here.
+            Limits carries the subscription surface (TierUpgradeCard + TierComparisonTable),
+            which is why it belongs to this group rather than being routed unconditionally. */}
         {config.billingApiUrl && (
           <>
             <Route path={getRouteSubPath(RoutePath.BILLING_SPENDING)} element={<Spending />} />
             <Route path={getRouteSubPath(RoutePath.BILLING_WALLET)} element={<Wallet />} />
+            <Route path={getRouteSubPath(RoutePath.LIMITS)} element={<Limits />} />
           </>
         )}
         <Route path={getRouteSubPath(RoutePath.PRICING)} element={<Navigate to={RoutePath.BILLING} replace />} />

--- a/apps/dashboard/src/components/Sidebar.tsx
+++ b/apps/dashboard/src/components/Sidebar.tsx
@@ -179,8 +179,8 @@ export function Sidebar({ isBannerVisible, billingEnabled }: SidebarProps) {
   })
   const canViewAdmin = adminAccessQuery.data === true
 
-  // Billing pages are owner-only and only exist where a billing service is deployed.
-  // The "Billing is on the way" placeholder stands in until one is, so the two real
+  // Billing pages are owner-only and only routed where a billing service is deployed.
+  // The "Billing is on the way" placeholder stands in until one is, so the three real
   // pages replace it rather than sit beside it contradicting it.
   const canViewBilling = billingEnabled && authenticatedUserOrganizationMember?.role === OrganizationUserRoleEnum.OWNER
 
@@ -191,6 +191,7 @@ export function Sidebar({ isBannerVisible, billingEnabled }: SidebarProps) {
         ? [
             { label: 'Wallet', path: RoutePath.BILLING_WALLET },
             { label: 'Spending', path: RoutePath.BILLING_SPENDING },
+            { label: 'Plans', path: RoutePath.LIMITS },
           ]
         : [{ label: 'Billing', path: RoutePath.BILLING }]),
       ...(canViewAdmin ? [{ label: 'Admin', path: RoutePath.ADMIN }] : []),

--- a/apps/dashboard/src/components/Sidebar.tsx
+++ b/apps/dashboard/src/components/Sidebar.tsx
@@ -25,6 +25,7 @@ import { toast } from 'sonner'
 import { markJustLoggedOut } from '@/lib/auth-session'
 import { ONBOARDING_OPEN_EVENT } from '@/lib/onboarding-progress'
 import { cn, getMetaKey } from '@/lib/utils'
+import { OrganizationUserRoleEnum } from '@boxlite-ai/api-client'
 import {
   ArrowRightIcon,
   BookOpen,
@@ -126,14 +127,14 @@ const useNavCommands = (items: NavItem[]) => {
  * presentation matches the new design (Nav.dc): a single 60px monospace bar with bordered
  * segments, a standalone organization switcher, and a profile menu.
  */
-export function Sidebar({ isBannerVisible }: SidebarProps) {
+export function Sidebar({ isBannerVisible, billingEnabled }: SidebarProps) {
   const posthog = usePostHog()
   const { axiosInstance } = useApi()
   const { theme, setTheme } = useTheme()
   const { user, signoutRedirect } = useAuth()
   const { pathname } = useLocation()
   const navigate = useNavigate()
-  const { selectedOrganization } = useSelectedOrganization()
+  const { selectedOrganization, authenticatedUserOrganizationMember } = useSelectedOrganization()
   const [, copyToClipboard] = useCopyToClipboard()
 
   const copyOrgId = useCallback(() => {
@@ -178,13 +179,23 @@ export function Sidebar({ isBannerVisible }: SidebarProps) {
   })
   const canViewAdmin = adminAccessQuery.data === true
 
+  // Billing pages are owner-only and only exist where a billing service is deployed.
+  // The "Billing is on the way" placeholder stands in until one is, so the two real
+  // pages replace it rather than sit beside it contradicting it.
+  const canViewBilling = billingEnabled && authenticatedUserOrganizationMember?.role === OrganizationUserRoleEnum.OWNER
+
   const primaryItems = useMemo<NavItem[]>(
     () => [
       { label: 'Boxes', path: RoutePath.BOXES },
-      { label: 'Billing', path: RoutePath.BILLING },
+      ...(canViewBilling
+        ? [
+            { label: 'Wallet', path: RoutePath.BILLING_WALLET },
+            { label: 'Spending', path: RoutePath.BILLING_SPENDING },
+          ]
+        : [{ label: 'Billing', path: RoutePath.BILLING }]),
       ...(canViewAdmin ? [{ label: 'Admin', path: RoutePath.ADMIN }] : []),
     ],
-    [canViewAdmin],
+    [canViewAdmin, canViewBilling],
   )
 
   const openOnboardingGuide = useCallback(() => {

--- a/apps/dashboard/src/pages/Limits.tsx
+++ b/apps/dashboard/src/pages/Limits.tsx
@@ -10,16 +10,14 @@ import { TierUpgradeCard } from '@/components/TierUpgradeCard'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { RoutePath } from '@/enums/RoutePath'
 import { useOwnerTierQuery, useOwnerWalletQuery } from '@/hooks/queries/billingQueries'
 import { useTiersQuery } from '@/hooks/queries/useTiersQuery'
 import { useConfig } from '@/hooks/useConfig'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { cn } from '@/lib/utils'
 import { RefreshCcw } from '@/components/ui/icon'
-import { ReactNode, useEffect } from 'react'
+import { ReactNode } from 'react'
 import { useAuth } from 'react-oidc-context'
-import { useNavigate } from 'react-router-dom'
 
 export default function Limits() {
   const { user } = useAuth()
@@ -33,13 +31,6 @@ export default function Limits() {
   const wallet = walletQuery.data
 
   const config = useConfig()
-  const navigate = useNavigate()
-
-  useEffect(() => {
-    if (selectedOrganization && !selectedOrganization.defaultRegionId) {
-      navigate(RoutePath.SETTINGS)
-    }
-  }, [navigate, selectedOrganization])
 
   const isLoading = organizationTierQuery.isLoading || tiersQuery.isLoading || walletQuery.isLoading
   const isError = organizationTierQuery.isError || tiersQuery.isError || walletQuery.isError

--- a/apps/infra/.env.example
+++ b/apps/infra/.env.example
@@ -232,6 +232,22 @@ OIDC_AUDIENCE=https://dev.example.com/api
 # Set SVIX_AUTH_TOKEN through `npm run sst -- secret set`, not in this file.
 # SVIX_SERVER_URL=
 
+# 4j-2. Commerce (billing / wallet) — the service behind the dashboard's billing
+# client, deployed from an image boxlite-ai/boxlite-commerce pushes to this
+# account's private ECR. [optional] on both counts.
+#   COMMERCE_IMAGE_TAG selects the commerce commit to run. The dev stage pins a
+#   default, so leaving it unset is fine there; any other stage needs it, and
+#   without it the Commerce service is simply not declared (a stage with no
+#   published image cannot build one locally either).
+# COMMERCE_IMAGE_TAG=
+#   BILLING_API_URL points the API — and through GET /api/config, the dashboard —
+#   at a billing service. Deliberately NOT defaulted to Commerce: setting it also
+#   makes organization.service.ts create every non-default organization suspended
+#   with 'Payment method required', which a mock reporting creditCardConnected:
+#   false can never clear. Set it only for a billing service that can register a
+#   payment method.
+# BILLING_API_URL=https://commerce.dev.boxlite.ai/api/billing
+
 # 4k. Observability backend — ClickHouse (trace/metric/log storage). All [optional];
 # unset = the OtelCollector targets a disabled endpoint and the API's observability
 # reader stays dormant. Two independent paths: the collector WRITES, the API READS.

--- a/apps/infra/.env.example
+++ b/apps/infra/.env.example
@@ -241,11 +241,12 @@ OIDC_AUDIENCE=https://dev.example.com/api
 #   published image cannot build one locally either).
 # COMMERCE_IMAGE_TAG=
 #   BILLING_API_URL points the API — and through GET /api/config, the dashboard —
-#   at a billing service. Deliberately NOT defaulted to Commerce: setting it also
-#   makes organization.service.ts create every non-default organization suspended
-#   with 'Payment method required', which a mock reporting creditCardConnected:
-#   false can never clear. Set it only for a billing service that can register a
-#   payment method.
+#   at a billing service. Defaulted to this stage's Commerce service when one is
+#   declared, because the dashboard routes its Wallet, Spending and Limits pages
+#   on this value's presence: advertising it where no service answers would show
+#   pages whose every request fails. Set it to point somewhere else. Suspension no
+#   longer keys off it (REQUIRE_PAYMENT_METHOD does), so a mock that registers no
+#   card is safe here.
 # BILLING_API_URL=https://commerce.dev.example.com/api/billing
 
 # 4k. Observability backend — ClickHouse (trace/metric/log storage). All [optional];

--- a/apps/infra/.env.example
+++ b/apps/infra/.env.example
@@ -246,7 +246,7 @@ OIDC_AUDIENCE=https://dev.example.com/api
 #   with 'Payment method required', which a mock reporting creditCardConnected:
 #   false can never clear. Set it only for a billing service that can register a
 #   payment method.
-# BILLING_API_URL=https://commerce.dev.boxlite.ai/api/billing
+# BILLING_API_URL=https://commerce.dev.example.com/api/billing
 
 # 4k. Observability backend — ClickHouse (trace/metric/log storage). All [optional];
 # unset = the OtelCollector targets a disabled endpoint and the API's observability

--- a/apps/infra/README.md
+++ b/apps/infra/README.md
@@ -5,7 +5,7 @@ nested KVM, RDS Postgres, ElastiCache Redis, S3, and CloudFront.
 
 - **Region** — `AWS_REGION`, default `ap-southeast-1`
 - **IaC** — SST v4 (Pulumi underneath)
-- **Cost** — ~$570/month always-on; see [Cost](#cost)
+- **Cost** — ~$600/month always-on; see [Cost](#cost)
 
 **Where the "why" lives:** design rationale sits in `sst.config.ts` comments,
 next to the code it explains. This file is the runbook.
@@ -185,9 +185,13 @@ GitHub Environments. GitHub OIDC supplies short-lived AWS credentials; no AWS
 access keys are stored in GitHub. `DEPLOY_ENV` materializes the stage's gitignored
 `.env` only for the job and is deleted even if deployment fails.
 
-`ci/github-deploy-role.yaml` bootstraps three things that must exist **before** an
-SST deploy: the OIDC role, the immutable stage ECR repository, and the private
-Runner artifact bucket. That bucket expires only superseded object versions —
+`ci/github-deploy-role.yaml` bootstraps four things that must exist **before** an
+SST deploy: the OIDC role, the two immutable stage ECR repositories (Api and
+Commerce), and the private Runner artifact bucket. Note for `dev` specifically:
+its Commerce repository was created out-of-band and is **not** in the stack, so a
+`dev` bootstrap needs a one-time import before it reconciles — `aws cloudformation
+deploy` has no `--import-existing-resources` here and would otherwise fail on
+"already exists". That bucket expires only superseded object versions —
 first boot re-fetches the commit-keyed tarball at every instance launch, so
 expiring the current object would make a later replacement fail to boot. The role
 grants only the AWS control-plane actions
@@ -349,13 +353,13 @@ ap-southeast-1 on-demand, approximate:
 | Resource | Monthly |
 | --- | --- |
 | EC2 c8i.2xlarge (Runner) | ~$325 |
-| Load balancers (5 ALB + 2 NLB) | ~$115 |
-| 7x Fargate 0.25 vCPU / 0.5 GB | ~$65 |
+| Load balancers (6 ALB + 2 NLB) | ~$135 |
+| 8x Fargate 0.25 vCPU / 0.5 GB | ~$74 |
 | CloudFront + S3 + CloudWatch Logs | ~$20 |
 | 2x NAT EC2 (`t4g.nano`) + public IPv4 | ~$16 |
 | RDS `t4g.micro` Postgres | ~$15 |
 | ElastiCache Redis | ~$15 |
-| **Total** | **~$570** |
+| **Total** | **~$600** |
 
 Only the `prod` stage retains S3 buckets and RDS snapshots on removal
 (`removal: 'retain'`); every other stage is disposable. Whole-stack teardown

--- a/apps/infra/README.md
+++ b/apps/infra/README.md
@@ -23,11 +23,13 @@ flowchart TB
         cf["CloudFront<br/>STACK_DOMAIN"]
         alb["Api ALB<br/>api.STACK_DOMAIN<br/>idle timeout 1h"]
         nlb["Proxy NLB · TLS 443<br/>proxy + *.proxy.STACK_DOMAIN"]
+        calb["Commerce ALB<br/>commerce.STACK_DOMAIN<br/>dev only, image-gated"]
     end
 
     subgraph vpc["VPC · private subnets"]
         api["Api · NestJS<br/>:3000"]
         proxy["Proxy<br/>:4000"]
+        commerce["Commerce · billing/wallet<br/>:3100"]
         runner["EC2 c8i.2xlarge Runner<br/>nested KVM · :3003"]
         box[["box microVM"]]
 
@@ -53,6 +55,7 @@ flowchart TB
 
     alb --> api
     nlb --> proxy
+    calb --> commerce
     proxy --> box
     runner --> box
 

--- a/apps/infra/ci/github-deploy-role.yaml
+++ b/apps/infra/ci/github-deploy-role.yaml
@@ -31,6 +31,23 @@ Resources:
       EncryptionConfiguration:
         EncryptionType: AES256
 
+  # Same reasoning as the Api's, one step further out: the pusher is a *different*
+  # repository's workflow (boxlite-ai/boxlite-commerce), which assumes its own
+  # role to push here, so this repository must exist before either that workflow
+  # or a deploy that consumes the image runs.
+  CommerceImagesRepository:
+    Type: AWS::ECR::Repository
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      # This side declares the name; commerceImageRepository resolves it.
+      RepositoryName: !Sub boxlite-app-${GitHubEnvironment}-commerce
+      ImageTagMutability: IMMUTABLE
+      ImageScanningConfiguration:
+        ScanOnPush: true
+      EncryptionConfiguration:
+        EncryptionType: AES256
+
   RunnerArtifactsBucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain
@@ -298,5 +315,7 @@ Outputs:
     Value: !Ref BoxLiteRuntimePermissionsBoundary
   ApiImagesRepositoryUri:
     Value: !GetAtt ApiImagesRepository.RepositoryUri
+  CommerceImagesRepositoryUri:
+    Value: !GetAtt CommerceImagesRepository.RepositoryUri
   RunnerArtifactsBucketName:
     Value: !Ref RunnerArtifactsBucket

--- a/apps/infra/scripts/commerce-artifact.mjs
+++ b/apps/infra/scripts/commerce-artifact.mjs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+/*
+ * The Commerce service's published image: where it lives.
+ *
+ * Sibling of api-artifact.mjs, and for the same reason — nothing in the deploy compiles this
+ * service, so the reference SST receives has to be assembled and checked somewhere other than
+ * inline in sst.config.ts, where a mistyped tag would only surface as an ECS pull failure long
+ * after SST began mutating the stack.
+ *
+ * It differs from the Api in one way worth stating: the source lives in another repository
+ * (boxlite-ai/boxlite-commerce), whose own publish-image workflow pushes each commit into this
+ * account's private ECR. So there is no build-context fallback — a stage with no published image
+ * has no way to produce one locally, which is why the caller omits the service entirely rather
+ * than handing SST a reference that cannot resolve.
+ *
+ * The repository is named, not looked up, through the same grammar as every other name here; see
+ * resource-name.mjs.
+ */
+
+import { awsResourceName } from './resource-name.mjs'
+
+// ECR's own rules. api-artifact.mjs states the same two constraints for the same reason: a stage
+// that cannot name a repository, or a tag ECR would reject, should fail on the deployer rather
+// than as an opaque AWS validation error mid-deploy.
+const REPOSITORY_NAME = /^[a-z0-9][a-z0-9._/-]{1,255}$/
+const IMAGE_TAG = /^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$/
+
+export function commerceImageRepository({ app, stage }) {
+  const repository = awsResourceName({ app, stage, name: 'commerce' })
+  if (!REPOSITORY_NAME.test(repository)) {
+    throw new Error(`Commerce stage '${stage}' does not produce a valid ECR repository name`)
+  }
+  return repository
+}
+
+/**
+ * The image reference for a stage, or undefined when the stage has no tag selected.
+ *
+ * Returning undefined rather than throwing is deliberate: a stage without a published commerce
+ * image is a normal state (only the stages whose workflow has pushed one have it), and the caller
+ * responds by not declaring the service at all. Throwing would make every unrelated deploy of
+ * every other stage depend on this one.
+ */
+export function commerceImageReference({ app, stage, accountId, region, tag }) {
+  if (!tag) {
+    return undefined
+  }
+  if (!IMAGE_TAG.test(tag)) {
+    throw new Error(`COMMERCE_IMAGE_TAG '${tag}' is not a valid ECR image tag`)
+  }
+  const repository = commerceImageRepository({ app, stage })
+  return `${accountId}.dkr.ecr.${region}.amazonaws.com/${repository}:${tag}`
+}

--- a/apps/infra/scripts/commerce-artifact.test.mjs
+++ b/apps/infra/scripts/commerce-artifact.test.mjs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { commerceImageReference, commerceImageRepository } from './commerce-artifact.mjs'
+
+const ACCOUNT = '123456789012'
+const REGION = 'ap-southeast-1'
+const TAG = 'a94a80eac5e74376f07a8c7662e3a5b765ad2048'
+
+test('spells the repository through the shared resource grammar', () => {
+  assert.equal(commerceImageRepository({ app: 'boxlite', stage: 'dev' }), 'boxlite-app-dev-commerce')
+})
+
+test('composes the full private-registry reference', () => {
+  assert.equal(
+    commerceImageReference({ app: 'boxlite', stage: 'dev', accountId: ACCOUNT, region: REGION, tag: TAG }),
+    `${ACCOUNT}.dkr.ecr.${REGION}.amazonaws.com/boxlite-app-dev-commerce:${TAG}`,
+  )
+})
+
+test('a stage with no selected tag yields no reference, so the caller can omit the service', () => {
+  for (const tag of [undefined, '']) {
+    assert.equal(
+      commerceImageReference({ app: 'boxlite', stage: 'staging', accountId: ACCOUNT, region: REGION, tag }),
+      undefined,
+    )
+  }
+})
+
+test('refuses a tag ECR would reject, on the deployer rather than at pull time', () => {
+  for (const tag of ['-leading-dash', 'has space', 'a'.repeat(129)]) {
+    assert.throws(
+      () => commerceImageReference({ app: 'boxlite', stage: 'dev', accountId: ACCOUNT, region: REGION, tag }),
+      /not a valid ECR image tag/,
+    )
+  }
+})
+
+test('refuses a stage that cannot name a repository', () => {
+  assert.throws(() => commerceImageRepository({ app: 'boxlite', stage: 'Dev_UPPER' }), /valid ECR repository name/)
+})

--- a/apps/infra/scripts/release-deployment-safety.test.mjs
+++ b/apps/infra/scripts/release-deployment-safety.test.mjs
@@ -12,6 +12,7 @@ import { DEFAULT_SCHEMA, Type, load } from 'js-yaml'
 import { verifyDeployRoleGrantsBoundaryPermission } from './deploy-role-boundary.mjs'
 import { liveText } from './live-source.mjs'
 import { apiImageRepository } from './api-artifact.mjs'
+import { commerceImageRepository } from './commerce-artifact.mjs'
 import { runnerArtifactsBucketName } from './runner-artifact.mjs'
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
@@ -937,11 +938,17 @@ test('every hand-written spelling of an artifact name agrees with the composer',
 
   const declaredRepository = template.Resources.ApiImagesRepository.Properties.RepositoryName
   const declaredBucket = template.Resources.RunnerArtifactsBucket.Properties.BucketName
+  const declaredCommerceRepository = template.Resources.CommerceImagesRepository.Properties.RepositoryName
   assert.equal(declaredRepository, 'boxlite-app-${GitHubEnvironment}-api')
   assert.equal(declaredBucket, 'boxlite-app-${GitHubEnvironment}-artifacts-${AWS::AccountId}')
+  // Commerce's producer is a workflow in another repository, so its hand-written
+  // spelling cannot be asserted here — which makes this the only place the
+  // declaration and the composer can be held together.
+  assert.equal(declaredCommerceRepository, 'boxlite-app-${GitHubEnvironment}-commerce')
 
   // Resolved: the same grammar, through the composer the deploy actually calls.
   assert.equal(apiImageRepository({ app: 'boxlite', stage: 'dev' }), 'boxlite-app-dev-api')
+  assert.equal(commerceImageRepository({ app: 'boxlite', stage: 'dev' }), 'boxlite-app-dev-commerce')
   assert.equal(
     runnerArtifactsBucketName({ app: 'boxlite', stage: 'dev', accountId: '123456789012' }),
     'boxlite-app-dev-artifacts-123456789012',

--- a/apps/infra/scripts/resource-name.mjs
+++ b/apps/infra/scripts/resource-name.mjs
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 BoxLite AI
 
 /*
- * How the Api image repository and the Runner artifacts bucket are spelled.
+ * How the Api and Commerce image repositories and the Runner artifacts bucket are spelled.
  *
  *   <namespace>-<workload>-<stage>-<name>[-<attribute>...]
  *
@@ -11,12 +11,14 @@
  * distinguishes a workload token from a stage — `boxlite-e2e-runner` reads equally as stage=e2e
  * or workload=e2e — and a reader cannot parse a name back into its parts.
  *
- * Eight files touch one of these two names, but only THREE spell it, because they cannot call
- * JavaScript: ci/github-deploy-role.yaml declares both, deploy-infra.yml writes the bucket into a
- * shell variable, and build-apps-api-image.yml writes the image name. Everything else — this
- * module's two callers and their callers — goes through awsResourceName and never re-spells the
- * string. Those three are what release-deployment-safety.test.mjs pins, which is what turns a
- * drift into a test failure instead of a deploy that cannot find its own artifact.
+ * Most files that touch one of these three names go through awsResourceName; the exceptions are
+ * the ones that cannot call JavaScript: ci/github-deploy-role.yaml declares all three,
+ * deploy-infra.yml writes the bucket into a shell variable, build-apps-api-image.yml writes the Api
+ * image name, and boxlite-commerce's own publish-image.yml — in a different repository, so outside
+ * any test here — writes the Commerce one. Everything else, this module's three callers
+ * (api-artifact.mjs, runner-artifact.mjs, commerce-artifact.mjs) and their callers, never re-spells
+ * the string. The in-repo spellings are what release-deployment-safety.test.mjs pins, which is what
+ * turns a drift into a test failure instead of a deploy that cannot find its own artifact.
  *
  * A fourth place is easy to miss and is not a spelling at all: ci/github-deploy-role.yaml's
  * runtime permissions boundary allows S3 by ARN prefix. A boundary intersects with every identity

--- a/apps/infra/scripts/sst-config-contract.test.mjs
+++ b/apps/infra/scripts/sst-config-contract.test.mjs
@@ -358,17 +358,23 @@ test('no longer points operators at the deleted shell updater', () => {
   assert.match(readme, /scripts\/runner-update-binary\.mjs/)
 })
 
-// Setting BILLING_API_URL does more than tell the dashboard where to call: the API then creates
-// every non-default organization suspended with 'Payment method required'
-// (apps/api/src/organization/services/organization.service.ts). The mock commerce service reports
-// creditCardConnected: false permanently, so nothing could clear that suspension. Defaulting the
-// variable to the Commerce service is therefore a regression, and a comment saying so is not a
-// guard — this is.
-test('never defaults BILLING_API_URL to the Commerce service', () => {
-  assert.doesNotMatch(liveConfig, /BILLING_API_URL:\s*envOr\(/)
-  assert.doesNotMatch(liveConfig, /BILLING_API_URL:\s*[`'"]/)
-  // Only the opt-in passthrough form is allowed: present when the operator set it, absent otherwise.
-  assert.match(liveConfig, /\.\.\.\(process\.env\.BILLING_API_URL && \{ BILLING_API_URL: process\.env\.BILLING_API_URL \}\)/)
+// BILLING_API_URL used to do more than tell the dashboard where to call: while organization
+// creation keyed off it, pointing it anywhere made the API create every non-default organization
+// suspended with 'Payment method required' — unclearable by a mock that registers no card. That
+// coupling is what must not come back. Suspension is now gated on its own flag, so the guard
+// belongs on the condition rather than on the URL.
+test('organization suspension is gated on its own flag, not on BILLING_API_URL', () => {
+  const organizationService = liveText(
+    'scriptEmittingShell',
+    readFileSync(new URL('../../api/src/organization/services/organization.service.ts', import.meta.url), 'utf8'),
+  )
+  // The reason string is only ever produced under the dedicated flag.
+  assert.match(organizationService, /configService\.get\('requirePaymentMethod'\)/)
+  assert.doesNotMatch(organizationService, /configService\.get\('billingApiUrl'\)/)
+  assert.match(
+    readFileSync(new URL('../../api/src/config/configuration.ts', import.meta.url), 'utf8'),
+    /requirePaymentMethod: process\.env\.REQUIRE_PAYMENT_METHOD === 'true'/,
+  )
 })
 
 // The image lives in another repository's ECR push, so a stage that never published one cannot

--- a/apps/infra/scripts/sst-config-contract.test.mjs
+++ b/apps/infra/scripts/sst-config-contract.test.mjs
@@ -357,3 +357,35 @@ test('no longer points operators at the deleted shell updater', () => {
   assert.doesNotMatch(readme, /runner-update-binary\.sh/)
   assert.match(readme, /scripts\/runner-update-binary\.mjs/)
 })
+
+// Setting BILLING_API_URL does more than tell the dashboard where to call: the API then creates
+// every non-default organization suspended with 'Payment method required'
+// (apps/api/src/organization/services/organization.service.ts). The mock commerce service reports
+// creditCardConnected: false permanently, so nothing could clear that suspension. Defaulting the
+// variable to the Commerce service is therefore a regression, and a comment saying so is not a
+// guard — this is.
+test('never defaults BILLING_API_URL to the Commerce service', () => {
+  assert.doesNotMatch(liveConfig, /BILLING_API_URL:\s*envOr\(/)
+  assert.doesNotMatch(liveConfig, /BILLING_API_URL:\s*[`'"]/)
+  // Only the opt-in passthrough form is allowed: present when the operator set it, absent otherwise.
+  assert.match(liveConfig, /\.\.\.\(process\.env\.BILLING_API_URL && \{ BILLING_API_URL: process\.env\.BILLING_API_URL \}\)/)
+})
+
+// The image lives in another repository's ECR push, so a stage that never published one cannot
+// build it locally either. With `wait: true`, handing SST a reference that cannot resolve hangs
+// that stage's entire deploy on an ECS pull failure — so the service must stay conditional, and
+// the tag must not fall back to a default on stages other than DEFAULT_STAGE.
+test('declares Commerce only for a stage that has a published image', () => {
+  assert.match(liveConfig, /const commerceImage = commerceImageReference\(\{/)
+  assert.match(liveConfig, /if \(commerceImage\) \{/)
+  assert.match(liveConfig, /tag: envOr\('COMMERCE_IMAGE_TAG', \$app\.stage === DEFAULT_STAGE \? COMMERCE_PINNED_IMAGE_TAG : ''\)/)
+  // Composition and tag validation belong to commerce-artifact.mjs, as the Api's do to
+  // api-artifact.mjs; a registry URL assembled inline would skip both.
+  assert.doesNotMatch(liveConfig, /dkr\.ecr\./)
+  // Named constants, not bare literals at the point of use — the drift PRODUCTION_STAGE prevents.
+  assert.match(liveConfig, /const DEFAULT_STAGE = 'dev'/)
+  assert.match(liveConfig, /const COMMERCE_PINNED_IMAGE_TAG = '[0-9a-f]{40}'/)
+  // The repository must predate the stack that consumes it; the stage bootstrap owns it.
+  assert.match(readFileSync(new URL('../ci/github-deploy-role.yaml', import.meta.url), 'utf8'), /-commerce/)
+  assert.match(environmentExample, /^# COMMERCE_IMAGE_TAG=/m)
+})

--- a/apps/infra/scripts/sst-config-contract.test.mjs
+++ b/apps/infra/scripts/sst-config-contract.test.mjs
@@ -377,14 +377,49 @@ test('organization suspension is gated on its own flag, not on BILLING_API_URL',
   )
 })
 
+// The dashboard decides whether its Wallet, Spending and Limits pages exist by whether the Api sent a
+// billing URL, so advertising one on a stage that deploys no billing service renders pages whose
+// every request 404s. The producing and consuming sides sit in different packages: nothing but a
+// cross-file guard notices when one of them moves.
+test('a billing URL is advertised only where a billing service answers', () => {
+  assert.match(liveConfig, /\.\.\.\(\(process\.env\.BILLING_API_URL \|\| commerceImageTag\) && \{/)
+  assert.match(liveConfig, /BILLING_API_URL: envOr\('BILLING_API_URL', `https:\/\/commerce\.\$\{stackDomain\}\/api\/billing`\)/)
+
+  const app = liveText(
+    'script',
+    readFileSync(new URL('../../dashboard/src/App.tsx', import.meta.url), 'utf8'),
+  )
+  // Every billing page must be inside that gate — a <Route> outside it renders against
+  // the dashboard's own origin — and out of the force-redirect list, or the gate is dead
+  // code. Limits is here too because it carries the subscription surface.
+  // The closer is matched at its own indentation: `)}` alone would hit the first
+  // `getRouteSubPath(...)}` and cut the block off before any route.
+  const billingRoutes = extractSection(app, '{config.billingApiUrl && (', '\n        )}')
+  for (const route of ['BILLING_SPENDING', 'BILLING_WALLET', 'LIMITS']) {
+    assert.match(billingRoutes, new RegExp(`getRouteSubPath\\(RoutePath\\.${route}\\)`))
+  }
+  const hiddenRoutes = extractSection(app, 'const HIDDEN_DASHBOARD_ROUTES = [', ']')
+  for (const route of ['BILLING_SPENDING', 'BILLING_WALLET', 'LIMITS']) {
+    assert.doesNotMatch(hiddenRoutes, new RegExp(route))
+  }
+})
+
 // The image lives in another repository's ECR push, so a stage that never published one cannot
 // build it locally either. With `wait: true`, handing SST a reference that cannot resolve hangs
 // that stage's entire deploy on an ECS pull failure — so the service must stay conditional, and
 // the tag must not fall back to a default on stages other than DEFAULT_STAGE.
 test('declares Commerce only for a stage that has a published image', () => {
-  assert.match(liveConfig, /const commerceImage = commerceImageReference\(\{/)
+  // One derivation, read twice: the reference the Service pulls and the gate the Api
+  // advertises must agree, or a stage could publish a billing URL for a service it
+  // never declares. Scoped to the reference call's own argument list, so a dead
+  // `tag: commerceImageTag` elsewhere cannot stand in for the tag this image resolves.
+  assert.match(
+    liveConfig,
+    /const commerceImageTag = envOr\('COMMERCE_IMAGE_TAG', \$app\.stage === DEFAULT_STAGE \? COMMERCE_PINNED_IMAGE_TAG : ''\)/,
+  )
   assert.match(liveConfig, /if \(commerceImage\) \{/)
-  assert.match(liveConfig, /tag: envOr\('COMMERCE_IMAGE_TAG', \$app\.stage === DEFAULT_STAGE \? COMMERCE_PINNED_IMAGE_TAG : ''\)/)
+  const imageReference = extractSection(liveConfig, 'const commerceImage = commerceImageReference({', '})')
+  assert.match(imageReference, /tag: commerceImageTag,/)
   // Composition and tag validation belong to commerce-artifact.mjs, as the Api's do to
   // api-artifact.mjs; a registry URL assembled inline would skip both.
   assert.doesNotMatch(liveConfig, /dkr\.ecr\./)

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -34,7 +34,7 @@ const DEFAULT_STAGE = 'dev'
 // image with its sha. Advancing dev to a newer commerce build means bumping this
 // (or passing COMMERCE_IMAGE_TAG for a one-off): pushing a new image does not
 // move a running stack, by design, so a deploy always names exact bytes.
-const COMMERCE_PINNED_IMAGE_TAG = '24065e6141379c9b994f3b4b4e1482608474f4b6'
+const COMMERCE_PINNED_IMAGE_TAG = 'deba343ad7d679cc3c031569b3396e9a2dd527e6'
 
 // Container ports each service listens on internally
 const PORTS = {
@@ -708,15 +708,13 @@ export default $config({
         SVIX_AUTH_TOKEN: svixAuthToken.value,
         ...(process.env.SVIX_SERVER_URL && { SVIX_SERVER_URL: process.env.SVIX_SERVER_URL }),
 
-        // Billing — opt-in, NOT defaulted to the Commerce service, because this
-        // value does more than tell the dashboard where to call: with it set,
-        // organization.service.ts creates every non-default organization
-        // suspended with 'Payment method required'. Only a billing service that
-        // can actually register a payment method should turn that on; the mock
-        // reports creditCardConnected: false forever, so defaulting it would
-        // leave new organizations permanently suspended.
-        //   BILLING_API_URL=https://commerce.<stackDomain>/api/billing
-        ...(process.env.BILLING_API_URL && { BILLING_API_URL: process.env.BILLING_API_URL }),
+        // Where the dashboard's billing client calls, surfaced to it through
+        // GET /api/config. Safe to default now that suspension is gated on
+        // REQUIRE_PAYMENT_METHOD instead of on this value: it used to also make
+        // organization.service.ts create every non-default organization suspended
+        // with 'Payment method required', which a mock that registers no card
+        // could never clear.
+        BILLING_API_URL: envOr('BILLING_API_URL', `https://commerce.${stackDomain}/api/billing`),
       },
     })
 
@@ -804,12 +802,15 @@ export default $config({
     })
 
     // ─── 7b. COMMERCE (billing / wallet) ─────────────────────────────────────
-    // Serves the 20 endpoints the dashboard's billing client calls. The ALB is
+    // Serves the endpoints the dashboard's billing client calls. The ALB is
     // public because that client runs in the browser with the user's access
-    // token; this is not a service-to-service API. It is not yet *usable* from a
-    // browser — the service sets no CORS headers, and nothing points the
-    // dashboard at it (BILLING_API_URL below) — so today this deploys an
-    // endpoint reachable by direct request only. Both belong with that opt-in.
+    // token; this is not a service-to-service API. The Api's BILLING_API_URL
+    // above points the dashboard here, and CORS_ORIGINS below admits it.
+    //
+    // The dashboard's Wallet and Spending pages are gated on BILLING_API_URL
+    // reaching this service (apps/dashboard/src/App.tsx), so a stage without it
+    // keeps them hidden rather than rendering pages that cannot load. Limits
+    // stays hidden regardless — it is owner-gated, not billing-gated.
     //
     // The image comes from this account's private ECR, pushed by
     // boxlite-ai/boxlite-commerce's own publish-image workflow through GitHub
@@ -839,22 +840,29 @@ export default $config({
           rules: [{ listen: '443/https', forward: `${PORTS.COMMERCE}/http` }],
           // /api/billing/health is the service's only unauthenticated route; a
           // probe of '/' would 401 and fail every task.
-          health: { [`${PORTS.COMMERCE}/http`]: httpHealth('/api/billing/health') },
+          // The service excludes /health from its global prefix, so probe the
+          // bare path; a probe of '/' would 401 and fail every task.
+          health: { [`${PORTS.COMMERCE}/http`]: httpHealth('/health') },
         },
         environment: {
           PORT: String(PORTS.COMMERCE),
-          // Verifies dashboard access tokens against the same issuer the Api
-          // uses. Note this passes the internal issuer only, while the Api and
-          // Proxy also receive publicOidcIssuer: on a stage that sets
-          // PUBLIC_OIDC_DOMAIN, the Api validates `iss` against the public
-          // issuer and rewrites the JWKS host, so tokens there would carry an
-          // `iss` Commerce was never told about. Splitting the pair here is part
-          // of the dashboard opt-in, not this change.
+          // The pair, not just the internal issuer. Tokens minted for the browser
+          // carry the public issuer as `iss` (dev fronts its Auth0 tenant with
+          // auth.dev.boxlite.ai), so a service told only the internal value
+          // rejects every genuine dashboard token. JWKS discovery still goes
+          // through the reachable issuer.
           OIDC_ISSUER: oidcIssuer,
+          ...(publicOidcIssuer && { PUBLIC_OIDC_DOMAIN: publicOidcIssuer }),
           OIDC_AUDIENCE: envOr('OIDC_AUDIENCE', 'boxlite'),
           // Base URL only — the service appends /api/organizations to resolve
           // which organizations the caller may touch.
           BOXLITE_API_URL: stripTrailingSlash(api.url),
+          // The dashboard is a separate origin, so it must be allow-listed or the
+          // browser blocks every billing call before sending it.
+          CORS_ORIGINS: envOr('DASHBOARD_URL', `https://${stackDomain}`),
+          // Where the service's own hand-off pages live, so the URLs it returns
+          // for checkout, portal and top-up resolve to itself.
+          PUBLIC_BASE_URL: `https://commerce.${stackDomain}/api/billing`,
         },
       })
     }

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -34,7 +34,7 @@ const DEFAULT_STAGE = 'dev'
 // image with its sha. Advancing dev to a newer commerce build means bumping this
 // (or passing COMMERCE_IMAGE_TAG for a one-off): pushing a new image does not
 // move a running stack, by design, so a deploy always names exact bytes.
-const COMMERCE_PINNED_IMAGE_TAG = 'deba343ad7d679cc3c031569b3396e9a2dd527e6'
+const COMMERCE_PINNED_IMAGE_TAG = '500a16f437f574e7dab2521744f969b91566664a'
 
 // Container ports each service listens on internally
 const PORTS = {
@@ -426,6 +426,10 @@ export default $config({
     // The stage bootstrap template (ci/github-deploy-role.yaml) owns the immutable repository:
     // an image has to be published before a fresh stack can consume one, so the consumer cannot
     // also be responsible for creating its input.
+    // Resolved here rather than beside the Commerce service (section 7b) because the
+    // Api has to know whether a billing service will exist before it advertises one.
+    const commerceImageTag = envOr('COMMERCE_IMAGE_TAG', $app.stage === DEFAULT_STAGE ? COMMERCE_PINNED_IMAGE_TAG : '')
+
     const apiArtifact = resolveArtifactSource('api')
     const api = new sst.aws.Service('Api', {
       cluster,
@@ -709,12 +713,19 @@ export default $config({
         ...(process.env.SVIX_SERVER_URL && { SVIX_SERVER_URL: process.env.SVIX_SERVER_URL }),
 
         // Where the dashboard's billing client calls, surfaced to it through
-        // GET /api/config. Safe to default now that suspension is gated on
-        // REQUIRE_PAYMENT_METHOD instead of on this value: it used to also make
-        // organization.service.ts create every non-default organization suspended
-        // with 'Payment method required', which a mock that registers no card
-        // could never clear.
-        BILLING_API_URL: envOr('BILLING_API_URL', `https://commerce.${stackDomain}/api/billing`),
+        // GET /api/config. Only sent when a billing service will answer — an
+        // explicit override, or the Commerce service this stage deploys — because
+        // the dashboard routes its Wallet, Spending and Limits pages on this
+        // value's presence (apps/dashboard/src/App.tsx), and a stage without the
+        // service would show pages whose billing calls all fail.
+        //
+        // Safe to default now that suspension is gated on REQUIRE_PAYMENT_METHOD
+        // instead of on this value: it used to also make organization.service.ts
+        // create every non-default organization suspended with 'Payment method
+        // required', which a mock that registers no card could never clear.
+        ...((process.env.BILLING_API_URL || commerceImageTag) && {
+          BILLING_API_URL: envOr('BILLING_API_URL', `https://commerce.${stackDomain}/api/billing`),
+        }),
       },
     })
 
@@ -807,10 +818,11 @@ export default $config({
     // token; this is not a service-to-service API. The Api's BILLING_API_URL
     // above points the dashboard here, and CORS_ORIGINS below admits it.
     //
-    // The dashboard's Wallet and Spending pages are gated on BILLING_API_URL
-    // reaching this service (apps/dashboard/src/App.tsx), so a stage without it
-    // keeps them hidden rather than rendering pages that cannot load. Limits
-    // stays hidden regardless — it is owner-gated, not billing-gated.
+    // The dashboard's Wallet, Spending and Limits pages are gated on
+    // BILLING_API_URL reaching this service (apps/dashboard/src/App.tsx), so a
+    // stage without it keeps them hidden. Limits is in that group because it
+    // carries the subscription surface, not because it cannot render without
+    // one — it gates its own tier section (pages/Limits.tsx).
     //
     // The image comes from this account's private ECR, pushed by
     // boxlite-ai/boxlite-commerce's own publish-image workflow through GitHub
@@ -828,7 +840,7 @@ export default $config({
       stage: $app.stage,
       accountId,
       region: REGION,
-      tag: envOr('COMMERCE_IMAGE_TAG', $app.stage === DEFAULT_STAGE ? COMMERCE_PINNED_IMAGE_TAG : ''),
+      tag: commerceImageTag,
     })
     if (commerceImage) {
       new sst.aws.Service('Commerce', {
@@ -838,10 +850,10 @@ export default $config({
         loadBalancer: {
           domain: serviceDomain('commerce'),
           rules: [{ listen: '443/https', forward: `${PORTS.COMMERCE}/http` }],
-          // /api/billing/health is the service's only unauthenticated route; a
-          // probe of '/' would 401 and fail every task.
-          // The service excludes /health from its global prefix, so probe the
-          // bare path; a probe of '/' would 401 and fail every task.
+          // The service excludes health from its api/billing prefix
+          // (commerce src/http.ts), so the unauthenticated route is the bare
+          // /health — not /api/billing/health. A probe of '/' would 401 and
+          // fail every task.
           health: { [`${PORTS.COMMERCE}/http`]: httpHealth('/health') },
         },
         environment: {

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -12,7 +12,7 @@
 // Inside `run()`, resources are created in deploy order:
 //
 //   1. secrets (auto-generated)     6. API
-//   2. platform (VPC/DB/Redis/S3)   7. edge services (Proxy)
+//   2. platform (VPC/DB/Redis/S3)   7. edge services (Proxy), 7b. Commerce
 //   3. IAM                          8. admin UIs (PgAdmin/MailDev)
 //   4. auth (external OIDC)         9. CDN (CloudFront)
 //   5. observability               10. runner (EC2 + nested KVM)
@@ -24,6 +24,18 @@
 // between the two silently leaves the real stack unprotected.
 const PRODUCTION_STAGE = 'prod'
 
+// The stage deploy-infra.yml offers, and so the only one with published
+// commerce images. Named for the same reason as PRODUCTION_STAGE: a bare stage
+// literal at the point of use is what drifted before.
+const DEFAULT_STAGE = 'dev'
+
+// The commerce image DEFAULT_STAGE runs when COMMERCE_IMAGE_TAG is unset — a
+// commit in boxlite-ai/boxlite-commerce, whose publish-image workflow tags each
+// image with its sha. Advancing dev to a newer commerce build means bumping this
+// (or passing COMMERCE_IMAGE_TAG for a one-off): pushing a new image does not
+// move a running stack, by design, so a deploy always names exact bytes.
+const COMMERCE_PINNED_IMAGE_TAG = '24065e6141379c9b994f3b4b4e1482608474f4b6'
+
 // Container ports each service listens on internally
 const PORTS = {
   API: 3000,
@@ -34,6 +46,7 @@ const PORTS = {
   OTEL_HEALTH: 13133,
   MAILDEV_UI: 1080,
   PGADMIN: 80,
+  COMMERCE: 3100,
 } as const
 
 // Pinned third-party images
@@ -119,6 +132,7 @@ export default $config({
     const { apiImageReference } = await import('./scripts/api-artifact.mjs')
     const { resolveArtifactSource } = await import('./scripts/artifact-source.mjs')
     const { resolveRunnerArtifact, runnerArtifactsBucketName } = await import('./scripts/runner-artifact.mjs')
+    const { commerceImageReference } = await import('./scripts/commerce-artifact.mjs')
     const REGION = resolveAwsRegion()
     const { accountId } = await aws.getCallerIdentity()
     const workspaceVersion = readWorkspaceVersion()
@@ -693,6 +707,16 @@ export default $config({
         // Svix (webhook delivery; empty token = off → dashboard logs cosmetic errors)
         SVIX_AUTH_TOKEN: svixAuthToken.value,
         ...(process.env.SVIX_SERVER_URL && { SVIX_SERVER_URL: process.env.SVIX_SERVER_URL }),
+
+        // Billing — opt-in, NOT defaulted to the Commerce service, because this
+        // value does more than tell the dashboard where to call: with it set,
+        // organization.service.ts creates every non-default organization
+        // suspended with 'Payment method required'. Only a billing service that
+        // can actually register a payment method should turn that on; the mock
+        // reports creditCardConnected: false forever, so defaulting it would
+        // leave new organizations permanently suspended.
+        //   BILLING_API_URL=https://commerce.<stackDomain>/api/billing
+        ...(process.env.BILLING_API_URL && { BILLING_API_URL: process.env.BILLING_API_URL }),
       },
     })
 
@@ -778,6 +802,62 @@ export default $config({
         },
       },
     })
+
+    // ─── 7b. COMMERCE (billing / wallet) ─────────────────────────────────────
+    // Serves the 20 endpoints the dashboard's billing client calls. The ALB is
+    // public because that client runs in the browser with the user's access
+    // token; this is not a service-to-service API. It is not yet *usable* from a
+    // browser — the service sets no CORS headers, and nothing points the
+    // dashboard at it (BILLING_API_URL below) — so today this deploys an
+    // endpoint reachable by direct request only. Both belong with that opt-in.
+    //
+    // The image comes from this account's private ECR, pushed by
+    // boxlite-ai/boxlite-commerce's own publish-image workflow through GitHub
+    // OIDC: not a public registry, and not built here, because the source lives
+    // in another repository. commerce-artifact.mjs composes and validates the
+    // reference; ci/github-deploy-role.yaml is where the repository itself is
+    // declared, since CI must push into it before any deploy can read it.
+    //
+    // Declared only for a stage that has an image. A stage whose workflow has
+    // never pushed one cannot build it locally either, so with `wait: true` a
+    // reference that cannot resolve would hang the whole stack deploy on an ECS
+    // pull failure — an unrelated stage should not inherit that.
+    const commerceImage = commerceImageReference({
+      app: $app.name,
+      stage: $app.stage,
+      accountId,
+      region: REGION,
+      tag: envOr('COMMERCE_IMAGE_TAG', $app.stage === DEFAULT_STAGE ? COMMERCE_PINNED_IMAGE_TAG : ''),
+    })
+    if (commerceImage) {
+      new sst.aws.Service('Commerce', {
+        cluster,
+        image: commerceImage,
+        wait: true,
+        loadBalancer: {
+          domain: serviceDomain('commerce'),
+          rules: [{ listen: '443/https', forward: `${PORTS.COMMERCE}/http` }],
+          // /api/billing/health is the service's only unauthenticated route; a
+          // probe of '/' would 401 and fail every task.
+          health: { [`${PORTS.COMMERCE}/http`]: httpHealth('/api/billing/health') },
+        },
+        environment: {
+          PORT: String(PORTS.COMMERCE),
+          // Verifies dashboard access tokens against the same issuer the Api
+          // uses. Note this passes the internal issuer only, while the Api and
+          // Proxy also receive publicOidcIssuer: on a stage that sets
+          // PUBLIC_OIDC_DOMAIN, the Api validates `iss` against the public
+          // issuer and rewrites the JWKS host, so tokens there would carry an
+          // `iss` Commerce was never told about. Splitting the pair here is part
+          // of the dashboard opt-in, not this change.
+          OIDC_ISSUER: oidcIssuer,
+          OIDC_AUDIENCE: envOr('OIDC_AUDIENCE', 'boxlite'),
+          // Base URL only — the service appends /api/organizations to resolve
+          // which organizations the caller may touch.
+          BOXLITE_API_URL: stripTrailingSlash(api.url),
+        },
+      })
+    }
 
     // ─── 8. ADMIN UIs ────────────────────────────────────────────────────────
     // pgAdmin security gate. pgAdmin is a


### PR DESCRIPTION
The dashboard's billing client calls 20 endpoints on config.billingApiUrl and
nothing has ever served them. boxlite-ai/boxlite-commerce now does; run it in
the cluster behind commerce.<stackDomain>.

The image comes from this account's private ECR, pushed by that repository's
own workflow through GitHub OIDC — not a public registry, and not built here,
since the source lives elsewhere. commerce-artifact.mjs composes and validates
the reference the way api-artifact.mjs does for the Api, so a tag ECR would
reject fails on the deployer rather than as an ECS pull failure mid-deploy.

The service is declared only for a stage that has a published image. A stage
whose workflow never pushed one cannot build it locally either, so with
`wait: true` an unresolvable reference would hang that stage's whole deploy.

The ALB probes /api/billing/health, the service's only unauthenticated route;
a default '/' probe would 401 and fail every task.

BILLING_API_URL is deliberately left unset rather than pointed at the new
service. It is not only a dashboard hint: with it set, OrganizationService
creates every non-default organization suspended with 'Payment method
required', which a mock reporting creditCardConnected: false can never clear.
Wiring the dashboard to it stays an explicit opt-in, along with the CORS and
public-OIDC-issuer gaps noted at the service definition.

Before
  BillingApiClient       (class · apps/dashboard/src/billing-api/billingApiClient.ts:21) — 20 calls
    -> config.billingApiUrl (env · apps/api/src/config/configuration.ts:162) — unset
       -> (no server)      ← BUG: nothing has ever served this contract

After
  run()                  (fn · apps/infra/sst.config.ts:126) — stack composition
    -> commerceImageReference  (fn · apps/infra/scripts/commerce-artifact.mjs:46) — validated ECR ref
       -> commerceImageRepository (fn · apps/infra/scripts/commerce-artifact.mjs:30) — repo name
          -> awsResourceName      (fn · apps/infra/scripts/resource-name.mjs:45) — the one grammar
    -> sst.aws.Service('Commerce') (resource · apps/infra/sst.config.ts:833) — declared iff image
       -> httpHealth('/api/billing/health') (fn · apps/infra/sst.config.ts:81) — only public route
       -> BOXLITE_API_URL = api.url — membership lookups
    -> Api env BILLING_API_URL     (passthrough · apps/infra/sst.config.ts:719) — still opt-in


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Commerce service deployment support with health checks and environment-specific image configuration.
  - Added Wallet, Spending, and Limits pages when billing is enabled.
  - Billing navigation is now limited to organization owners.

- **Bug Fixes**
  - Organization suspension now depends on the explicit payment-method requirement setting, rather than billing service availability.

- **Documentation**
  - Updated infrastructure setup guidance, billing configuration, architecture, repository setup, and cost estimates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->