### PR TITLE
fix(api): harden Redis lock lease ownership

### DIFF
--- a/apps/api/src/api-key/api-key.service.ts
+++ b/apps/api/src/api-key/api-key.service.ts
@@ -155,7 +155,7 @@ export class ApiKeyService {
   async updateLastUsedAt(organizationId: string, userId: string, name: string, lastUsedAt: Date): Promise<void> {
     const cooldownKey = `api-key-last-used-update-${organizationId}-${userId}-${name}`
 
-    const aquired = await this.redisLockProvider.lock(cooldownKey, 10)
+    const aquired = await this.redisLockProvider.lockUntilExpiry(cooldownKey, 10)
 
     // redis for cooldown period - 10 seconds
     // prevents database flooding when multiple requests are made at the same time

--- a/apps/api/src/audit/services/audit.service.spec.ts
+++ b/apps/api/src/audit/services/audit.service.spec.ts
@@ -6,11 +6,17 @@
 import { AuditService } from './audit.service'
 
 describe('AuditService cleanup cancellation', () => {
-  const makeService = (deleteLogs: jest.Mock) => {
+  const makeService = (deleteLogs: jest.Mock, controller = new AbortController()) => {
     const service = Object.create(AuditService.prototype) as AuditService
     Object.assign(service as any, {
       auditLogRepository: { delete: deleteLogs },
       configService: { get: jest.fn().mockReturnValue(1) },
+      redisLockProvider: {
+        acquireLease: jest.fn().mockResolvedValue({
+          signal: controller.signal,
+          release: jest.fn().mockResolvedValue(undefined),
+        }),
+      },
       logger: { log: jest.fn(), error: jest.fn() },
     })
     return service
@@ -24,9 +30,10 @@ describe('AuditService cleanup cancellation', () => {
         controller.abort(new Error('ownership was lost'))
         throw repositoryError
       }),
+      controller,
     )
 
-    await service.cleanupOldAuditLogs(controller.signal)
+    await service.cleanupOldAuditLogs()
 
     expect((service as any).logger.error).toHaveBeenCalledWith(
       expect.stringContaining(repositoryError.message),
@@ -38,8 +45,8 @@ describe('AuditService cleanup cancellation', () => {
     const ownershipError = new Error('ownership was lost')
     const controller = new AbortController()
     controller.abort(ownershipError)
-    const service = makeService(jest.fn())
+    const service = makeService(jest.fn(), controller)
 
-    await expect(service.cleanupOldAuditLogs(controller.signal)).rejects.toBe(ownershipError)
+    await expect(service.cleanupOldAuditLogs()).rejects.toBe(ownershipError)
   })
 })

--- a/apps/api/src/audit/services/audit.service.spec.ts
+++ b/apps/api/src/audit/services/audit.service.spec.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { AuditService } from './audit.service'
+
+describe('AuditService cleanup cancellation', () => {
+  const makeService = (deleteLogs: jest.Mock) => {
+    const service = Object.create(AuditService.prototype) as AuditService
+    Object.assign(service as any, {
+      auditLogRepository: { delete: deleteLogs },
+      configService: { get: jest.fn().mockReturnValue(1) },
+      logger: { log: jest.fn(), error: jest.fn() },
+    })
+    return service
+  }
+
+  it('preserves a repository failure when cancellation happens concurrently', async () => {
+    const repositoryError = new Error('database unavailable')
+    const controller = new AbortController()
+    const service = makeService(
+      jest.fn(async () => {
+        controller.abort(new Error('ownership was lost'))
+        throw repositoryError
+      }),
+    )
+
+    await service.cleanupOldAuditLogs(controller.signal)
+
+    expect((service as any).logger.error).toHaveBeenCalledWith(
+      expect.stringContaining(repositoryError.message),
+      repositoryError.stack,
+    )
+  })
+
+  it('rethrows the cancellation reason produced by the signal', async () => {
+    const ownershipError = new Error('ownership was lost')
+    const controller = new AbortController()
+    controller.abort(ownershipError)
+    const service = makeService(jest.fn())
+
+    await expect(service.cleanupOldAuditLogs(controller.signal)).rejects.toBe(ownershipError)
+  })
+})

--- a/apps/api/src/audit/services/audit.service.spec.ts
+++ b/apps/api/src/audit/services/audit.service.spec.ts
@@ -33,12 +33,7 @@ describe('AuditService cleanup cancellation', () => {
       controller,
     )
 
-    await service.cleanupOldAuditLogs()
-
-    expect((service as any).logger.error).toHaveBeenCalledWith(
-      expect.stringContaining(repositoryError.message),
-      repositoryError.stack,
-    )
+    await expect(service.cleanupOldAuditLogs()).rejects.toBe(repositoryError)
   })
 
   it('rethrows the cancellation reason produced by the signal', async () => {

--- a/apps/api/src/audit/services/audit.service.ts
+++ b/apps/api/src/audit/services/audit.service.ts
@@ -141,7 +141,7 @@ export class AuditService implements OnApplicationBootstrap {
 
       this.logger.log(`Completed cleanup of audit logs older than ${retentionDays} days (${totalDeleted} logs deleted)`)
     } catch (error) {
-      if (signal?.aborted) {
+      if (signal?.aborted && error === signal.reason) {
         throw signal.reason
       }
       this.logger.error(`An error occurred during cleanup of old audit logs: ${error.message}`, error.stack)

--- a/apps/api/src/audit/services/audit.service.ts
+++ b/apps/api/src/audit/services/audit.service.ts
@@ -122,7 +122,8 @@ export class AuditService implements OnApplicationBootstrap {
   })
   @DistributedLock()
   @LogExecution('cleanup-old-audit-logs')
-  async cleanupOldAuditLogs(signal?: AbortSignal): Promise<void> {
+  async cleanupOldAuditLogs(...args: unknown[]): Promise<void> {
+    const signal = args.at(-1) as AbortSignal | undefined
     try {
       const retentionDays = this.configService.get('audit.retentionDays')
       if (!retentionDays) {

--- a/apps/api/src/audit/services/audit.service.ts
+++ b/apps/api/src/audit/services/audit.service.ts
@@ -122,7 +122,7 @@ export class AuditService implements OnApplicationBootstrap {
   })
   @DistributedLock()
   @LogExecution('cleanup-old-audit-logs')
-  async cleanupOldAuditLogs(): Promise<void> {
+  async cleanupOldAuditLogs(signal?: AbortSignal): Promise<void> {
     try {
       const retentionDays = this.configService.get('audit.retentionDays')
       if (!retentionDays) {
@@ -132,6 +132,7 @@ export class AuditService implements OnApplicationBootstrap {
       const cutoffDate = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000)
       this.logger.log(`Starting cleanup of audit logs older than ${retentionDays} days`)
 
+      signal?.throwIfAborted()
       const deletedLogs = await this.auditLogRepository.delete({
         createdAt: LessThan(cutoffDate),
       })
@@ -140,6 +141,9 @@ export class AuditService implements OnApplicationBootstrap {
 
       this.logger.log(`Completed cleanup of audit logs older than ${retentionDays} days (${totalDeleted} logs deleted)`)
     } catch (error) {
+      if (signal?.aborted) {
+        throw signal.reason
+      }
       this.logger.error(`An error occurred during cleanup of old audit logs: ${error.message}`, error.stack)
     }
   }
@@ -152,7 +156,7 @@ export class AuditService implements OnApplicationBootstrap {
   @DistributedLock()
   @WithInstrumentation()
   @LogExecution('resolve-dangling-audit-logs')
-  async resolveDanglingLogs() {
+  async resolveDanglingLogs(signal?: AbortSignal) {
     const danglingLogs = await this.auditLogRepository.find({
       where: {
         statusCode: IsNull(),
@@ -161,6 +165,7 @@ export class AuditService implements OnApplicationBootstrap {
     })
 
     for (const log of danglingLogs) {
+      signal?.throwIfAborted()
       // set status code to unknown
       log.statusCode = 0
       await this.auditLogRepository.save(log)
@@ -179,7 +184,7 @@ export class AuditService implements OnApplicationBootstrap {
   @LogExecution('publish-audit-logs')
   @DistributedLock()
   @WithInstrumentation()
-  async publishAuditLogs() {
+  async publishAuditLogs(signal?: AbortSignal) {
     // Safeguard
     if (!this.auditLogPublisher) {
       this.logger.warn('Audit log publisher not configured, skipping publish')
@@ -200,7 +205,9 @@ export class AuditService implements OnApplicationBootstrap {
       return
     }
 
+    signal?.throwIfAborted()
     await this.auditLogPublisher.write(auditLogs)
+    signal?.throwIfAborted()
     await this.auditLogRepository.delete(auditLogs.map((log) => log.id))
   }
 }

--- a/apps/api/src/audit/services/audit.service.ts
+++ b/apps/api/src/audit/services/audit.service.ts
@@ -142,8 +142,10 @@ export class AuditService implements OnApplicationBootstrap {
 
       this.logger.log(`Completed cleanup of audit logs older than ${retentionDays} days (${totalDeleted} logs deleted)`)
     } catch (error) {
-      if (signal?.aborted && error === signal.reason) {
-        throw signal.reason
+      if (signal?.aborted) {
+        // Preserve a concurrent repository failure; the lock helper will otherwise
+        // replace it with the cancellation observed after this method returns.
+        throw error === signal.reason ? signal.reason : error
       }
       this.logger.error(`An error occurred during cleanup of old audit logs: ${error.message}`, error.stack)
     }

--- a/apps/api/src/box/common/redis-lock.provider.spec.ts
+++ b/apps/api/src/box/common/redis-lock.provider.spec.ts
@@ -89,6 +89,26 @@ describe('RedisLockProvider owned locks', () => {
     await expect(lease?.release()).rejects.toBe(retryError)
   })
 
+  it('aborts before expiry when a renewal command never settles', async () => {
+    jest.useFakeTimers()
+    const redis = {
+      set: jest.fn().mockResolvedValue('OK'),
+      eval: jest.fn(() => new Promise(() => undefined)),
+    }
+    const provider = new RedisLockProvider(redis as any)
+    const lease = await provider.acquireLease('stalled-renewal', 2)
+
+    await jest.advanceTimersByTimeAsync(1_800)
+
+    expect(lease?.signal.aborted).toBe(true)
+    expect(lease?.signal.reason).toEqual(expect.objectContaining({ message: expect.stringContaining('timed out') }))
+    expect(redis.eval).toHaveBeenCalledTimes(2)
+    const release = expect(lease?.release()).rejects.toThrow('renewal timed out')
+    await jest.advanceTimersByTimeAsync(250)
+    await release
+    expect(redis.eval).toHaveBeenCalledTimes(3)
+  })
+
   it('releases the lease when ownership is lost before the operation returns', async () => {
     const ownershipError = new Error('ownership was lost')
     const abortController = new AbortController()

--- a/apps/api/src/box/common/redis-lock.provider.spec.ts
+++ b/apps/api/src/box/common/redis-lock.provider.spec.ts
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { LockCode, RedisLockProvider, withRedisLockLease } from './redis-lock.provider'
+
+describe('RedisLockProvider owned locks', () => {
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('aborts the protected operation when lease renewal fails', async () => {
+    jest.useFakeTimers()
+    const redis = {
+      set: jest.fn().mockResolvedValue('OK'),
+      eval: jest.fn().mockResolvedValue(0),
+    }
+    const provider = new RedisLockProvider(redis as any)
+    const lease = await provider.acquireLease('managed-lock', 10)
+    let operationStopped = false
+
+    const operation = withRedisLockLease(lease!, async (signal) => {
+      await new Promise<void>((resolve) => signal.addEventListener('abort', () => resolve(), { once: true }))
+      operationStopped = true
+    })
+    const rejected = expect(operation).rejects.toThrow('ownership was lost')
+    await jest.advanceTimersByTimeAsync(5_000)
+
+    await rejected
+    expect(operationStopped).toBe(true)
+  })
+
+  it('preserves the operation error when release also fails', async () => {
+    const operationError = new Error('operation failed')
+    const lease = { release: jest.fn().mockRejectedValue(new Error('release failed')) }
+
+    await expect(
+      withRedisLockLease(lease as any, async () => {
+        throw operationError
+      }),
+    ).rejects.toBe(operationError)
+  })
+
+  it('reports a suppressed release error without replacing the operation error', async () => {
+    const operationError = new Error('operation failed')
+    const releaseError = new Error('release failed')
+    const onSuppressedReleaseError = jest.fn()
+    const lease = { release: jest.fn().mockRejectedValue(releaseError) }
+
+    await expect(
+      withRedisLockLease(
+        lease as any,
+        async () => {
+          throw operationError
+        },
+        onSuppressedReleaseError,
+      ),
+    ).rejects.toBe(operationError)
+    expect(onSuppressedReleaseError).toHaveBeenCalledWith(releaseError)
+  })
+
+  it('releases a lease with the owner token it acquired', async () => {
+    const redis = {
+      set: jest.fn().mockResolvedValue('OK'),
+      eval: jest.fn().mockResolvedValue(1),
+    }
+    const provider = new RedisLockProvider(redis as any)
+
+    const lease = await provider.acquireLease('owned-lock', 10)
+    const ownerCode = redis.set.mock.calls[0][1]
+    await lease?.release()
+
+    expect(ownerCode).not.toBe('1')
+    expect(redis.eval).toHaveBeenCalledWith(expect.stringContaining("redis.call('del'"), 1, 'owned-lock', ownerCode)
+  })
+
+  it('releases a lock only while the caller still owns it', async () => {
+    const redis = {
+      set: jest.fn().mockResolvedValue('OK'),
+      eval: jest.fn().mockResolvedValue(0),
+    }
+    const provider = new RedisLockProvider(redis as any)
+    const owner = new LockCode('owner-1')
+
+    await provider.unlock('usage-period-box-1', owner)
+
+    expect(redis.eval).toHaveBeenCalledWith(
+      expect.stringContaining("redis.call('get', KEYS[1])"),
+      1,
+      'usage-period-box-1',
+      owner.getCode(),
+    )
+    expect(redis.eval).toHaveBeenCalledWith(
+      expect.stringContaining("redis.call('del', KEYS[1])"),
+      1,
+      'usage-period-box-1',
+      owner.getCode(),
+    )
+  })
+
+  it('does not release a replacement owner after managed renewal loses ownership', async () => {
+    jest.useFakeTimers()
+    let currentOwner: string | null = null
+    const redis = {
+      set: jest.fn(async (_key: string, owner: string) => {
+        currentOwner = owner
+        return 'OK'
+      }),
+      get: jest.fn(async () => currentOwner),
+      eval: jest.fn(async (script: string, _keys: number, _key: string, owner: string) => {
+        if (script.includes("redis.call('expire'")) {
+          currentOwner = 'replacement-owner'
+          return 0
+        }
+        if (currentOwner === owner) {
+          currentOwner = null
+          return 1
+        }
+        return 0
+      }),
+    }
+    const provider = new RedisLockProvider(redis as any)
+
+    const lease = await provider.acquireLease('legacy-lock', 10)
+    await jest.advanceTimersByTimeAsync(5_000)
+    await expect(lease?.release()).rejects.toThrow('ownership was lost')
+
+    expect(currentOwner).toBe('replacement-owner')
+    jest.useRealTimers()
+  })
+
+  it('does not let an expired owner release a replacement owner', async () => {
+    let currentOwner = 'replacement-owner'
+    const redis = {
+      eval: jest.fn(async (script: string, _keys: number, _key: string, owner: string) => {
+        if (currentOwner === owner) {
+          currentOwner = ''
+          return 1
+        }
+        return 0
+      }),
+    }
+    const provider = new RedisLockProvider(redis as any)
+
+    await provider.unlock('shared-key', new LockCode('expired-owner'))
+
+    expect(currentOwner).toBe('replacement-owner')
+  })
+
+  it('renews an acquired lease before its TTL expires', async () => {
+    jest.useFakeTimers()
+    const redis = {
+      set: jest.fn().mockResolvedValue('OK'),
+      eval: jest.fn().mockResolvedValue(1),
+    }
+    const provider = new RedisLockProvider(redis as any)
+
+    const lease = await provider.acquireLease('archive-usage-periods', 60)
+    await jest.advanceTimersByTimeAsync(30_000)
+
+    expect(redis.eval).toHaveBeenCalledWith(
+      expect.stringContaining("redis.call('expire', KEYS[1], ARGV[2])"),
+      1,
+      'archive-usage-periods',
+      expect.any(String),
+      60,
+    )
+
+    await lease?.release()
+    jest.useRealTimers()
+  })
+
+  it('stops renewal and releases with the same owner token', async () => {
+    jest.useFakeTimers()
+    const redis = {
+      set: jest.fn().mockResolvedValue('OK'),
+      eval: jest.fn().mockResolvedValue(1),
+    }
+    const provider = new RedisLockProvider(redis as any)
+
+    const lease = await provider.acquireLease('archive-usage-periods', 60)
+    const ownerCode = redis.set.mock.calls[0][1]
+    await lease?.release()
+    await jest.advanceTimersByTimeAsync(60_000)
+
+    expect(redis.eval).toHaveBeenCalledTimes(1)
+    expect(redis.eval).toHaveBeenCalledWith(
+      expect.stringContaining("redis.call('del', KEYS[1])"),
+      1,
+      'archive-usage-periods',
+      ownerCode,
+    )
+    jest.useRealTimers()
+  })
+})

--- a/apps/api/src/box/common/redis-lock.provider.spec.ts
+++ b/apps/api/src/box/common/redis-lock.provider.spec.ts
@@ -42,6 +42,23 @@ describe('RedisLockProvider owned locks', () => {
     ).rejects.toBe(operationError)
   })
 
+  it('releases the lease when ownership is lost before the operation returns', async () => {
+    const ownershipError = new Error('ownership was lost')
+    const abortController = new AbortController()
+    const lease = {
+      signal: abortController.signal,
+      release: jest.fn().mockResolvedValue(undefined),
+    }
+
+    await expect(
+      withRedisLockLease(lease as any, async () => {
+        abortController.abort(ownershipError)
+      }),
+    ).rejects.toBe(ownershipError)
+
+    expect(lease.release).toHaveBeenCalledTimes(1)
+  })
+
   it('reports a suppressed release error without replacing the operation error', async () => {
     const operationError = new Error('operation failed')
     const releaseError = new Error('release failed')
@@ -192,5 +209,77 @@ describe('RedisLockProvider owned locks', () => {
       ownerCode,
     )
     jest.useRealTimers()
+  })
+
+  it('stops waiting when lock acquisition times out', async () => {
+    jest.useFakeTimers()
+    const redis = { set: jest.fn().mockResolvedValue(null) }
+    const provider = new RedisLockProvider(redis as any)
+
+    const waiting = provider.waitForLock('busy-lock', 60, { timeoutMs: 100, retryDelayMs: 25 })
+    const rejected = expect(waiting).rejects.toThrow('Timed out waiting for Redis lock busy-lock')
+    await jest.advanceTimersByTimeAsync(100)
+
+    await rejected
+  })
+
+  it('stops waiting when the caller aborts', async () => {
+    jest.useFakeTimers()
+    const redis = { set: jest.fn().mockResolvedValue(null) }
+    const provider = new RedisLockProvider(redis as any)
+    const controller = new AbortController()
+
+    const waiting = provider.waitForLock('busy-lock', 60, { signal: controller.signal })
+    const rejected = expect(waiting).rejects.toThrow('service is shutting down')
+    controller.abort(new Error('service is shutting down'))
+    await jest.runOnlyPendingTimersAsync()
+
+    await rejected
+  })
+
+  it('releases a lease acquired after the caller aborts', async () => {
+    const provider = new RedisLockProvider({} as any)
+    const controller = new AbortController()
+    const lease = { release: jest.fn().mockResolvedValue(undefined) }
+    let finishAcquire!: (lease: any) => void
+    jest.spyOn(provider, 'acquireLease').mockReturnValue(
+      new Promise((resolve) => {
+        finishAcquire = resolve
+      }),
+    )
+
+    const waiting = provider.waitForLock('busy-lock', 60, { signal: controller.signal })
+    const rejected = expect(waiting).rejects.toThrow('service is shutting down')
+    controller.abort(new Error('service is shutting down'))
+
+    await rejected
+    expect(lease.release).not.toHaveBeenCalled()
+
+    finishAcquire(lease)
+    await Promise.resolve()
+    expect(lease.release).toHaveBeenCalledTimes(1)
+  })
+
+  it('releases a lease acquired after the wait deadline', async () => {
+    jest.useFakeTimers()
+    const provider = new RedisLockProvider({} as any)
+    const lease = { release: jest.fn().mockResolvedValue(undefined) }
+    let finishAcquire!: (lease: any) => void
+    jest.spyOn(provider, 'acquireLease').mockReturnValue(
+      new Promise((resolve) => {
+        finishAcquire = resolve
+      }),
+    )
+
+    const waiting = provider.waitForLock('busy-lock', 60, { timeoutMs: 100 })
+    const rejected = expect(waiting).rejects.toThrow('Timed out waiting for Redis lock busy-lock')
+    await jest.advanceTimersByTimeAsync(100)
+
+    await rejected
+    expect(lease.release).not.toHaveBeenCalled()
+
+    finishAcquire(lease)
+    await Promise.resolve()
+    expect(lease.release).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/api/src/box/common/redis-lock.provider.spec.ts
+++ b/apps/api/src/box/common/redis-lock.provider.spec.ts
@@ -42,6 +42,53 @@ describe('RedisLockProvider owned locks', () => {
     ).rejects.toBe(operationError)
   })
 
+  it('releases a lease after a successful protected operation', async () => {
+    const lease = { release: jest.fn().mockResolvedValue(undefined) }
+
+    await expect(withRedisLockLease(lease as any, async () => 'done')).resolves.toBe('done')
+
+    expect(lease.release).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries one transient renewal failure before aborting the lease', async () => {
+    jest.useFakeTimers()
+    const redis = {
+      set: jest.fn().mockResolvedValue('OK'),
+      eval: jest.fn().mockRejectedValueOnce(new Error('Redis unavailable')).mockResolvedValue(1),
+    }
+    const provider = new RedisLockProvider(redis as any)
+    const lease = await provider.acquireLease('transient-renewal', 10)
+
+    await jest.advanceTimersByTimeAsync(5_000)
+    await Promise.resolve()
+    await jest.advanceTimersByTimeAsync(1_000)
+
+    expect(lease?.signal.aborted).toBe(false)
+    expect(redis.eval).toHaveBeenCalledTimes(2)
+    await lease?.release()
+  })
+
+  it('aborts after the renewal retry also fails and schedules no third attempt', async () => {
+    jest.useFakeTimers()
+    const retryError = new Error('Redis still unavailable')
+    const redis = {
+      set: jest.fn().mockResolvedValue('OK'),
+      eval: jest.fn().mockRejectedValueOnce(new Error('Redis unavailable')).mockRejectedValueOnce(retryError),
+    }
+    const provider = new RedisLockProvider(redis as any)
+    const lease = await provider.acquireLease('failed-renewal-retry', 10)
+
+    await jest.advanceTimersByTimeAsync(5_000)
+    await Promise.resolve()
+    await jest.advanceTimersByTimeAsync(1_000)
+    await jest.advanceTimersByTimeAsync(20_000)
+
+    expect(lease?.signal.aborted).toBe(true)
+    expect(lease?.signal.reason).toBe(retryError)
+    expect(redis.eval).toHaveBeenCalledTimes(2)
+    await expect(lease?.release()).rejects.toBe(retryError)
+  })
+
   it('releases the lease when ownership is lost before the operation returns', async () => {
     const ownershipError = new Error('ownership was lost')
     const abortController = new AbortController()
@@ -240,7 +287,11 @@ describe('RedisLockProvider owned locks', () => {
   it('releases a lease acquired after the caller aborts', async () => {
     const provider = new RedisLockProvider({} as any)
     const controller = new AbortController()
-    const lease = { release: jest.fn().mockResolvedValue(undefined) }
+    let releaseFinished!: () => void
+    const released = new Promise<void>((resolve) => {
+      releaseFinished = resolve
+    })
+    const lease = { release: jest.fn(async () => releaseFinished()) }
     let finishAcquire!: (lease: any) => void
     jest.spyOn(provider, 'acquireLease').mockReturnValue(
       new Promise((resolve) => {
@@ -256,14 +307,18 @@ describe('RedisLockProvider owned locks', () => {
     expect(lease.release).not.toHaveBeenCalled()
 
     finishAcquire(lease)
-    await Promise.resolve()
+    await released
     expect(lease.release).toHaveBeenCalledTimes(1)
   })
 
   it('releases a lease acquired after the wait deadline', async () => {
     jest.useFakeTimers()
     const provider = new RedisLockProvider({} as any)
-    const lease = { release: jest.fn().mockResolvedValue(undefined) }
+    let releaseFinished!: () => void
+    const released = new Promise<void>((resolve) => {
+      releaseFinished = resolve
+    })
+    const lease = { release: jest.fn(async () => releaseFinished()) }
     let finishAcquire!: (lease: any) => void
     jest.spyOn(provider, 'acquireLease').mockReturnValue(
       new Promise((resolve) => {
@@ -279,7 +334,7 @@ describe('RedisLockProvider owned locks', () => {
     expect(lease.release).not.toHaveBeenCalled()
 
     finishAcquire(lease)
-    await Promise.resolve()
+    await released
     expect(lease.release).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/api/src/box/common/redis-lock.provider.ts
+++ b/apps/api/src/box/common/redis-lock.provider.ts
@@ -7,6 +7,7 @@
 import { InjectRedis } from '@nestjs-modules/ioredis'
 import { Injectable } from '@nestjs/common'
 import { Redis } from 'ioredis'
+import { randomUUID } from 'crypto'
 
 type Acquired = boolean
 
@@ -18,14 +19,91 @@ export class LockCode {
   }
 }
 
+export class RedisLockLease {
+  private readonly abortController = new AbortController()
+  private renewalTimer: ReturnType<typeof setTimeout> | null = null
+  private renewal: Promise<void> = Promise.resolve()
+  private renewalError: unknown
+  private isReleased = false
+
+  constructor(
+    private readonly provider: RedisLockProvider,
+    private readonly key: string,
+    private readonly ttl: number,
+    private readonly code: LockCode,
+  ) {
+    this.scheduleRenewal()
+  }
+
+  async release(): Promise<void> {
+    if (this.isReleased) {
+      return
+    }
+    this.isReleased = true
+    if (this.renewalTimer) {
+      clearTimeout(this.renewalTimer)
+    }
+    await this.renewal
+    await this.provider.unlock(this.key, this.code)
+    if (this.renewalError) {
+      throw this.renewalError
+    }
+  }
+
+  get ownerCode(): LockCode {
+    return this.code
+  }
+
+  get signal(): AbortSignal {
+    return this.abortController.signal
+  }
+
+  private scheduleRenewal() {
+    this.renewalTimer = setTimeout(() => {
+      this.renewal = this.provider
+        .renew(this.key, this.ttl, this.code)
+        .catch((error) => {
+          this.renewalError = error
+          this.abortController.abort(error)
+        })
+        .then(() => {
+          if (!this.isReleased && !this.renewalError) {
+            this.scheduleRenewal()
+          }
+        })
+    }, (this.ttl * 1000) / 2)
+  }
+}
+
+export async function withRedisLockLease<T>(
+  lease: RedisLockLease,
+  operation: (signal: AbortSignal) => Promise<T>,
+  onSuppressedReleaseError?: (error: unknown) => void,
+): Promise<T> {
+  const signal = lease.signal ?? new AbortController().signal
+  let result: T
+  try {
+    result = await operation(signal)
+  } catch (error) {
+    try {
+      await lease.release()
+    } catch (releaseError) {
+      // Preserve the operation error; it is the actionable failure.
+      onSuppressedReleaseError?.(releaseError)
+    }
+    throw error
+  }
+  signal.throwIfAborted()
+  await lease.release()
+  return result
+}
+
 @Injectable()
 export class RedisLockProvider {
   constructor(@InjectRedis() private readonly redis: Redis) {}
 
-  async lock(key: string, ttl: number, code?: LockCode | null): Promise<Acquired> {
-    const keyValue = code ? code.getCode() : '1'
-    const acquired = await this.redis.set(key, keyValue, 'EX', ttl, 'NX')
-    return !!acquired
+  async lockUntilExpiry(key: string, ttl: number): Promise<Acquired> {
+    return this.setLock(key, ttl, new LockCode(randomUUID()))
   }
 
   async getCode(key: string): Promise<LockCode | null> {
@@ -33,8 +111,40 @@ export class RedisLockProvider {
     return keyValue ? new LockCode(keyValue) : null
   }
 
-  async unlock(key: string): Promise<void> {
-    await this.redis.del(key)
+  async acquireLease(key: string, ttl: number): Promise<RedisLockLease | null> {
+    const code = new LockCode(randomUUID())
+    if (!(await this.setLock(key, ttl, code))) {
+      return null
+    }
+    return new RedisLockLease(this, key, ttl, code)
+  }
+
+  async renew(key: string, ttl: number, code: LockCode): Promise<void> {
+    const renewed = await this.redis.eval(
+      `if redis.call('get', KEYS[1]) == ARGV[1] then
+        return redis.call('expire', KEYS[1], ARGV[2])
+      end
+      return 0`,
+      1,
+      key,
+      code.getCode(),
+      ttl,
+    )
+    if (renewed !== 1) {
+      throw new Error(`Cannot renew Redis lock lease for ${key}: ownership was lost`)
+    }
+  }
+
+  async unlock(key: string, owner: LockCode): Promise<void> {
+    await this.redis.eval(
+      `if redis.call('get', KEYS[1]) == ARGV[1] then
+        return redis.call('del', KEYS[1])
+      end
+      return 0`,
+      1,
+      key,
+      owner.getCode(),
+    )
   }
 
   async isLocked(key: string): Promise<boolean> {
@@ -42,11 +152,15 @@ export class RedisLockProvider {
     return exists === 1
   }
 
-  async waitForLock(key: string, ttl: number): Promise<void> {
+  async waitForLock(key: string, ttl: number): Promise<RedisLockLease> {
     while (true) {
-      const acquired = await this.lock(key, ttl)
-      if (acquired) break
+      const lease = await this.acquireLease(key, ttl)
+      if (lease) return lease
       await new Promise((resolve) => setTimeout(resolve, 50))
     }
+  }
+
+  private async setLock(key: string, ttl: number, code: LockCode): Promise<Acquired> {
+    return !!(await this.redis.set(key, code.getCode(), 'EX', ttl, 'NX'))
   }
 }

--- a/apps/api/src/box/common/redis-lock.provider.ts
+++ b/apps/api/src/box/common/redis-lock.provider.ts
@@ -5,11 +5,22 @@
  */
 
 import { InjectRedis } from '@nestjs-modules/ioredis'
-import { Injectable } from '@nestjs/common'
+import { Injectable, Logger } from '@nestjs/common'
 import { Redis } from 'ioredis'
 import { randomUUID } from 'crypto'
+import { setTimeout as sleep } from 'timers/promises'
 
 type Acquired = boolean
+
+type WaitForLockOptions = {
+  signal?: AbortSignal
+  timeoutMs?: number
+  retryDelayMs?: number
+}
+
+type LeaseAcquisitionOutcome =
+  | { kind: 'acquired'; lease: RedisLockLease | null }
+  | { kind: 'failed'; error: unknown }
 
 export class LockCode {
   constructor(private readonly code: string) {}
@@ -84,6 +95,7 @@ export async function withRedisLockLease<T>(
   let result: T
   try {
     result = await operation(signal)
+    signal.throwIfAborted()
   } catch (error) {
     try {
       await lease.release()
@@ -93,13 +105,14 @@ export async function withRedisLockLease<T>(
     }
     throw error
   }
-  signal.throwIfAborted()
   await lease.release()
   return result
 }
 
 @Injectable()
 export class RedisLockProvider {
+  private readonly logger = new Logger(RedisLockProvider.name)
+
   constructor(@InjectRedis() private readonly redis: Redis) {}
 
   async lockUntilExpiry(key: string, ttl: number): Promise<Acquired> {
@@ -152,11 +165,105 @@ export class RedisLockProvider {
     return exists === 1
   }
 
-  async waitForLock(key: string, ttl: number): Promise<RedisLockLease> {
+  async waitForLock(key: string, ttl: number, options: WaitForLockOptions = {}): Promise<RedisLockLease> {
+    const startedAt = Date.now()
+    const retryDelayMs = options.retryDelayMs ?? 50
+
     while (true) {
-      const lease = await this.acquireLease(key, ttl)
+      this.throwIfLockWaitEnded(key, startedAt, options)
+      const lease = await this.acquireLeaseWhileWaiting(key, ttl, startedAt, options)
       if (lease) return lease
-      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      const elapsedMs = Date.now() - startedAt
+      const delayMs =
+        options.timeoutMs === undefined ? retryDelayMs : Math.min(retryDelayMs, options.timeoutMs - elapsedMs)
+      try {
+        await sleep(delayMs, undefined, { signal: options.signal })
+      } catch (error) {
+        options.signal?.throwIfAborted()
+        throw error
+      }
+    }
+  }
+
+  private async acquireLeaseWhileWaiting(
+    key: string,
+    ttl: number,
+    startedAt: number,
+    options: WaitForLockOptions,
+  ): Promise<RedisLockLease | null> {
+    const acquisition = this.acquireLease(key, ttl).then<LeaseAcquisitionOutcome, LeaseAcquisitionOutcome>(
+      (lease) => ({ kind: 'acquired', lease }),
+      (error) => ({ kind: 'failed', error }),
+    )
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined
+    let abortListener: (() => void) | undefined
+    const waitEnded = new Promise<{ kind: 'ended'; error: unknown }>((resolve) => {
+      if (options.signal) {
+        abortListener = () => resolve({ kind: 'ended', error: options.signal?.reason })
+        options.signal.addEventListener('abort', abortListener, { once: true })
+        if (options.signal.aborted) {
+          abortListener()
+        }
+      }
+
+      if (options.timeoutMs !== undefined) {
+        const remainingMs = Math.max(0, options.timeoutMs - (Date.now() - startedAt))
+        timeoutId = setTimeout(
+          () =>
+            resolve({
+              kind: 'ended',
+              error: new Error(`Timed out waiting for Redis lock ${key} after ${options.timeoutMs}ms`),
+            }),
+          remainingMs,
+        )
+      }
+    })
+
+    const outcome = await Promise.race([acquisition, waitEnded])
+    if (timeoutId) {
+      clearTimeout(timeoutId)
+    }
+    if (abortListener) {
+      options.signal?.removeEventListener('abort', abortListener)
+    }
+
+    if (outcome.kind === 'ended') {
+      void acquisition.then(async (lateOutcome) => {
+        if (lateOutcome.kind === 'acquired' && lateOutcome.lease) {
+          await lateOutcome.lease.release().catch((releaseError) => {
+            this.logger.error(`Error releasing Redis lock ${key} acquired after its wait ended`, releaseError)
+          })
+        } else if (lateOutcome.kind === 'failed') {
+          this.logger.error(`Error acquiring Redis lock ${key} after its wait ended`, lateOutcome.error)
+        }
+      })
+      throw outcome.error
+    }
+
+    if (outcome.kind === 'failed') {
+      throw outcome.error
+    }
+
+    try {
+      this.throwIfLockWaitEnded(key, startedAt, options)
+    } catch (error) {
+      if (outcome.lease) {
+        await outcome.lease.release().catch((releaseError) => {
+          this.logger.error(`Error releasing Redis lock ${key} acquired after its wait ended`, releaseError)
+        })
+      }
+      throw error
+    }
+
+    return outcome.lease
+  }
+
+  private throwIfLockWaitEnded(key: string, startedAt: number, options: WaitForLockOptions): void {
+    options.signal?.throwIfAborted()
+    if (options.timeoutMs !== undefined && Date.now() - startedAt >= options.timeoutMs) {
+      throw new Error(`Timed out waiting for Redis lock ${key} after ${options.timeoutMs}ms`)
     }
   }
 

--- a/apps/api/src/box/common/redis-lock.provider.ts
+++ b/apps/api/src/box/common/redis-lock.provider.ts
@@ -57,9 +57,17 @@ export class RedisLockLease {
       clearTimeout(this.renewalTimer)
     }
     await this.renewal
-    await this.provider.unlock(this.key, this.code)
+    let unlockError: unknown
+    try {
+      await this.unlockWithTimeout(Math.min((this.ttl * 1000) / 8, 1000))
+    } catch (error) {
+      unlockError = error
+    }
     if (this.renewalError) {
       throw this.renewalError
+    }
+    if (unlockError) {
+      throw unlockError
     }
   }
 
@@ -72,9 +80,11 @@ export class RedisLockLease {
   }
 
   private scheduleRenewal() {
+    // Two bounded attempts plus the retry delay must finish before the lease
+    // expires, including for short TTLs.
+    const renewalAttemptTimeoutMs = Math.min((this.ttl * 1000) / 8, 1000)
     this.renewalTimer = setTimeout(() => {
-      this.renewal = this.provider
-        .renew(this.key, this.ttl, this.code)
+      this.renewal = this.renewWithTimeout(renewalAttemptTimeoutMs)
         .catch((error) => {
           if (error instanceof LockOwnershipLostError) {
             throw error
@@ -83,10 +93,10 @@ export class RedisLockLease {
             return
           }
           return new Promise<void>((resolve) => {
-            setTimeout(resolve, Math.min((this.ttl * 1000) / 4, 1000))
+            setTimeout(resolve, renewalAttemptTimeoutMs)
           }).then(() => {
             if (!this.isReleased) {
-              return this.provider.renew(this.key, this.ttl, this.code)
+              return this.renewWithTimeout(renewalAttemptTimeoutMs)
             }
           })
         })
@@ -100,6 +110,35 @@ export class RedisLockLease {
           }
         })
     }, (this.ttl * 1000) / 2)
+  }
+
+  private async renewWithTimeout(timeoutMs: number): Promise<void> {
+    await this.withTimeout(
+      this.provider.renew(this.key, this.ttl, this.code),
+      timeoutMs,
+      `Redis lock renewal timed out for ${this.key}`,
+    )
+  }
+
+  private async unlockWithTimeout(timeoutMs: number): Promise<void> {
+    await this.withTimeout(
+      this.provider.unlock(this.key, this.code),
+      timeoutMs,
+      `Redis lock release timed out for ${this.key}`,
+    )
+  }
+
+  private async withTimeout(operation: Promise<void>, timeoutMs: number, timeoutMessage: string): Promise<void> {
+    let timeout: ReturnType<typeof setTimeout>
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeout = setTimeout(() => reject(new Error(timeoutMessage)), timeoutMs)
+    })
+
+    try {
+      await Promise.race([operation, timeoutPromise])
+    } finally {
+      clearTimeout(timeout)
+    }
   }
 }
 

--- a/apps/api/src/box/common/redis-lock.provider.ts
+++ b/apps/api/src/box/common/redis-lock.provider.ts
@@ -22,6 +22,8 @@ type LeaseAcquisitionOutcome =
   | { kind: 'acquired'; lease: RedisLockLease | null }
   | { kind: 'failed'; error: unknown }
 
+export class LockOwnershipLostError extends Error {}
+
 export class LockCode {
   constructor(private readonly code: string) {}
 
@@ -73,6 +75,21 @@ export class RedisLockLease {
     this.renewalTimer = setTimeout(() => {
       this.renewal = this.provider
         .renew(this.key, this.ttl, this.code)
+        .catch((error) => {
+          if (error instanceof LockOwnershipLostError) {
+            throw error
+          }
+          if (this.isReleased) {
+            return
+          }
+          return new Promise<void>((resolve) => {
+            setTimeout(resolve, Math.min((this.ttl * 1000) / 4, 1000))
+          }).then(() => {
+            if (!this.isReleased) {
+              return this.provider.renew(this.key, this.ttl, this.code)
+            }
+          })
+        })
         .catch((error) => {
           this.renewalError = error
           this.abortController.abort(error)
@@ -144,7 +161,7 @@ export class RedisLockProvider {
       ttl,
     )
     if (renewed !== 1) {
-      throw new Error(`Cannot renew Redis lock lease for ${key}: ownership was lost`)
+      throw new LockOwnershipLostError(`Cannot renew Redis lock lease for ${key}: ownership was lost`)
     }
   }
 

--- a/apps/api/src/box/managers/box.manager.spec.ts
+++ b/apps/api/src/box/managers/box.manager.spec.ts
@@ -6,6 +6,7 @@
 import { BoxDesiredState } from '../enums/box-desired-state.enum'
 import { BoxState } from '../enums/box-state.enum'
 import { BoxManager } from './box.manager'
+import { Readable } from 'stream'
 
 describe('BoxManager.syncInstanceState', () => {
   it('releases the state-change lease it acquired', async () => {
@@ -37,5 +38,46 @@ describe('BoxManager.syncInstanceState', () => {
 
     expect(redisLockProvider.acquireLease).toHaveBeenCalledWith('box:box-1:state-change', 30)
     expect(release).toHaveBeenCalled()
+  })
+
+  it('destroys the state stream without scheduling work after ownership is lost', async () => {
+    const ownershipError = new Error('ownership was lost')
+    const controller = new AbortController()
+    const stream = Readable.from([{ box_id: 'box-1' }])
+    const queryBuilder = {
+      select: jest.fn().mockReturnThis(),
+      leftJoin: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      stream: jest.fn().mockResolvedValue(stream),
+    }
+    const boxRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+    }
+    const release = jest.fn().mockResolvedValue(undefined)
+    const redisLockProvider = {
+      acquireLease: jest.fn().mockResolvedValue({ signal: controller.signal, release }),
+      isLocked: jest.fn(async () => {
+        controller.abort(ownershipError)
+        return false
+      }),
+    }
+    const manager = new BoxManager(
+      boxRepository as any,
+      {} as any,
+      {} as any,
+      redisLockProvider as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    )
+    const syncInstanceState = jest.spyOn(manager, 'syncInstanceState').mockResolvedValue(undefined)
+
+    await expect(manager.syncStates()).rejects.toBe(ownershipError)
+
+    expect(syncInstanceState).not.toHaveBeenCalled()
+    expect(stream.destroyed).toBe(true)
+    expect(release).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/api/src/box/managers/box.manager.spec.ts
+++ b/apps/api/src/box/managers/box.manager.spec.ts
@@ -21,6 +21,7 @@ describe('BoxManager.syncInstanceState', () => {
     const redisLockProvider = {
       acquireLease: jest.fn().mockResolvedValue({
         ownerCode: { getCode: () => 'owner-1' },
+        signal: new AbortController().signal,
         release,
       }),
     }

--- a/apps/api/src/box/managers/box.manager.spec.ts
+++ b/apps/api/src/box/managers/box.manager.spec.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BoxDesiredState } from '../enums/box-desired-state.enum'
+import { BoxState } from '../enums/box-state.enum'
+import { BoxManager } from './box.manager'
+
+describe('BoxManager.syncInstanceState', () => {
+  it('releases the state-change lease it acquired', async () => {
+    const boxRepository = {
+      findOneOrFail: jest.fn().mockResolvedValue({
+        id: 'box-1',
+        state: BoxState.STARTED,
+        desiredState: BoxDesiredState.STARTED,
+      }),
+    }
+    const release = jest.fn().mockResolvedValue(undefined)
+    const redisLockProvider = {
+      acquireLease: jest.fn().mockResolvedValue({
+        ownerCode: { getCode: () => 'owner-1' },
+        release,
+      }),
+    }
+    const manager = new BoxManager(
+      boxRepository as any,
+      {} as any,
+      {} as any,
+      redisLockProvider as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    )
+
+    await manager.syncInstanceState('box-1')
+
+    expect(redisLockProvider.acquireLease).toHaveBeenCalledWith('box:box-1:state-change', 30)
+    expect(release).toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/box/managers/box.manager.ts
+++ b/apps/api/src/box/managers/box.manager.ts
@@ -43,7 +43,7 @@ import { Box } from '../entities/box.entity'
 
 @Injectable()
 export class BoxManager implements TrackableJobExecutions, OnApplicationShutdown {
-  activeJobs = new Set<string>()
+  activeJobs = new Set<symbol>()
 
   private readonly logger = new Logger(BoxManager.name)
 
@@ -257,52 +257,55 @@ export class BoxManager implements TrackableJobExecutions, OnApplicationShutdown
       const stream = await queryBuilder.stream()
       let processedCount = 0
       const maxProcessPerRun = 1000
-      const pendingProcesses: Promise<void>[] = []
+      const pendingProcesses = new Set<Promise<void>>()
+      const abortStream = () => {
+        const reason = signal.reason instanceof Error ? signal.reason : new Error('Redis lock lease was lost')
+        stream.destroy(reason)
+      }
 
+      signal.addEventListener('abort', abortStream, { once: true })
       try {
-        await new Promise<void>((resolve, reject) => {
-          stream.on('data', async (row: any) => {
-            if (processedCount >= maxProcessPerRun) {
-              resolve()
-              return
-            }
+        if (signal.aborted) {
+          abortStream()
+        }
 
-            const lockKey = getStateChangeLockKey(row.box_id)
-            if (await this.redisLockProvider.isLocked(lockKey)) {
-              // Box is already being processed, skip it
-              return
-            }
+        for await (const row of stream) {
+          signal.throwIfAborted()
+          if (processedCount >= maxProcessPerRun) {
+            break
+          }
 
-            // Process box asynchronously but track the promise
-            const processPromise = this.syncInstanceState(row.box_id).catch((err) => {
-              this.logger.error(`Error syncing box state for ${row.box_id}`, err)
-            })
-            pendingProcesses.push(processPromise)
-            processedCount++
+          const lockKey = getStateChangeLockKey(row.box_id)
+          const isLocked = await this.redisLockProvider.isLocked(lockKey)
+          signal.throwIfAborted()
+          if (isLocked) {
+            continue
+          }
 
-            // Limit concurrent processing to avoid overwhelming the system
-            if (pendingProcesses.length >= 10) {
-              stream.pause()
-              Promise.allSettled(pendingProcesses.splice(0, pendingProcesses.length))
-                .then(() => stream.resume())
-                .catch(reject)
-            }
+          const processPromise = this.syncInstanceState(row.box_id).catch((err) => {
+            this.logger.error(`Error syncing box state for ${row.box_id}`, err)
           })
+          pendingProcesses.add(processPromise)
+          void processPromise.finally(() => pendingProcesses.delete(processPromise))
+          processedCount++
 
-          stream.on('end', () => {
-            Promise.allSettled(pendingProcesses)
-              .then(() => {
-                resolve()
-              })
-              .catch(reject)
-          })
-
-          stream.on('error', reject)
-        })
+          if (pendingProcesses.size >= 10) {
+            await Promise.allSettled([...pendingProcesses])
+            signal.throwIfAborted()
+          }
+        }
+        signal.throwIfAborted()
+      } catch (error) {
+        if (signal.aborted) {
+          throw signal.reason
+        }
+        throw error
       } finally {
+        signal.removeEventListener('abort', abortStream)
         if (!stream.destroyed) {
           stream.destroy()
         }
+        await Promise.allSettled([...pendingProcesses])
       }
     })
   }

--- a/apps/api/src/box/managers/box.manager.ts
+++ b/apps/api/src/box/managers/box.manager.ts
@@ -6,7 +6,6 @@
 
 import { Injectable, Logger, OnApplicationShutdown } from '@nestjs/common'
 import { Cron, CronExpression } from '@nestjs/schedule'
-import { randomUUID } from 'crypto'
 
 import { BoxConflictError } from '../errors/box-conflict.error'
 import { JobConflictError } from '../errors/job-conflict.error'
@@ -15,7 +14,7 @@ import { BoxDesiredState } from '../enums/box-desired-state.enum'
 import { RunnerService } from '../services/runner.service'
 import { BoxActivityService } from '../services/box-activity.service'
 
-import { RedisLockProvider, LockCode } from '../common/redis-lock.provider'
+import { RedisLockProvider, withRedisLockLease } from '../common/redis-lock.provider'
 
 import { BOX_WARM_POOL_UNASSIGNED_ORGANIZATION } from '../constants/box.constants'
 
@@ -73,16 +72,18 @@ export class BoxManager implements TrackableJobExecutions, OnApplicationShutdown
   async autostopCheck(): Promise<void> {
     const lockKey = 'auto-stop-check-worker-selected'
     // lock the sync to only run one instance at a time
-    if (!(await this.redisLockProvider.lock(lockKey, 60))) {
+    const lease = await this.redisLockProvider.acquireLease(lockKey, 60)
+    if (!lease) {
       return
     }
 
-    try {
+    await withRedisLockLease(lease, async (signal) => {
       const readyRunners = await this.runnerService.findAllReady()
 
       // Process all runners in parallel
       await Promise.all(
         readyRunners.map(async (runner) => {
+          signal.throwIfAborted()
           const boxes = await this.boxRepository
             .createQueryBuilder('box')
             .leftJoin('box_last_activity', 'activity', 'activity."boxId" = box.id')
@@ -106,49 +107,50 @@ export class BoxManager implements TrackableJobExecutions, OnApplicationShutdown
           await Promise.all(
             boxes.map(async (box) => {
               const lockKey = getStateChangeLockKey(box.id)
-              const acquired = await this.redisLockProvider.lock(lockKey, 30)
-              if (!acquired) {
+              const boxLease = await this.redisLockProvider.acquireLease(lockKey, 30)
+              if (!boxLease) {
                 return
               }
 
               try {
-                // Activity is buffered in Redis before the periodic DB flush.
-                // Recheck after taking the state lock so a recent Exec/Files
-                // call cannot be stopped based on a stale SQL timestamp.
-                const lastActivityAt = await this.boxActivityService.getLastActivityAt(box.id)
-                if (lastActivityAt && Date.now() - lastActivityAt.getTime() < box.autoStop * 1000) {
-                  return
-                }
+                await withRedisLockLease(boxLease, async (boxSignal) => {
+                  // Activity is buffered in Redis before the periodic DB flush.
+                  // Recheck after taking the state lock so a recent Exec/Files
+                  // call cannot be stopped based on a stale SQL timestamp.
+                  const lastActivityAt = await this.boxActivityService.getLastActivityAt(box.id)
+                  boxSignal.throwIfAborted()
+                  if (lastActivityAt && Date.now() - lastActivityAt.getTime() < box.autoStop * 1000) {
+                    return
+                  }
 
-                const updateData: Partial<Box> = {
-                  pending: true,
-                  desiredState: BoxDesiredState.STOPPED,
-                }
+                  const updateData: Partial<Box> = {
+                    pending: true,
+                    desiredState: BoxDesiredState.STOPPED,
+                  }
 
-                this.logger.log(`Auto-stopping box ${box.id}: autoStop=${box.autoStop}s, autoDelete=${box.autoDelete}s`)
-                await this.boxRepository.updateWhere(box.id, {
-                  updateData,
-                  whereCondition: {
-                    pending: false,
-                    state: box.state,
-                    desiredState: BoxDesiredState.STARTED,
-                    autoStop: box.autoStop,
-                  },
+                  this.logger.log(
+                    `Auto-stopping box ${box.id}: autoStop=${box.autoStop}s, autoDelete=${box.autoDelete}s`,
+                  )
+                  await this.boxRepository.updateWhere(box.id, {
+                    updateData,
+                    whereCondition: {
+                      pending: false,
+                      state: box.state,
+                      desiredState: BoxDesiredState.STARTED,
+                      autoStop: box.autoStop,
+                    },
+                  })
+
+                  this.syncInstanceState(box.id).catch(this.logger.error)
                 })
-
-                this.syncInstanceState(box.id).catch(this.logger.error)
               } catch (error) {
                 this.logger.error(`Error processing auto-stop state for box ${box.id}:`, error)
-              } finally {
-                await this.redisLockProvider.unlock(lockKey)
               }
             }),
           )
         }),
       )
-    } finally {
-      await this.redisLockProvider.unlock(lockKey)
-    }
+    })
   }
 
   @Cron(CronExpression.EVERY_10_SECONDS, { name: 'auto-delete-check' })
@@ -158,16 +160,18 @@ export class BoxManager implements TrackableJobExecutions, OnApplicationShutdown
   async autoDeleteCheck(): Promise<void> {
     const lockKey = 'auto-delete-check-worker-selected'
     // lock the sync to only run one instance at a time
-    if (!(await this.redisLockProvider.lock(lockKey, 60))) {
+    const lease = await this.redisLockProvider.acquireLease(lockKey, 60)
+    if (!lease) {
       return
     }
 
-    try {
+    await withRedisLockLease(lease, async (signal) => {
       const readyRunners = await this.runnerService.findAllReady()
 
       // Process all runners in parallel
       await Promise.all(
         readyRunners.map(async (runner) => {
+          signal.throwIfAborted()
           const boxes = await this.boxRepository
             .createQueryBuilder('box')
             .innerJoin('box.lastActivityAt', 'activity')
@@ -190,38 +194,37 @@ export class BoxManager implements TrackableJobExecutions, OnApplicationShutdown
           await Promise.all(
             boxes.map(async (box) => {
               const lockKey = getStateChangeLockKey(box.id)
-              const acquired = await this.redisLockProvider.lock(lockKey, 30)
-              if (!acquired) {
+              const boxLease = await this.redisLockProvider.acquireLease(lockKey, 30)
+              if (!boxLease) {
                 return
               }
 
               this.logger.log(`Auto-deleting box ${box.id}: autoDelete=${box.autoDelete}s`)
 
               try {
-                const updateData = Box.getSoftDeleteUpdate(box)
-                await this.boxRepository.updateWhere(box.id, {
-                  updateData,
-                  whereCondition: {
-                    pending: false,
-                    state: box.state,
-                    desiredState: BoxDesiredState.STOPPED,
-                    autoDelete: box.autoDelete,
-                  },
-                })
+                await withRedisLockLease(boxLease, async (boxSignal) => {
+                  boxSignal.throwIfAborted()
+                  const updateData = Box.getSoftDeleteUpdate(box)
+                  await this.boxRepository.updateWhere(box.id, {
+                    updateData,
+                    whereCondition: {
+                      pending: false,
+                      state: box.state,
+                      desiredState: BoxDesiredState.STOPPED,
+                      autoDelete: box.autoDelete,
+                    },
+                  })
 
-                this.syncInstanceState(box.id).catch(this.logger.error)
+                  this.syncInstanceState(box.id).catch(this.logger.error)
+                })
               } catch (error) {
                 this.logger.error(`Error processing auto-delete state for box ${box.id}:`, error)
-              } finally {
-                await this.redisLockProvider.unlock(lockKey)
               }
             }),
           )
         }),
       )
-    } finally {
-      await this.redisLockProvider.unlock(lockKey)
-    }
+    })
   }
 
   @Cron(CronExpression.EVERY_10_SECONDS, { name: 'sync-states' })
@@ -231,11 +234,13 @@ export class BoxManager implements TrackableJobExecutions, OnApplicationShutdown
   async syncStates(): Promise<void> {
     const globalLockKey = 'sync-states'
     const lockTtl = 10 * 60 // seconds (10 min)
-    if (!(await this.redisLockProvider.lock(globalLockKey, lockTtl))) {
+    const lease = await this.redisLockProvider.acquireLease(globalLockKey, lockTtl)
+    if (!lease) {
       return
     }
 
-    try {
+    await withRedisLockLease(lease, async (signal) => {
+      signal.throwIfAborted()
       const queryBuilder = this.boxRepository
         .createQueryBuilder('box')
         .select(['box.id'])
@@ -299,9 +304,7 @@ export class BoxManager implements TrackableJobExecutions, OnApplicationShutdown
           stream.destroy()
         }
       }
-    } finally {
-      await this.redisLockProvider.unlock(globalLockKey)
-    }
+    })
   }
 
   /**
@@ -315,22 +318,21 @@ export class BoxManager implements TrackableJobExecutions, OnApplicationShutdown
     // Track the start time of the sync operation.
     const startedAt = new Date()
 
-    // Generate a random lock code to prevent race condition if box action continues after the lock expires.
-    const lockCode = new LockCode(randomUUID())
-
     // Prevent syncState cron from running multiple instances of the same box.
     const lockKey = getStateChangeLockKey(boxId)
-    const acquired = await this.redisLockProvider.lock(lockKey, 30, lockCode)
-    if (!acquired) {
+    const lease = await this.redisLockProvider.acquireLease(lockKey, 30)
+    if (!lease) {
       return
     }
+    const lockCode = lease.ownerCode
 
-    try {
+    await withRedisLockLease(lease, async (signal) => {
       const box = await this.boxRepository.findOneOrFail({
         where: { id: boxId },
       })
 
       while (new Date().getTime() - startedAt.getTime() <= 10000) {
+        signal.throwIfAborted()
         if ([BoxState.DESTROYED, BoxState.RESIZING].includes(box.state) || box.state === BoxState.ERROR) {
           // Break sync loop if box reaches a terminal state.
           break
@@ -399,9 +401,7 @@ export class BoxManager implements TrackableJobExecutions, OnApplicationShutdown
           break
         }
       }
-    } finally {
-      await this.redisLockProvider.unlock(lockKey)
-    }
+    })
   }
 
   @OnAsyncEvent({

--- a/apps/api/src/box/managers/volume.manager.spec.ts
+++ b/apps/api/src/box/managers/volume.manager.spec.ts
@@ -32,7 +32,7 @@ describe('VolumeManager S3 client setup', () => {
         return value
       }),
     }
-    return new VolumeManager({} as any, configService as any, {} as any, {} as any, {} as any)
+    return new VolumeManager({} as any, configService as any, {} as any, {} as any)
   }
 
   const awsConfig = {
@@ -86,5 +86,91 @@ describe('VolumeManager S3 client setup', () => {
     expect(() => buildManager({ 's3.endpoint': 'http://minio:9000', 's3.region': 'us-east-1' })).toThrow(
       /MinIO requires S3_ACCESS_KEY and S3_SECRET_KEY/,
     )
+  })
+})
+
+describe('VolumeManager owned volume locks', () => {
+  it('does not write an error state after the volume lease is lost', async () => {
+    const abortController = new AbortController()
+    const volume = {
+      id: 'volume-1',
+      organizationId: 'org-1',
+      state: 'pending_create',
+      getBucketName: () => 'bucket-1',
+    }
+    const volumeRepository = {
+      save: jest.fn().mockResolvedValue(undefined),
+      update: jest.fn().mockResolvedValue(undefined),
+    }
+    const manager = new VolumeManager(
+      volumeRepository as any,
+      {
+        get: jest.fn((key: string) =>
+          ({ 's3.endpoint': 'https://s3.example.com', skipConnections: true })[key],
+        ),
+        getOrThrow: jest.fn((key: string) =>
+          ({ 's3.endpoint': 'https://s3.example.com', 's3.region': 'us-east-1' })[key],
+        ),
+      } as any,
+      {} as any,
+      {} as any,
+    )
+    mockSend.mockImplementationOnce(async () => {
+      abortController.abort(new Error('ownership was lost'))
+    })
+
+    await expect((manager as any).processVolumeState(volume, abortController.signal)).rejects.toThrow(
+      'ownership was lost',
+    )
+
+    expect(volumeRepository.save).toHaveBeenCalledTimes(1)
+    expect(volumeRepository.update).not.toHaveBeenCalled()
+  })
+
+  it('holds and releases the worker and volume leases while processing a volume', async () => {
+    mockSend.mockResolvedValue({})
+    const volume = {
+      id: 'volume-1',
+      organizationId: 'org-1',
+      state: 'pending_create',
+      getBucketName: () => 'bucket-1',
+    }
+    const volumeRepository = {
+      find: jest.fn().mockResolvedValue([volume]),
+      save: jest.fn().mockResolvedValue(undefined),
+    }
+    const configService = {
+      get: jest.fn((key: string) =>
+        ({
+          's3.endpoint': 'https://s3.example.com',
+          's3.region': 'us-east-1',
+          skipConnections: true,
+        })[key],
+      ),
+      getOrThrow: jest.fn((key: string) =>
+        ({ 's3.endpoint': 'https://s3.example.com', 's3.region': 'us-east-1' })[key],
+      ),
+    }
+    const releaseWorkerLease = jest.fn()
+    const releaseVolumeLease = jest.fn()
+    const redisLockProvider = {
+      acquireLease: jest
+        .fn()
+        .mockResolvedValueOnce({ release: releaseWorkerLease })
+        .mockResolvedValueOnce({ release: releaseVolumeLease }),
+    }
+    const manager = new VolumeManager(
+      volumeRepository as any,
+      configService as any,
+      redisLockProvider as any,
+      {} as any,
+    )
+
+    await manager.processPendingVolumes()
+
+    expect(redisLockProvider.acquireLease).toHaveBeenNthCalledWith(1, 'process-pending-volumes', 30)
+    expect(redisLockProvider.acquireLease).toHaveBeenNthCalledWith(2, 'volume-state-volume-1', 30)
+    expect(releaseVolumeLease).toHaveBeenCalled()
+    expect(releaseWorkerLease).toHaveBeenCalled()
   })
 })

--- a/apps/api/src/box/managers/volume.manager.spec.ts
+++ b/apps/api/src/box/managers/volume.manager.spec.ts
@@ -14,6 +14,9 @@ jest.mock('@aws-sdk/client-s3', () => ({
   CreateBucketCommand: jest.fn().mockImplementation((input) => ({ input })),
   ListObjectsV2Command: jest.fn().mockImplementation((input) => ({ input })),
   PutBucketTaggingCommand: jest.fn().mockImplementation((input) => ({ input })),
+  ListObjectVersionsCommand: jest.fn().mockImplementation((input) => ({ operation: 'list-versions', input })),
+  DeleteObjectsCommand: jest.fn().mockImplementation((input) => ({ operation: 'delete-objects', input })),
+  DeleteBucketCommand: jest.fn().mockImplementation((input) => ({ operation: 'delete-bucket', input })),
 }))
 
 describe('VolumeManager S3 client setup', () => {
@@ -115,6 +118,8 @@ describe('VolumeManager owned volume locks', () => {
       {} as any,
       {} as any,
     )
+    const logger = { error: jest.fn() }
+    Object.assign(manager as any, { logger })
     mockSend.mockImplementationOnce(async () => {
       abortController.abort(new Error('ownership was lost'))
     })
@@ -123,7 +128,7 @@ describe('VolumeManager owned volume locks', () => {
       'ownership was lost',
     )
 
-    expect(volumeRepository.save).toHaveBeenCalledTimes(1)
+    expect(volumeRepository.save).not.toHaveBeenCalled()
     expect(volumeRepository.update).not.toHaveBeenCalled()
   })
 
@@ -172,5 +177,129 @@ describe('VolumeManager owned volume locks', () => {
     expect(redisLockProvider.acquireLease).toHaveBeenNthCalledWith(2, 'volume-state-volume-1', 30)
     expect(releaseVolumeLease).toHaveBeenCalled()
     expect(releaseWorkerLease).toHaveBeenCalled()
+  })
+
+  it('retries a create after the bucket was already created and reaches ready', async () => {
+    const alreadyCreated = Object.assign(new Error('already created'), { name: 'BucketAlreadyOwnedByYou' })
+    mockSend.mockRejectedValueOnce(alreadyCreated).mockResolvedValueOnce({})
+    const volume = {
+      id: 'volume-1',
+      organizationId: 'org-1',
+      state: 'pending_create',
+      getBucketName: () => 'bucket-1',
+    }
+    const volumeRepository = { save: jest.fn().mockResolvedValue(undefined), update: jest.fn() }
+    const manager = new VolumeManager(
+      volumeRepository as any,
+      {
+        get: jest.fn((key: string) =>
+          ({ 's3.endpoint': 'https://s3.example.com', skipConnections: true, environment: 'test' })[key],
+        ),
+        getOrThrow: jest.fn((key: string) =>
+          ({ 's3.endpoint': 'https://s3.example.com', 's3.region': 'us-east-1' })[key],
+        ),
+      } as any,
+      {} as any,
+      {} as any,
+    )
+
+    await (manager as any).processVolumeState(volume, new AbortController().signal)
+
+    expect(volumeRepository.save).toHaveBeenCalledTimes(1)
+    expect(volumeRepository.save).toHaveBeenCalledWith(expect.objectContaining({ state: 'ready' }))
+  })
+
+  it('keeps a deleted bucket pending when its lease is lost so the delete can retry', async () => {
+    const ownershipError = new Error('ownership was lost')
+    const abortController = new AbortController()
+    mockSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({})
+      .mockImplementationOnce(async () => {
+        abortController.abort(ownershipError)
+      })
+    const volume = {
+      id: 'volume-1',
+      name: 'volume',
+      organizationId: 'org-1',
+      state: 'pending_delete',
+      getBucketName: () => 'bucket-1',
+    }
+    const volumeRepository = {
+      delete: jest.fn().mockResolvedValue(undefined),
+      save: jest.fn().mockResolvedValue(undefined),
+      update: jest.fn(),
+    }
+    const manager = new VolumeManager(
+      volumeRepository as any,
+      {
+        get: jest.fn((key: string) =>
+          ({ 's3.endpoint': 'https://s3.example.com', skipConnections: true })[key],
+        ),
+        getOrThrow: jest.fn((key: string) =>
+          ({ 's3.endpoint': 'https://s3.example.com', 's3.region': 'us-east-1' })[key],
+        ),
+      } as any,
+      {} as any,
+      {} as any,
+    )
+
+    await expect((manager as any).processVolumeState(volume, abortController.signal)).rejects.toBe(ownershipError)
+
+    expect(volumeRepository.delete).not.toHaveBeenCalled()
+    expect(volumeRepository.save).not.toHaveBeenCalled()
+    expect(volumeRepository.update).not.toHaveBeenCalled()
+  })
+
+  it('waits for sibling volume work before releasing the worker lease', async () => {
+    const volumes = [
+      { id: 'volume-1', state: 'pending_create' },
+      { id: 'volume-2', state: 'pending_create' },
+    ]
+    const volumeRepository = { find: jest.fn().mockResolvedValue(volumes) }
+    const releaseWorkerLease = jest.fn().mockResolvedValue(undefined)
+    const redisLockProvider = {
+      acquireLease: jest
+        .fn()
+        .mockResolvedValueOnce({ release: releaseWorkerLease })
+        .mockResolvedValueOnce({ release: jest.fn().mockResolvedValue(undefined) })
+        .mockResolvedValueOnce({ release: jest.fn().mockResolvedValue(undefined) }),
+    }
+    const manager = new VolumeManager(
+      volumeRepository as any,
+      {
+        get: jest.fn((key: string) =>
+          ({ 's3.endpoint': 'https://s3.example.com', skipConnections: true })[key],
+        ),
+        getOrThrow: jest.fn((key: string) =>
+          ({ 's3.endpoint': 'https://s3.example.com', 's3.region': 'us-east-1' })[key],
+        ),
+      } as any,
+      redisLockProvider as any,
+      {} as any,
+    )
+    const logger = { error: jest.fn() }
+    Object.assign(manager as any, { logger })
+    let finishSecond!: () => void
+    jest.spyOn(manager as any, 'processVolumeState').mockImplementation((volume: { id: string }) => {
+      if (volume.id === 'volume-1') {
+        return Promise.reject(new Error('volume lease lost'))
+      }
+      return new Promise<void>((resolve) => {
+        finishSecond = resolve
+      })
+    })
+
+    const processing = manager.processPendingVolumes()
+    while (!finishSecond) {
+      await Promise.resolve()
+    }
+    await Promise.resolve()
+    expect(releaseWorkerLease).not.toHaveBeenCalled()
+
+    finishSecond()
+    await processing
+    expect(releaseWorkerLease).toHaveBeenCalledTimes(1)
+    expect(logger.error).toHaveBeenCalledWith('Error processing pending volumes:', expect.any(Error))
   })
 })

--- a/apps/api/src/box/managers/volume.manager.ts
+++ b/apps/api/src/box/managers/volume.manager.ts
@@ -27,7 +27,7 @@ const VOLUME_STATE_LOCK_KEY = 'volume-state-'
 export class VolumeManager
   implements OnModuleInit, TrackableJobExecutions, OnApplicationShutdown, OnApplicationBootstrap
 {
-  activeJobs = new Set<string>()
+  activeJobs = new Set<symbol>()
 
   private readonly logger = new Logger(VolumeManager.name)
   private processingVolumes: Set<string> = new Set()
@@ -145,7 +145,7 @@ export class VolumeManager
           },
         })
 
-        await Promise.all(
+        const results = await Promise.allSettled(
           pendingVolumes.map(async (volume) => {
             signal.throwIfAborted()
             if (this.processingVolumes.has(volume.id)) {
@@ -160,6 +160,7 @@ export class VolumeManager
             }
 
             await withRedisLockLease(volumeLease, async (volumeSignal) => {
+              signal.throwIfAborted()
               this.processingVolumes.add(volume.id)
               try {
                 await this.processVolumeState(volume, volumeSignal)
@@ -169,6 +170,11 @@ export class VolumeManager
             })
           }),
         )
+        signal.throwIfAborted()
+        const rejected = results.find((result): result is PromiseRejectedResult => result.status === 'rejected')
+        if (rejected) {
+          throw rejected.reason
+        }
       })
     } catch (error) {
       this.logger.error('Error processing pending volumes:', error)
@@ -187,7 +193,7 @@ export class VolumeManager
       }
     } catch (error) {
       if (signal.aborted) {
-        throw signal.reason
+        throw error
       }
       this.logger.error(`Error processing volume ${volume.id}:`, error)
       await this.volumeRepository.update(volume.id, {
@@ -199,19 +205,19 @@ export class VolumeManager
 
   private async handlePendingCreate(volume: Volume, signal: AbortSignal): Promise<void> {
     try {
-      // Update state to CREATING
-      await this.volumeRepository.save({
-        ...volume,
-        state: VolumeState.CREATING,
-      })
-
       signal.throwIfAborted()
       // Create bucket in Minio/S3
       const createBucketCommand = new CreateBucketCommand({
         Bucket: volume.getBucketName(),
       })
 
-      await this.s3Client.send(createBucketCommand)
+      try {
+        await this.s3Client.send(createBucketCommand)
+      } catch (error) {
+        if (error.name !== 'BucketAlreadyOwnedByYou') {
+          throw error
+        }
+      }
       signal.throwIfAborted()
 
       await this.s3Client.send(
@@ -237,6 +243,7 @@ export class VolumeManager
       )
 
       // Update volume state to READY
+      signal.throwIfAborted()
       await this.volumeRepository.save({
         ...volume,
         state: VolumeState.READY,
@@ -244,7 +251,7 @@ export class VolumeManager
       this.logger.debug(`Volume ${volume.id} created successfully`)
     } catch (error) {
       if (signal.aborted) {
-        throw signal.reason
+        throw error
       }
       this.logger.error(`Error creating volume ${volume.id}:`, error)
       await this.volumeRepository.save({
@@ -257,12 +264,6 @@ export class VolumeManager
 
   private async handlePendingDelete(volume: Volume, signal: AbortSignal): Promise<void> {
     try {
-      // Update state to DELETING
-      await this.volumeRepository.save({
-        ...volume,
-        state: VolumeState.DELETING,
-      })
-
       signal.throwIfAborted()
       // Delete bucket from Minio/S3
       try {
@@ -279,6 +280,7 @@ export class VolumeManager
       }
 
       // Delete any existing volume record with the deleted state and the same name in the same organization
+      signal.throwIfAborted()
       await this.volumeRepository.delete({
         organizationId: volume.organizationId,
         name: `${volume.name}-deleted`,
@@ -286,6 +288,7 @@ export class VolumeManager
       })
 
       // Update volume state to DELETED and rename
+      signal.throwIfAborted()
       await this.volumeRepository.save({
         ...volume,
         state: VolumeState.DELETED,
@@ -294,7 +297,7 @@ export class VolumeManager
       this.logger.debug(`Volume ${volume.id} deleted successfully`)
     } catch (error) {
       if (signal.aborted) {
-        throw signal.reason
+        throw error
       }
       this.logger.error(`Error deleting volume ${volume.id}:`, error)
       await this.volumeRepository.save({

--- a/apps/api/src/box/managers/volume.manager.ts
+++ b/apps/api/src/box/managers/volume.manager.ts
@@ -11,9 +11,7 @@ import { Volume } from '../entities/volume.entity'
 import { VolumeState } from '../enums/volume-state.enum'
 import { Cron, CronExpression, SchedulerRegistry } from '@nestjs/schedule'
 import { S3Client, CreateBucketCommand, ListObjectsV2Command, PutBucketTaggingCommand } from '@aws-sdk/client-s3'
-import { InjectRedis } from '@nestjs-modules/ioredis'
-import { Redis } from 'ioredis'
-import { RedisLockProvider } from '../common/redis-lock.provider'
+import { RedisLockProvider, withRedisLockLease } from '../common/redis-lock.provider'
 import { TypedConfigService } from '../../config/typed-config.service'
 import { deleteS3Bucket } from '../../common/utils/delete-s3-bucket'
 
@@ -40,7 +38,6 @@ export class VolumeManager
     @InjectRepository(Volume)
     private readonly volumeRepository: Repository<Volume>,
     private readonly configService: TypedConfigService,
-    @InjectRedis() private readonly redis: Redis,
     private readonly redisLockProvider: RedisLockProvider,
     private readonly schedulerRegistry: SchedulerRegistry,
   ) {
@@ -133,61 +130,65 @@ export class VolumeManager
       return
     }
 
+    const lockKey = 'process-pending-volumes'
     try {
       // Lock the entire process
-      const lockKey = 'process-pending-volumes'
-      if (!(await this.redisLockProvider.lock(lockKey, 30))) {
+      const lease = await this.redisLockProvider.acquireLease(lockKey, 30)
+      if (!lease) {
         return
       }
 
-      const pendingVolumes = await this.volumeRepository.find({
-        where: {
-          state: In([VolumeState.PENDING_CREATE, VolumeState.PENDING_DELETE]),
-        },
+      await withRedisLockLease(lease, async (signal) => {
+        const pendingVolumes = await this.volumeRepository.find({
+          where: {
+            state: In([VolumeState.PENDING_CREATE, VolumeState.PENDING_DELETE]),
+          },
+        })
+
+        await Promise.all(
+          pendingVolumes.map(async (volume) => {
+            signal.throwIfAborted()
+            if (this.processingVolumes.has(volume.id)) {
+              return
+            }
+
+            // Get lock for this specific volume
+            const volumeLockKey = `${VOLUME_STATE_LOCK_KEY}${volume.id}`
+            const volumeLease = await this.redisLockProvider.acquireLease(volumeLockKey, 30)
+            if (!volumeLease) {
+              return
+            }
+
+            await withRedisLockLease(volumeLease, async (volumeSignal) => {
+              this.processingVolumes.add(volume.id)
+              try {
+                await this.processVolumeState(volume, volumeSignal)
+              } finally {
+                this.processingVolumes.delete(volume.id)
+              }
+            })
+          }),
+        )
       })
-
-      await Promise.all(
-        pendingVolumes.map(async (volume) => {
-          if (this.processingVolumes.has(volume.id)) {
-            return
-          }
-
-          // Get lock for this specific volume
-          const volumeLockKey = `${VOLUME_STATE_LOCK_KEY}${volume.id}`
-          const acquired = await this.redisLockProvider.lock(volumeLockKey, 30)
-          if (!acquired) {
-            return
-          }
-
-          try {
-            this.processingVolumes.add(volume.id)
-            await this.processVolumeState(volume)
-          } finally {
-            this.processingVolumes.delete(volume.id)
-            await this.redisLockProvider.unlock(volumeLockKey)
-          }
-        }),
-      )
-
-      await this.redisLockProvider.unlock(lockKey)
     } catch (error) {
       this.logger.error('Error processing pending volumes:', error)
     }
   }
 
-  private async processVolumeState(volume: Volume): Promise<void> {
-    const volumeLockKey = `${VOLUME_STATE_LOCK_KEY}${volume.id}`
-
+  private async processVolumeState(volume: Volume, signal: AbortSignal): Promise<void> {
     try {
       switch (volume.state) {
         case VolumeState.PENDING_CREATE:
-          await this.handlePendingCreate(volume, volumeLockKey)
+          await this.handlePendingCreate(volume, signal)
           break
         case VolumeState.PENDING_DELETE:
-          await this.handlePendingDelete(volume, volumeLockKey)
+          await this.handlePendingDelete(volume, signal)
           break
       }
     } catch (error) {
+      if (signal.aborted) {
+        throw signal.reason
+      }
       this.logger.error(`Error processing volume ${volume.id}:`, error)
       await this.volumeRepository.update(volume.id, {
         state: VolumeState.ERROR,
@@ -196,26 +197,22 @@ export class VolumeManager
     }
   }
 
-  private async handlePendingCreate(volume: Volume, lockKey: string): Promise<void> {
+  private async handlePendingCreate(volume: Volume, signal: AbortSignal): Promise<void> {
     try {
-      // Refresh lock before state change
-      await this.redis.setex(lockKey, 30, '1')
-
       // Update state to CREATING
       await this.volumeRepository.save({
         ...volume,
         state: VolumeState.CREATING,
       })
 
-      // Refresh lock before S3 operation
-      await this.redis.setex(lockKey, 30, '1')
-
+      signal.throwIfAborted()
       // Create bucket in Minio/S3
       const createBucketCommand = new CreateBucketCommand({
         Bucket: volume.getBucketName(),
       })
 
       await this.s3Client.send(createBucketCommand)
+      signal.throwIfAborted()
 
       await this.s3Client.send(
         new PutBucketTaggingCommand({
@@ -239,9 +236,6 @@ export class VolumeManager
         }),
       )
 
-      // Refresh lock before final state update
-      await this.redis.setex(lockKey, 30, '1')
-
       // Update volume state to READY
       await this.volumeRepository.save({
         ...volume,
@@ -249,6 +243,9 @@ export class VolumeManager
       })
       this.logger.debug(`Volume ${volume.id} created successfully`)
     } catch (error) {
+      if (signal.aborted) {
+        throw signal.reason
+      }
       this.logger.error(`Error creating volume ${volume.id}:`, error)
       await this.volumeRepository.save({
         ...volume,
@@ -258,23 +255,19 @@ export class VolumeManager
     }
   }
 
-  private async handlePendingDelete(volume: Volume, lockKey: string): Promise<void> {
+  private async handlePendingDelete(volume: Volume, signal: AbortSignal): Promise<void> {
     try {
-      // Refresh lock before state change
-      await this.redis.setex(lockKey, 30, '1')
-
       // Update state to DELETING
       await this.volumeRepository.save({
         ...volume,
         state: VolumeState.DELETING,
       })
 
-      // Refresh lock before S3 operation
-      await this.redis.setex(lockKey, 30, '1')
-
+      signal.throwIfAborted()
       // Delete bucket from Minio/S3
       try {
         await deleteS3Bucket(this.s3Client, volume.getBucketName())
+        signal.throwIfAborted()
       } catch (error) {
         if (error.name === 'NoSuchBucket') {
           this.logger.warn(`Bucket for volume ${volume.id} does not exist, treating as already deleted`)
@@ -284,9 +277,6 @@ export class VolumeManager
           throw error
         }
       }
-
-      // Refresh lock before final state update
-      await this.redis.setex(lockKey, 30, '1')
 
       // Delete any existing volume record with the deleted state and the same name in the same organization
       await this.volumeRepository.delete({
@@ -303,6 +293,9 @@ export class VolumeManager
       })
       this.logger.debug(`Volume ${volume.id} deleted successfully`)
     } catch (error) {
+      if (signal.aborted) {
+        throw signal.reason
+      }
       this.logger.error(`Error deleting volume ${volume.id}:`, error)
       await this.volumeRepository.save({
         ...volume,

--- a/apps/api/src/box/services/box-activity.service.ts
+++ b/apps/api/src/box/services/box-activity.service.ts
@@ -9,7 +9,7 @@ import Redis from 'ioredis'
 import { InjectDataSource } from '@nestjs/typeorm'
 import { DataSource, IsNull, Raw } from 'typeorm'
 import { Cron, CronExpression } from '@nestjs/schedule'
-import { RedisLockProvider } from '../common/redis-lock.provider'
+import { RedisLockProvider, withRedisLockLease } from '../common/redis-lock.provider'
 import { BoxLastActivity } from '../entities/box-last-activity.entity'
 import { LogExecution } from '../../common/decorators/log-execution.decorator'
 import { WithInstrumentation } from '../../common/decorators/otel.decorator'
@@ -40,7 +40,7 @@ export class BoxActivityService {
    */
   async updateLastActivityAt(boxId: string, lastActivityAt: Date): Promise<void> {
     const lockKey = `box:update-last-activity:${boxId}`
-    const acquired = await this.redisLockProvider.lock(
+    const acquired = await this.redisLockProvider.lockUntilExpiry(
       lockKey,
       this.configService.getOrThrow('boxActivity.throttleTtlSeconds'),
     )
@@ -78,12 +78,12 @@ export class BoxActivityService {
   async flushActivityToDb(): Promise<void> {
     const lockKey = 'flush-activity-to-db-lock'
     const lockTtl = 30
-    const acquired = await this.redisLockProvider.lock(lockKey, lockTtl)
-    if (!acquired) {
+    const lease = await this.redisLockProvider.acquireLease(lockKey, lockTtl)
+    if (!lease) {
       return
     }
 
-    try {
+    await withRedisLockLease(lease, async (signal) => {
       let totalFlushed = 0
 
       const batchSize = this.configService.getOrThrow('boxActivity.flushBatchSize')
@@ -104,6 +104,7 @@ export class BoxActivityService {
       }
 
       for (let offset = 0; offset < updates.length; offset += batchSize) {
+        signal.throwIfAborted()
         const batch = updates.slice(offset, offset + batchSize)
         await this.bulkUpsertActivity(batch)
         totalFlushed += batch.length
@@ -114,11 +115,9 @@ export class BoxActivityService {
       if (totalFlushed > 0) {
         this.logger.debug(`Flushed ${totalFlushed} activity timestamps to the database`)
       }
-    } catch (error) {
+    }).catch((error) => {
       this.logger.error('Error flushing activity timestamps to the database:', error)
-    } finally {
-      await this.redisLockProvider.unlock(lockKey)
-    }
+    })
   }
 
   /**

--- a/apps/api/src/box/services/box-warm-pool.service.spec.ts
+++ b/apps/api/src/box/services/box-warm-pool.service.spec.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BoxWarmPoolService } from './box-warm-pool.service'
+
+describe('BoxWarmPoolService lease lifecycle', () => {
+  it('waits for already-started top-ups before releasing a lost lease', async () => {
+    const ownershipError = new Error('ownership was lost')
+    const controller = new AbortController()
+    let finishTopUp!: () => void
+    const topUp = new Promise<void>((resolve) => {
+      finishTopUp = resolve
+    })
+    const release = jest.fn().mockResolvedValue(undefined)
+    const eventEmitter = {
+      emitAsync: jest.fn(() => {
+        controller.abort(ownershipError)
+        return topUp
+      }),
+    }
+    const service = new BoxWarmPoolService(
+      { find: jest.fn().mockResolvedValue([{ id: 'pool-1', pool: 2 }]) } as any,
+      { count: jest.fn().mockResolvedValue(0) } as any,
+      {} as any,
+      { acquireLease: jest.fn().mockResolvedValue({ signal: controller.signal, release }) } as any,
+      {} as any,
+      eventEmitter as any,
+      {} as any,
+    )
+
+    const checking = service.warmPoolCheck()
+    while (eventEmitter.emitAsync.mock.calls.length === 0) {
+      await Promise.resolve()
+    }
+    await Promise.resolve()
+    expect(release).not.toHaveBeenCalled()
+
+    finishTopUp()
+    await expect(checking).rejects.toBe(ownershipError)
+    expect(release).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/api/src/box/services/box-warm-pool.service.ts
+++ b/apps/api/src/box/services/box-warm-pool.service.ts
@@ -169,18 +169,23 @@ export class BoxWarmPoolService {
 
           const missingCount = warmPoolItem.pool - boxCount
           if (missingCount > 0) {
-            const promises = []
+            const promises: Promise<unknown>[] = []
             this.logger.debug(`Creating ${missingCount} boxes for warm pool id ${warmPoolItem.id}`)
 
-            for (let i = 0; i < missingCount; i++) {
-              signal.throwIfAborted()
-              promises.push(
-                this.eventEmitter.emitAsync(WarmPoolEvents.TOPUP_REQUESTED, new WarmPoolTopUpRequested(warmPoolItem)),
-              )
+            try {
+              for (let i = 0; i < missingCount; i++) {
+                signal.throwIfAborted()
+                promises.push(
+                  this.eventEmitter.emitAsync(
+                    WarmPoolEvents.TOPUP_REQUESTED,
+                    new WarmPoolTopUpRequested(warmPoolItem),
+                  ),
+                )
+              }
+            } finally {
+              // Started top-ups must finish before the lease is released, including cancellation paths.
+              await Promise.allSettled(promises)
             }
-
-            // Wait for all promises to settle before releasing the lock. Otherwise, another worker could start creating boxes
-            await Promise.allSettled(promises)
           }
         })
       }),

--- a/apps/api/src/box/services/box-warm-pool.service.ts
+++ b/apps/api/src/box/services/box-warm-pool.service.ts
@@ -144,7 +144,7 @@ export class BoxWarmPoolService {
     await Promise.all(
       warmPoolItems.map(async (warmPoolItem) => {
         const lockKey = `warm-pool-lock-${warmPoolItem.id}`
-        const lease = await this.redisLockProvider.acquireLease(lockKey, 720)
+        const lease = await this.redisLockProvider.acquireLease(lockKey, 30)
         if (!lease) {
           return
         }

--- a/apps/api/src/box/services/box-warm-pool.service.ts
+++ b/apps/api/src/box/services/box-warm-pool.service.ts
@@ -8,7 +8,7 @@ import { Inject, Injectable, Logger } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Cron, CronExpression } from '@nestjs/schedule'
 import { In, MoreThan, Not, Repository } from 'typeorm'
-import { RedisLockProvider } from '../common/redis-lock.provider'
+import { RedisLockProvider, withRedisLockLease } from '../common/redis-lock.provider'
 import { BoxRepository } from '../repositories/box.repository'
 import { Box } from '../entities/box.entity'
 import { BOX_WARM_POOL_UNASSIGNED_ORGANIZATION } from '../constants/box.constants'
@@ -117,7 +117,7 @@ export class BoxWarmPoolService {
       let warmPoolBox: Box | null = null
       for (const box of warmPoolBoxes) {
         const lockKey = `box-warm-pool-${box.id}`
-        if (!(await this.redisLockProvider.lock(lockKey, 10))) {
+        if (!(await this.redisLockProvider.lockUntilExpiry(lockKey, 10))) {
           continue
         }
 
@@ -144,43 +144,45 @@ export class BoxWarmPoolService {
     await Promise.all(
       warmPoolItems.map(async (warmPoolItem) => {
         const lockKey = `warm-pool-lock-${warmPoolItem.id}`
-        if (!(await this.redisLockProvider.lock(lockKey, 720))) {
+        const lease = await this.redisLockProvider.acquireLease(lockKey, 720)
+        if (!lease) {
           return
         }
 
-        const boxCount = await this.boxRepository.count({
-          where: {
-            organizationId: BOX_WARM_POOL_UNASSIGNED_ORGANIZATION,
-            image: warmPoolItem.image,
-            class: warmPoolItem.class,
-            osUser: warmPoolItem.osUser,
-            env: warmPoolItem.env,
-            region: warmPoolItem.target,
-            cpu: warmPoolItem.cpu,
-            gpu: warmPoolItem.gpu,
-            mem: warmPoolItem.mem,
-            disk: warmPoolItem.disk,
-            desiredState: BoxDesiredState.STARTED,
-            state: Not(In([BoxState.ERROR])),
-          },
-        })
+        await withRedisLockLease(lease, async (signal) => {
+          const boxCount = await this.boxRepository.count({
+            where: {
+              organizationId: BOX_WARM_POOL_UNASSIGNED_ORGANIZATION,
+              image: warmPoolItem.image,
+              class: warmPoolItem.class,
+              osUser: warmPoolItem.osUser,
+              env: warmPoolItem.env,
+              region: warmPoolItem.target,
+              cpu: warmPoolItem.cpu,
+              gpu: warmPoolItem.gpu,
+              mem: warmPoolItem.mem,
+              disk: warmPoolItem.disk,
+              desiredState: BoxDesiredState.STARTED,
+              state: Not(In([BoxState.ERROR])),
+            },
+          })
 
-        const missingCount = warmPoolItem.pool - boxCount
-        if (missingCount > 0) {
-          const promises = []
-          this.logger.debug(`Creating ${missingCount} boxes for warm pool id ${warmPoolItem.id}`)
+          const missingCount = warmPoolItem.pool - boxCount
+          if (missingCount > 0) {
+            const promises = []
+            this.logger.debug(`Creating ${missingCount} boxes for warm pool id ${warmPoolItem.id}`)
 
-          for (let i = 0; i < missingCount; i++) {
-            promises.push(
-              this.eventEmitter.emitAsync(WarmPoolEvents.TOPUP_REQUESTED, new WarmPoolTopUpRequested(warmPoolItem)),
-            )
+            for (let i = 0; i < missingCount; i++) {
+              signal.throwIfAborted()
+              promises.push(
+                this.eventEmitter.emitAsync(WarmPoolEvents.TOPUP_REQUESTED, new WarmPoolTopUpRequested(warmPoolItem)),
+              )
+            }
+
+            // Wait for all promises to settle before releasing the lock. Otherwise, another worker could start creating boxes
+            await Promise.allSettled(promises)
           }
-
-          // Wait for all promises to settle before releasing the lock. Otherwise, another worker could start creating boxes
-          await Promise.allSettled(promises)
-        }
-
-        await this.redisLockProvider.unlock(lockKey)
+        })
       }),
     )
   }

--- a/apps/api/src/box/services/box.service.spec.ts
+++ b/apps/api/src/box/services/box.service.spec.ts
@@ -218,6 +218,30 @@ describe('BoxService.ensureStartedForProxy', () => {
     expect(eventEmitter.emit).not.toHaveBeenCalled()
   })
 
+  it('preserves the conditional-start error when quota rollback also fails', async () => {
+    const { service, boxRepository, organizationUsageService } = makeService()
+    const startError = new Error('db connection lost')
+    jest.spyOn(service, 'findOneByIdOrName').mockResolvedValue(stoppedBox as any)
+    boxRepository.conditionalStartForProxy.mockRejectedValue(startError)
+    organizationUsageService.rollbackPendingUsage.mockRejectedValue(new Error('quota rollback failed'))
+
+    await expect(service.ensureStartedForProxy('box-1', activeOrg)).rejects.toBe(startError)
+  })
+
+  it('preserves lease cancellation when quota rollback also fails after a lost race', async () => {
+    const { service, boxRepository, organizationUsageService } = makeService()
+    const ownershipError = new Error('ownership was lost')
+    const controller = new AbortController()
+    jest.spyOn(service, 'findOneByIdOrName').mockResolvedValue(stoppedBox as any)
+    boxRepository.conditionalStartForProxy.mockImplementation(async () => {
+      controller.abort(ownershipError)
+      return null
+    })
+    organizationUsageService.rollbackPendingUsage.mockRejectedValue(new Error('quota rollback failed'))
+
+    await expect(service.ensureStartedForProxy('box-1', activeOrg, controller.signal)).rejects.toBe(ownershipError)
+  })
+
   it('rejects auto-resume when the org is over quota and does not start the box', async () => {
     const { service, boxRepository, organizationUsageService } = makeService()
     jest.spyOn(service, 'findOneByIdOrName').mockResolvedValue(stoppedBox as any)

--- a/apps/api/src/box/services/box.service.spec.ts
+++ b/apps/api/src/box/services/box.service.spec.ts
@@ -226,6 +226,7 @@ describe('BoxService.ensureStartedForProxy', () => {
     organizationUsageService.rollbackPendingUsage.mockRejectedValue(new Error('quota rollback failed'))
 
     await expect(service.ensureStartedForProxy('box-1', activeOrg)).rejects.toBe(startError)
+    expect(organizationUsageService.rollbackPendingUsage).toHaveBeenCalledTimes(1)
   })
 
   it('preserves lease cancellation when quota rollback also fails after a lost race', async () => {
@@ -240,6 +241,7 @@ describe('BoxService.ensureStartedForProxy', () => {
     organizationUsageService.rollbackPendingUsage.mockRejectedValue(new Error('quota rollback failed'))
 
     await expect(service.ensureStartedForProxy('box-1', activeOrg, controller.signal)).rejects.toBe(ownershipError)
+    expect(organizationUsageService.rollbackPendingUsage).toHaveBeenCalledTimes(1)
   })
 
   it('rejects auto-resume when the org is over quota and does not start the box', async () => {

--- a/apps/api/src/box/services/box.service.ts
+++ b/apps/api/src/box/services/box.service.ts
@@ -923,13 +923,31 @@ export class BoxService {
       signal?.throwIfAborted()
       updated = await this.boxRepository.conditionalStartForProxy(box.id, organization.id)
     } catch (error) {
-      await this.organizationUsageService.rollbackPendingUsage(organization.id, quotaReservation)
+      try {
+        await this.organizationUsageService.rollbackPendingUsage(organization.id, quotaReservation)
+      } catch (rollbackError) {
+        this.logger.error(`Failed to roll back quota reservation for box ${box.id}`, rollbackError)
+      }
       throw error
     }
 
     if (!updated) {
-      await this.organizationUsageService.rollbackPendingUsage(organization.id, quotaReservation)
-      signal?.throwIfAborted()
+      let rollbackError: unknown
+      try {
+        await this.organizationUsageService.rollbackPendingUsage(organization.id, quotaReservation)
+      } catch (error) {
+        rollbackError = error
+      }
+
+      if (signal?.aborted) {
+        if (rollbackError) {
+          this.logger.error(`Failed to roll back quota reservation for box ${box.id}`, rollbackError)
+        }
+        throw signal.reason
+      }
+      if (rollbackError) {
+        throw rollbackError
+      }
       return this.findOneByIdOrName(box.id, organization.id)
     }
 

--- a/apps/api/src/box/services/box.service.ts
+++ b/apps/api/src/box/services/box.service.ts
@@ -893,9 +893,15 @@ export class BoxService {
    * states are returned unchanged so the caller can wait and retry. Unexpected
    * database errors propagate; AutoResume must never proxy before readiness.
    */
-  async ensureStartedForProxy(boxIdOrName: string, organization: Organization): Promise<Box> {
+  async ensureStartedForProxy(
+    boxIdOrName: string,
+    organization: Organization,
+    signal?: AbortSignal,
+  ): Promise<Box> {
+    signal?.throwIfAborted()
     this.organizationService.assertOrganizationIsNotSuspended(organization)
     const box = await this.findOneByIdOrName(boxIdOrName, organization.id)
+    signal?.throwIfAborted()
 
     if (box.state !== BoxState.STOPPED || box.desiredState !== BoxDesiredState.STOPPED || box.pending) {
       return box
@@ -914,6 +920,7 @@ export class BoxService {
 
     let updated: Box
     try {
+      signal?.throwIfAborted()
       updated = await this.boxRepository.conditionalStartForProxy(box.id, organization.id)
     } catch (error) {
       await this.organizationUsageService.rollbackPendingUsage(organization.id, quotaReservation)
@@ -922,6 +929,7 @@ export class BoxService {
 
     if (!updated) {
       await this.organizationUsageService.rollbackPendingUsage(organization.id, quotaReservation)
+      signal?.throwIfAborted()
       return this.findOneByIdOrName(box.id, organization.id)
     }
 

--- a/apps/api/src/box/services/job-state-handler.service.spec.ts
+++ b/apps/api/src/box/services/job-state-handler.service.spec.ts
@@ -10,41 +10,8 @@ import { JobType } from '../enums/job-type.enum'
 import { ResourceType } from '../enums/resource-type.enum'
 import { BoxState } from '../enums/box-state.enum'
 import { BoxDesiredState } from '../enums/box-desired-state.enum'
-import { RedisLockProvider } from '../common/redis-lock.provider'
 
 describe('JobStateHandlerService RESIZE_BOX completion', () => {
-  it('does not release a state-change lock acquired after the job was dispatched', async () => {
-    let currentOwner: string | null = 'new-request-owner'
-    const redis = {
-      get: jest.fn(async () => currentOwner),
-      eval: jest.fn(async (_script: string, _keys: number, _key: string, owner: string) => {
-        if (currentOwner === owner) {
-          currentOwner = null
-          return 1
-        }
-        return 0
-      }),
-    } as any
-    const redisLockProvider = new RedisLockProvider(redis)
-    const boxRepository = {
-      findOne: jest.fn().mockResolvedValue(undefined),
-    } as any
-    const service = new (JobStateHandlerService as any)(boxRepository, redisLockProvider)
-    const job = new Job({
-      id: 'job-from-prior-request',
-      type: JobType.START_BOX,
-      status: JobStatus.COMPLETED,
-      runnerId: 'runner-1',
-      resourceType: ResourceType.BOX,
-      resourceId: 'box-1',
-    })
-
-    await service.handleJobCompletion(job)
-    await new Promise((resolve) => setImmediate(resolve))
-
-    expect(currentOwner).toBe('new-request-owner')
-  })
-
   it('persists completed V2 resize resources and restores the prior state', async () => {
     const box = {
       id: 'box-1',

--- a/apps/api/src/box/services/job-state-handler.service.spec.ts
+++ b/apps/api/src/box/services/job-state-handler.service.spec.ts
@@ -10,8 +10,41 @@ import { JobType } from '../enums/job-type.enum'
 import { ResourceType } from '../enums/resource-type.enum'
 import { BoxState } from '../enums/box-state.enum'
 import { BoxDesiredState } from '../enums/box-desired-state.enum'
+import { RedisLockProvider } from '../common/redis-lock.provider'
 
 describe('JobStateHandlerService RESIZE_BOX completion', () => {
+  it('does not release a state-change lock acquired after the job was dispatched', async () => {
+    let currentOwner: string | null = 'new-request-owner'
+    const redis = {
+      get: jest.fn(async () => currentOwner),
+      eval: jest.fn(async (_script: string, _keys: number, _key: string, owner: string) => {
+        if (currentOwner === owner) {
+          currentOwner = null
+          return 1
+        }
+        return 0
+      }),
+    } as any
+    const redisLockProvider = new RedisLockProvider(redis)
+    const boxRepository = {
+      findOne: jest.fn().mockResolvedValue(undefined),
+    } as any
+    const service = new (JobStateHandlerService as any)(boxRepository, redisLockProvider)
+    const job = new Job({
+      id: 'job-from-prior-request',
+      type: JobType.START_BOX,
+      status: JobStatus.COMPLETED,
+      runnerId: 'runner-1',
+      resourceType: ResourceType.BOX,
+      resourceId: 'box-1',
+    })
+
+    await service.handleJobCompletion(job)
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(currentOwner).toBe('new-request-owner')
+  })
+
   it('persists completed V2 resize resources and restores the prior state', async () => {
     const box = {
       id: 'box-1',
@@ -25,10 +58,7 @@ describe('JobStateHandlerService RESIZE_BOX completion', () => {
       findOne: jest.fn().mockResolvedValue(box),
       update: jest.fn().mockResolvedValue(undefined),
     } as any
-    const redisLockProvider = {
-      unlock: jest.fn().mockResolvedValue(undefined),
-    } as any
-    const service = new JobStateHandlerService(boxRepository, redisLockProvider)
+    const service = new JobStateHandlerService(boxRepository)
     const job = new Job({
       id: 'job-1',
       type: JobType.RESIZE_BOX,

--- a/apps/api/src/box/services/job-state-handler.service.ts
+++ b/apps/api/src/box/services/job-state-handler.service.ts
@@ -13,9 +13,6 @@ import { BoxDesiredState } from '../enums/box-desired-state.enum'
 import { sanitizeBoxError } from '../utils/sanitize-error.util'
 import { BoxRepository } from '../repositories/box.repository'
 import { Box } from '../entities/box.entity'
-import { RedisLockProvider } from '../common/redis-lock.provider'
-import { ResourceType } from '../enums/resource-type.enum'
-import { getStateChangeLockKey } from '../utils/lock-key.util'
 
 /**
  * Service for handling entity state updates based on job completion (v2 runners only).
@@ -25,10 +22,7 @@ import { getStateChangeLockKey } from '../utils/lock-key.util'
 export class JobStateHandlerService {
   private readonly logger = new Logger(JobStateHandlerService.name)
 
-  constructor(
-    private readonly boxRepository: BoxRepository,
-    private readonly redisLockProvider: RedisLockProvider,
-  ) {}
+  constructor(private readonly boxRepository: BoxRepository) {}
 
   /**
    * Handle job completion and update entity state accordingly.
@@ -64,18 +58,6 @@ export class JobStateHandlerService {
       case JobType.RECOVER_BOX:
         await this.handleRecoverBoxJobCompletion(job)
         break
-      default:
-        break
-    }
-
-    switch (job.resourceType) {
-      case ResourceType.BOX: {
-        const lockKey = getStateChangeLockKey(job.resourceId)
-        this.redisLockProvider
-          .unlock(lockKey)
-          .catch((error) => this.logger.error(`Error unlocking Redis lock for box ${job.resourceId}:`, error)) // Clean up lock after job completion
-        break
-      }
       default:
         break
     }

--- a/apps/api/src/box/services/runner.service.spec.ts
+++ b/apps/api/src/box/services/runner.service.spec.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { RunnerState } from '../enums/runner-state.enum'
+import { RunnerService } from './runner.service'
+
+describe('RunnerService lease cancellation', () => {
+  const makeService = () => {
+    const service = Object.create(RunnerService.prototype) as RunnerService
+    Object.assign(service as any, {
+      logger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn(), log: jest.fn() },
+      eventEmitter: { emit: jest.fn() },
+      dataSource: {},
+      serviceStartTime: new Date(Date.now() - 120_000),
+    })
+    return service
+  }
+
+  it('does not update a stale v2 runner when ownership is lost during lookup', async () => {
+    const ownershipError = new Error('ownership was lost')
+    const controller = new AbortController()
+    const runner = {
+      id: 'runner-1',
+      apiVersion: '2',
+      state: RunnerState.READY,
+      lastChecked: new Date(Date.now() - 120_000),
+    }
+    const service = makeService()
+    Object.assign(service as any, {
+      findOne: jest.fn(async () => {
+        controller.abort(ownershipError)
+        return runner
+      }),
+      updateRunner: jest.fn().mockResolvedValue(undefined),
+    })
+
+    await expect((service as any).checkRunnerV2Health(runner, controller.signal)).rejects.toBe(ownershipError)
+    expect((service as any).updateRunner).not.toHaveBeenCalled()
+  })
+
+  it('propagates a v2 runner update failure after all runner work settles', async () => {
+    const updateError = new Error('runner update failed')
+    const release = jest.fn().mockResolvedValue(undefined)
+    const runner = {
+      id: 'runner-1',
+      apiVersion: '2',
+      state: RunnerState.READY,
+      lastChecked: new Date(Date.now() - 120_000),
+    }
+    const service = makeService()
+    Object.assign(service as any, {
+      runnerRepository: { find: jest.fn().mockResolvedValue([runner]) },
+      redisLockProvider: { acquireLease: jest.fn().mockResolvedValue({ release }) },
+      findOne: jest.fn().mockResolvedValue(runner),
+      updateRunner: jest.fn().mockRejectedValue(updateError),
+    })
+
+    await expect((service as any).handleCheckRunners()).rejects.toBe(updateError)
+    expect(release).toHaveBeenCalledTimes(1)
+  })
+
+  it('propagates lease cancellation to an in-flight v0 health request', async () => {
+    const ownershipError = new Error('ownership was lost')
+    const controller = new AbortController()
+    const release = jest.fn().mockResolvedValue(undefined)
+    let healthSignal: AbortSignal | undefined
+    const service = makeService()
+    Object.assign(service as any, {
+      runnerRepository: {
+        find: jest.fn().mockResolvedValue([
+          { id: 'runner-1', apiVersion: '0', state: RunnerState.UNRESPONSIVE },
+        ]),
+      },
+      redisLockProvider: {
+        acquireLease: jest.fn().mockResolvedValue({ signal: controller.signal, release }),
+      },
+      runnerAdapterFactory: {
+        create: jest.fn().mockResolvedValue({
+          healthCheck: jest.fn(async (signal: AbortSignal) => {
+            healthSignal = signal
+            controller.abort(ownershipError)
+            signal.throwIfAborted()
+          }),
+        }),
+      },
+      configService: { get: jest.fn().mockReturnValue(60) },
+    })
+
+    await expect((service as any).handleCheckRunners()).rejects.toBe(ownershipError)
+
+    expect(healthSignal?.aborted).toBe(true)
+    expect(release).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not mutate draining state after ownership is lost during the box count', async () => {
+    const ownershipError = new Error('ownership was lost')
+    const controller = new AbortController()
+    const release = jest.fn().mockResolvedValue(undefined)
+    const service = makeService()
+    const redis = { get: jest.fn(), set: jest.fn(), del: jest.fn() }
+    Object.assign(service as any, {
+      runnerRepository: {
+        find: jest.fn().mockResolvedValue([{ id: 'runner-1', draining: true, state: RunnerState.READY }]),
+      },
+      boxRepository: {
+        count: jest.fn(async () => {
+          controller.abort(ownershipError)
+          return 0
+        }),
+      },
+      redisLockProvider: {
+        acquireLease: jest.fn().mockResolvedValue({ signal: controller.signal, release }),
+      },
+      redis,
+      updateRunner: jest.fn(),
+    })
+
+    await expect((service as any).handleCheckDecommissionRunners()).rejects.toBe(ownershipError)
+
+    expect(redis.get).not.toHaveBeenCalled()
+    expect(redis.set).not.toHaveBeenCalled()
+    expect(redis.del).not.toHaveBeenCalled()
+    expect((service as any).updateRunner).not.toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/box/services/runner.service.ts
+++ b/apps/api/src/box/services/runner.service.ts
@@ -25,7 +25,7 @@ import { BadRequestError } from '../../exceptions/bad-request.exception'
 import { EventEmitter2 } from '@nestjs/event-emitter'
 import { BoxState } from '../enums/box-state.enum'
 import { RunnerAdapterFactory, RunnerInfo } from '../runner-adapter/runnerAdapter'
-import { RedisLockProvider } from '../common/redis-lock.provider'
+import { RedisLockProvider, withRedisLockLease } from '../common/redis-lock.provider'
 import { TypedConfigService } from '../../config/typed-config.service'
 import { LogExecution } from '../../common/decorators/log-execution.decorator'
 import { WithInstrumentation } from '../../common/decorators/otel.decorator'
@@ -482,12 +482,12 @@ export class RunnerService {
   @WithInstrumentation()
   private async handleCheckRunners() {
     const lockKey = 'check-runners'
-    const hasLock = await this.redisLockProvider.lock(lockKey, 60)
-    if (!hasLock) {
+    const lease = await this.redisLockProvider.acquireLease(lockKey, 60)
+    if (!lease) {
       return
     }
 
-    try {
+    await withRedisLockLease(lease, async (signal) => {
       const runners = await this.runnerRepository.find({
         where: [
           {
@@ -511,6 +511,7 @@ export class RunnerService {
 
       await Promise.allSettled(
         runners.map(async (runner) => {
+          signal.throwIfAborted()
           // v2 runners report health via healthcheck endpoint, check based on lastChecked timestamp
           if (runner.apiVersion === '2') {
             await this.checkRunnerV2Health(runner)
@@ -522,6 +523,7 @@ export class RunnerService {
           const retryDelays = shouldRetry ? [500, 1000] : []
 
           for (let attempt = 0; attempt <= retryDelays.length; attempt++) {
+            signal.throwIfAborted()
             if (attempt > 0) {
               await new Promise((resolve) => setTimeout(resolve, retryDelays[attempt - 1]))
             }
@@ -593,9 +595,7 @@ export class RunnerService {
           }
         }),
       )
-    } finally {
-      await this.redisLockProvider.unlock(lockKey)
-    }
+    })
   }
 
   /**
@@ -642,12 +642,12 @@ export class RunnerService {
   @WithInstrumentation()
   private async handleCheckDecommissionRunners() {
     const lockKey = 'check-decommission-runners'
-    const hasLock = await this.redisLockProvider.lock(lockKey, 60)
-    if (!hasLock) {
+    const lease = await this.redisLockProvider.acquireLease(lockKey, 60)
+    if (!lease) {
       return
     }
 
-    try {
+    await withRedisLockLease(lease, async (signal) => {
       const drainingRunners = await this.runnerRepository.find({
         where: {
           draining: true,
@@ -660,6 +660,7 @@ export class RunnerService {
       await Promise.allSettled(
         drainingRunners.map(async (runner) => {
           try {
+            signal.throwIfAborted()
             // Check if runner has any boxes with desiredState != DESTROYED
             const nonDestroyedBoxCount = await this.boxRepository.count({
               where: {
@@ -700,9 +701,7 @@ export class RunnerService {
           }
         }),
       )
-    } finally {
-      await this.redisLockProvider.unlock(lockKey)
-    }
+    })
   }
 
   async updateSchedulingStatus(id: string, unschedulable: boolean): Promise<Runner> {

--- a/apps/api/src/box/services/runner.service.ts
+++ b/apps/api/src/box/services/runner.service.ts
@@ -44,6 +44,7 @@ import { BoxDesiredState } from '../enums/box-desired-state.enum'
 import { runnerLookupCacheKeyById, RUNNER_LOOKUP_CACHE_TTL_MS } from '../utils/runner-lookup-cache.util'
 import { BoxRepository } from '../repositories/box.repository'
 import { RunnerServiceInfo } from '../common/runner-service-info'
+import { setTimeout as sleep } from 'timers/promises'
 
 @Injectable()
 export class RunnerService {
@@ -370,8 +371,10 @@ export class RunnerService {
       diskGiB?: number
     },
     appVersion?: string,
+    signal?: AbortSignal,
   ): Promise<void> {
     const runner = await this.findOne(runnerId)
+    signal?.throwIfAborted()
     if (!runner) {
       this.logger.error(`Runner ${runnerId} not found when trying to update health`)
       return
@@ -447,17 +450,20 @@ export class RunnerService {
       })
     }
 
+    signal?.throwIfAborted()
     await this.updateRunner(runnerId, updateData)
     this.logger.debug(`Updated health for runner ${runnerId}`)
 
+    signal?.throwIfAborted()
     this.eventEmitter.emit(
       RunnerEvents.STATE_UPDATED,
       new RunnerStateUpdatedEvent(runner, runner.state, updateData.state),
     )
   }
 
-  private async updateRunnerState(runnerId: string, newState: RunnerState): Promise<void> {
+  private async updateRunnerState(runnerId: string, newState: RunnerState, signal: AbortSignal): Promise<void> {
     const runner = await this.findOne(runnerId)
+    signal.throwIfAborted()
     if (!runner) {
       this.logger.error(`Runner ${runnerId} not found when trying to update state`)
       return
@@ -469,11 +475,13 @@ export class RunnerService {
       return
     }
 
+    signal.throwIfAborted()
     await this.updateRunner(runnerId, {
       state: newState,
       lastChecked: new Date(),
     })
 
+    signal.throwIfAborted()
     this.eventEmitter.emit(RunnerEvents.STATE_UPDATED, new RunnerStateUpdatedEvent(runner, runner.state, newState))
   }
 
@@ -509,12 +517,12 @@ export class RunnerService {
         take: 100,
       })
 
-      await Promise.allSettled(
+      const results = await Promise.allSettled(
         runners.map(async (runner) => {
           signal.throwIfAborted()
           // v2 runners report health via healthcheck endpoint, check based on lastChecked timestamp
           if (runner.apiVersion === '2') {
-            await this.checkRunnerV2Health(runner)
+            await this.checkRunnerV2Health(runner, signal)
             return
           }
 
@@ -525,10 +533,15 @@ export class RunnerService {
           for (let attempt = 0; attempt <= retryDelays.length; attempt++) {
             signal.throwIfAborted()
             if (attempt > 0) {
-              await new Promise((resolve) => setTimeout(resolve, retryDelays[attempt - 1]))
+              await sleep(retryDelays[attempt - 1], undefined, { signal })
             }
 
             const abortController = new AbortController()
+            const abortHealthCheck = () => abortController.abort(signal.reason)
+            signal.addEventListener('abort', abortHealthCheck, { once: true })
+            if (signal.aborted) {
+              abortHealthCheck()
+            }
             let timeoutId: NodeJS.Timeout | null = null
 
             const runnerHealthTimeoutSeconds = this.configService.get('runnerHealthTimeout')
@@ -548,6 +561,7 @@ export class RunnerService {
                     this.logger.warn(`Failed to get runner info for runner ${runner.id}: ${e.message}`)
                   }
 
+                  signal.throwIfAborted()
                   await this.updateRunnerHealth(
                     runner.id,
                     undefined,
@@ -556,6 +570,7 @@ export class RunnerService {
                     runnerInfo?.serviceHealth,
                     runnerInfo?.metrics,
                     runnerInfo?.appVersion,
+                    signal,
                   )
                 })(),
                 new Promise((_, reject) => {
@@ -575,7 +590,9 @@ export class RunnerService {
                 clearTimeout(timeoutId)
               }
 
-              if (e.message === 'Health check timeout') {
+              if (signal.aborted) {
+                throw signal.reason
+              } else if (e.message === 'Health check timeout') {
                 this.logger.error(
                   `Runner ${runner.id} health check timed out after ${runnerHealthTimeoutSeconds} seconds`,
                 )
@@ -589,12 +606,20 @@ export class RunnerService {
 
               // If last attempt, mark as unresponsive
               if (attempt === retryDelays.length) {
-                await this.updateRunnerState(runner.id, RunnerState.UNRESPONSIVE)
+                signal.throwIfAborted()
+                await this.updateRunnerState(runner.id, RunnerState.UNRESPONSIVE, signal)
               }
+            } finally {
+              signal.removeEventListener('abort', abortHealthCheck)
             }
           }
         }),
       )
+      signal.throwIfAborted()
+      const rejected = results.find((result): result is PromiseRejectedResult => result.status === 'rejected')
+      if (rejected) {
+        throw rejected.reason
+      }
     })
   }
 
@@ -602,12 +627,13 @@ export class RunnerService {
    * Check v2 runner health based on lastChecked timestamp.
    * v2 runners report health via the healthcheck endpoint, so we check if lastChecked is within threshold.
    */
-  private async checkRunnerV2Health(runner: Runner): Promise<void> {
+  private async checkRunnerV2Health(runner: Runner, signal: AbortSignal): Promise<void> {
     const markAsUnresponsive = async () => {
       this.logger.warn(
         `v2 Runner ${runner.id} health check stale (last: ${Math.round((Date.now() - runner.lastChecked.getTime()) / 1000)}s ago), marking as UNRESPONSIVE`,
       )
-      await this.updateRunnerState(runner.id, RunnerState.UNRESPONSIVE)
+      signal.throwIfAborted()
+      await this.updateRunnerState(runner.id, RunnerState.UNRESPONSIVE, signal)
     }
 
     if (!runner.lastChecked) {
@@ -657,7 +683,7 @@ export class RunnerService {
 
       this.logger.debug(`Checking ${drainingRunners.length} draining runners`)
 
-      await Promise.allSettled(
+      const results = await Promise.allSettled(
         drainingRunners.map(async (runner) => {
           try {
             signal.throwIfAborted()
@@ -668,6 +694,7 @@ export class RunnerService {
                 desiredState: Not(BoxDesiredState.DESTROYED),
               },
             })
+            signal.throwIfAborted()
 
             const redisKey = `runner:draining-check:${runner.id}`
 
@@ -680,10 +707,12 @@ export class RunnerService {
             } else {
               // Increment counter
               const currentCount = await this.redis.get(redisKey)
+              signal.throwIfAborted()
               const count = currentCount ? parseInt(currentCount, 10) + 1 : 1
 
               if (count >= 3) {
                 // Decommission the runner
+                signal.throwIfAborted()
                 await this.updateRunner(runner.id, {
                   state: RunnerState.DECOMMISSIONED,
                 })
@@ -697,10 +726,18 @@ export class RunnerService {
               }
             }
           } catch (e) {
+            if (signal.aborted) {
+              throw signal.reason
+            }
             this.logger.error(`Error checking draining runner ${runner.id}`, e)
           }
         }),
       )
+      signal.throwIfAborted()
+      const rejected = results.find((result): result is PromiseRejectedResult => result.status === 'rejected')
+      if (rejected) {
+        throw rejected.reason
+      }
     })
   }
 

--- a/apps/api/src/box/services/runner.service.ts
+++ b/apps/api/src/box/services/runner.service.ts
@@ -454,7 +454,8 @@ export class RunnerService {
     await this.updateRunner(runnerId, updateData)
     this.logger.debug(`Updated health for runner ${runnerId}`)
 
-    signal?.throwIfAborted()
+    // Persistence and its domain event are one logical side effect. Once the
+    // write succeeds, always emit so downstream state cannot miss the change.
     this.eventEmitter.emit(
       RunnerEvents.STATE_UPDATED,
       new RunnerStateUpdatedEvent(runner, runner.state, updateData.state),
@@ -481,7 +482,6 @@ export class RunnerService {
       lastChecked: new Date(),
     })
 
-    signal.throwIfAborted()
     this.eventEmitter.emit(RunnerEvents.STATE_UPDATED, new RunnerStateUpdatedEvent(runner, runner.state, newState))
   }
 

--- a/apps/api/src/box/services/volume.service.ts
+++ b/apps/api/src/box/services/volume.service.ts
@@ -225,7 +225,7 @@ export class VolumeService {
       const results = await Promise.allSettled(
         volumes.map(async (volume) => {
           // Update once per minute at most
-          if (!(await this.redisLockProvider.lock(`volume:${volume.id}:update-last-used`, 60))) {
+          if (!(await this.redisLockProvider.lockUntilExpiry(`volume:${volume.id}:update-last-used`, 60))) {
             return
           }
           volume.lastUsedAt = event.box.createdAt

--- a/apps/api/src/boxlite-rest/box-auto-resume.service.spec.ts
+++ b/apps/api/src/boxlite-rest/box-auto-resume.service.spec.ts
@@ -16,20 +16,22 @@ function makeHarness(initial: Record<string, unknown>) {
     waitForStopped: jest.fn().mockResolvedValue({ state: BoxState.STOPPED }),
   }
   const redisLockProvider = {
-    lock: jest.fn().mockResolvedValue(true),
-    unlock: jest.fn().mockResolvedValue(undefined),
+    acquireLease: jest.fn(),
   }
+  const release = jest.fn().mockResolvedValue(undefined)
+  redisLockProvider.acquireLease.mockResolvedValue({ release })
   return {
     service: new BoxAutoResumeService(boxService as never, waiter as never, redisLockProvider as never),
     boxService,
     waiter,
     redisLockProvider,
+    release,
   }
 }
 
 describe('BoxAutoResumeService', () => {
   it('returns immediately for an already STARTED box', async () => {
-    const { service, waiter, redisLockProvider } = makeHarness({
+    const { service, waiter, redisLockProvider, release } = makeHarness({
       id: 'box-1',
       state: BoxState.STARTED,
       desiredState: BoxDesiredState.STARTED,
@@ -37,8 +39,8 @@ describe('BoxAutoResumeService', () => {
 
     await service.ensureReady('box-1', organization)
     expect(waiter.waitForStarted).not.toHaveBeenCalled()
-    expect(redisLockProvider.lock).toHaveBeenCalledWith('box:box-1:state-change', 30)
-    expect(redisLockProvider.unlock).toHaveBeenCalledWith('box:box-1:state-change')
+    expect(redisLockProvider.acquireLease).toHaveBeenCalledWith('box:box-1:state-change', 30)
+    expect(release).toHaveBeenCalled()
   })
 
   it('joins an in-flight Start and waits for STARTED', async () => {

--- a/apps/api/src/boxlite-rest/box-auto-resume.service.spec.ts
+++ b/apps/api/src/boxlite-rest/box-auto-resume.service.spec.ts
@@ -16,22 +16,24 @@ function makeHarness(initial: Record<string, unknown>) {
     waitForStopped: jest.fn().mockResolvedValue({ state: BoxState.STOPPED }),
   }
   const redisLockProvider = {
-    acquireLease: jest.fn(),
+    waitForLock: jest.fn(),
   }
   const release = jest.fn().mockResolvedValue(undefined)
-  redisLockProvider.acquireLease.mockResolvedValue({ release })
+  const signal = new AbortController().signal
+  redisLockProvider.waitForLock.mockResolvedValue({ signal, release })
   return {
     service: new BoxAutoResumeService(boxService as never, waiter as never, redisLockProvider as never),
     boxService,
     waiter,
     redisLockProvider,
     release,
+    signal,
   }
 }
 
 describe('BoxAutoResumeService', () => {
   it('returns immediately for an already STARTED box', async () => {
-    const { service, waiter, redisLockProvider, release } = makeHarness({
+    const { service, boxService, waiter, redisLockProvider, release, signal } = makeHarness({
       id: 'box-1',
       state: BoxState.STARTED,
       desiredState: BoxDesiredState.STARTED,
@@ -39,7 +41,8 @@ describe('BoxAutoResumeService', () => {
 
     await service.ensureReady('box-1', organization)
     expect(waiter.waitForStarted).not.toHaveBeenCalled()
-    expect(redisLockProvider.acquireLease).toHaveBeenCalledWith('box:box-1:state-change', 30)
+    expect(redisLockProvider.waitForLock).toHaveBeenCalledWith('box:box-1:state-change', 30, { timeoutMs: 30_000 })
+    expect(boxService.ensureStartedForProxy).toHaveBeenCalledWith('box-1', organization, signal)
     expect(release).toHaveBeenCalled()
   })
 

--- a/apps/api/src/boxlite-rest/box-auto-resume.service.ts
+++ b/apps/api/src/boxlite-rest/box-auto-resume.service.ts
@@ -6,7 +6,7 @@
 import { Injectable, RequestTimeoutException } from '@nestjs/common'
 import { BoxService } from '../box/services/box.service'
 import { BoxStateWaiterService } from '../box/services/box-state-waiter.service'
-import { RedisLockProvider } from '../box/common/redis-lock.provider'
+import { RedisLockProvider, withRedisLockLease } from '../box/common/redis-lock.provider'
 import { getStateChangeLockKey } from '../box/utils/lock-key.util'
 import { Box } from '../box/entities/box.entity'
 import { BoxState } from '../box/enums/box-state.enum'
@@ -43,17 +43,18 @@ export class BoxAutoResumeService {
   private async submitOrJoinStart(boxId: string, organization: Organization): Promise<Box> {
     const lockKey = getStateChangeLockKey(boxId)
     const deadline = Date.now() + AUTO_RESUME_TIMEOUT_SECONDS * 1000
-    while (!(await this.redisLockProvider.lock(lockKey, AUTO_RESUME_TIMEOUT_SECONDS))) {
+    let lease = await this.redisLockProvider.acquireLease(lockKey, AUTO_RESUME_TIMEOUT_SECONDS)
+    while (!lease) {
       if (Date.now() >= deadline) {
         throw new RequestTimeoutException(`Timed out waiting to resume box ${boxId}`)
       }
       await new Promise((resolve) => setTimeout(resolve, 50))
+      lease = await this.redisLockProvider.acquireLease(lockKey, AUTO_RESUME_TIMEOUT_SECONDS)
     }
 
-    try {
-      return await this.boxService.ensureStartedForProxy(boxId, organization)
-    } finally {
-      await this.redisLockProvider.unlock(lockKey)
-    }
+    return withRedisLockLease(lease, (signal) => {
+      signal.throwIfAborted()
+      return this.boxService.ensureStartedForProxy(boxId, organization)
+    })
   }
 }

--- a/apps/api/src/boxlite-rest/box-auto-resume.service.ts
+++ b/apps/api/src/boxlite-rest/box-auto-resume.service.ts
@@ -42,19 +42,21 @@ export class BoxAutoResumeService {
 
   private async submitOrJoinStart(boxId: string, organization: Organization): Promise<Box> {
     const lockKey = getStateChangeLockKey(boxId)
-    const deadline = Date.now() + AUTO_RESUME_TIMEOUT_SECONDS * 1000
-    let lease = await this.redisLockProvider.acquireLease(lockKey, AUTO_RESUME_TIMEOUT_SECONDS)
-    while (!lease) {
-      if (Date.now() >= deadline) {
+    let lease
+    try {
+      lease = await this.redisLockProvider.waitForLock(lockKey, AUTO_RESUME_TIMEOUT_SECONDS, {
+        timeoutMs: AUTO_RESUME_TIMEOUT_SECONDS * 1000,
+      })
+    } catch (error) {
+      if (error instanceof Error && error.message.startsWith('Timed out waiting for Redis lock')) {
         throw new RequestTimeoutException(`Timed out waiting to resume box ${boxId}`)
       }
-      await new Promise((resolve) => setTimeout(resolve, 50))
-      lease = await this.redisLockProvider.acquireLease(lockKey, AUTO_RESUME_TIMEOUT_SECONDS)
+      throw error
     }
 
     return withRedisLockLease(lease, (signal) => {
       signal.throwIfAborted()
-      return this.boxService.ensureStartedForProxy(boxId, organization)
+      return this.boxService.ensureStartedForProxy(boxId, organization, signal)
     })
   }
 }

--- a/apps/api/src/common/decorators/distributed-lock.decorator.spec.ts
+++ b/apps/api/src/common/decorators/distributed-lock.decorator.spec.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { DistributedLock } from './distributed-lock.decorator'
+
+describe('DistributedLock', () => {
+  it('passes the lease abort signal to the protected method', async () => {
+    const controller = new AbortController()
+    class Worker {
+      redisLockProvider = {
+        acquireLease: jest.fn().mockResolvedValue({ signal: controller.signal, release: jest.fn() }),
+      }
+
+      @DistributedLock()
+      async run(signal?: AbortSignal) {
+        return signal
+      }
+    }
+
+    await expect(new Worker().run()).resolves.toBe(controller.signal)
+  })
+})

--- a/apps/api/src/common/decorators/distributed-lock.decorator.ts
+++ b/apps/api/src/common/decorators/distributed-lock.decorator.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { RedisLockProvider } from '../../box/common/redis-lock.provider'
+import { RedisLockProvider, withRedisLockLease } from '../../box/common/redis-lock.provider'
 
 type DistributedLockOptions = {
   lockKey?: string
@@ -36,15 +36,11 @@ export function DistributedLock(options?: DistributedLockOptions): MethodDecorat
       // Set default TTL if not provided
       const lockTtlMs = options?.lockTtl || 30 // 30 seconds default
 
-      const hasLock = await redisLockProvider.lock(lockKey, lockTtlMs)
-      if (!hasLock) {
+      const lease = await redisLockProvider.acquireLease(lockKey, lockTtlMs)
+      if (!lease) {
         return
       }
-      try {
-        return await originalMethod.apply(this, args)
-      } finally {
-        await redisLockProvider.unlock(lockKey)
-      }
+      return withRedisLockLease(lease, (signal) => originalMethod.apply(this, [...args, signal]))
     }
   }
 }

--- a/apps/api/src/common/decorators/track-job-execution.decorator.spec.ts
+++ b/apps/api/src/common/decorators/track-job-execution.decorator.spec.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { TrackJobExecution } from './track-job-execution.decorator'
+
+describe('TrackJobExecution', () => {
+  it('tracks concurrent calls of the same method independently', async () => {
+    const completions: Array<() => void> = []
+
+    class Worker {
+      activeJobs = new Set<symbol>()
+
+      @TrackJobExecution()
+      async run() {
+        await new Promise<void>((resolve) => completions.push(resolve))
+      }
+    }
+
+    const worker = new Worker()
+    const first = worker.run()
+    const second = worker.run()
+    expect(worker.activeJobs.size).toBe(2)
+
+    completions[0]()
+    await first
+    expect(worker.activeJobs.size).toBe(1)
+
+    completions[1]()
+    await second
+    expect(worker.activeJobs.size).toBe(0)
+  })
+})

--- a/apps/api/src/common/decorators/track-job-execution.decorator.ts
+++ b/apps/api/src/common/decorators/track-job-execution.decorator.ts
@@ -17,11 +17,12 @@ export function TrackJobExecution() {
         throw new Error(`@TrackExecution requires 'activeJobs' property on ${target.constructor.name}`)
       }
 
-      this.activeJobs.add(propertyKey)
+      const execution = Symbol(propertyKey)
+      this.activeJobs.add(execution)
       try {
         return await original.apply(this, args)
       } finally {
-        this.activeJobs.delete(propertyKey)
+        this.activeJobs.delete(execution)
       }
     }
   }

--- a/apps/api/src/common/interfaces/trackable-job-executions.ts
+++ b/apps/api/src/common/interfaces/trackable-job-executions.ts
@@ -5,5 +5,5 @@
  */
 
 export interface TrackableJobExecutions {
-  activeJobs: Set<string>
+  activeJobs: Set<symbol>
 }

--- a/apps/api/src/migrations/pre-deploy/1786200000000-add-usage-export-claim-token-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1786200000000-add-usage-export-claim-token-migration.ts
@@ -1,0 +1,43 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddUsageExportClaimToken1786200000000 implements MigrationInterface {
+  name = 'AddUsageExportClaimToken1786200000000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "box_usage_export_outbox" ADD "claimToken" uuid`)
+    // During a rolling deploy, an older publisher does not know about the
+    // token. Clear the token when that publisher changes only availableAt, so
+    // a superseded new publisher cannot still satisfy its fencing predicate.
+    await queryRunner.query(`
+      CREATE OR REPLACE FUNCTION clear_stale_usage_export_claim_token() RETURNS trigger AS $$
+      BEGIN
+        IF NEW."availableAt" IS DISTINCT FROM OLD."availableAt"
+          AND NEW."claimToken" IS NOT DISTINCT FROM OLD."claimToken" THEN
+          IF OLD."claimToken" IS NOT NULL
+            AND (NEW."attempts" IS DISTINCT FROM OLD."attempts"
+              OR NEW."lastError" IS DISTINCT FROM OLD."lastError"
+              OR NEW."status" IS DISTINCT FROM OLD."status") THEN
+            RAISE EXCEPTION 'stale usage export publisher cannot update a replacement claim';
+          END IF;
+          NEW."claimToken" = NULL;
+        END IF;
+        IF OLD."status" = 'pending' AND NEW."status" <> 'pending' AND NEW."claimToken" IS NOT NULL THEN
+          RAISE EXCEPTION 'usage export terminal update must release its claim token';
+        END IF;
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql
+    `)
+    await queryRunner.query(`
+      CREATE TRIGGER "box_usage_export_outbox_claim_fence"
+      BEFORE UPDATE ON "box_usage_export_outbox"
+      FOR EACH ROW EXECUTE FUNCTION clear_stale_usage_export_claim_token()
+    `)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TRIGGER "box_usage_export_outbox_claim_fence" ON "box_usage_export_outbox"`)
+    await queryRunner.query(`DROP FUNCTION clear_stale_usage_export_claim_token()`)
+    await queryRunner.query(`ALTER TABLE "box_usage_export_outbox" DROP COLUMN "claimToken"`)
+  }
+}

--- a/apps/api/src/organization/services/organization-lock-lifecycle.spec.ts
+++ b/apps/api/src/organization/services/organization-lock-lifecycle.spec.ts
@@ -35,20 +35,77 @@ describe('OrganizationService lock lifecycle', () => {
       boxRepository as any,
       eventEmitter as any,
       { getOrThrow: jest.fn().mockReturnValue(false) } as any,
-      { acquireLease: jest.fn().mockResolvedValue({ release }) } as any,
+      {
+        acquireLease: jest.fn().mockResolvedValue({ signal: new AbortController().signal, release }),
+      } as any,
       {} as any,
       {} as any,
       {} as any,
     )
 
     const stopping = service.stopSuspendedOrganizationBoxes()
-    while (eventEmitter.emitAsync.mock.calls.length === 0) {
+    for (let attempt = 0; attempt < 10 && eventEmitter.emitAsync.mock.calls.length === 0; attempt += 1) {
       await Promise.resolve()
     }
 
+    expect(eventEmitter.emitAsync).toHaveBeenCalledTimes(1)
     expect(release).not.toHaveBeenCalled()
     settleEvent()
     await stopping
     expect(release).toHaveBeenCalled()
+  })
+
+  it('waits for every started stop event before releasing after one fails', async () => {
+    const eventError = new Error('event failed')
+    const controller = new AbortController()
+    let settleSibling!: () => void
+    const release = jest.fn().mockResolvedValue(undefined)
+    const queryBuilder = {
+      select: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      andWhereExists: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue([{ id: 'org-1' }]),
+    }
+    const service = new OrganizationService(
+      { createQueryBuilder: jest.fn().mockReturnValue(queryBuilder) } as any,
+      {
+        createQueryBuilder: jest.fn().mockReturnValue({ select: jest.fn().mockReturnThis(), where: jest.fn() }),
+        find: jest.fn().mockResolvedValue([{ id: 'box-1' }, { id: 'box-2' }]),
+      } as any,
+      {
+        emitAsync: jest
+          .fn()
+          .mockImplementationOnce(() => {
+            controller.abort(eventError)
+            return Promise.reject(eventError)
+          })
+          .mockImplementationOnce(
+            () =>
+              new Promise<void>((resolve) => {
+                settleSibling = resolve
+              }),
+          ),
+      } as any,
+      { getOrThrow: jest.fn().mockReturnValue(false) } as any,
+      {
+        acquireLease: jest.fn().mockResolvedValue({ signal: controller.signal, release }),
+      } as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    )
+
+    const stopping = service.stopSuspendedOrganizationBoxes()
+    for (let attempt = 0; attempt < 10 && !settleSibling; attempt += 1) {
+      await Promise.resolve()
+    }
+
+    expect(settleSibling).toBeDefined()
+    expect(release).not.toHaveBeenCalled()
+    settleSibling()
+    await expect(stopping).rejects.toBe(eventError)
+    expect(release).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/api/src/organization/services/organization-lock-lifecycle.spec.ts
+++ b/apps/api/src/organization/services/organization-lock-lifecycle.spec.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { OrganizationService } from './organization.service'
+
+describe('OrganizationService lock lifecycle', () => {
+  it('holds the suspended-box lease until all stop events settle', async () => {
+    const queryBuilder = {
+      select: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      andWhereExists: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue([{ id: 'org-1' }]),
+    }
+    const organizationRepository = { createQueryBuilder: jest.fn().mockReturnValue(queryBuilder) }
+    const boxRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue({ select: jest.fn().mockReturnThis(), where: jest.fn() }),
+      find: jest.fn().mockResolvedValue([{ id: 'box-1' }]),
+    }
+    let settleEvent!: () => void
+    const eventEmitter = {
+      emitAsync: jest.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            settleEvent = resolve
+          }),
+      ),
+    }
+    const release = jest.fn().mockResolvedValue(undefined)
+    const service = new OrganizationService(
+      organizationRepository as any,
+      boxRepository as any,
+      eventEmitter as any,
+      { getOrThrow: jest.fn().mockReturnValue(false) } as any,
+      { acquireLease: jest.fn().mockResolvedValue({ release }) } as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    )
+
+    const stopping = service.stopSuspendedOrganizationBoxes()
+    while (eventEmitter.emitAsync.mock.calls.length === 0) {
+      await Promise.resolve()
+    }
+
+    expect(release).not.toHaveBeenCalled()
+    settleEvent()
+    await stopping
+    expect(release).toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/organization/services/organization-usage.service.ts
+++ b/apps/api/src/organization/services/organization-usage.service.ts
@@ -14,7 +14,7 @@ import { BoxState } from '../../box/enums/box-state.enum'
 import { BoxEvents } from '../../box/constants/box-events.constants'
 import { BoxCreatedEvent } from '../../box/events/box-create.event'
 import { BoxStateUpdatedEvent } from '../../box/events/box-state-updated.event'
-import { RedisLockProvider } from '../../box/common/redis-lock.provider'
+import { RedisLockProvider, withRedisLockLease } from '../../box/common/redis-lock.provider'
 import { Organization } from '../entities/organization.entity'
 import { OrganizationQuota } from '../entities/organization-quota.entity'
 import { BOX_STATES_CONSUMING_COMPUTE, BOX_STATES_CONSUMING_DISK } from '../constants/box-consuming-states.constant'
@@ -141,20 +141,19 @@ export class OrganizationUsageService {
     }
 
     const lockKey = `org:${organizationId}:fetch-box-usage`
-    await this.redisLockProvider.waitForLock(lockKey, 60)
-    try {
+    const lease = await this.redisLockProvider.waitForLock(lockKey, 60)
+    return withRedisLockLease(lease, async (signal) => {
       const recheck = await this.getCachedBoxUsage(organizationId)
       if (recheck) {
         return excludeBoxId ? await this.excludeBoxFromUsage(recheck, excludeBoxId) : recheck
       }
 
       const current = await this.fetchBoxUsageFromDb(organizationId)
+      signal.throwIfAborted()
       const pending = await this.getCachedPendingUsage(organizationId)
       const overview: BoxUsageOverview = { ...current, ...pending }
       return excludeBoxId ? await this.excludeBoxFromUsage(overview, excludeBoxId) : overview
-    } finally {
-      await this.redisLockProvider.unlock(lockKey)
-    }
+    })
   }
 
   private async excludeBoxFromUsage(overview: BoxUsageOverview, excludeBoxId: string): Promise<BoxUsageOverview> {
@@ -375,33 +374,39 @@ export class OrganizationUsageService {
   async handleBoxCreated(event: BoxCreatedEvent): Promise<void> {
     const box = event.box
     const lockKey = `box:${box.id}:quota-usage-update`
-    await this.redisLockProvider.waitForLock(lockKey, 60)
-    try {
+    const lease = await this.redisLockProvider.waitForLock(lockKey, 60)
+    await withRedisLockLease(lease, async (signal) => {
       await this.updateCurrentQuotaUsage(box.organizationId, 'cpu', box.cpu)
+      signal.throwIfAborted()
       await this.updateCurrentQuotaUsage(box.organizationId, 'memory', box.mem)
+      signal.throwIfAborted()
       await this.updateCurrentQuotaUsage(box.organizationId, 'disk', box.disk)
+      signal.throwIfAborted()
       await this.updateCurrentQuotaUsage(box.organizationId, 'gpu', box.gpu)
+      signal.throwIfAborted()
       await this.updateCurrentQuotaUsage(box.organizationId, 'count', 1)
-    } catch (error) {
+    }).catch((error) => {
       this.logger.warn(`Error updating cached box quota usage for organization ${box.organizationId}: ${error}`)
-    } finally {
-      await this.redisLockProvider.unlock(lockKey)
-    }
+    })
   }
 
   @OnEvent(BoxEvents.STATE_UPDATED)
   async handleBoxStateUpdated(event: BoxStateUpdatedEvent): Promise<void> {
     const box = event.box
     const lockKey = `box:${box.id}:quota-usage-update`
-    await this.redisLockProvider.waitForLock(lockKey, 60)
-    try {
+    const lease = await this.redisLockProvider.waitForLock(lockKey, 60)
+    await withRedisLockLease(lease, async (signal) => {
       // Warm-pool assignment re-emits STARTED -> STARTED to attribute an already
       // running box to its new organization; the membership deltas would be zero.
       if (event.oldState === event.newState && event.newState === BoxState.STARTED) {
         await this.updateCurrentQuotaUsage(box.organizationId, 'cpu', box.cpu)
+        signal.throwIfAborted()
         await this.updateCurrentQuotaUsage(box.organizationId, 'memory', box.mem)
+        signal.throwIfAborted()
         await this.updateCurrentQuotaUsage(box.organizationId, 'disk', box.disk)
+        signal.throwIfAborted()
         await this.updateCurrentQuotaUsage(box.organizationId, 'gpu', box.gpu)
+        signal.throwIfAborted()
         await this.updateCurrentQuotaUsage(box.organizationId, 'count', 1)
         return
       }
@@ -413,15 +418,17 @@ export class OrganizationUsageService {
       const countDelta = stateTransitionDelta(1, event.oldState, event.newState, BOX_STATES_CONSUMING_COMPUTE)
 
       await this.updateCurrentQuotaUsage(box.organizationId, 'cpu', cpuDelta)
+      signal.throwIfAborted()
       await this.updateCurrentQuotaUsage(box.organizationId, 'memory', memoryDelta)
+      signal.throwIfAborted()
       await this.updateCurrentQuotaUsage(box.organizationId, 'disk', diskDelta)
+      signal.throwIfAborted()
       await this.updateCurrentQuotaUsage(box.organizationId, 'gpu', gpuDelta)
+      signal.throwIfAborted()
       await this.updateCurrentQuotaUsage(box.organizationId, 'count', countDelta)
-    } catch (error) {
+    }).catch((error) => {
       this.logger.warn(`Error updating cached box quota usage for organization ${box.organizationId}: ${error}`)
-    } finally {
-      await this.redisLockProvider.unlock(lockKey)
-    }
+    })
   }
 
   private currentKey(organizationId: string, resource: QuotaResource): string {

--- a/apps/api/src/organization/services/organization.service.ts
+++ b/apps/api/src/organization/services/organization.service.ts
@@ -52,7 +52,7 @@ import { BoxRepository } from '../../box/repositories/box.repository'
 export class OrganizationService implements OnModuleInit, TrackableJobExecutions, OnApplicationShutdown {
   private static readonly DEFAULT_ORGANIZATION_NAME = 'Default Organization'
 
-  activeJobs = new Set<string>()
+  activeJobs = new Set<symbol>()
   private readonly logger = new Logger(OrganizationService.name)
   private defaultBoxLimitedNetworkEgress: boolean
 

--- a/apps/api/src/organization/services/organization.service.ts
+++ b/apps/api/src/organization/services/organization.service.ts
@@ -29,7 +29,7 @@ import { EventEmitter2 } from '@nestjs/event-emitter'
 import { OrganizationEvents } from '../constants/organization-events.constant'
 import { UserEmailVerifiedEvent } from '../../user/events/user-email-verified.event'
 import { Cron, CronExpression } from '@nestjs/schedule'
-import { RedisLockProvider } from '../../box/common/redis-lock.provider'
+import { RedisLockProvider, withRedisLockLease } from '../../box/common/redis-lock.provider'
 import { OrganizationSuspendedBoxStoppedEvent } from '../events/organization-suspended-box-stopped.event'
 import { BoxDesiredState } from '../../box/enums/box-desired-state.enum'
 import { SystemRole } from '../../user/enums/system-role.enum'
@@ -541,51 +541,55 @@ export class OrganizationService implements OnModuleInit, TrackableJobExecutions
   async stopSuspendedOrganizationBoxes(): Promise<void> {
     //  lock the sync to only run one instance at a time
     const lockKey = 'stop-suspended-organization-boxes'
-    if (!(await this.redisLockProvider.lock(lockKey, 60))) {
+    const lease = await this.redisLockProvider.acquireLease(lockKey, 60)
+    if (!lease) {
       return
     }
 
-    const queryResult = await this.organizationRepository
-      .createQueryBuilder('organization')
-      .select('id')
-      .where('suspended = true')
-      .andWhere(`"suspendedAt" < NOW() - INTERVAL '1 hour' * "suspensionCleanupGracePeriodHours"`)
-      .andWhere(`"suspendedAt" > NOW() - INTERVAL '7 day'`)
-      .andWhereExists(
-        this.boxRepository
-          .createQueryBuilder('box')
-          .select('1')
-          .where(
-            `"box"."organizationId" = "organization"."id" AND "box"."desiredState" = '${BoxDesiredState.STARTED}' and "box"."state" NOT IN ('${BoxState.ERROR}')`,
-          ),
+    await withRedisLockLease(lease, async (signal) => {
+      const queryResult = await this.organizationRepository
+        .createQueryBuilder('organization')
+        .select('id')
+        .where('suspended = true')
+        .andWhere(`"suspendedAt" < NOW() - INTERVAL '1 hour' * "suspensionCleanupGracePeriodHours"`)
+        .andWhere(`"suspendedAt" > NOW() - INTERVAL '7 day'`)
+        .andWhereExists(
+          this.boxRepository
+            .createQueryBuilder('box')
+            .select('1')
+            .where(
+              `"box"."organizationId" = "organization"."id" AND "box"."desiredState" = '${BoxDesiredState.STARTED}' and "box"."state" NOT IN ('${BoxState.ERROR}')`,
+            ),
+        )
+        .take(100)
+        .getRawMany()
+
+      const suspendedOrganizationIds = queryResult.map((result) => result.id)
+
+      // Skip if no suspended organizations found to avoid empty IN clause
+      if (suspendedOrganizationIds.length === 0) {
+        return
+      }
+
+      const boxes = await this.boxRepository.find({
+        where: {
+          organizationId: In(suspendedOrganizationIds),
+          desiredState: BoxDesiredState.STARTED,
+          state: Not(In([BoxState.ERROR])),
+        },
+      })
+
+      signal.throwIfAborted()
+      await Promise.all(
+        boxes.map((box) => {
+          signal.throwIfAborted()
+          return this.eventEmitter.emitAsync(
+            OrganizationEvents.SUSPENDED_BOX_STOPPED,
+            new OrganizationSuspendedBoxStoppedEvent(box.id),
+          )
+        }),
       )
-      .take(100)
-      .getRawMany()
-
-    const suspendedOrganizationIds = queryResult.map((result) => result.id)
-
-    // Skip if no suspended organizations found to avoid empty IN clause
-    if (suspendedOrganizationIds.length === 0) {
-      await this.redisLockProvider.unlock(lockKey)
-      return
-    }
-
-    const boxes = await this.boxRepository.find({
-      where: {
-        organizationId: In(suspendedOrganizationIds),
-        desiredState: BoxDesiredState.STARTED,
-        state: Not(In([BoxState.ERROR])),
-      },
     })
-
-    boxes.map((box) =>
-      this.eventEmitter.emitAsync(
-        OrganizationEvents.SUSPENDED_BOX_STOPPED,
-        new OrganizationSuspendedBoxStoppedEvent(box.id),
-      ),
-    )
-
-    await this.redisLockProvider.unlock(lockKey)
   }
 
   // TODO(image-rewrite): deactivateSuspendedOrganizationTemplates cron removed with box_template;

--- a/apps/api/src/organization/services/organization.service.ts
+++ b/apps/api/src/organization/services/organization.service.ts
@@ -580,15 +580,22 @@ export class OrganizationService implements OnModuleInit, TrackableJobExecutions
       })
 
       signal.throwIfAborted()
-      await Promise.all(
-        boxes.map((box) => {
-          signal.throwIfAborted()
-          return this.eventEmitter.emitAsync(
-            OrganizationEvents.SUSPENDED_BOX_STOPPED,
-            new OrganizationSuspendedBoxStoppedEvent(box.id),
-          )
-        }),
-      )
+      const batchSize = 20
+      for (let offset = 0; offset < boxes.length; offset += batchSize) {
+        signal.throwIfAborted()
+        const results = await Promise.allSettled(
+          boxes.slice(offset, offset + batchSize).map((box) => {
+            return this.eventEmitter.emitAsync(
+              OrganizationEvents.SUSPENDED_BOX_STOPPED,
+              new OrganizationSuspendedBoxStoppedEvent(box.id),
+            )
+          }),
+        )
+        const rejected = results.find((result): result is PromiseRejectedResult => result.status === 'rejected')
+        if (rejected) {
+          throw rejected.reason
+        }
+      }
     })
   }
 

--- a/apps/api/src/usage/entities/box-usage-export-outbox.entity.ts
+++ b/apps/api/src/usage/entities/box-usage-export-outbox.entity.ts
@@ -64,6 +64,10 @@ export class BoxUsageExportOutbox {
   @Column({ type: 'timestamp with time zone', default: () => 'CURRENT_TIMESTAMP' })
   availableAt: Date
 
+  /** Unique fencing value for the publisher that most recently claimed this row. */
+  @Column({ type: 'uuid', nullable: true })
+  claimToken: string | null
+
   @Column({ type: 'timestamp with time zone', nullable: true })
   deliveredAt: Date | null
 

--- a/apps/api/src/usage/services/usage-export-publisher.service.spec.ts
+++ b/apps/api/src/usage/services/usage-export-publisher.service.spec.ts
@@ -12,6 +12,7 @@ jest.mock('axios', () => ({
 }))
 
 import axios from 'axios'
+import { USAGE_EXPORT_VISIBILITY_TIMEOUT_MS } from '../../config/configuration'
 import { BoxUsageExportOutbox, UsageExportStatus } from '../entities/box-usage-export-outbox.entity'
 import { UsageExportPublisherService } from './usage-export-publisher.service'
 
@@ -32,6 +33,8 @@ const row = (overrides: Partial<BoxUsageExportOutbox> = {}): BoxUsageExportOutbo
     payload: { eventKey: 'key-1', schemaVersion: 1, cpu: '2' },
     status: UsageExportStatus.PENDING,
     attempts: 1,
+    availableAt: new Date('2026-01-01T00:00:00.000Z'),
+    claimToken: 'f64ef7e8-7d8b-4db9-9c3a-51fe7e75e814',
     ...overrides,
   }) as BoxUsageExportOutbox
 
@@ -45,12 +48,15 @@ const httpError = (status?: number) => ({
 const makeService = (claimed: BoxUsageExportOutbox[], overrides: Record<string, unknown> = {}) => {
   const outboxRepository = {
     query: jest.fn().mockResolvedValue(claimed),
-    update: jest.fn().mockResolvedValue({ affected: claimed.length }),
+    update: jest.fn().mockImplementation(async (where) => ({ affected: where.eventKey._value.length })),
   }
   const outboxService = { pruneDelivered: jest.fn().mockResolvedValue(0) }
+  const release = jest.fn().mockResolvedValue(undefined)
   const redisLockProvider = {
-    lock: jest.fn().mockResolvedValue(true),
-    unlock: jest.fn().mockResolvedValue(undefined),
+    acquireLease: jest.fn().mockResolvedValue({
+      signal: new AbortController().signal,
+      release,
+    }),
   }
   const configService = {
     get: jest.fn((key: string) => {
@@ -69,7 +75,7 @@ const makeService = (claimed: BoxUsageExportOutbox[], overrides: Record<string, 
     configService as any,
   )
 
-  return { service, outboxRepository, outboxService, redisLockProvider }
+  return { service, outboxRepository, outboxService, redisLockProvider, release }
 }
 
 beforeEach(() => {
@@ -88,7 +94,7 @@ describe('UsageExportPublisherService.publishPendingExports', () => {
 
   it('yields to whichever replica holds the lock', async () => {
     const { service, outboxRepository, redisLockProvider } = makeService([row()])
-    redisLockProvider.lock.mockResolvedValue(false)
+    redisLockProvider.acquireLease.mockResolvedValue(null)
 
     await service.publishPendingExports()
 
@@ -118,9 +124,20 @@ describe('UsageExportPublisherService.publishPendingExports', () => {
     await service.publishPendingExports()
 
     expect(outboxRepository.update).toHaveBeenCalledWith(
-      expect.anything(),
+      expect.objectContaining({
+        status: UsageExportStatus.PENDING,
+        claimToken: 'f64ef7e8-7d8b-4db9-9c3a-51fe7e75e814',
+      }),
       expect.objectContaining({ status: UsageExportStatus.DELIVERED, lastError: null }),
     )
+  })
+
+  it('does not overwrite a row claimed again by another publisher', async () => {
+    const { service, outboxRepository } = makeService([row()])
+    post.mockResolvedValue({ status: 200, data: { accepted: 1 } })
+    outboxRepository.update.mockResolvedValueOnce({ affected: 0 })
+
+    await expect(service.publishPendingExports()).rejects.toThrow('Usage export claim was replaced')
   })
 
   // A transient failure must stay claimable. Marking it anything else would
@@ -221,11 +238,15 @@ describe('UsageExportPublisherService.publishPendingExports', () => {
   })
 
   it('releases the lock even when the claim throws', async () => {
-    const { service, redisLockProvider, outboxRepository } = makeService([row()])
+    const { service, redisLockProvider, release, outboxRepository } = makeService([row()])
     outboxRepository.query.mockRejectedValue(new Error('database is down'))
 
     await expect(service.publishPendingExports()).rejects.toThrow('database is down')
-    expect(redisLockProvider.unlock).toHaveBeenCalledWith('publish-usage-exports')
+    expect(redisLockProvider.acquireLease).toHaveBeenCalledWith(
+      'publish-usage-exports',
+      USAGE_EXPORT_VISIBILITY_TIMEOUT_MS / 1000,
+    )
+    expect(release).toHaveBeenCalledTimes(1)
   })
 })
 
@@ -275,7 +296,7 @@ describe('UsageExportPublisherService claiming', () => {
     expect(sql).toContain('"availableAt" = now()')
     // The retry budget is spent by a failed delivery, never by taking the row.
     expect(sql).not.toContain('"attempts"')
-    expect(parameters).toEqual([60_000, UsageExportStatus.PENDING, 200])
+    expect(parameters).toEqual([60_000, UsageExportStatus.PENDING, 200, expect.any(String)])
   })
 
   it('never moves a claimed row into a state a crash could strand', async () => {

--- a/apps/api/src/usage/services/usage-export-publisher.service.ts
+++ b/apps/api/src/usage/services/usage-export-publisher.service.ts
@@ -7,8 +7,9 @@ import { Injectable, Logger, OnApplicationShutdown } from '@nestjs/common'
 import { Cron, CronExpression } from '@nestjs/schedule'
 import { InjectRepository } from '@nestjs/typeorm'
 import axios from 'axios'
-import { In, Repository } from 'typeorm'
-import { RedisLockProvider } from '../../box/common/redis-lock.provider'
+import { randomUUID } from 'crypto'
+import { In, Repository, UpdateResult } from 'typeorm'
+import { RedisLockProvider, withRedisLockLease } from '../../box/common/redis-lock.provider'
 import { LogExecution } from '../../common/decorators/log-execution.decorator'
 import { WithInstrumentation } from '../../common/decorators/otel.decorator'
 import { TrackJobExecution } from '../../common/decorators/track-job-execution.decorator'
@@ -41,7 +42,7 @@ const PERMANENT_REJECTION_STATUSES = new Set([400, 422])
  */
 @Injectable()
 export class UsageExportPublisherService implements TrackableJobExecutions, OnApplicationShutdown {
-  activeJobs = new Set<string>()
+  activeJobs = new Set<symbol>()
   private readonly logger = new Logger(UsageExportPublisherService.name)
 
   constructor(
@@ -72,24 +73,28 @@ export class UsageExportPublisherService implements TrackableJobExecutions, OnAp
     if (!this.configService.get('usageExport.enabled')) {
       return
     }
-    if (!(await this.redisLockProvider.lock(PUBLISH_LOCK_KEY, USAGE_EXPORT_VISIBILITY_TIMEOUT_MS / 1000))) {
+    const lease = await this.redisLockProvider.acquireLease(
+      PUBLISH_LOCK_KEY,
+      USAGE_EXPORT_VISIBILITY_TIMEOUT_MS / 1000,
+    )
+    if (!lease) {
       return
     }
 
-    try {
+    await withRedisLockLease(lease, async (signal) => {
       const claimed = await this.claimBatch()
+      signal.throwIfAborted()
       if (claimed.length > 0) {
-        await this.deliver(claimed)
+        await this.deliver(claimed, signal)
         return
       }
 
       const pruned = await this.outboxService.pruneDelivered(RETENTION_DAYS)
+      signal.throwIfAborted()
       if (pruned > 0) {
         this.logger.log(`Pruned ${pruned} delivered usage export rows`)
       }
-    } finally {
-      await this.redisLockProvider.unlock(PUBLISH_LOCK_KEY)
-    }
+    })
   }
 
   /**
@@ -108,6 +113,7 @@ export class UsageExportPublisherService implements TrackableJobExecutions, OnAp
    * publish cron takes a Redis lock first, which would serialise them.
    */
   async claimBatch(): Promise<BoxUsageExportOutbox[]> {
+    const claimToken = randomUUID()
     // Wrapped in a CTE so the statement is a SELECT: a bare `UPDATE … RETURNING`
     // comes back from the driver as [rows, affectedCount], and mapping over that
     // tuple silently yields undefined payloads instead of events.
@@ -118,7 +124,8 @@ export class UsageExportPublisherService implements TrackableJobExecutions, OnAp
     return this.outboxRepository.query(
       `WITH claimed AS (
          UPDATE "box_usage_export_outbox"
-         SET "availableAt" = now() + ($1 || ' milliseconds')::interval
+         SET "availableAt" = now() + ($1 || ' milliseconds')::interval,
+             "claimToken" = $4
          WHERE "eventKey" IN (
            SELECT "eventKey" FROM "box_usage_export_outbox"
            WHERE "status" = $2 AND "availableAt" <= now()
@@ -129,11 +136,16 @@ export class UsageExportPublisherService implements TrackableJobExecutions, OnAp
          RETURNING *
        )
        SELECT * FROM claimed`,
-      [USAGE_EXPORT_VISIBILITY_TIMEOUT_MS, UsageExportStatus.PENDING, this.configService.get('usageExport.batchSize')],
+      [
+        USAGE_EXPORT_VISIBILITY_TIMEOUT_MS,
+        UsageExportStatus.PENDING,
+        this.configService.get('usageExport.batchSize'),
+        claimToken,
+      ],
     )
   }
 
-  private async deliver(rows: BoxUsageExportOutbox[]): Promise<void> {
+  private async deliver(rows: BoxUsageExportOutbox[], signal: AbortSignal): Promise<void> {
     const eventKeys = rows.map((row) => row.eventKey)
 
     try {
@@ -142,6 +154,7 @@ export class UsageExportPublisherService implements TrackableJobExecutions, OnAp
         { events: rows.map((row) => row.payload) },
         {
           timeout: this.configService.get('usageExport.timeoutMs'),
+          signal,
           headers: {
             authorization: `Bearer ${this.configService.get('usageExport.token')}`,
             'content-type': 'application/json',
@@ -149,14 +162,17 @@ export class UsageExportPublisherService implements TrackableJobExecutions, OnAp
         },
       )
     } catch (error) {
+      signal.throwIfAborted()
       await this.recordFailure(rows, error)
       return
     }
 
-    await this.outboxRepository.update(
-      { eventKey: In(eventKeys) },
-      { status: UsageExportStatus.DELIVERED, deliveredAt: new Date(), lastError: null },
+    signal.throwIfAborted()
+    const updated = await this.outboxRepository.update(
+      this.claimPredicate(rows),
+      { status: UsageExportStatus.DELIVERED, deliveredAt: new Date(), lastError: null, claimToken: null },
     )
+    this.assertClaimStillOwned(updated, rows.length)
     this.logger.log(`Delivered ${eventKeys.length} usage export events`)
   }
 
@@ -181,34 +197,50 @@ export class UsageExportPublisherService implements TrackableJobExecutions, OnAp
     // scoop up, so its members can carry different budgets; deciding for all of
     // them from the first row, or only when every row is spent, makes the
     // outcome depend on batch composition rather than on each row's own history.
-    const blocked: string[] = []
-    const deferredByAttempt = new Map<number, string[]>()
+    const blocked: BoxUsageExportOutbox[] = []
+    const deferredByAttempt = new Map<number, BoxUsageExportOutbox[]>()
     for (const row of rows) {
       const attempt = row.attempts + 1
       if (permanent || attempt >= maxAttempts) {
-        blocked.push(row.eventKey)
+        blocked.push(row)
         continue
       }
-      deferredByAttempt.set(attempt, [...(deferredByAttempt.get(attempt) ?? []), row.eventKey])
+      deferredByAttempt.set(attempt, [...(deferredByAttempt.get(attempt) ?? []), row])
     }
 
     if (blocked.length > 0) {
-      await this.outboxRepository.update(
-        { eventKey: In(blocked) },
-        { status: UsageExportStatus.BLOCKED, attempts: () => '"attempts" + 1', lastError: message },
+      const updated = await this.outboxRepository.update(
+        this.claimPredicate(blocked),
+        { status: UsageExportStatus.BLOCKED, attempts: () => '"attempts" + 1', lastError: message, claimToken: null },
       )
+      this.assertClaimStillOwned(updated, blocked.length)
       this.logger.error(
         `Blocked ${blocked.length} usage export events after ${permanent ? `HTTP ${status}` : `${maxAttempts} attempts`}: ${message}`,
       )
     }
 
-    for (const [attempt, eventKeys] of deferredByAttempt) {
+    for (const [attempt, deferred] of deferredByAttempt) {
       const backoffMs = Math.min(MAX_BACKOFF_MS, 2 ** Math.max(0, attempt - 1) * 30_000)
-      await this.outboxRepository.update(
-        { eventKey: In(eventKeys) },
-        { attempts: attempt, availableAt: new Date(Date.now() + backoffMs), lastError: message },
+      const updated = await this.outboxRepository.update(
+        this.claimPredicate(deferred),
+        { attempts: attempt, availableAt: new Date(Date.now() + backoffMs), lastError: message, claimToken: null },
       )
-      this.logger.warn(`Deferred ${eventKeys.length} usage export events for ${backoffMs}ms: ${message}`)
+      this.assertClaimStillOwned(updated, deferred.length)
+      this.logger.warn(`Deferred ${deferred.length} usage export events for ${backoffMs}ms: ${message}`)
+    }
+  }
+
+  private claimPredicate(rows: BoxUsageExportOutbox[]) {
+    return {
+      eventKey: In(rows.map((row) => row.eventKey)),
+      status: UsageExportStatus.PENDING,
+      claimToken: rows[0].claimToken,
+    }
+  }
+
+  private assertClaimStillOwned(result: UpdateResult, expectedRows: number): void {
+    if (result.affected !== expectedRows) {
+      throw new Error(`Usage export claim was replaced before ${expectedRows} row(s) could be updated`)
     }
   }
 

--- a/apps/api/src/usage/services/usage.service.integration.spec.ts
+++ b/apps/api/src/usage/services/usage.service.integration.spec.ts
@@ -13,6 +13,7 @@ import { RedisLockProvider } from '../../box/common/redis-lock.provider'
 import { CustomNamingStrategy } from '../../common/utils/naming-strategy.util'
 import { AddBoxUsagePeriods1785250000000 } from '../../migrations/pre-deploy/1785250000000-add-box-usage-periods-migration'
 import { AddBoxUsageExportOutbox1786100000000 } from '../../migrations/pre-deploy/1786100000000-add-box-usage-export-outbox-migration'
+import { AddUsageExportClaimToken1786200000000 } from '../../migrations/pre-deploy/1786200000000-add-usage-export-claim-token-migration'
 import { BoxUsagePeriod } from '../entities/box-usage-period.entity'
 import { BoxUsagePeriodArchive } from '../entities/box-usage-period-archive.entity'
 import { BoxUsageExportOutbox, UsageExportStatus } from '../entities/box-usage-export-outbox.entity'
@@ -130,6 +131,7 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
     try {
       await new AddBoxUsagePeriods1785250000000().up(queryRunner)
       await new AddBoxUsageExportOutbox1786100000000().up(queryRunner)
+      await new AddUsageExportClaimToken1786200000000().up(queryRunner)
       ownsTables = true
     } finally {
       await queryRunner.release()
@@ -579,6 +581,45 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
 
       expect(first).toHaveLength(5)
       expect(second).toHaveLength(0)
+    })
+
+    it('fences a new publisher when an older publisher reclaims its row', async () => {
+      await enqueueRows(1)
+      const [claimed] = await publisher({ 'usageExport.batchSize': 1 }).claimBatch()
+
+      // This is the pre-claimToken statement used by a publisher that is still
+      // draining during a rolling deploy: it changes visibility, but cannot
+      // supply a replacement token.
+      await dataSource.query(
+        `UPDATE "box_usage_export_outbox" SET "availableAt" = now() + interval '1 minute' WHERE "eventKey" = $1`,
+        [claimed.eventKey],
+      )
+      const staleUpdate = await outboxes.update(
+        { eventKey: claimed.eventKey, status: UsageExportStatus.PENDING, claimToken: claimed.claimToken },
+        { status: UsageExportStatus.DELIVERED, claimToken: null },
+      )
+
+      expect(staleUpdate.affected).toBe(0)
+      await outboxes.update({ eventKey: claimed.eventKey }, { availableAt: new Date(Date.now() - 1_000) })
+      const [replacement] = await publisher({ 'usageExport.batchSize': 1 }).claimBatch()
+
+      await expect(
+        dataSource.query(
+          `UPDATE "box_usage_export_outbox"
+           SET "availableAt" = now() + interval '1 minute', "attempts" = "attempts" + 1, "lastError" = 'late failure'
+           WHERE "eventKey" = $1`,
+          [claimed.eventKey],
+        ),
+      ).rejects.toThrow('stale usage export publisher')
+      await expect(
+        dataSource.query(`UPDATE "box_usage_export_outbox" SET "status" = 'delivered' WHERE "eventKey" = $1`, [
+          claimed.eventKey,
+        ]),
+      ).rejects.toThrow('terminal update must release its claim token')
+
+      const current = await outboxes.findOneByOrFail({ eventKey: claimed.eventKey })
+      expect(current.status).toBe(UsageExportStatus.PENDING)
+      expect(current.claimToken).toBe(replacement.claimToken)
     })
 
     it('keeps history only for the retention window', async () => {

--- a/apps/api/src/usage/services/usage.service.spec.ts
+++ b/apps/api/src/usage/services/usage.service.spec.ts
@@ -65,10 +65,13 @@ const makeService = (stored: BoxUsagePeriod[] = []) => {
   const redisLockProvider = {
     unlock: jest.fn().mockResolvedValue(undefined),
     acquireLease: jest.fn(),
+    waitForLock: jest.fn(),
   }
-  redisLockProvider.acquireLease.mockImplementation(async (key: string) => ({
+  const leaseFor = (key: string) => ({
     release: () => redisLockProvider.unlock(key, { getCode: () => key }),
-  }))
+  })
+  redisLockProvider.acquireLease.mockImplementation(async (key: string) => leaseFor(key))
+  redisLockProvider.waitForLock.mockImplementation(async (key: string) => leaseFor(key))
   const boxRepository = { findOne: jest.fn() }
   const usageExportOutboxService = { enqueue: jest.fn().mockResolvedValue(0) }
 
@@ -101,6 +104,30 @@ describe('UsageService event subscriptions', () => {
 })
 
 describe('UsageService.handleBoxStateUpdate', () => {
+  it('cancels a pending lock wait during application shutdown', async () => {
+    const { service, redisLockProvider } = makeService()
+    redisLockProvider.waitForLock.mockImplementation(
+      (_key: string, _ttl: number, options: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          options.signal.addEventListener('abort', () => reject(options.signal.reason), { once: true })
+        }),
+    )
+
+    const handling = service.handleBoxStateUpdate(event(BoxState.STARTING)).catch((error) => error)
+    while (redisLockProvider.waitForLock.mock.calls.length === 0) {
+      await Promise.resolve()
+    }
+    await service.onApplicationShutdown()
+
+    await expect(handling).resolves.toThrow('UsageService is shutting down')
+    expect(redisLockProvider.waitForLock).toHaveBeenCalledWith(
+      `usage-period-${box.id}`,
+      60,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+    expect(redisLockProvider.waitForLock.mock.calls[0][2]).not.toHaveProperty('timeoutMs')
+  })
+
   it('does not finish until its lock has been released', async () => {
     const { service, redisLockProvider } = makeService()
     let finishUnlock!: () => void

--- a/apps/api/src/usage/services/usage.service.spec.ts
+++ b/apps/api/src/usage/services/usage.service.spec.ts
@@ -63,12 +63,21 @@ const makeService = (stored: BoxUsagePeriod[] = []) => {
     },
   }
   const redisLockProvider = {
-    unlock: jest.fn().mockResolvedValue(undefined),
     acquireLease: jest.fn(),
     waitForLock: jest.fn(),
   }
+  const leaseReleases = new Map<string, jest.Mock>()
+  const releaseFor = (key: string) => {
+    let release = leaseReleases.get(key)
+    if (!release) {
+      release = jest.fn().mockResolvedValue(undefined)
+      leaseReleases.set(key, release)
+    }
+    return release
+  }
   const leaseFor = (key: string) => ({
-    release: () => redisLockProvider.unlock(key, { getCode: () => key }),
+    signal: new AbortController().signal,
+    release: releaseFor(key),
   })
   redisLockProvider.acquireLease.mockImplementation(async (key: string) => leaseFor(key))
   redisLockProvider.waitForLock.mockImplementation(async (key: string) => leaseFor(key))
@@ -82,7 +91,7 @@ const makeService = (stored: BoxUsagePeriod[] = []) => {
     usageExportOutboxService as any,
   )
 
-  return { service, usagePeriodRepository, redisLockProvider, usageExportOutboxService }
+  return { service, usagePeriodRepository, redisLockProvider, usageExportOutboxService, releaseFor }
 }
 
 const OTHER_BOX_ID = 'box-2'
@@ -129,9 +138,10 @@ describe('UsageService.handleBoxStateUpdate', () => {
   })
 
   it('does not finish until its lock has been released', async () => {
-    const { service, redisLockProvider } = makeService()
+    const { service, releaseFor } = makeService()
     let finishUnlock!: () => void
-    redisLockProvider.unlock.mockImplementation(
+    const release = releaseFor(`usage-period-${box.id}`)
+    release.mockImplementation(
       () =>
         new Promise<void>((resolve) => {
           finishUnlock = resolve
@@ -139,7 +149,7 @@ describe('UsageService.handleBoxStateUpdate', () => {
     )
 
     const handling = service.handleBoxStateUpdate(event(BoxState.STARTING))
-    while (redisLockProvider.unlock.mock.calls.length === 0) {
+    while (release.mock.calls.length === 0) {
       await Promise.resolve()
     }
 
@@ -304,72 +314,60 @@ describe('UsageService.handleBoxStateUpdate', () => {
   })
 
   it('releases the per-box lock even when the transition is not billable', async () => {
-    const { service, redisLockProvider } = makeService()
+    const { service, releaseFor } = makeService()
 
     await service.handleBoxStateUpdate(event(BoxState.STARTING))
 
-    expect(redisLockProvider.unlock).toHaveBeenCalledWith(
-      `usage-period-${box.id}`,
-      expect.objectContaining({ getCode: expect.any(Function) }),
-    )
+    expect(releaseFor(`usage-period-${box.id}`)).toHaveBeenCalledTimes(1)
   })
 })
 
 describe('UsageService cron lock cleanup', () => {
-  it('rolls back archival when ownership is lost after its writes', async () => {
+  it('propagates ownership loss after archival writes', async () => {
     const { service, usagePeriodRepository, redisLockProvider } = makeService()
     const controller = new AbortController()
     redisLockProvider.acquireLease.mockResolvedValue({ signal: controller.signal, release: jest.fn() })
-    let committed = false
     usagePeriodRepository.manager.transaction.mockImplementation(async (callback: (manager: any) => Promise<void>) => {
       await callback({
         find: jest.fn().mockResolvedValue([{ id: 'period-1' }]),
         delete: jest.fn(),
         save: jest.fn(async () => controller.abort(new Error('ownership was lost'))),
       })
-      committed = true
     })
 
     await expect(service.archiveUsagePeriods()).rejects.toThrow('ownership was lost')
-    expect(committed).toBe(false)
   })
 
   it('releases the rollover lock when loading periods fails', async () => {
-    const { service, usagePeriodRepository, redisLockProvider } = makeService()
+    const { service, usagePeriodRepository, releaseFor } = makeService()
     usagePeriodRepository.find.mockRejectedValue(new Error('find failed'))
 
     await expect(service.closeAndReopenUsagePeriods()).rejects.toThrow('find failed')
 
-    expect(redisLockProvider.unlock).toHaveBeenCalledWith(
-      'close-and-reopen-usage-periods',
-      expect.objectContaining({ getCode: expect.any(Function) }),
-    )
+    expect(releaseFor('close-and-reopen-usage-periods')).toHaveBeenCalledTimes(1)
   })
 
   it('releases the archive lock when the transaction fails', async () => {
-    const { service, usagePeriodRepository, redisLockProvider } = makeService()
+    const { service, usagePeriodRepository, releaseFor } = makeService()
     usagePeriodRepository.manager.transaction.mockRejectedValue(new Error('transaction failed'))
 
     await expect(service.archiveUsagePeriods()).rejects.toThrow('transaction failed')
 
-    expect(redisLockProvider.unlock).toHaveBeenCalledWith(
-      'archive-usage-periods',
-      expect.objectContaining({ getCode: expect.any(Function) }),
-    )
+    expect(releaseFor('archive-usage-periods')).toHaveBeenCalledTimes(1)
   })
 
   it('preserves the rollover error when releasing its lease also fails', async () => {
-    const { service, usagePeriodRepository, redisLockProvider } = makeService()
+    const { service, usagePeriodRepository, releaseFor } = makeService()
     usagePeriodRepository.find.mockRejectedValue(new Error('find failed'))
-    redisLockProvider.unlock.mockRejectedValue(new Error('release failed'))
+    releaseFor('close-and-reopen-usage-periods').mockRejectedValue(new Error('release failed'))
 
     await expect(service.closeAndReopenUsagePeriods()).rejects.toThrow('find failed')
   })
 
   it('preserves the archive error when releasing its lease also fails', async () => {
-    const { service, usagePeriodRepository, redisLockProvider } = makeService()
+    const { service, usagePeriodRepository, releaseFor } = makeService()
     usagePeriodRepository.manager.transaction.mockRejectedValue(new Error('transaction failed'))
-    redisLockProvider.unlock.mockRejectedValue(new Error('release failed'))
+    releaseFor('archive-usage-periods').mockRejectedValue(new Error('release failed'))
 
     await expect(service.archiveUsagePeriods()).rejects.toThrow('transaction failed')
   })
@@ -399,15 +397,12 @@ describe('UsageService.handleBoxDesiredStateUpdate', () => {
   })
 
   it('releases the per-box lock it took', async () => {
-    const { service, redisLockProvider } = makeService([openPeriod()])
+    const { service, releaseFor } = makeService([openPeriod()])
 
     await service.handleBoxDesiredStateUpdate(
       new BoxDesiredStateUpdatedEvent(box, BoxDesiredState.STARTED, BoxDesiredState.DESTROYED),
     )
 
-    expect(redisLockProvider.unlock).toHaveBeenCalledWith(
-      `usage-period-${box.id}`,
-      expect.objectContaining({ getCode: expect.any(Function) }),
-    )
+    expect(releaseFor(`usage-period-${box.id}`)).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/api/src/usage/services/usage.service.spec.ts
+++ b/apps/api/src/usage/services/usage.service.spec.ts
@@ -45,17 +45,30 @@ const satisfies = (actual: unknown, condition: unknown): boolean => {
 
 const makeService = (stored: BoxUsagePeriod[] = []) => {
   const usagePeriodRepository = {
+    find: jest.fn().mockResolvedValue([]),
     findOne: jest.fn(async ({ where }: any) =>
       stored.find((period) =>
         Object.entries(where).every(([column, condition]) => satisfies((period as any)[column], condition)),
       ),
     ),
     save: jest.fn().mockImplementation(async (period) => period),
+    manager: {
+      transaction: jest.fn(async (callback: (manager: any) => Promise<unknown>) =>
+        callback({
+          find: jest.fn().mockResolvedValue([]),
+          delete: jest.fn(),
+          save: jest.fn(),
+        }),
+      ),
+    },
   }
   const redisLockProvider = {
-    lock: jest.fn().mockResolvedValue(true),
     unlock: jest.fn().mockResolvedValue(undefined),
+    acquireLease: jest.fn(),
   }
+  redisLockProvider.acquireLease.mockImplementation(async (key: string) => ({
+    release: () => redisLockProvider.unlock(key, { getCode: () => key }),
+  }))
   const boxRepository = { findOne: jest.fn() }
   const usageExportOutboxService = { enqueue: jest.fn().mockResolvedValue(0) }
 
@@ -88,6 +101,33 @@ describe('UsageService event subscriptions', () => {
 })
 
 describe('UsageService.handleBoxStateUpdate', () => {
+  it('does not finish until its lock has been released', async () => {
+    const { service, redisLockProvider } = makeService()
+    let finishUnlock!: () => void
+    redisLockProvider.unlock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishUnlock = resolve
+        }),
+    )
+
+    const handling = service.handleBoxStateUpdate(event(BoxState.STARTING))
+    while (redisLockProvider.unlock.mock.calls.length === 0) {
+      await Promise.resolve()
+    }
+
+    let isFinished = false
+    handling.then(() => {
+      isFinished = true
+    })
+    await Promise.resolve()
+    expect(isFinished).toBe(false)
+
+    finishUnlock()
+    await handling
+    expect(isFinished).toBe(true)
+  })
+
   it('opens a full-resource period when the box starts', async () => {
     const { service, usagePeriodRepository } = makeService()
 
@@ -241,7 +281,70 @@ describe('UsageService.handleBoxStateUpdate', () => {
 
     await service.handleBoxStateUpdate(event(BoxState.STARTING))
 
-    expect(redisLockProvider.unlock).toHaveBeenCalledWith(`usage-period-${box.id}`)
+    expect(redisLockProvider.unlock).toHaveBeenCalledWith(
+      `usage-period-${box.id}`,
+      expect.objectContaining({ getCode: expect.any(Function) }),
+    )
+  })
+})
+
+describe('UsageService cron lock cleanup', () => {
+  it('rolls back archival when ownership is lost after its writes', async () => {
+    const { service, usagePeriodRepository, redisLockProvider } = makeService()
+    const controller = new AbortController()
+    redisLockProvider.acquireLease.mockResolvedValue({ signal: controller.signal, release: jest.fn() })
+    let committed = false
+    usagePeriodRepository.manager.transaction.mockImplementation(async (callback: (manager: any) => Promise<void>) => {
+      await callback({
+        find: jest.fn().mockResolvedValue([{ id: 'period-1' }]),
+        delete: jest.fn(),
+        save: jest.fn(async () => controller.abort(new Error('ownership was lost'))),
+      })
+      committed = true
+    })
+
+    await expect(service.archiveUsagePeriods()).rejects.toThrow('ownership was lost')
+    expect(committed).toBe(false)
+  })
+
+  it('releases the rollover lock when loading periods fails', async () => {
+    const { service, usagePeriodRepository, redisLockProvider } = makeService()
+    usagePeriodRepository.find.mockRejectedValue(new Error('find failed'))
+
+    await expect(service.closeAndReopenUsagePeriods()).rejects.toThrow('find failed')
+
+    expect(redisLockProvider.unlock).toHaveBeenCalledWith(
+      'close-and-reopen-usage-periods',
+      expect.objectContaining({ getCode: expect.any(Function) }),
+    )
+  })
+
+  it('releases the archive lock when the transaction fails', async () => {
+    const { service, usagePeriodRepository, redisLockProvider } = makeService()
+    usagePeriodRepository.manager.transaction.mockRejectedValue(new Error('transaction failed'))
+
+    await expect(service.archiveUsagePeriods()).rejects.toThrow('transaction failed')
+
+    expect(redisLockProvider.unlock).toHaveBeenCalledWith(
+      'archive-usage-periods',
+      expect.objectContaining({ getCode: expect.any(Function) }),
+    )
+  })
+
+  it('preserves the rollover error when releasing its lease also fails', async () => {
+    const { service, usagePeriodRepository, redisLockProvider } = makeService()
+    usagePeriodRepository.find.mockRejectedValue(new Error('find failed'))
+    redisLockProvider.unlock.mockRejectedValue(new Error('release failed'))
+
+    await expect(service.closeAndReopenUsagePeriods()).rejects.toThrow('find failed')
+  })
+
+  it('preserves the archive error when releasing its lease also fails', async () => {
+    const { service, usagePeriodRepository, redisLockProvider } = makeService()
+    usagePeriodRepository.manager.transaction.mockRejectedValue(new Error('transaction failed'))
+    redisLockProvider.unlock.mockRejectedValue(new Error('release failed'))
+
+    await expect(service.archiveUsagePeriods()).rejects.toThrow('transaction failed')
   })
 })
 
@@ -275,6 +378,9 @@ describe('UsageService.handleBoxDesiredStateUpdate', () => {
       new BoxDesiredStateUpdatedEvent(box, BoxDesiredState.STARTED, BoxDesiredState.DESTROYED),
     )
 
-    expect(redisLockProvider.unlock).toHaveBeenCalledWith(`usage-period-${box.id}`)
+    expect(redisLockProvider.unlock).toHaveBeenCalledWith(
+      `usage-period-${box.id}`,
+      expect.objectContaining({ getCode: expect.any(Function) }),
+    )
   })
 })

--- a/apps/api/src/usage/services/usage.service.ts
+++ b/apps/api/src/usage/services/usage.service.ts
@@ -15,7 +15,7 @@ import { BoxState } from '../../box/enums/box-state.enum'
 import { BoxDesiredState } from '../../box/enums/box-desired-state.enum'
 import { BoxEvents } from './../../box/constants/box-events.constants'
 import { Cron, CronExpression } from '@nestjs/schedule'
-import { RedisLockProvider } from '../../box/common/redis-lock.provider'
+import { RedisLockLease, RedisLockProvider, withRedisLockLease } from '../../box/common/redis-lock.provider'
 import { BOX_WARM_POOL_UNASSIGNED_ORGANIZATION } from '../../box/constants/box.constants'
 import { BoxUsagePeriodArchive } from '../entities/box-usage-period-archive.entity'
 import { TrackableJobExecutions } from '../../common/interfaces/trackable-job-executions'
@@ -50,28 +50,26 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
   @OnEvent(BoxEvents.DESIRED_STATE_UPDATED)
   @TrackJobExecution()
   async handleBoxDesiredStateUpdate(event: BoxDesiredStateUpdatedEvent) {
-    await this.waitForLock(event.box.id)
+    const lease = await this.waitForLock(event.box.id)
 
-    try {
+    await this.withLease(lease, async (signal) => {
+      signal.throwIfAborted()
       switch (event.newDesiredState) {
         case BoxDesiredState.DESTROYED: {
           await this.closeUsagePeriod(event.box.id)
           break
         }
       }
-    } finally {
-      this.releaseLock(event.box.id).catch((error) => {
-        this.logger.error(`Error releasing lock for box ${event.box.id}`, error)
-      })
-    }
+    }, `box ${event.box.id}`)
   }
 
   @OnEvent(BoxEvents.STATE_UPDATED)
   @TrackJobExecution()
   async handleBoxStateUpdate(event: BoxStateUpdatedEvent) {
-    await this.waitForLock(event.box.id)
+    const lease = await this.waitForLock(event.box.id)
 
-    try {
+    await this.withLease(lease, async (signal) => {
+      signal.throwIfAborted()
       switch (event.newState) {
         case BoxState.STARTED: {
           await this.closeUsagePeriod(event.box.id)
@@ -110,11 +108,7 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
           break
         }
       }
-    } finally {
-      this.releaseLock(event.box.id).catch((error) => {
-        this.logger.error(`Error releasing lock for box ${event.box.id}`, error)
-      })
-    }
+    }, `box ${event.box.id}`)
   }
 
   private async createUsagePeriod(event: BoxStateUpdatedEvent, diskOnly = false) {
@@ -157,66 +151,69 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
   @LogExecution('close-and-reopen-usage-periods')
   @WithInstrumentation()
   async closeAndReopenUsagePeriods() {
-    if (!(await this.redisLockProvider.lock('close-and-reopen-usage-periods', 60))) {
+    const lockKey = 'close-and-reopen-usage-periods'
+    const lease = await this.redisLockProvider.acquireLease(lockKey, 60)
+    if (!lease) {
       return
     }
 
-    const usagePeriods = await this.boxUsagePeriodRepository.find({
-      where: {
-        endAt: IsNull(),
-        // 1 day ago
-        startAt: LessThan(new Date(Date.now() - 1000 * 60 * 60 * 24)),
-        organizationId: Not(BOX_WARM_POOL_UNASSIGNED_ORGANIZATION),
-      },
-      order: {
-        startAt: 'ASC',
-      },
-      take: 100,
-    })
+    await this.withLease(lease, async (signal) => {
+      const usagePeriods = await this.boxUsagePeriodRepository.find({
+        where: {
+          endAt: IsNull(),
+          // 1 day ago
+          startAt: LessThan(new Date(Date.now() - 1000 * 60 * 60 * 24)),
+          organizationId: Not(BOX_WARM_POOL_UNASSIGNED_ORGANIZATION),
+        },
+        order: {
+          startAt: 'ASC',
+        },
+        take: 100,
+      })
 
-    for (const usagePeriod of usagePeriods) {
-      if (!(await this.aquireLock(usagePeriod.boxId))) {
-        continue
-      }
+      for (const usagePeriod of usagePeriods) {
+        signal.throwIfAborted()
+        const boxLease = await this.acquireLease(usagePeriod.boxId)
+        if (!boxLease) {
+          continue
+        }
 
-      // validate that the usage period should remain active just in case
-      try {
-        const box = await this.boxRepository.findOne({
-          where: {
-            id: usagePeriod.boxId,
-          },
-        })
+        // validate that the usage period should remain active just in case
+        await this.withLease(boxLease, async (boxSignal) => {
+          const box = await this.boxRepository.findOne({
+            where: {
+              id: usagePeriod.boxId,
+            },
+          })
 
-        await this.boxUsagePeriodRepository.manager.transaction(async (transactionalEntityManager) => {
-          // Close usage period
-          const closeTime = new Date()
-          usagePeriod.endAt = closeTime
-          await transactionalEntityManager.save(usagePeriod)
+          await this.boxUsagePeriodRepository.manager.transaction(async (transactionalEntityManager) => {
+            boxSignal.throwIfAborted()
+            // Close usage period
+            const closeTime = new Date()
+            usagePeriod.endAt = closeTime
+            await transactionalEntityManager.save(usagePeriod)
 
-          if (
-            box &&
-            (box.state === BoxState.STARTED || box.state === BoxState.STOPPED || box.state === BoxState.STOPPING)
-          ) {
-            // Create new usage period
-            const newUsagePeriod = BoxUsagePeriod.fromUsagePeriod(usagePeriod)
-            newUsagePeriod.startAt = closeTime
-            newUsagePeriod.endAt = null
-            if (box.state === BoxState.STOPPED) {
-              newUsagePeriod.cpu = 0
-              newUsagePeriod.gpu = 0
-              newUsagePeriod.mem = 0
+            if (
+              box &&
+              (box.state === BoxState.STARTED || box.state === BoxState.STOPPED || box.state === BoxState.STOPPING)
+            ) {
+              const newUsagePeriod = BoxUsagePeriod.fromUsagePeriod(usagePeriod)
+              newUsagePeriod.startAt = closeTime
+              newUsagePeriod.endAt = null
+              if (box.state === BoxState.STOPPED) {
+                newUsagePeriod.cpu = 0
+                newUsagePeriod.gpu = 0
+                newUsagePeriod.mem = 0
+              }
+              await transactionalEntityManager.save(newUsagePeriod)
             }
-            await transactionalEntityManager.save(newUsagePeriod)
-          }
+            boxSignal.throwIfAborted()
+          })
+        }, `usage period ${usagePeriod.boxId}`).catch((error) => {
+          this.logger.error(`Error closing and reopening usage period ${usagePeriod.boxId}`, error)
         })
-      } catch (error) {
-        this.logger.error(`Error closing and reopening usage period ${usagePeriod.boxId}`, error)
-      } finally {
-        await this.releaseLock(usagePeriod.boxId)
       }
-    }
-
-    await this.redisLockProvider.unlock('close-and-reopen-usage-periods')
+    }, lockKey)
   }
 
   @Cron(CronExpression.EVERY_MINUTE, { name: 'archive-usage-periods' })
@@ -225,51 +222,57 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
   @WithInstrumentation()
   async archiveUsagePeriods() {
     const lockKey = 'archive-usage-periods'
-    if (!(await this.redisLockProvider.lock(lockKey, 60))) {
+    const lease = await this.redisLockProvider.acquireLease(lockKey, 60)
+    if (!lease) {
       return
     }
 
-    await this.boxUsagePeriodRepository.manager.transaction(async (transactionalEntityManager) => {
-      const usagePeriods = await transactionalEntityManager.find(BoxUsagePeriod, {
-        where: {
-          endAt: Not(IsNull()),
-        },
-        order: {
-          startAt: 'ASC',
-        },
-        take: 1000,
+    await this.withLease(lease, async (signal) => {
+      await this.boxUsagePeriodRepository.manager.transaction(async (transactionalEntityManager) => {
+        signal.throwIfAborted()
+        const usagePeriods = await transactionalEntityManager.find(BoxUsagePeriod, {
+          where: {
+            endAt: Not(IsNull()),
+          },
+          order: {
+            startAt: 'ASC',
+          },
+          take: 1000,
+        })
+
+        if (usagePeriods.length === 0) {
+          return
+        }
+
+        this.logger.debug(`Found ${usagePeriods.length} usage periods to archive`)
+
+        await transactionalEntityManager.delete(
+          BoxUsagePeriod,
+          usagePeriods.map((usagePeriod) => usagePeriod.id),
+        )
+        await transactionalEntityManager.save(usagePeriods.map(BoxUsagePeriodArchive.fromUsagePeriod))
+        // Keep the archive and export intent atomic so neither can survive without the other.
+        await this.usageExportOutboxService.enqueue(transactionalEntityManager, usagePeriods)
+        signal.throwIfAborted()
       })
-
-      if (usagePeriods.length === 0) {
-        return
-      }
-
-      this.logger.debug(`Found ${usagePeriods.length} usage periods to archive`)
-
-      await transactionalEntityManager.delete(
-        BoxUsagePeriod,
-        usagePeriods.map((usagePeriod) => usagePeriod.id),
-      )
-      await transactionalEntityManager.save(usagePeriods.map(BoxUsagePeriodArchive.fromUsagePeriod))
-      // Same transaction as the archive write, so a usage period can never be
-      // archived without an export intent, nor an intent survive a rollback.
-      await this.usageExportOutboxService.enqueue(transactionalEntityManager, usagePeriods)
-    })
-
-    await this.redisLockProvider.unlock(lockKey)
+    }, lockKey)
   }
 
-  private async waitForLock(boxId: string) {
-    while (!(await this.aquireLock(boxId))) {
+  private async waitForLock(boxId: string): Promise<RedisLockLease> {
+    let lease: RedisLockLease | null
+    while (!(lease = await this.acquireLease(boxId))) {
       await new Promise((resolve) => setTimeout(resolve, 500))
     }
+    return lease
   }
 
-  private async aquireLock(boxId: string): Promise<boolean> {
-    return await this.redisLockProvider.lock(`usage-period-${boxId}`, 60)
+  private async acquireLease(boxId: string): Promise<RedisLockLease | null> {
+    return this.redisLockProvider.acquireLease(`usage-period-${boxId}`, 60)
   }
 
-  private async releaseLock(boxId: string) {
-    await this.redisLockProvider.unlock(`usage-period-${boxId}`)
+  private withLease<T>(lease: RedisLockLease, operation: (signal: AbortSignal) => Promise<T>, context: string) {
+    return withRedisLockLease(lease, operation, (releaseError) => {
+      this.logger.error(`Error releasing Redis lock lease after ${context} operation failed`, releaseError)
+    })
   }
 }

--- a/apps/api/src/usage/services/usage.service.ts
+++ b/apps/api/src/usage/services/usage.service.ts
@@ -261,6 +261,8 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
   }
 
   private async waitForLock(boxId: string): Promise<RedisLockLease> {
+    // State events are not replayed, so a fixed timeout would silently drop
+    // billing transitions. Shutdown is the only safe reason to stop waiting.
     return this.redisLockProvider.waitForLock(`usage-period-${boxId}`, 60, {
       signal: this.shutdownController.signal,
       retryDelayMs: 500,

--- a/apps/api/src/usage/services/usage.service.ts
+++ b/apps/api/src/usage/services/usage.service.ts
@@ -28,8 +28,9 @@ import { UsageExportOutboxService } from './usage-export-outbox.service'
 
 @Injectable()
 export class UsageService implements TrackableJobExecutions, OnApplicationShutdown {
-  activeJobs = new Set<string>()
+  activeJobs = new Set<symbol>()
   private readonly logger = new Logger(UsageService.name)
+  private readonly shutdownController = new AbortController()
 
   constructor(
     @InjectRepository(BoxUsagePeriod)
@@ -40,6 +41,7 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
   ) {}
 
   async onApplicationShutdown() {
+    this.shutdownController.abort(new Error('UsageService is shutting down'))
     //  wait for all active jobs to finish
     while (this.activeJobs.size > 0) {
       this.logger.log(`Waiting for ${this.activeJobs.size} active jobs to finish`)
@@ -259,11 +261,10 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
   }
 
   private async waitForLock(boxId: string): Promise<RedisLockLease> {
-    let lease: RedisLockLease | null
-    while (!(lease = await this.acquireLease(boxId))) {
-      await new Promise((resolve) => setTimeout(resolve, 500))
-    }
-    return lease
+    return this.redisLockProvider.waitForLock(`usage-period-${boxId}`, 60, {
+      signal: this.shutdownController.signal,
+      retryDelayMs: 500,
+    })
   }
 
   private async acquireLease(boxId: string): Promise<RedisLockLease | null> {


### PR DESCRIPTION
Add owner-scoped renewable leases with atomic compare-and-renew and compare-and-delete operations. Migrate lock users to cooperative cancellation and reliable cleanup while preserving expiry-only cooldown locks.

## Summary
Replace ownerless, fixed-TTL Redis locks with owner-scoped renewable leases. This prevents expired lock holders from deleting replacement locks and lets protected workflows stop safely when lease ownership is lost.

## Call graph

### Before

```text
closeAndReopenUsagePeriods  (UsageService · apps/api/src/usage/services/usage.service.ts:157)  — manually acquires global and per-box locks
└─ lock                     (RedisLockProvider · apps/api/src/box/common/redis-lock.provider.ts:25)  — SET NX with shared owner value "1"
   └─ protected operation   (API services · apps/api/src:various)  — may continue after the fixed TTL expires
      └─ unlock             (RedisLockProvider · apps/api/src/box/common/redis-lock.provider.ts:36)  — unconditional DEL  ← BUG: an expired owner can delete a replacement owner's lock
```

### After

```text
closeAndReopenUsagePeriods  (UsageService · apps/api/src/usage/services/usage.service.ts:151)  — acquires global and per-box leases
└─ acquireLease             (RedisLockProvider · apps/api/src/box/common/redis-lock.provider.ts:114)  — creates a lease with a unique UUID owner
   └─ scheduleRenewal       (RedisLockLease · apps/api/src/box/common/redis-lock.provider.ts:61)  — renews with compare-and-expire at half the TTL
      └─ withRedisLockLease (Function · apps/api/src/box/common/redis-lock.provider.ts:78)  — runs the operation with cooperative cancellation and preserves the operation error
         └─ release         (RedisLockLease · apps/api/src/box/common/redis-lock.provider.ts:38)  — stops and joins renewal before releasing
            └─ unlock       (RedisLockProvider · apps/api/src/box/common/redis-lock.provider.ts:138)  — deletes only when the owner token still matches
```

## Changes
- Add UUID-scoped Redis leases with automatic half-TTL renewal and atomic compare-and-renew/compare-and-delete Lua operations.
- Expose an AbortSignal when renewal fails so protected workflows can stop before further database, event, or publishing side effects.
- Centralize lease execution and cleanup in withRedisLockLease, preserving the original operation error if cleanup also fails.
- Separate operation leases from cooldown and throttle keys through lockUntilExpiry.
- Migrate API key, audit, box, volume, runner, warm-pool, auto-resume, organization, and usage lock callers to the appropriate lock API.
- Pass lease cancellation through @DistributedLock into audit cleanup, resolution, and publishing workflows.
- Remove the delayed ownerless unlock from JobStateHandlerService; the code that acquires a lease now owns its complete release lifecycle.
- Check lease ownership at UsageService transaction boundaries so renewal loss causes rollback before commit.
- Add regression coverage for replacement-owner safety, lease renewal and cancellation, release races, error precedence, transactional rollback, and migrated caller lifecycles.

## How to verify
- make test:apps
- Confirm the Redis lock provider tests cover renewal loss, replacement-owner release protection, and operation/release error precedence.
- Confirm the UsageService tests roll back transactional changes when lease ownership is lost.
- Confirm the distributed-lock test passes the lease AbortSignal into the protected method.

## Risks / rollout
- Use a coordinated API rollout or drain old API instances before enabling new ones. During a mixed-version rollout, an old instance still uses unconditional DEL and could remove a lease created by the new implementation.
- Cancellation is cooperative: protected workflows must continue checking the supplied AbortSignal before irreversible side effects.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability Improvements**
  * Improved coordination of background operations to prevent conflicts and stale updates.
  * Added automatic lock renewal, ownership validation, and safe cancellation for long-running tasks.
  * Improved shutdown, cleanup, and error handling while preserving cancellation reasons.

* **Bug Fixes**
  * Prevented completed jobs from releasing newer locks.
  * Ensured asynchronous synchronization and resource operations finish before release.
  * Improved cooldown handling and protection against stale usage-export updates.

* **Tests**
  * Expanded coverage for lock recovery, cancellation, concurrent jobs, and resource lifecycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->