### PR TITLE
feat(ci): select which components deploy-infra builds and deploys

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -178,15 +178,31 @@ preview-only; `apply=true` repeats the full structured preview and deploys only
 when the Runner safety gate accepts the
 plan. Routine control-plane deployment rejects every Runner create, delete,
 replacement, or protected-property change; the routine workflow does not
-provision Runners. The job rejects partial `--target`/`--exclude` deploys so
-provider changes and resources reconcile together. It is serialized, uses the
+provision Runners. The job rejects `--target` deploys outright — a targeted
+update omits the shared and provider resources it still depends on, which is
+how a `--target Api` dispatch stalled this stack on `StorageBucket`
+mid-provider-migration — and accepts `--exclude` only for the two scopes the
+`components` input can produce. It is serialized, uses the
 selected stage's protected GitHub Environment, and authenticates to AWS with
 short-lived OIDC credentials. Docker runs entirely in CI; no developer machine
 or public SSH builder participates.
 
-The `stage` input is an allowlist rather than free text, so a
+`components` (`api+runner`, `api`, `runner`) narrows a dispatch to one
+deployable leg: the other leg's build jobs are skipped and its mutable half — the
+service or instance, and the binary-upgrade commands — leaves the plan, so an
+Api-only change need not rebuild the Runner. Its ref-independent scaffolding
+(IAM role, instance profile, security group) still reconciles as a no-op. The
+exclusion covers `sst.config.ts` as well as the SST command line — the
+`UpgradeRunnerBinary-*` commands are siblings of the Runner instance rather
+than children, so `--exclude Runner` alone would leave them firing against an
+artifact the skipped build never published. `apps/infra/scripts/deployment-scope.mjs`
+is the allowlist for both halves. A narrowed deploy leaves the excluded leg on
+whatever commit an earlier run put there, so the stack is then mixed-commit.
+
+The `stage` and `components` inputs are allowlists rather than free text: a
 required-reviewers Environment cannot be targeted by an unbootstrapped or
-misspelled name. Every workflow that binds `environment:` to an input follows
+misspelled name, and a deploy scope is picked from reviewed shapes rather than
+composed on the spot. Every workflow that binds `environment:` to an input follows
 this rule, and each list is independent — it names the stages *that* path is
 meant to reach. Today the commit-build path (`deploy-infra.yml`) lists `dev`,
 while the release path (`deploy-release.yml`, and `build-apps-api-image.yml`'s

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -1,5 +1,5 @@
 name: Deploy stack
-run-name: Deploy ${{ inputs.stage }} stack
+run-name: Deploy ${{ inputs.components }} to ${{ inputs.stage }}
 
 # A build deploy sources both deployable components from one commit — on main, or the head of an
 # open pull request when a change needs a real stage before it merges — each in its own job:
@@ -10,6 +10,12 @@ run-name: Deploy ${{ inputs.stage }} stack
 # The two legs share only resolve-ref, so they run side by side. The final deploy sets one
 # BOXLITE_ARTIFACT_SOURCE=build selector for both and compiles neither. A release deploy uses the
 # other selector and consumes the Api image / Runner tarball published for VERSION instead.
+#
+# `components` narrows both halves at once: an unselected leg is neither built nor deployed. It
+# drops the build jobs here and becomes `--exclude <Component>` on the SST commands below, which
+# apps/infra/scripts/deployment-scope.mjs accepts as one of exactly two reviewed partial shapes.
+# Never `--target`: PR #1095 stalled this stack mid-provider-migration that way, because a targeted
+# update omits the shared resources it still depends on. `--exclude` keeps them in the plan.
 
 on:
   workflow_dispatch:
@@ -21,8 +27,17 @@ on:
         type: choice
         options:
           - dev
+      components:
+        description: 'Which legs to build and deploy. An unselected leg is neither built nor reconciled.'
+        required: true
+        default: api+runner
+        type: choice
+        options:
+          - api+runner
+          - api
+          - runner
       apply:
-        description: Preview again, then deploy the full stack
+        description: Preview again, then deploy the selected components
         required: true
         default: false
         type: boolean
@@ -126,6 +141,9 @@ jobs:
   build-api:
     name: Build commit Api image
     needs: resolve-ref
+    # `contains` rather than equality: the value is one of api+runner / api / runner, and no
+    # option's name contains the other's, so a substring test reads as the membership it is.
+    if: ${{ contains(inputs.components, 'api') }}
     # Nothing here depends on the C SDK, so this runs beside build-c rather than behind it.
     # The called workflow reaches ECR through OIDC, and a job-level block replaces the
     # workflow-level one rather than merging with it, so contents: read is restated.
@@ -140,6 +158,7 @@ jobs:
   build-c:
     name: Build commit C SDK
     needs: resolve-ref
+    if: ${{ contains(inputs.components, 'runner') }}
     # The called workflow's release-upload job declares contents: write, and a callee cannot go
     # past what its caller grants (see the caller-grant test in release-deployment-safety.test.mjs
     # for what is documented and what is inferred). Granted here rather than at workflow level so
@@ -154,6 +173,9 @@ jobs:
   build-runner:
     name: Build commit Runner
     needs: [resolve-ref, build-c]
+    # Stated as well as inherited: a skipped build-c already cascades here, but the C SDK is an
+    # input to this job rather than the reason it exists, so the scope is declared on both.
+    if: ${{ contains(inputs.components, 'runner') }}
     # The called workflow's release-upload job declares contents: write, and a callee cannot go
     # past what its caller grants (see the caller-grant test in release-deployment-safety.test.mjs
     # for what is documented and what is inferred). Granted here rather than at workflow level so
@@ -166,9 +188,16 @@ jobs:
       libboxlite_source: artifact
 
   deploy:
-    name: Deploy ${{ inputs.stage }} stack
+    name: Deploy ${{ inputs.components }} to ${{ inputs.stage }}
     needs: [resolve-ref, build-api, build-runner]
-    if: github.ref == 'refs/heads/main'
+    # A narrowed scope SKIPS a build job, and a skipped `needs` entry would cascade a skip to this
+    # job under the implicit success(). Naming any status-check function turns that off, so the
+    # states that must still stop the deploy — a build that failed or was cancelled — are listed.
+    if: >-
+      ${{ !cancelled()
+      && !contains(needs.*.result, 'failure')
+      && !contains(needs.*.result, 'cancelled')
+      && github.ref == 'refs/heads/main' }}
     environment: ${{ inputs.stage }}
     runs-on: ubuntu-24.04
     timeout-minutes: 90
@@ -181,6 +210,11 @@ jobs:
       API_ARTIFACT_SOURCE: build
       RUNNER_ARTIFACT_SOURCE: build
       BOXLITE_ARTIFACT_REF: ${{ needs.resolve-ref.outputs.sha }}
+      # The SST resource whose leg this run leaves alone; empty for a full deploy. Both selectors
+      # stay `build` above even when one leg is excluded: everything the plan declares still comes
+      # from this one commit, and an exclusion that turned out to be narrower than the leg would
+      # then fail loudly on the missing artifact rather than quietly reinstalling a release.
+      DEPLOY_EXCLUDE: ${{ inputs.components == 'api' && 'Runner' || inputs.components == 'runner' && 'Api' || '' }}
 
     steps:
       - name: Checkout selected commit
@@ -212,12 +246,16 @@ jobs:
           role-session-name: deploy-${{ inputs.stage }}-stack-${{ github.run_id }}
 
       - name: Download commit Runner artifact
+        if: ${{ contains(inputs.components, 'runner') }}
         uses: actions/download-artifact@v4
         with:
           name: runner-linux-amd64
           path: dist/runner
 
+      # Both steps are gated: with the Runner out of scope build-runner never ran, so there is no
+      # artifact to download and nothing to publish under this commit's prefix.
       - name: Stage commit Runner artifact
+        if: ${{ contains(inputs.components, 'runner') }}
         shell: bash
         run: |
           set -euo pipefail
@@ -300,7 +338,7 @@ jobs:
       # scripts/sst-with-cloudflare.mjs prefers an already-set env var and
       # otherwise reads SSM, so a stage seeded via SSM keeps working with
       # these unset.
-      - name: Preview the full stack
+      - name: Preview the selected components
         shell: bash
         working-directory: apps/infra
         env:
@@ -308,16 +346,29 @@ jobs:
           CLOUDFLARE_DEFAULT_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_DEFAULT_ACCOUNT_ID }}
         run: |
           set -euo pipefail
-          npm run --silent sst -- diff --stage "$STAGE" --policy . --json |
+          # An array, so an empty scope contributes no argument at all rather than an empty string
+          # SST would read as a component name. The fixed arguments seed it because expanding an
+          # EMPTY array under `set -u` is an unbound-variable error before bash 4.4 — seeded, it
+          # is never empty, so the line does not depend on the runner image's bash version.
+          args=(diff --stage "$STAGE" --policy .)
+          [ -z "$DEPLOY_EXCLUDE" ] || args+=(--exclude "$DEPLOY_EXCLUDE")
+          args+=(--json)
+          npm run --silent sst -- "${args[@]}" |
             node scripts/deployment-preview.mjs
 
-      - name: Deploy the full stack
+      - name: Deploy the selected components
         if: ${{ inputs.apply }}
+        shell: bash
         working-directory: apps/infra
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_DEFAULT_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_DEFAULT_ACCOUNT_ID }}
-        run: npm run deploy -- --stage "$STAGE" --policy .
+        run: |
+          set -euo pipefail
+          # Seeded for the same reason as the preview above: an empty array must never be expanded.
+          args=(--stage "$STAGE" --policy .)
+          [ -z "$DEPLOY_EXCLUDE" ] || args+=(--exclude "$DEPLOY_EXCLUDE")
+          npm run deploy -- "${args[@]}"
 
       - name: Remove materialized configuration
         if: always()
@@ -334,6 +385,10 @@ jobs:
   #
   # The stage is always `dev`, so the suite's own BOXLITE_DEV_API_URL
   # default is the right target and no api_url is passed.
+  #
+  # Runs whatever `components` was: a narrowed deploy leaves the excluded leg on the commit some
+  # earlier run put there, so the suite is then testing a mixed-commit stack. That is the point of
+  # exercising it — the pairing is exactly what a partial deploy makes uncertain.
   e2e:
     name: E2E suite against ${{ inputs.stage }}
     needs: [resolve-ref, deploy]

--- a/apps/infra/README.md
+++ b/apps/infra/README.md
@@ -171,12 +171,37 @@ preview before the full-stack deploy:
 npm run deploy -- --stage dev
 ```
 
-Both commands deliberately avoid `--target` and `--exclude`. Pulumi treats both
-as partial updates, which cannot safely migrate a provider while omitted
-resources still reference the old provider. Full reconciliation also avoids
-silently accumulating stack drift. The deployment wrapper rejects partial
-deploy selectors; targeted `diff` remains available for read-only inspection.
-The Runner EC2 identity and binary remain stable through the controls under
+`--target` is rejected for deploys, always. Pulumi treats a targeted update as a
+partial one that still depends on resources it omits, so it cannot safely migrate
+a provider while those resources reference the old registration — deploying this
+stack with `--target Api` stopped SST on `StorageBucket` before any application
+resource reached AWS. Targeted `diff` remains available for read-only inspection.
+
+`--exclude` is accepted for exactly two scopes, which drop the mutable half of one
+deployable leg — its service or instance, and the binary-upgrade commands that go
+with it — while keeping every shared and provider resource in the plan. The leg's
+ref-independent scaffolding (`RunnerRole`, `RunnerProfile`, `RunnerSecurityGroup`,
+`RunnerArtifactS3Policy`) still reconciles, as a no-op:
+
+```bash
+npm run deploy -- --stage dev                     # both legs
+npm run deploy -- --stage dev --exclude Runner    # Api leg only
+npm run deploy -- --stage dev --exclude Api       # Runner leg only
+```
+
+`scripts/deployment-scope.mjs` is the allowlist, and it is also what tells the
+preflight which artifacts to verify — an excluded leg is not deployed, so its
+artifact is not required to exist. Any other selector is refused. `deploy-infra.yml`
+exposes the same three scopes as its `components` input and skips the build jobs
+for a leg it excludes.
+
+A narrowed deploy leaves the excluded leg on whatever commit an earlier run put
+there, so the stack is then mixed-commit; the residual partial-update risk above
+is why `apply` defaults to false and the guarded preview runs first. Run the
+first `--exclude Api` (`components=runner`) dispatch with `apply=false` and read
+the plan: only `--exclude Runner` has been exercised against this stack, and that
+scope is also the one that turns off the Api image preflight. The Runner
+EC2 identity and binary remain stable through the controls under
 [Operating rules](#operating-rules), and the matching artifact preflight always
 runs before deployment.
 

--- a/apps/infra/scripts/deployment-scope.mjs
+++ b/apps/infra/scripts/deployment-scope.mjs
@@ -1,8 +1,33 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (c) 2026 BoxLite AI
 
+/*
+ * Which components a deploy covers, and which partial shapes are allowed to say so.
+ *
+ * A full deploy is still the default and still what an unqualified `npm run deploy` gets. The two
+ * partial shapes below exist so a change to one leg does not have to rebuild and reconcile the
+ * other — a Runner build is the long pole, and an Api-only change should not pay for it.
+ *
+ * Only `--exclude` expresses that, never `--target`. PR #1095 took the dev stack down with
+ * `--target Api`: Pulumi cannot migrate a provider while untargeted resources still reference the
+ * old registration, and SST stopped on StorageBucket before any application resource deployed.
+ * `--exclude` was the recovery, because it leaves shared and provider resources in the plan and
+ * omits one leaf. That distinction is the whole reason this module is an allowlist rather than a
+ * parser: an operator may pick a reviewed shape, not compose a new one.
+ *
+ * The residual risk from README.md ("Deploy an existing stack") is unchanged and conditional — an
+ * omitted resource still referencing an old provider is a problem whenever the provider version
+ * moves. Preview first; the workflow's `apply` input defaults to false for this reason.
+ */
+
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+
+// The components with a published artifact, and so the only ones a scope can drop. The Proxy and
+// the OtelCollector build from the checkout on every path and stay in every plan.
+const DEPLOY_COMPONENTS = ['api', 'runner']
+// The SST resource whose exclusion drops each component's leg.
+const COMPONENT_EXCLUSIONS = { Api: 'api', Runner: 'runner' }
 
 const PARTIAL_DEPLOY_SELECTOR = /^--(?:target|exclude)(?:=|$)/
 const RUNNER_POLICY_ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)))
@@ -20,15 +45,124 @@ export function requireSstSubcommandFirst(args) {
   }
 }
 
-export function requireFullStackDeploy(args) {
-  if (args[0] !== 'deploy') return
+// A flag's value whether it was spelled `--exclude Runner` or `--exclude=Runner`, so a scope
+// cannot be smuggled past the allowlist by choosing the other spelling.
+function readSelectors(args) {
+  const selectors = []
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    if (!PARTIAL_DEPLOY_SELECTOR.test(argument)) continue
+    const separator = argument.indexOf('=')
+    const inline = separator === -1 ? undefined : argument.slice(separator + 1)
+    const flag = separator === -1 ? argument : argument.slice(0, separator)
+    let value = inline
+    if (inline === undefined) {
+      const next = args[index + 1]
+      // A following flag is a missing value, not the value itself — the same rule cli-flags.mjs
+      // applies, so `--exclude --stage` fails here instead of excluding a component named --stage.
+      value = next && !next.startsWith('-') ? next : undefined
+      if (value !== undefined) index += 1
+    }
+    selectors.push({ flag: flag.slice(2), value, raw: argument })
+  }
+  return selectors
+}
 
-  const selector = args.find((argument) => PARTIAL_DEPLOY_SELECTOR.test(argument))
-  if (selector) {
+const FULL_SCOPE = Object.freeze({ components: Object.freeze([...DEPLOY_COMPONENTS]), excluded: Object.freeze([]) })
+
+/*
+ * The components this invocation deploys.
+ *
+ * Read by the deploy wrapper's preflight as well as by the guard: a component that is not being
+ * deployed must not be verified, or an Api-only deploy would still demand a published Runner
+ * artifact for a commit whose Runner was deliberately never built. One resolver answers both so
+ * the plan and the preflight cannot disagree about what is in scope.
+ */
+export function resolveDeployScope(args) {
+  const selectors = readSelectors(args)
+
+  // Only `deploy` mutates, so only `deploy` is held to the allowlist — a targeted `diff` stays
+  // legal for read-only inspection.
+  if (args[0] === 'deploy') {
+    if (selectors.length > 1) {
+      throw new Error(
+        `a deploy carries at most one scope selector (got ${selectors.map((s) => s.raw).join(', ')}); ` +
+          'a composed scope is not one of the reviewed shapes',
+      )
+    }
+    for (const selector of selectors) {
+      if (selector.flag === 'target') {
+        throw new Error(
+          `--target is disabled for deploys (${selector.raw}); it omits the shared and provider resources a ` +
+            'targeted update still depends on, which is how PR #1095 stalled the stack mid-provider-migration. ' +
+            `Use --exclude ${Object.keys(COMPONENT_EXCLUSIONS).join(' or --exclude ')} instead`,
+        )
+      }
+      if (!COMPONENT_EXCLUSIONS[selector.value ?? '']) {
+        throw new Error(
+          `--exclude ${selector.value || '(no value)'} is not a reviewed deploy scope; ` +
+            `exclude exactly one of ${Object.keys(COMPONENT_EXCLUSIONS).join(', ')}`,
+        )
+      }
+    }
+  }
+
+  // Derived from the selector, never from the subcommand — `diff` has to build the same resource
+  // graph the `deploy` behind it will build. Scoping this on `args[0] === 'deploy'` made the
+  // preview declare UpgradeRunnerBinary-* and plan an update where the apply, having undeclared
+  // it, planned a delete: the plan an operator approved was not the plan that ran.
+  //
+  // `--target` never narrows it. It filters which declared resources are acted on; it does not
+  // remove declarations, and Pulumi reads a missing declaration as a delete.
+  const excluded = selectors
+    .filter((selector) => selector.flag === 'exclude')
+    .map((selector) => COMPONENT_EXCLUSIONS[selector.value ?? ''])
+    .filter(Boolean)
+  if (excluded.length === 0) return FULL_SCOPE
+
+  return Object.freeze({
+    components: Object.freeze(DEPLOY_COMPONENTS.filter((candidate) => !excluded.includes(candidate))),
+    excluded: Object.freeze([...new Set(excluded)]),
+  })
+}
+
+// How the resolved scope reaches sst.config.ts. The config cannot see argv — SST parses it — so
+// the wrapper exports what it already resolved and the config reads it back. One resolver still
+// owns the answer; this is only its transport.
+export const DEPLOY_SCOPE_KEY = 'BOXLITE_DEPLOY_SCOPE'
+
+export function exportDeployScope(scope, environment = process.env) {
+  environment[DEPLOY_SCOPE_KEY] = scope.components.join(',')
+}
+
+/*
+ * The scope sst.config.ts must build for.
+ *
+ * An ABSENT key means the full stack — a bare `sst` invocation, or a local `npm run deploy`.
+ * A key that is present but empty means the empty scope, which `diff --exclude Api --exclude
+ * Runner` legitimately produces; keyed on presence rather than truthiness so that case does not
+ * round-trip back to the full stack and preview a graph the operator did not ask for.
+ *
+ * A value that is set but unreadable throws rather than defaulting: silently widening it would
+ * declare resources an excluded deploy is not allowed to touch, and silently narrowing it would
+ * drop resources from a full deploy — Pulumi reads "not declared" as "delete".
+ */
+export function readDeployScope(environment = process.env) {
+  if (!(DEPLOY_SCOPE_KEY in environment) || environment[DEPLOY_SCOPE_KEY] === undefined) {
+    return [...DEPLOY_COMPONENTS]
+  }
+  const configured = environment[DEPLOY_SCOPE_KEY].trim()
+  if (!configured) return []
+
+  const components = configured.split(',').map((entry) => entry.trim())
+  const unknown = components.filter((component) => !DEPLOY_COMPONENTS.includes(component))
+  if (unknown.length > 0 || new Set(components).size !== components.length) {
     throw new Error(
-      `partial SST deploys are disabled (${selector}); run a full deploy so provider state and resources reconcile together`,
+      `${DEPLOY_SCOPE_KEY} must be a unique comma-separated subset of ${DEPLOY_COMPONENTS.join(', ')} ` +
+        `(got '${configured}')`,
     )
   }
+  return components
 }
 
 export function withRequiredRunnerPolicy(args, workingDirectory = process.cwd()) {

--- a/apps/infra/scripts/deployment-scope.test.mjs
+++ b/apps/infra/scripts/deployment-scope.test.mjs
@@ -6,7 +6,14 @@ import { resolve } from 'node:path'
 import test from 'node:test'
 import { fileURLToPath } from 'node:url'
 
-import { requireFullStackDeploy, requireSstSubcommandFirst, withRequiredRunnerPolicy } from './deployment-scope.mjs'
+import {
+  DEPLOY_SCOPE_KEY,
+  exportDeployScope,
+  readDeployScope,
+  resolveDeployScope,
+  requireSstSubcommandFirst,
+  withRequiredRunnerPolicy,
+} from './deployment-scope.mjs'
 
 const RUNNER_POLICY_ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)))
 
@@ -32,19 +39,118 @@ test('rejects flag-first SST syntax so deployment guards cannot be bypassed', ()
   assert.throws(() => requireSstSubcommandFirst(['deploy', '--', '--policy', '.']), /argument delimiter is disabled/)
 })
 
-test('accepts full-stack deploys and read-only targeted diffs', () => {
-  assert.doesNotThrow(() => requireFullStackDeploy(['deploy', '--stage', 'dev']))
-  assert.doesNotThrow(() => requireFullStackDeploy(['diff', '--stage', 'dev', '--target', 'Api']))
+test('an unqualified deploy still covers both components', () => {
+  assert.deepEqual(resolveDeployScope(['deploy', '--stage', 'dev']).components, ['api', 'runner'])
+  assert.deepEqual(resolveDeployScope(['deploy', '--stage', 'dev']).excluded, [])
 })
 
-test('rejects every partial deploy selector form before SST runs', () => {
+test('an excluded diff is narrowed exactly like the deploy behind it', () => {
+  // The preview and the apply must build the SAME resource graph. Deriving the scope from the
+  // subcommand instead of the selector made `diff --exclude Runner` declare UpgradeRunnerBinary-*
+  // and plan an update, while `deploy --exclude Runner` undeclared it and planned a delete — the
+  // plan the operator approved was not the plan that ran.
+  for (const excluded of ['Runner', 'Api']) {
+    const preview = resolveDeployScope(['diff', '--stage', 'dev', '--exclude', excluded])
+    const apply = resolveDeployScope(['deploy', '--stage', 'dev', '--exclude', excluded])
+    assert.deepEqual([...preview.components], [...apply.components], `--exclude ${excluded} graphs must agree`)
+  }
+})
+
+test('--target never narrows the graph, on any subcommand', () => {
+  // It filters which declared resources are acted on; it does not remove declarations, and
+  // Pulumi reads a missing declaration as a delete.
+  assert.deepEqual(resolveDeployScope(['diff', '--stage', 'dev', '--target', 'Api']).components, ['api', 'runner'])
+  assert.deepEqual(resolveDeployScope(['diff', '--stage', 'dev', '--target', 'Runner']).components, ['api', 'runner'])
+})
+
+test('each reviewed exclusion drops exactly the leg it names', () => {
+  // Both spellings, because accepting only one would let the other reach SST unexamined while
+  // the preflight still believed the excluded component was in scope.
   for (const args of [
-    ['deploy', '--stage', 'dev', '--target', 'Api'],
-    ['deploy', '--stage', 'dev', '--target=Api'],
     ['deploy', '--stage', 'dev', '--exclude', 'Runner'],
     ['deploy', '--stage', 'dev', '--exclude=Runner'],
   ]) {
-    assert.throws(() => requireFullStackDeploy(args), /partial SST deploys are disabled/)
+    const scope = resolveDeployScope(args)
+    assert.deepEqual(scope.components, ['api'], `${args.join(' ')} must leave only the Api in scope`)
+    assert.deepEqual(scope.excluded, ['runner'])
+  }
+  for (const args of [
+    ['deploy', '--stage', 'dev', '--exclude', 'Api'],
+    ['deploy', '--stage', 'dev', '--exclude=Api'],
+  ]) {
+    const scope = resolveDeployScope(args)
+    assert.deepEqual(scope.components, ['runner'], `${args.join(' ')} must leave only the Runner in scope`)
+    assert.deepEqual(scope.excluded, ['api'])
+  }
+})
+
+test('--target stays banned for deploys — it is what stalled the stack in #1095', () => {
+  // Not interchangeable with --exclude. A targeted update omits the shared and provider resources
+  // it still depends on, which is how SST stopped on StorageBucket mid-provider-migration.
+  for (const args of [
+    ['deploy', '--stage', 'dev', '--target', 'Api'],
+    ['deploy', '--stage', 'dev', '--target=Api'],
+    ['deploy', '--stage', 'dev', '--target', 'Runner'],
+  ]) {
+    assert.throws(() => resolveDeployScope(args), /--target is disabled for deploys/)
+  }
+})
+
+test('rejects any scope that is not one of the reviewed shapes', () => {
+  // An allowlist, not a parser: an operator picks a reviewed scope rather than composing one.
+  for (const args of [
+    ['deploy', '--stage', 'dev', '--exclude', 'Proxy'],
+    ['deploy', '--stage', 'dev', '--exclude', 'Storage'],
+    ['deploy', '--stage', 'dev', '--exclude'],
+    // A flag is a missing value, not the value — otherwise this excludes a component named
+    // `--stage` and silently deploys everything while reporting a narrowed scope.
+    ['deploy', '--exclude', '--stage', 'dev'],
+  ]) {
+    assert.throws(() => resolveDeployScope(args), /not a reviewed deploy scope/, args.join(' '))
+  }
+  assert.throws(
+    () => resolveDeployScope(['deploy', '--stage', 'dev', '--exclude', 'Api', '--exclude', 'Runner']),
+    /at most one scope selector/,
+  )
+})
+
+test('the resolved scope reaches sst.config.ts unchanged', () => {
+  // The config cannot read argv, so the wrapper exports what it resolved. A round-trip, not two
+  // parsers: if these ever disagreed, the plan would exclude one leg while the resource graph
+  // still declared it.
+  for (const args of [
+    ['deploy', '--stage', 'dev'],
+    ['deploy', '--stage', 'dev', '--exclude', 'Runner'],
+    ['deploy', '--stage', 'dev', '--exclude', 'Api'],
+  ]) {
+    const environment = {}
+    const scope = resolveDeployScope(args)
+    exportDeployScope(scope, environment)
+    assert.deepEqual(readDeployScope(environment), [...scope.components], args.join(' '))
+  }
+})
+
+test('an absent scope is the full stack, but a present empty one stays empty', () => {
+  // Absent is what a bare `sst` invocation and a local `npm run deploy` get.
+  assert.deepEqual(readDeployScope({}), ['api', 'runner'])
+  assert.deepEqual(readDeployScope({ [DEPLOY_SCOPE_KEY]: undefined }), ['api', 'runner'])
+  // Present-but-empty is a real scope, not a missing one. `diff --exclude Api --exclude Runner`
+  // produces it, and keying on truthiness round-tripped it back to the full stack — previewing
+  // a graph the operator excluded both legs from.
+  const bothExcluded = resolveDeployScope(['diff', '--exclude', 'Api', '--exclude', 'Runner'])
+  assert.deepEqual([...bothExcluded.components], [])
+  const environment = {}
+  exportDeployScope(bothExcluded, environment)
+  assert.deepEqual(readDeployScope(environment), [])
+  assert.deepEqual(readDeployScope({ [DEPLOY_SCOPE_KEY]: '  ' }), [])
+  // Never a silent default: widening declares resources an excluded deploy must not touch, and
+  // narrowing drops resources from a full deploy — which Pulumi reads as "delete".
+  for (const value of ['proxy', 'api,proxy', 'api,api', 'Runner', 'api runner']) {
+    assert.throws(
+      () => readDeployScope({ [DEPLOY_SCOPE_KEY]: value }),
+      new RegExp(`${DEPLOY_SCOPE_KEY} must be a unique comma-separated subset`),
+      value,
+    )
   }
 })
 

--- a/apps/infra/scripts/release-deployment-safety.test.mjs
+++ b/apps/infra/scripts/release-deployment-safety.test.mjs
@@ -79,12 +79,27 @@ test('SST deploy verifies the selected Runner artifact before invoking SST', () 
   // would skip the check for exactly the deploy `npm run runner:build-artifact` produces.
   assertLiveLine(source, /requireCheckoutMatchesArtifactRefs\(\[apiSource, runnerSource\]\)/)
   assert.match(source, /verifyRunnerArtifact \} from '\.\/runner-artifact\.mjs'/)
-  assert.match(source, /const runnerSource = resolveArtifactSource\('runner'/)
+  // Resolved only when the scope covers it. Dropping the guard restores the failure this scope
+  // exists to avoid: an Api-only deploy demanding a published Runner artifact for a commit whose
+  // Runner was deliberately never built, so a complete deploy fails on a missing thing nobody
+  // asked for. Pin the conditional itself — `resolveArtifactSource('runner')` alone would pass
+  // while verifying a component the plan excludes.
+  assertLiveLine(source, /const runnerSource = deployScope\.components\.includes\('runner'\)/)
+  assertLiveLine(source, /const apiSource = deployScope\.components\.includes\('api'\)/)
   assert.notEqual(preflightIndex, -1, 'the Runner artifact preflight is missing')
   assert.notEqual(sstIndex, -1, 'the guarded SST invocation is missing')
   assert.ok(preflightIndex < sstIndex, 'SST may run before Runner artifact availability is known')
-  assert.doesNotMatch(source, /isSstComponentExcluded/)
-  assert.match(source, /requireFullStackDeploy\(sstArgs\)/)
+  // The scope comes from the args SST is actually handed, resolved once. A second, independent
+  // notion of scope here (an env var, a re-parse) could disagree with the plan and verify the
+  // wrong half.
+  assertLiveLine(source, /deployScope = resolveDeployScope\(sstArgs\)/)
+  // Exported before sst is spawned, so the resource graph is built for the same scope as the
+  // plan. Without it sst.config.ts declares UpgradeRunnerBinary-* on an Api-only deploy, and that
+  // command — a sibling of the excluded instance, so `--exclude Runner` misses it — installs a
+  // Runner binary from a commit whose build-runner job never ran.
+  assertLiveLine(source, /exportDeployScope\(deployScope\)/)
+  const exportIndex = liveText('script', source).indexOf('exportDeployScope(deployScope)')
+  assert.ok(exportIndex !== -1 && exportIndex < sstIndex, 'the scope must be exported before SST is invoked')
   assert.match(source, /withRequiredRunnerPolicy\(sstArgs\)/)
   assert.doesNotMatch(source, /RUNNER_POLICY_ROOT/)
 })
@@ -123,12 +138,16 @@ test('SST deploy verifies the selected API image before invoking SST', () => {
   const preflightIndex = source.indexOf('const image = verifyApiImage(')
   const sstIndex = source.indexOf('await withPulumiEventLogCleanup(')
 
-  assert.match(source, /const apiSource = resolveArtifactSource\('api'\)/)
+  assert.match(source, /resolveArtifactSource\('api'\)/)
   assert.notEqual(preflightIndex, -1, 'the API image preflight is missing')
   assert.ok(preflightIndex < sstIndex, 'SST may run before the selected API image is known to exist')
   // Both published sources go through it. Gating on release alone would let a build deploy name a
   // commit tag nothing ever pushed, and discover it when the ECS task fails to pull.
-  assertLiveLine(source, /if \(apiSource\.kind === 'release' \|\| apiSource\.ref\) \{/)
+  //
+  // The `apiSource &&` is the out-of-scope case, not defensive noise: a Runner-only deploy
+  // excludes the Api, leaves apiSource undefined, and would otherwise throw reading `.kind`
+  // before SST is reached.
+  assertLiveLine(source, /if \(apiSource && \(apiSource\.kind === 'release' \|\| apiSource\.ref\)\) \{/)
 })
 
 test('SST deploy does not depend on a laptop-managed remote builder', () => {
@@ -158,14 +177,14 @@ test('deployment previews and reconciles the full stack in guarded GitHub CI', (
   )
   const materializeStep = workflow.jobs.deploy.steps.find((step) => step.name === 'Materialize stage configuration')
   const installStep = workflow.jobs.deploy.steps.find((step) => step.name === 'Install SST providers')
-  const previewStep = workflow.jobs.deploy.steps.find((step) => step.name === 'Preview the full stack')
-  const deployStep = workflow.jobs.deploy.steps.find((step) => step.name === 'Deploy the full stack')
+  const previewStep = workflow.jobs.deploy.steps.find((step) => step.name === 'Preview the selected components')
+  const deployStep = workflow.jobs.deploy.steps.find((step) => step.name === 'Deploy the selected components')
 
   assert.match(source, /workflow_dispatch:/)
   assert.equal(workflow.on.workflow_dispatch.inputs.stage.type, 'choice')
   assert.ok(workflow.on.workflow_dispatch.inputs.stage.options.includes('dev'))
   assert.deepEqual(workflow.on.workflow_dispatch.inputs.apply, {
-    description: 'Preview again, then deploy the full stack',
+    description: 'Preview again, then deploy the selected components',
     required: true,
     default: false,
     type: 'boolean',
@@ -253,6 +272,49 @@ test('deployment previews and reconciles the full stack in guarded GitHub CI', (
   // expression, so the default success() is what stops the suite running behind a failed deploy.
   assert.deepEqual(workflow.jobs.e2e.needs, ['resolve-ref', 'deploy'])
 
+  // A narrowed scope must drop the build AND the reconcile, or it is not a scope. Each half is
+  // pinned separately because either alone is a distinct bug: the builds without the exclusion
+  // deploys a component from a commit it was never built for, and the exclusion without the
+  // build gating just burns the CI time the input exists to save.
+  const components = workflow.on.workflow_dispatch.inputs.components
+  assert.equal(components.type, 'choice', 'components must be an allowlist, not free text')
+  assert.deepEqual(components.options, ['api+runner', 'api', 'runner'])
+  assert.equal(components.default, 'api+runner', 'an unqualified dispatch must still deploy everything')
+  // `contains` reads as membership only while no single-leg option contains the other leg's name.
+  // The combined option contains both by design; a leg that contained the other would make its
+  // gate fire for a scope that excludes it — an `api`-only dispatch building the Runner anyway.
+  const legs = components.options.filter((option) => option !== 'api+runner')
+  for (const leg of legs) {
+    for (const other of legs.filter((candidate) => candidate !== leg)) {
+      assert.ok(!leg.includes(other), `option '${leg}' contains '${other}', which breaks the contains() gates`)
+    }
+    assert.ok(components.default.includes(leg), `the default must select '${leg}'`)
+  }
+  assert.equal(workflow.jobs['build-api'].if, "${{ contains(inputs.components, 'api') }}")
+  assert.equal(workflow.jobs['build-c'].if, "${{ contains(inputs.components, 'runner') }}")
+  assert.equal(workflow.jobs['build-runner'].if, "${{ contains(inputs.components, 'runner') }}")
+  for (const stepName of ['Download commit Runner artifact', 'Stage commit Runner artifact']) {
+    const step = workflow.jobs.deploy.steps.find((candidate) => candidate.name === stepName)
+    assert.ok(step, `${stepName} is missing`)
+    assert.equal(step.if, "${{ contains(inputs.components, 'runner') }}", `${stepName} must be scope-gated`)
+  }
+  // The SST component each scope excludes. `--target` must never appear: it omits the shared and
+  // provider resources a partial update still depends on, which is how PR #1095 stalled the stack
+  // mid-provider-migration. deployment-scope.mjs rejects it, and this keeps the workflow honest
+  // before it ever gets there.
+  assert.equal(
+    workflow.jobs.deploy.env.DEPLOY_EXCLUDE,
+    "${{ inputs.components == 'api' && 'Runner' || inputs.components == 'runner' && 'Api' || '' }}",
+  )
+  assert.doesNotMatch(liveShell(source), /--target/)
+  // A skipped build job would cascade a skip to the deploy under the implicit success(). Naming a
+  // status-check function turns that off — without one, every narrowed dispatch silently deploys
+  // nothing while reporting green.
+  assert.match(workflow.jobs.deploy.if, /!cancelled\(\)/)
+  assert.match(workflow.jobs.deploy.if, /!contains\(needs\.\*\.result, 'failure'\)/)
+  assert.match(workflow.jobs.deploy.if, /!contains\(needs\.\*\.result, 'cancelled'\)/)
+  assert.match(workflow.jobs.deploy.if, /github\.ref == 'refs\/heads\/main'/)
+
   // Both components resolve to the one commit the build jobs actually produced. The stage secret
   // cannot redirect that: deploy-environment-validation.mjs rejects the selector keys outright.
   for (const selector of ['BOXLITE_ARTIFACT_SOURCE', 'API_ARTIFACT_SOURCE', 'RUNNER_ARTIFACT_SOURCE']) {
@@ -308,18 +370,32 @@ test('deployment previews and reconciles the full stack in guarded GitHub CI', (
   assert.equal(previewStep.if, undefined, 'Preview validation must not be conditional')
   assert.equal(previewStep['continue-on-error'], undefined, 'Preview failures must stop deployment')
   assert.equal(previewStep.shell, 'bash')
-  assert.equal(
-    previewStep.run,
-    [
-      'set -euo pipefail',
-      'npm run --silent sst -- diff --stage "$STAGE" --policy . --json |',
-      '  node scripts/deployment-preview.mjs',
-      '',
-    ].join('\n'),
-  )
-  assert.ok(deployStep, 'the full-stack deployment step is missing')
+  // Every executed line and its order, comments stripped: the scope must reach SST, and nothing
+  // may be appended alongside it. Compared as lines rather than one string so rewording a comment
+  // does not churn the pin, while adding or dropping a command still fails.
+  const liveCommands = (run) => liveShell(run).split('\n').filter(Boolean)
+  // Seeded with the fixed arguments, never `args=()`: expanding an empty array under `set -u` is
+  // an unbound-variable error before bash 4.4, so a full-scope deploy would die on the runner's
+  // bash rather than on anything about this stack. Verified against bash 3.2.
+  assert.deepEqual(liveCommands(previewStep.run), [
+    'set -euo pipefail',
+    'args=(diff --stage "$STAGE" --policy .)',
+    '[ -z "$DEPLOY_EXCLUDE" ] || args+=(--exclude "$DEPLOY_EXCLUDE")',
+    'args+=(--json)',
+    'npm run --silent sst -- "${args[@]}" |',
+    '  node scripts/deployment-preview.mjs',
+  ])
+  assert.ok(deployStep, 'the deployment step is missing')
   assert.equal(deployStep.if, '${{ inputs.apply }}')
-  assert.equal(deployStep.run, 'npm run deploy -- --stage "$STAGE" --policy .')
+  assert.deepEqual(liveCommands(deployStep.run), [
+    'set -euo pipefail',
+    'args=(--stage "$STAGE" --policy .)',
+    '[ -z "$DEPLOY_EXCLUDE" ] || args+=(--exclude "$DEPLOY_EXCLUDE")',
+    'npm run deploy -- "${args[@]}"',
+  ])
+  // The `"${args[@]}"` spelling in both invocations above is the whole guard: `--exclude
+  // "$DEPLOY_EXCLUDE"` inline would hand SST an empty component name on every full deploy, and
+  // unquoted it would word-split. The deepEqual pins those lines exactly, so no separate check.
   assert.ok(
     workflow.jobs.deploy.steps.indexOf(previewStep) < workflow.jobs.deploy.steps.indexOf(deployStep),
     'Preview validation must complete before deployment',
@@ -339,7 +415,13 @@ test('deployment previews and reconciles the full stack in guarded GitHub CI', (
       workflow.jobs.deploy.steps.indexOf(installStep) < workflow.jobs.deploy.steps.indexOf(previewStep),
     'SST providers must be installed after stage config and before the deployment preview',
   )
-  assert.doesNotMatch(`${previewStep.run}\n${deployStep.run}`, /--(?:target|exclude)(?:[=\s]|$)/)
+  // A selector may name a component only through DEPLOY_EXCLUDE, whose value the `components`
+  // choice allowlists. Hardcoding one here would deploy a fixed partial scope on every dispatch,
+  // including the default full one — invisible to the input the operator actually set.
+  assert.doesNotMatch(
+    `${liveShell(previewStep.run)}\n${liveShell(deployStep.run)}`,
+    /--(?:target|exclude)[=\s]+(?!"\$DEPLOY_EXCLUDE")[A-Za-z]/,
+  )
   assert.doesNotMatch(source, /setup-qemu/)
 })
 
@@ -920,7 +1002,7 @@ test('one release selector resolves the API and Runner to the same published ver
   // resolveArtifactSource uses the same resolveReleaseVersion(workspace, env) contract as the
   // public deployment config. VERSION therefore selects both artifacts instead of producing an
   // API/Runner split-brain release.
-  assert.match(source, /const runnerSource = resolveArtifactSource\('runner'\)/)
+  assert.match(source, /resolveArtifactSource\('runner'\)/)
   assert.match(source, /await verifyRunnerArtifact\(runnerSource/)
   assert.doesNotMatch(source, /verifyRunnerReleaseAssets\(publicDeploymentConfig\.releaseVersion\)/)
 })

--- a/apps/infra/scripts/sst-config-contract.test.mjs
+++ b/apps/infra/scripts/sst-config-contract.test.mjs
@@ -140,13 +140,22 @@ test('requires the OIDC client ID through the SST secret store', () => {
 })
 
 test('the runbook never hands an operator a deploy the wrapper rejects', () => {
-  // requireFullStackDeploy throws on --target/--exclude before any preflight runs, so a runbook
-  // command carrying one is not a documented escape hatch — it is a step that exits 1.
-  // Both spellings reach the same guard: package.json points `deploy` and `sst` at one wrapper,
-  // which calls requireFullStackDeploy unconditionally, and that gates on `args[0] === 'deploy'`.
-  // `npm run sst --` is what this runbook actually uses, so covering only `npm run deploy` would
-  // guard the rarer spelling. Targeted `diff` stays legal and must not be flagged.
-  assert.doesNotMatch(readme, /npm run (?:deploy|sst -- deploy)[^\n]*--(?:target|exclude)\b/)
+  // resolveDeployScope throws before any preflight runs, so a runbook command it refuses is not a
+  // documented escape hatch — it is a step that exits 1. Both spellings reach the same guard:
+  // package.json points `deploy` and `sst` at one wrapper, which resolves the scope
+  // unconditionally, and that gates on `args[0] === 'deploy'`. `npm run sst --` is what this
+  // runbook actually uses, so covering only `npm run deploy` would guard the rarer spelling.
+  // Targeted `diff` stays legal and must not be flagged.
+  //
+  // `--target` is still refused for deploys; `--exclude` is refused for anything but the two
+  // reviewed component scopes, so the runbook may show those and nothing else.
+  assert.doesNotMatch(readme, /npm run (?:deploy|sst -- deploy)[^\n]*--target\b/)
+  for (const [, excluded] of readme.matchAll(/npm run (?:deploy|sst -- deploy)[^\n]*--exclude[=\s]+(\S+)/g)) {
+    assert.ok(
+      ['Api', 'Runner'].includes(excluded),
+      `the runbook documents --exclude ${excluded}, which resolveDeployScope refuses`,
+    )
+  }
   // The prod stage is `prod`, and PRODUCTION_STAGE is why: a runbook naming `production` sends
   // an operator at a stage that does not exist, which is the same drift the guards above pin.
   assert.doesNotMatch(readme, /\bstage[= ]production\b/)
@@ -175,6 +184,23 @@ test('no stage-name comparison hardcodes a bare production literal', () => {
   assert.doesNotMatch(liveConfig, /\bstage\b\s*(?:===|!==|==|!=)\s*(?:'production'|"production"|`production`)/)
   assert.doesNotMatch(liveConfig, /(?:'production'|"production"|`production`)\s*(?:===|!==|==|!=)\s*\bstage\b/)
   assert.match(liveConfig, /NODE_ENV: 'production'/)
+})
+
+test('the Runner binary upgrade is declared only when the Runner is in scope', () => {
+  // `--exclude Runner` keeps the EC2 instance out of the plan, but UpgradeRunnerBinary-* is a
+  // sibling of it, not a child, and SST is never passed --exclude-dependents. Its trigger carries
+  // the deployed commit, so left declared on an Api-only deploy it fetches runner/<sha>/ for a
+  // commit whose build-runner job was skipped. deployment-preview.mjs cannot catch that:
+  // isRunnerLikeResource matches a name against /^Runner(?:-|$)/ OR an aws:ec2/instance:Instance
+  // carrying Runner identity tags, and this command satisfies neither arm.
+  const live = liveText('scriptEmittingShell', source)
+  assert.match(live, /const deploysRunner = readDeployScope\(\)\.includes\('runner'\)/)
+  assert.match(live, /readDeployScope \} = await import\('\.\/scripts\/deployment-scope\.mjs'\)/)
+  // The gate must sit on the loop that constructs them, not merely exist somewhere in the file.
+  const upgradeIndex = live.indexOf('`UpgradeRunnerBinary-${label}`')
+  assert.notEqual(upgradeIndex, -1, 'the Runner upgrade command is missing')
+  const loopHeader = live.slice(live.lastIndexOf('let previousUpgrade', upgradeIndex), upgradeIndex)
+  assert.match(loopHeader, /!deploysRunner\s*\?\s*\[\]/, 'the upgrade loop is not gated on the deploy scope')
 })
 
 test('every local Command pins dir, so it runs from the app root', () => {

--- a/apps/infra/scripts/sst-with-cloudflare.mjs
+++ b/apps/infra/scripts/sst-with-cloudflare.mjs
@@ -40,7 +40,12 @@ import {
   resolveAwsRegion,
   resolvePublicDeploymentConfig,
 } from './deployment-environment.mjs'
-import { requireFullStackDeploy, requireSstSubcommandFirst, withRequiredRunnerPolicy } from './deployment-scope.mjs'
+import {
+  exportDeployScope,
+  resolveDeployScope,
+  requireSstSubcommandFirst,
+  withRequiredRunnerPolicy,
+} from './deployment-scope.mjs'
 import {
   resolveAwsCliPath,
   verifyProxyDeploymentWithRetry,
@@ -119,9 +124,16 @@ if (sstArgs.length === 0) {
   console.error('sst-with-cloudflare: expected an sst subcommand (e.g. "deploy --stage dev")')
   process.exit(1)
 }
+let deployScope
 try {
   requireSstSubcommandFirst(sstArgs)
-  requireFullStackDeploy(sstArgs)
+  deployScope = resolveDeployScope(sstArgs)
+  // Before sst is spawned, and unconditionally: sst inherits this process's env, and an excluded
+  // leg has to be absent from the resource graph as well as from the plan. `--exclude Runner`
+  // omits the instance but not UpgradeRunnerBinary-*, a sibling command whose artifact trigger
+  // moves with the deployed commit — left declared, it would install a Runner binary this run
+  // deliberately never built.
+  exportDeployScope(deployScope)
   sstArgs = withRequiredRunnerPolicy(sstArgs)
 } catch (error) {
   console.error(`sst-with-cloudflare: ${error.message}`)
@@ -221,16 +233,22 @@ if (sstArgs[0] === 'deploy') {
     publicDeploymentConfig = resolvePublicDeploymentConfig(process.env, workspaceVersion)
     const signal = artifactPreflightAbortController.signal
 
-    const apiSource = resolveArtifactSource('api')
-    const runnerSource = resolveArtifactSource('runner')
-    // Across both components, before either is verified. The Proxy and the OtelCollector are built
-    // from this checkout on every path, so any ref that is not the checkout deploys two commits —
-    // and nothing downstream would notice: the staged Runner object still verifies and the
-    // post-deploy check only reads X.Y.Z. Checking one component's ref would miss the deploy that
-    // addresses only the other, which is what `npm run runner:build-artifact` produces.
+    // Only what this deploy declares. A scope that excludes a component omits its resources from
+    // the plan, so verifying its artifact would fail a complete deploy for a missing thing nobody
+    // asked to deploy — an Api-only run deliberately never builds a Runner for that commit.
+    // resolveDeployScope answers "in scope?" for both the guard and here, so the plan and the
+    // preflight cannot disagree about what is being deployed.
+    const apiSource = deployScope.components.includes('api') ? resolveArtifactSource('api') : undefined
+    const runnerSource = deployScope.components.includes('runner') ? resolveArtifactSource('runner') : undefined
+    // Across every component in scope, before any of them is verified. The Proxy and the
+    // OtelCollector are built from this checkout on every path, so any ref that is not the
+    // checkout deploys two commits — and nothing downstream would notice: the staged Runner object
+    // still verifies and the post-deploy check only reads X.Y.Z. Checking one component's ref
+    // would miss the deploy that addresses only the other, which is what
+    // `npm run runner:build-artifact` produces. Out-of-scope entries are undefined and drop out.
     requireCheckoutMatchesArtifactRefs([apiSource, runnerSource])
 
-    if (apiSource.kind === 'release' || apiSource.ref) {
+    if (apiSource && (apiSource.kind === 'release' || apiSource.ref)) {
       const image = verifyApiImage(
         {
           app: APP,
@@ -248,21 +266,28 @@ if (sstArgs[0] === 'deploy') {
     // Verify whichever artifact this deploy actually resolved to, not always the published
     // release: a build-mode deploy 404-ing on the host is the failure this preflight exists to
     // prevent, and it would sail straight through a release-only check.
-    const artifactEnvironment =
-      runnerSource.kind === 'build'
-        ? {
-            ...process.env,
-            RUNNER_ARTIFACT_BUCKET: runnerArtifactsBucketName({
-              app: APP,
-              stage,
-              accountId: await resolveAwsAccountId({ signal }),
-            }),
-          }
-        : process.env
-    const runnerArtifact = await verifyRunnerArtifact(runnerSource, { environment: artifactEnvironment, signal })
-    console.log(
-      `sst-with-cloudflare: Runner ${runnerSource.kind} artifact verified (${runnerArtifact.tarballUrl}, linux-amd64)`,
-    )
+    if (runnerSource) {
+      const artifactEnvironment =
+        runnerSource.kind === 'build'
+          ? {
+              ...process.env,
+              RUNNER_ARTIFACT_BUCKET: runnerArtifactsBucketName({
+                app: APP,
+                stage,
+                accountId: await resolveAwsAccountId({ signal }),
+              }),
+            }
+          : process.env
+      const runnerArtifact = await verifyRunnerArtifact(runnerSource, { environment: artifactEnvironment, signal })
+      console.log(
+        `sst-with-cloudflare: Runner ${runnerSource.kind} artifact verified (${runnerArtifact.tarballUrl}, linux-amd64)`,
+      )
+    }
+    if (deployScope.excluded.length > 0) {
+      console.log(
+        `sst-with-cloudflare: ${deployScope.excluded.join(', ')} excluded from this deploy; artifact unverified`,
+      )
+    }
   } catch (error) {
     if (terminationSignal) process.exit(signalExitCode(terminationSignal))
     console.error(`sst-with-cloudflare: deployment preflight failed: ${error.message}`)

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -131,6 +131,7 @@ export default $config({
     const { requireIamPermissionsBoundaryStage } = await import('./scripts/sst-stage.mjs')
     const { apiImageReference } = await import('./scripts/api-artifact.mjs')
     const { resolveArtifactSource } = await import('./scripts/artifact-source.mjs')
+    const { readDeployScope } = await import('./scripts/deployment-scope.mjs')
     const { resolveRunnerArtifact, runnerArtifactsBucketName } = await import('./scripts/runner-artifact.mjs')
     const { commerceImageReference } = await import('./scripts/commerce-artifact.mjs')
     const REGION = resolveAwsRegion()
@@ -956,6 +957,7 @@ export default $config({
     // it owns the API repository: CI stages the object before this stack can consume it. The name
     // is derived in one helper shared with the preflight and the staging command.
     const artifactsBucketName = runnerArtifactsBucketName({ app: $app.name, stage: $app.stage, accountId })
+    const deploysRunner = readDeployScope().includes('runner')
     const runnerArtifactSource = resolveArtifactSource('runner')
     const runnerArtifact = resolveRunnerArtifact(runnerArtifactSource, {
       ...process.env,
@@ -1267,11 +1269,25 @@ export default $config({
       runnerArtifactSource.kind === 'build'
         ? `build:${runnerArtifactSource.version}:${runnerArtifactSource.ref}`
         : `release:${runnerArtifactSource.version}`
+    // Declared only when the Runner is in scope. `--exclude Runner` keeps the instance out of the
+    // plan but not these — they are siblings of it, not children, and SST is never passed
+    // --exclude-dependents. Their trigger carries the deployed commit, so on an Api-only deploy
+    // they would still fire and fetch runner/<sha>/ from S3 for a commit whose build-runner job
+    // was skipped, and deployment-preview.mjs would not catch it: isRunnerLikeResource matches a
+    // name against /^Runner(?:-|$)/ OR an aws:ec2/instance:Instance carrying Runner identity
+    // tags, and this command satisfies neither arm of that disjunction.
+    //
+    // Undeclaring is a delete in Pulumi's model, which is the honest trade here: command.local
+    // .Command has no `delete:` script, so the delete touches nothing on the host, and the next
+    // full deploy recreates it — `create:` re-runs the same convergence-guarded script, a no-op
+    // when the host already serves the target identity.
     let previousUpgrade: $util.Resource | undefined
-    for (const { label, instance } of [
-      { label: 'default', instance: defaultRunner },
-      ...extraRunners.map((r) => ({ label: r.name, instance: r.instance })),
-    ]) {
+    for (const { label, instance } of !deploysRunner
+      ? []
+      : [
+          { label: 'default', instance: defaultRunner },
+          ...extraRunners.map((r) => ({ label: r.name, instance: r.instance })),
+        ]) {
       previousUpgrade = new command.local.Command(
         `UpgradeRunnerBinary-${label}`,
         {


### PR DESCRIPTION
A components input (api+runner | api | runner) narrows a dispatch to one deployable leg. An unselected leg is neither built nor reconciled: its build jobs are skipped, and the SST commands carry --exclude <Component> so its mutable half — the service or instance, and the binary-upgrade commands — leaves the plan. Its ref-independent scaffolding still reconciles as a no-op.

deployment-scope.mjs replaces the blanket partial-deploy ban with an allowlist of exactly two exclusions. --target stays refused for deploys: it omits the shared and provider resources a partial update still depends on, which stalled this stack on StorageBucket in #1095, while --exclude keeps them in the plan.

The exclusion reaches sst.config.ts too. UpgradeRunnerBinary-* are siblings of the Runner instance rather than children, so --exclude Runner alone would leave them installing a binary from a commit whose Runner build was skipped; they are now declared only when the Runner is in scope. The scope is derived from the selector rather than the subcommand, so the preview and the apply build the same graph.

The same resolver tells the deploy wrapper which artifacts to verify, so an Api-only deploy no longer demands a published Runner artifact for a commit whose Runner was deliberately never built.

Claude-Session: https://claude.ai/code/session_017fMQRd1WBr3kmbjS9t2amY

## Summary
<!-- 1-2 sentences: what this changes and why. -->

## Call graph
<!-- Required. The end-to-end path this PR touches, before and after; one line
     per hop, only the hops that change. Worked example and the bug-fix markers:
     CONTRIBUTING.md#commit--pr-messages. -->

Before
<!-- replace with the hops: fn_name (Type · path/file.rs:LOC) — role -->

After
<!-- replace with the same hops, post-change -->

Fixes #<!-- issue number — bug fixes only; delete this line otherwise -->

## Changes
- <!-- notable change — what changed, not a restatement of the diff -->

## How to verify
- <!-- a command or step a reviewer can run -->

## Risks / rollout
- <!-- only if any; delete this section otherwise -->

<!-- Describe the change, not the process: no pasted logs, no AI/conversation
     narrative, no secrets. Keep it tight and delete sections that don't apply. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deploy the API, Runner, or both components independently.
  * Deployment previews and artifact checks now reflect the selected scope.
  * Workflow runs clearly show the selected components.

* **Bug Fixes**
  * Unsupported deployment targets and invalid component selections are rejected early.
  * Excluded components no longer trigger unnecessary build, verification, or upgrade steps.
  * Shared infrastructure remains protected during scoped deployments.

* **Documentation**
  * Updated deployment guidance covers component selection, exclusions, validation, and mixed-commit outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->