### PR TITLE
fix(ci): refuse a narrowed deploy on a commit that cannot scope

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -161,13 +161,25 @@ is enabled. The workflow is dormant until repository variable
 
 ### `deploy-infra.yml`
 
-Previews or deploys the full stack from one commit — already on `main` (current
-`main` by default), or the head of an open pull request in this repository, so a
-change can reach a stage before it merges; a fork's head is refused because the
-resolved commit is checked out with write permissions and run after the deploy
-role is configured — on a native AMD64 GitHub runner, for a
-`workflow_dispatch`-selected `stage` (an allowlisted `choice` input, `dev`
-today). Each component is built by its own job, and the two legs share only
+Previews or deploys the full stack from one commit, on a native AMD64 GitHub
+runner, for a `workflow_dispatch`-selected `stage` (an allowlisted `choice`
+input, `dev` today). That commit is either already on `main` (current `main` by
+default) or the merge of an open pull request with `main`, so a change can reach
+a stage before it merges.
+
+The merge commit rather than the head: the workflow definition comes from the
+dispatch ref while the deploy job checks out the resolved commit, so a head that
+is behind `main` would pair new workflow YAML with old `apps/infra` tooling.
+GitHub recomputes that merge whenever `main` or the head moves, so the resolved
+SHA is a snapshot rather than a commit in anyone's history.
+
+A fork's PR is accepted: dispatching already requires write access, and the
+credential-bearing jobs sit behind the stage Environment's required reviewer.
+`build-c`/`build-runner` are the exception — neither declares an `environment:`,
+so a fork's build code runs on a hosted runner with no second look; the risk
+there is compute abuse and build-time tampering, not credential theft.
+
+Each component is built by its own job, and the two legs share only
 `resolve-ref`, so they run side by side: the reusable C/Runner workflows produce
 a Linux AMD64 Runner with `<workspace-version>+<sha>` identity and stage it in
 the stage's private commit-keyed S3 path, while `build-api` calls

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -1,7 +1,7 @@
 name: Deploy stack
 run-name: Deploy ${{ inputs.components }} to ${{ inputs.stage }}
 
-# A build deploy sources both deployable components from one commit — on main, or the head of an
+# A build deploy sources both deployable components from one commit — on main, or the merge of an
 # open pull request when a change needs a real stage before it merges — each in its own job:
 #
 #   Api    → Build commit Api image ───────────────→ per-commit ECR tag
@@ -46,7 +46,7 @@ on:
         required: false
         type: string
       pr:
-        description: 'PR number to deploy its current head — same repo or fork. Mutually exclusive with ref.'
+        description: 'PR number. Deploys its merge with main, not its head. Mutually exclusive with ref.'
         required: false
         type: string
 
@@ -64,7 +64,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     # A job-level block replaces the workflow-level one rather than merging with it, so
-    # contents: read is restated. pull-requests: read is what lets a PR head qualify below.
+    # contents: read is restated. pull-requests: read is what lets a PR's merge resolve below.
     permissions:
       contents: read
       pull-requests: read
@@ -100,13 +100,46 @@ jobs:
           # unconditionally for same-repo and fork PRs alike; there is no lookup to fail.
           if [ -n "$INPUT_PR" ]; then
             [[ "$INPUT_PR" =~ ^[0-9]+$ ]] || { echo "pr must be a PR number" >&2; exit 1; }
-            pr_json="$(gh pr view "$INPUT_PR" --json state,headRefOid,headRepository,isCrossRepository)"
+            pr_json="$(gh pr view "$INPUT_PR" --json state,headRefOid,isCrossRepository,mergeable,potentialMergeCommit)"
             state="$(jq -r '.state' <<<"$pr_json")"
             [ "$state" = "OPEN" ] || {
               echo "PR #$INPUT_PR is $state, not open" >&2
               exit 1
             }
-            sha="$(jq -r '.headRefOid' <<<"$pr_json")"
+            # The MERGE, not the head. This workflow's definition comes from main while this job
+            # decides what gets checked out, so deploying the head pairs main's YAML with the
+            # tooling the branch happens to carry — which is how a components=api dispatch reached
+            # an apps/infra that could not scope at all. refs/pull/N/merge is main+PR by
+            # construction, so the deployed tree can never be behind main. Resolved before `fork`
+            # below so the conflict refusals stay out of the fork-acceptance path.
+            #
+            # GitHub recomputes this ref whenever main or the head moves, so the SHA is a snapshot
+            # of "this PR against main right now" — pinned once here and consumed by every
+            # downstream job, but not a commit in anyone's history and not necessarily a tree any
+            # CI run built (CI triggers on pull_request, not on every push to the base).
+            #
+            # Mergeability is computed lazily, so UNKNOWN is a "not yet", not a verdict; retry it
+            # rather than failing a dispatch on a cold cache. There is no event to await here —
+            # the answer only exists once GitHub recomputes it — so this polls.
+            for attempt in 1 2 3 4 5; do
+              mergeable="$(jq -r '.mergeable' <<<"$pr_json")"
+              sha="$(jq -r '.potentialMergeCommit.oid // empty' <<<"$pr_json")"
+              [ "$mergeable" = "UNKNOWN" ] || [ -z "$sha" ] || break
+              [ "$attempt" -lt 5 ] || break
+              sleep 5
+              pr_json="$(gh pr view "$INPUT_PR" --json state,headRefOid,isCrossRepository,mergeable,potentialMergeCommit)"
+            done
+            [ "$mergeable" != "CONFLICTING" ] || {
+              echo "PR #$INPUT_PR conflicts with main, so it has no merge commit to deploy." >&2
+              echo "Resolve the conflict and redispatch." >&2
+              exit 1
+            }
+            [ -n "$sha" ] || {
+              echo "PR #$INPUT_PR has no merge commit yet (mergeable=$mergeable) after 5 attempts." >&2
+              echo "GitHub computes this lazily; open the PR once to force it, then redispatch." >&2
+              exit 1
+            }
+            head_sha="$(jq -r '.headRefOid' <<<"$pr_json")"
             fork="$(jq -r '.isCrossRepository' <<<"$pr_json")"
             # $fork is logged for whoever reviews the run below, never gated on: PR #1148 refused a
             # fork head here deliberately, as its own security boundary. Accepting one is the point
@@ -121,7 +154,7 @@ jobs:
             # runner right after resolve-ref, with no second human look and nothing to steal. Risk
             # there is compute abuse and build-time tampering (e.g. a rewritten .gitmodules URL), not
             # credential theft — call it out rather than fold it into the build-api/deploy gate above.
-            echo "PR #$INPUT_PR ($([ "$fork" = "true" ] && echo fork || echo same-repo)) head is $sha"
+            echo "PR #$INPUT_PR ($([ "$fork" = "true" ] && echo fork || echo same-repo)) head is $head_sha; deploying merge $sha"
             echo "sha=$sha" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -224,12 +257,20 @@ jobs:
           persist-credentials: false
 
       # workflow_dispatch takes the workflow definition from the dispatch ref — main's tip — while
-      # this job checks out the SELECTED commit, so the two halves are versioned independently. A
-      # narrowed scope is the first thing that couples them: `--exclude` reaches a wrapper that may
-      # predate it, and every PR branched before component selection landed is in exactly that
-      # state. Detected on the deployed tree rather than assumed, because the alternative failure
-      # is `partial SST deploys are disabled` from the old guard — true of that commit, but it
-      # reads as a statement about this workflow and sends the operator to the wrong file.
+      # this job checks out the SELECTED commit, so the two halves are versioned independently and
+      # a narrowed scope couples them: `--exclude` reaches a wrapper that may predate it.
+      #
+      # A backstop, not the primary defence. resolve-ref answers `pr` with the merge commit, which
+      # carries main's tooling, so an ordinary branch being behind main no longer reaches here.
+      # Two things still can: `ref`, which names any commit on main including one older than
+      # component selection, and a pull request that itself removes or breaks the module. Detected
+      # on the deployed tree rather than assumed, because the alternative failure is `partial SST
+      # deploys are disabled` from the older guard — true of that commit, but it reads as a
+      # statement about this workflow and sends the operator to the wrong file.
+      #
+      # It answers "can this tree scope at all", not "does it support THIS scope": the probe reads
+      # one export. A commit that knew `--exclude Runner` but not some later selector would pass
+      # here and be refused by resolveDeployScope's own allowlist instead.
       #
       # Runs before the AWS credential step on purpose: an unsupported scope is knowable from the
       # checkout alone, so it should never reach the deploy role.
@@ -238,10 +279,10 @@ jobs:
       # module is pure, so importing it costs nothing.
       #
       # Absence is checked before the probe, not inferred from an import failure. The module only
-      # exists from PR #1095 onward, so most open pull-request heads do not have it at all — that
-      # is the ordinary "too old" case and shares the remedy with a module that lacks the export.
-      # Folding it into the load-failure arm instead would answer "the module is present but
-      # unreadable" for a file that is simply not there.
+      # exists from PR #1095 onward, so a `ref` older than that has no such file — the ordinary
+      # "too old" case, sharing a remedy with a module that lacks the export. Folding it into the
+      # load-failure arm instead would answer "the module is present but unreadable" for a file
+      # that is simply not there.
       - name: Require component selection support in the selected commit
         if: ${{ env.DEPLOY_EXCLUDE != '' }}
         shell: bash
@@ -258,8 +299,8 @@ jobs:
             unsupported)
               echo "commit $BOXLITE_ARTIFACT_REF predates component selection, so it cannot honour" >&2
               echo "--exclude $DEPLOY_EXCLUDE and would deploy the full stack instead." >&2
-              echo "Redispatch it with components=api+runner, or rebase it onto a main that has" >&2
-              echo "$module exporting resolveDeployScope." >&2
+              echo "Redispatch with components=api+runner, or name a newer ref: this needs a commit" >&2
+              echo "whose $module exports resolveDeployScope." >&2
               exit 1
               ;;
             *)

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -223,6 +223,53 @@ jobs:
           ref: ${{ needs.resolve-ref.outputs.sha }}
           persist-credentials: false
 
+      # workflow_dispatch takes the workflow definition from the dispatch ref — main's tip — while
+      # this job checks out the SELECTED commit, so the two halves are versioned independently. A
+      # narrowed scope is the first thing that couples them: `--exclude` reaches a wrapper that may
+      # predate it, and every PR branched before component selection landed is in exactly that
+      # state. Detected on the deployed tree rather than assumed, because the alternative failure
+      # is `partial SST deploys are disabled` from the old guard — true of that commit, but it
+      # reads as a statement about this workflow and sends the operator to the wrong file.
+      #
+      # Runs before the AWS credential step on purpose: an unsupported scope is knowable from the
+      # checkout alone, so it should never reach the deploy role.
+      #
+      # Probes the export rather than grepping for it: the capability is what matters, and the
+      # module is pure, so importing it costs nothing.
+      #
+      # Absence is checked before the probe, not inferred from an import failure. The module only
+      # exists from PR #1095 onward, so most open pull-request heads do not have it at all — that
+      # is the ordinary "too old" case and shares the remedy with a module that lacks the export.
+      # Folding it into the load-failure arm instead would answer "the module is present but
+      # unreadable" for a file that is simply not there.
+      - name: Require component selection support in the selected commit
+        if: ${{ env.DEPLOY_EXCLUDE != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          module=apps/infra/scripts/deployment-scope.mjs
+          if [ ! -f "$module" ]; then
+            status=unsupported
+          else
+            status=$(node -e "import('./$module').then(m => console.log(typeof m.resolveDeployScope === 'function' ? 'supported' : 'unsupported')).catch(e => { console.log('unreadable'); console.error(e.message) })")
+          fi
+          case "$status" in
+            supported) ;;
+            unsupported)
+              echo "commit $BOXLITE_ARTIFACT_REF predates component selection, so it cannot honour" >&2
+              echo "--exclude $DEPLOY_EXCLUDE and would deploy the full stack instead." >&2
+              echo "Redispatch it with components=api+runner, or rebase it onto a main that has" >&2
+              echo "$module exporting resolveDeployScope." >&2
+              exit 1
+              ;;
+            *)
+              echo "$module exists at commit $BOXLITE_ARTIFACT_REF but failed to load (reason" >&2
+              echo "above). That is not an age problem, so fix the module rather than widening" >&2
+              echo "the scope to api+runner." >&2
+              exit 1
+              ;;
+          esac
+
       - name: Verify native AMD64 Docker
         shell: bash
         run: |

--- a/apps/infra/README.md
+++ b/apps/infra/README.md
@@ -195,6 +195,15 @@ artifact is not required to exist. Any other selector is refused. `deploy-infra.
 exposes the same three scopes as its `components` input and skips the build jobs
 for a leg it excludes.
 
+A narrowed scope needs a *deployed commit* that understands it, which is not the
+same commit as the workflow: `workflow_dispatch` reads the workflow definition
+from the dispatch ref while the deploy job checks out the selected one. So a
+`ref`/`pr` dispatch can pair a new workflow with a wrapper that predates
+`resolveDeployScope`. The job probes for it right after checkout and refuses
+before assuming the deploy role; redispatch such a commit with `api+runner`, or
+rebase it. Only a narrowed scope is affected — `api+runner` passes no selector
+and works against any commit.
+
 A narrowed deploy leaves the excluded leg on whatever commit an earlier run put
 there, so the stack is then mixed-commit; the residual partial-update risk above
 is why `apply` defaults to false and the guarded preview runs first. Run the

--- a/apps/infra/scripts/release-deployment-safety.test.mjs
+++ b/apps/infra/scripts/release-deployment-safety.test.mjs
@@ -307,6 +307,54 @@ test('deployment previews and reconciles the full stack in guarded GitHub CI', (
     "${{ inputs.components == 'api' && 'Runner' || inputs.components == 'runner' && 'Api' || '' }}",
   )
   assert.doesNotMatch(liveShell(source), /--target/)
+  // The workflow definition comes from the dispatch ref while this job checks out the SELECTED
+  // commit, so the two are versioned independently and `--exclude` is the first thing that
+  // couples them. Observed: run 31229121181 dispatched `components=api` at a PR head predating
+  // component selection, and the old wrapper answered `partial SST deploys are disabled` — true
+  // of that commit, but it reads as a statement about this workflow.
+  const scopeSupportStep = workflow.jobs.deploy.steps.find(
+    (step) => step.name === 'Require component selection support in the selected commit',
+  )
+  assert.ok(scopeSupportStep, 'the component-selection capability check is missing')
+  assert.equal(scopeSupportStep.if, "${{ env.DEPLOY_EXCLUDE != '' }}", 'the check must run only for a narrowed scope')
+  // Probing the export, not grepping for it: a checkout can carry the identifier in a comment.
+  assertShellLine(scopeSupportStep.run, /typeof m\.resolveDeployScope === 'function'/)
+  // Absence is its own decision, taken before the probe. The module only exists from PR #1095
+  // onward, so most open pull-request heads do not have it at all — inferring that from an import
+  // failure lands them in the load-failure arm, which answers "present but failed to load" about
+  // a file that is not there and points at the wrong remedy.
+  assertShellLine(scopeSupportStep.run, /if \[ ! -f "\$module" \]; then/)
+  assertShellLine(scopeSupportStep.run, /status=unsupported/)
+  // Each arm, and the claim that distinguishes it. Pinning only the `if` leaves an arm free to
+  // carry another arm's message, which a passing suite would not notice: the arms differ solely
+  // in what they tell the operator, so a wrong cause here is invisible to every other assertion.
+  const scopeSupportShell = liveShell(scopeSupportStep.run)
+  assert.match(scopeSupportShell, /supported\) ;;/, 'the supported arm must be a no-op')
+  const tooOld = scopeSupportShell.slice(scopeSupportShell.indexOf('unsupported)'))
+  assert.match(
+    tooOld.slice(0, tooOld.indexOf(';;')),
+    /predates component selection/,
+    'the too-old arm must name age as the cause',
+  )
+  const unreadable = scopeSupportShell.slice(scopeSupportShell.indexOf('*)'))
+  assert.match(
+    unreadable,
+    /failed to load/,
+    'the load-failure arm must not describe the commit as too old — that is the other arm',
+  )
+  assert.doesNotMatch(
+    unreadable,
+    /predates component selection/,
+    'the load-failure arm must not reuse the too-old cause',
+  )
+  // Before the deploy role is assumed. An unsupported scope is knowable from the checkout alone,
+  // so it must never reach AWS credentials.
+  const deployStepNames = workflow.jobs.deploy.steps.map((step) => step.name)
+  assert.ok(
+    deployStepNames.indexOf('Require component selection support in the selected commit') <
+      deployStepNames.indexOf('Configure AWS credentials through OIDC'),
+    'the capability check must run before AWS credentials are configured',
+  )
   // A skipped build job would cascade a skip to the deploy under the implicit success(). Naming a
   // status-check function turns that off — without one, every narrowed dispatch silently deploys
   // nothing while reporting green.

--- a/apps/infra/scripts/release-deployment-safety.test.mjs
+++ b/apps/infra/scripts/release-deployment-safety.test.mjs
@@ -214,9 +214,43 @@ test('deployment previews and reconciles the full stack in guarded GitHub CI', (
   assert.match(refGuardStep.run, /^\s*\[\[ "\$INPUT_PR" =~ \^\[0-9\]\+\$ \]\]/m)
   assert.match(
     refGuardStep.run,
-    /^\s*pr_json="\$\(gh pr view "\$INPUT_PR" --json state,headRefOid,headRepository,isCrossRepository\)"/m,
+    /^\s*pr_json="\$\(gh pr view "\$INPUT_PR" --json state,headRefOid,isCrossRepository,mergeable,potentialMergeCommit\)"/m,
   )
   assert.match(refGuardStep.run, /^\s*\[ "\$state" = "OPEN" \] \|\| \{/m)
+  // The MERGE commit, not the head. The workflow definition comes from main while this job picks
+  // what is checked out, so deploying a head pairs main's YAML with whatever tooling that branch
+  // carries — the mismatch that sent a components=api dispatch into an apps/infra with no scope
+  // support at all. refs/pull/N/merge is main+PR by construction, so it cannot be behind main.
+  assertShellLine(refGuardStep.run, /sha="\$\(jq -r '\.potentialMergeCommit\.oid \/\/ empty' <<<"\$pr_json"\)"/)
+  assertShellLine(refGuardStep.run, /head_sha="\$\(jq -r '\.headRefOid' <<<"\$pr_json"\)"/)
+  // A conflicting PR has no merge commit, and an uncomputed one is a "not yet" rather than a
+  // verdict — distinct causes, so distinct refusals. Emitting the head as a fallback would
+  // silently reintroduce exactly the behaviour this replaces.
+  assertShellLine(refGuardStep.run, /\[ "\$mergeable" != "CONFLICTING" \] \|\| \{/)
+  assertShellLine(refGuardStep.run, /\[ -n "\$sha" \] \|\| \{/)
+  // Mergeability is computed lazily, so a cold cache answers UNKNOWN and the merge SHA is empty.
+  // Both the loop AND its re-query are pinned: without the re-query the loop spins over the same
+  // stale JSON, which fails a dispatch that one refresh would have resolved and makes the "after
+  // 5 attempts" message untrue.
+  assertShellLine(refGuardStep.run, /for attempt in 1 2 3 4 5; do/)
+  assertShellLine(refGuardStep.run, /\[ "\$mergeable" = "UNKNOWN" \] \|\| \[ -z "\$sha" \] \|\| break/)
+  const retryBody = liveShell(refGuardStep.run)
+  const loopStart = retryBody.indexOf('for attempt in 1 2 3 4 5; do')
+  assert.match(
+    retryBody.slice(loopStart, retryBody.indexOf('done', loopStart)),
+    /pr_json="\$\(gh pr view/,
+    'the retry loop must re-query, or it polls its own stale answer',
+  )
+  // Raw, not live: the message embeds `PR #$INPUT_PR`, and liveShell's stripper reads a `#`
+  // preceded by whitespace as a comment and deletes the rest of the line. The guards above are
+  // pinned live — they carry the behaviour; these two only pin that each cause says its own name.
+  assert.match(refGuardStep.run, /conflicts with main, so it has no merge commit to deploy/)
+  assert.match(refGuardStep.run, /has no merge commit yet \(mergeable=\$mergeable\)/)
+  assert.doesNotMatch(
+    liveShell(refGuardStep.run),
+    /sha="\$head_sha"/,
+    'the head must never stand in for a missing merge commit',
+  )
   // PR #1148 refused a fork head deliberately (`.head.repo.full_name == GITHUB_REPOSITORY`), a
   // named security boundary — not a side effect of the SHA-reverse-lookup bug this guard fixes.
   // This guard drops that boundary on purpose: isCrossRepository is fetched and logged for
@@ -224,7 +258,10 @@ test('deployment previews and reconciles the full stack in guarded GitHub CI', (
   // AND the absence (no `exit 1` between computing it and the block's `exit 0`) so a fork
   // exclusion added back later doesn't silently pass this test by accident.
   assert.match(refGuardStep.run, /^\s*fork="\$\(jq -r '\.isCrossRepository' <<<"\$pr_json"\)"/m)
-  assert.match(refGuardStep.run, /^\s*echo "PR #\$INPUT_PR \(\$\(\[ "\$fork" = "true" \] && echo fork \|\| echo same-repo\)\) head is \$sha"/m)
+  assert.match(
+    refGuardStep.run,
+    /^\s*echo "PR #\$INPUT_PR \(\$\(\[ "\$fork" = "true" \] && echo fork \|\| echo same-repo\)\) head is \$head_sha; deploying merge \$sha"/m,
+  )
   const forkOnwards = refGuardStep.run.slice(refGuardStep.run.indexOf('fork="$(jq'))
   const prBlockTail = forkOnwards.slice(0, forkOnwards.indexOf('exit 0') + 'exit 0'.length)
   assert.doesNotMatch(


### PR DESCRIPTION
workflow_dispatch takes the workflow definition from the dispatch ref while the deploy job checks out the selected commit, so the two are versioned independently. Component selection coupled them: --exclude reaches a wrapper that may predate it, and every pull request branched before it landed is in that state.

Run 31229121181 dispatched components=api at such a head and got "partial SST deploys are disabled" from the old guard — true of that commit, but it reads as a statement about this workflow. A preview-only dispatch fared worse: that guard returns early unless the subcommand is deploy, so the scoped diff ran unrefused. The capability is now probed on the deployed tree, before the deploy role is assumed.

Claude-Session: https://claude.ai/code/session_017fMQRd1WBr3kmbjS9t2amY

## Summary
<!-- 1-2 sentences: what this changes and why. -->

## Call graph
<!-- Required. The end-to-end path this PR touches, before and after; one line
     per hop, only the hops that change. Worked example and the bug-fix markers:
     CONTRIBUTING.md#commit--pr-messages. -->

Before
<!-- replace with the hops: fn_name (Type · path/file.rs:LOC) — role -->

After
<!-- replace with the same hops, post-change -->

Fixes #<!-- issue number — bug fixes only; delete this line otherwise -->

## Changes
- <!-- notable change — what changed, not a restatement of the diff -->

## How to verify
- <!-- a command or step a reviewer can run -->

## Risks / rollout
- <!-- only if any; delete this section otherwise -->

<!-- Describe the change, not the process: no pasted logs, no AI/conversation
     narrative, no secrets. Keep it tight and delete sections that don't apply. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull request deployments now use the resolved merge commit with `main`, including support for forked pull requests.
  * Deployments detect merge conflicts or unavailable commits and stop with clear diagnostics.
  * Partial deployments validate component-selection support before accessing deployment credentials.
* **Bug Fixes**
  * Prevented deployments from falling back to pull request head commits.
* **Documentation**
  * Clarified merge-commit handling and requirements for narrowed-scope deployments.
* **Tests**
  * Expanded coverage for merge resolution, conflict handling, compatibility checks, and credential protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->