### PR TITLE
fix(api): reject usage-export settings that cannot work

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -82,6 +82,16 @@ BILLING_API_URL=
 # BILLING_API_URL: pointing the dashboard at a billing service and shipping usage
 # to it are different decisions. USAGE_EXPORT_ENABLED gates the outbox write as
 # well as delivery, so a stage that leaves it false accumulates no rows.
+#
+# Validated at startup, so a bad value stops the process rather than surfacing
+# later as a stalled exporter. The counts are checked in every state, because a
+# malformed number is malformed whether or not it is read. The rest describe how
+# delivery must behave and are checked only while USAGE_EXPORT_ENABLED is true,
+# so a stage may leave a placeholder destination here without failing to boot:
+#   USAGE_EXPORT_URL   required, and an absolute http(s) URL
+#   USAGE_EXPORT_TOKEN required
+#   USAGE_EXPORT_TIMEOUT_MS below the window a claimed batch stays hidden for —
+#     at or above it, rows can be re-claimed while their request is in flight
 USAGE_EXPORT_ENABLED=false
 USAGE_EXPORT_URL=
 USAGE_EXPORT_TOKEN=

--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -36,6 +36,35 @@ function requiredCount(value: string | undefined, fallback: number, name: string
 }
 
 /**
+ * How long a claimed usage-export batch stays invisible to other publishers,
+ * and the TTL of the lock the publish cycle holds.
+ *
+ * Lives here rather than beside the publisher so the timeout validation below
+ * can enforce the one relationship between them that has to hold.
+ */
+export const USAGE_EXPORT_VISIBILITY_TIMEOUT_MS = 60_000
+
+/**
+ * An absolute http(s) URL, or a hard failure.
+ *
+ * The offending value is deliberately not echoed: a URL is the one setting that
+ * can carry credentials in its userinfo, and a boot log is the wrong place to
+ * put them. The variable name is enough to find it.
+ */
+function requiredHttpUrl(value: string, name: string): string {
+  let parsed: URL
+  try {
+    parsed = new URL(value)
+  } catch {
+    throw new Error(`${name} must be an absolute http(s) URL`)
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`${name} must use http or https`)
+  }
+  return value.replace(/\/+$/, '')
+}
+
+/**
  * Export of finalized usage periods to the Commerce service. Kept separate from
  * billingApiUrl on purpose, for the same reason requirePaymentMethod is:
  * pointing the dashboard at a billing service and shipping usage to it are
@@ -47,27 +76,50 @@ function requiredCount(value: string | undefined, fallback: number, name: string
  */
 export function usageExportConfig(env: NodeJS.ProcessEnv = process.env) {
   const enabled = env.USAGE_EXPORT_ENABLED === 'true'
-  const url = env.USAGE_EXPORT_URL?.trim()
+  const rawUrl = env.USAGE_EXPORT_URL?.trim()
   const token = env.USAGE_EXPORT_TOKEN?.trim()
 
-  // Enabled without a destination would post to "undefined/internal/usage-events",
-  // spend the retry budget, and block the batch — a silent stall dressed up as
-  // delivery failure.
-  if (enabled && !url) {
-    throw new Error('USAGE_EXPORT_URL is required when USAGE_EXPORT_ENABLED is true')
-  }
-  if (enabled && !token) {
-    throw new Error('USAGE_EXPORT_TOKEN is required when USAGE_EXPORT_ENABLED is true')
-  }
-
-  return {
+  // Counts are checked whether or not export is on: a value like "1e9" or a
+  // typo is malformed in every state, and rejecting it costs a stage nothing it
+  // could legitimately have wanted.
+  const settings = {
     enabled,
-    url,
+    url: rawUrl,
     token,
     batchSize: requiredCount(env.USAGE_EXPORT_BATCH_SIZE, 200, 'USAGE_EXPORT_BATCH_SIZE'),
     timeoutMs: requiredCount(env.USAGE_EXPORT_TIMEOUT_MS, 10_000, 'USAGE_EXPORT_TIMEOUT_MS'),
     maxAttempts: requiredCount(env.USAGE_EXPORT_MAX_ATTEMPTS, 10, 'USAGE_EXPORT_MAX_ATTEMPTS'),
   }
+
+  // Everything below describes how delivery must behave, and delivery does not
+  // happen while export is off. A stage that leaves a placeholder destination
+  // or an unused timeout behind should keep booting: refusing would fail it for
+  // a setting nothing reads.
+  if (!enabled) {
+    return settings
+  }
+
+  // Enabled without a destination would post to "undefined/internal/usage-events",
+  // spend the retry budget, and block the batch — a silent stall dressed up as
+  // delivery failure. A destination that is merely unusable, like "commerce",
+  // fails exactly the same way, so the check has to be the URL's shape rather
+  // than its length.
+  if (!rawUrl) {
+    throw new Error('USAGE_EXPORT_URL is required when USAGE_EXPORT_ENABLED is true')
+  }
+  if (!token) {
+    throw new Error('USAGE_EXPORT_TOKEN is required when USAGE_EXPORT_ENABLED is true')
+  }
+  // A request still in flight when its rows become claimable again is delivered
+  // twice — harmless, since the receiver deduplicates, but it doubles the load
+  // exactly when the receiver is already too slow to answer in time.
+  if (settings.timeoutMs >= USAGE_EXPORT_VISIBILITY_TIMEOUT_MS) {
+    throw new Error(
+      `USAGE_EXPORT_TIMEOUT_MS must be below the ${USAGE_EXPORT_VISIBILITY_TIMEOUT_MS}ms claim visibility window, got "${env.USAGE_EXPORT_TIMEOUT_MS}"`,
+    )
+  }
+
+  return { ...settings, url: requiredHttpUrl(rawUrl, 'USAGE_EXPORT_URL') }
 }
 
 const configuration = {

--- a/apps/api/src/config/usage-export-config.spec.ts
+++ b/apps/api/src/config/usage-export-config.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { usageExportConfig } from './configuration'
+import { usageExportConfig, USAGE_EXPORT_VISIBILITY_TIMEOUT_MS } from './configuration'
 
 const env = (overrides: Record<string, string> = {}) => ({ USAGE_EXPORT_ENABLED: 'true', ...overrides })
 
@@ -68,6 +68,106 @@ describe('usageExportConfig', () => {
   it('falls back when a count is absent or blank', () => {
     expect(usageExportConfig(enabled({ USAGE_EXPORT_BATCH_SIZE: '  ' }))).toEqual(
       expect.objectContaining({ batchSize: 200 }),
+    )
+  })
+
+  // A destination axios can never reach fails exactly like no destination at
+  // all: every delivery errors, the retry budget drains, and the batch blocks.
+  // Only the shape of the value separates the two, so only the shape can catch it.
+  it.each([
+    ['a bare hostname', 'commerce'],
+    ['a scheme-relative URL', '//commerce.test'],
+    ['a path', '/internal'],
+    ['an empty-looking URL', 'http://'],
+  ])('refuses %s as the destination', (_case, url) => {
+    expect(() => usageExportConfig(enabled({ USAGE_EXPORT_URL: url }))).toThrow(
+      /USAGE_EXPORT_URL must be an absolute http\(s\) URL/,
+    )
+  })
+
+  // A URL is the one setting that can carry credentials in its userinfo, so a
+  // rejection must not put the value in a boot log. An http(s) URL with
+  // credentials is accepted and so never echoed either way; the scheme error is
+  // the reachable leak.
+  it('names the variable without echoing the rejected URL', () => {
+    expect(() => usageExportConfig(enabled({ USAGE_EXPORT_URL: 'ftp://user:secret@commerce.test' }))).toThrow(
+      /^USAGE_EXPORT_URL must use http or https$/,
+    )
+  })
+
+  it.each([
+    ['ftp', 'ftp://commerce.test'],
+    ['file', 'file:///etc/passwd'],
+  ])('refuses the %s scheme', (_case, url) => {
+    expect(() => usageExportConfig(enabled({ USAGE_EXPORT_URL: url }))).toThrow(/must use http or https/)
+  })
+
+  it.each([
+    ['http', 'http://commerce.test'],
+    ['https with a port', 'https://commerce.test:3100'],
+    ['a path prefix', 'https://commerce.test/api/billing'],
+  ])('accepts %s', (_case, url) => {
+    expect(usageExportConfig(enabled({ USAGE_EXPORT_URL: url }))).toEqual(expect.objectContaining({ url }))
+  })
+
+  // The publisher appends "/internal/usage-events", so a stored trailing slash
+  // would produce a double slash in the path.
+  it('trims a trailing slash from the destination', () => {
+    expect(usageExportConfig(enabled({ USAGE_EXPORT_URL: 'https://commerce.test/' }))).toEqual(
+      expect.objectContaining({ url: 'https://commerce.test' }),
+    )
+  })
+
+  // A request still in flight when its rows become claimable again is delivered
+  // twice — doubling load exactly when the receiver is already too slow.
+  it.each([
+    ['at the window', String(USAGE_EXPORT_VISIBILITY_TIMEOUT_MS)],
+    ['past the window', String(USAGE_EXPORT_VISIBILITY_TIMEOUT_MS + 1)],
+  ])('refuses a timeout %s', (_case, timeout) => {
+    expect(() => usageExportConfig(enabled({ USAGE_EXPORT_TIMEOUT_MS: timeout }))).toThrow(
+      /must be below the .* claim visibility window/,
+    )
+  })
+
+  it('accepts a timeout just below the window', () => {
+    expect(
+      usageExportConfig(enabled({ USAGE_EXPORT_TIMEOUT_MS: String(USAGE_EXPORT_VISIBILITY_TIMEOUT_MS - 1) })),
+    ).toEqual(expect.objectContaining({ timeoutMs: USAGE_EXPORT_VISIBILITY_TIMEOUT_MS - 1 }))
+  })
+
+  // Nothing enforces the relationship at runtime, so the default has to satisfy
+  // it on its own.
+  it('ships a default timeout inside the window', () => {
+    expect(usageExportConfig(enabled()).timeoutMs).toBeLessThan(USAGE_EXPORT_VISIBILITY_TIMEOUT_MS)
+  })
+})
+
+// Delivery is what these rules describe, and delivery does not happen while
+// export is off. Refusing to boot over a setting nothing reads would fail a
+// stage for a placeholder it was entitled to leave behind.
+describe('usageExportConfig while export is disabled', () => {
+  const disabled = (overrides: Record<string, string> = {}) => ({ USAGE_EXPORT_ENABLED: 'false', ...overrides })
+
+  it.each([
+    ['a placeholder destination', { USAGE_EXPORT_URL: 'commerce-tbd' }],
+    ['an unsupported scheme', { USAGE_EXPORT_URL: 'ftp://commerce.test' }],
+    ['a timeout at the window', { USAGE_EXPORT_TIMEOUT_MS: String(USAGE_EXPORT_VISIBILITY_TIMEOUT_MS) }],
+    ['a timeout past the window', { USAGE_EXPORT_TIMEOUT_MS: String(USAGE_EXPORT_VISIBILITY_TIMEOUT_MS * 2) }],
+    ['no destination at all', {}],
+    ['a destination with no token', { USAGE_EXPORT_URL: 'https://commerce.test' }],
+  ])('still boots with %s', (_case, overrides) => {
+    expect(() => usageExportConfig(disabled(overrides))).not.toThrow()
+  })
+
+  // Malformed counts are malformed in every state, so those stay fatal.
+  it('still rejects a malformed count', () => {
+    expect(() => usageExportConfig(disabled({ USAGE_EXPORT_BATCH_SIZE: 'abc' }))).toThrow(/USAGE_EXPORT_BATCH_SIZE/)
+  })
+
+  // Enabling later is what turns the placeholder into a fault, and it must.
+  it('rejects the same placeholder once export is enabled', () => {
+    expect(() => usageExportConfig(enabled({ USAGE_EXPORT_URL: 'commerce-tbd' }))).toThrow(
+      /USAGE_EXPORT_URL must be an absolute http\(s\) URL/,
     )
   })
 })

--- a/apps/api/src/usage/services/usage-export-publisher.service.ts
+++ b/apps/api/src/usage/services/usage-export-publisher.service.ts
@@ -13,15 +13,13 @@ import { LogExecution } from '../../common/decorators/log-execution.decorator'
 import { WithInstrumentation } from '../../common/decorators/otel.decorator'
 import { TrackJobExecution } from '../../common/decorators/track-job-execution.decorator'
 import { TrackableJobExecutions } from '../../common/interfaces/trackable-job-executions'
+import { USAGE_EXPORT_VISIBILITY_TIMEOUT_MS } from '../../config/configuration'
 import { TypedConfigService } from '../../config/typed-config.service'
 import { BoxUsageExportOutbox, UsageExportStatus } from '../entities/box-usage-export-outbox.entity'
 import { UsageExportOutboxService } from './usage-export-outbox.service'
 
 const PUBLISH_LOCK_KEY = 'publish-usage-exports'
 const MAX_BACKOFF_MS = 15 * 60 * 1000
-
-/** How long a claimed batch stays invisible — longer than the HTTP timeout, so a delivery still in flight is not claimed twice. */
-const VISIBILITY_TIMEOUT_MS = 60 * 1000
 
 /** How long delivered rows are kept for inspection before the idle sweep drops them. */
 const RETENTION_DAYS = 30
@@ -74,7 +72,7 @@ export class UsageExportPublisherService implements TrackableJobExecutions, OnAp
     if (!this.configService.get('usageExport.enabled')) {
       return
     }
-    if (!(await this.redisLockProvider.lock(PUBLISH_LOCK_KEY, 60))) {
+    if (!(await this.redisLockProvider.lock(PUBLISH_LOCK_KEY, USAGE_EXPORT_VISIBILITY_TIMEOUT_MS / 1000))) {
       return
     }
 
@@ -131,7 +129,7 @@ export class UsageExportPublisherService implements TrackableJobExecutions, OnAp
          RETURNING *
        )
        SELECT * FROM claimed`,
-      [VISIBILITY_TIMEOUT_MS, UsageExportStatus.PENDING, this.configService.get('usageExport.batchSize')],
+      [USAGE_EXPORT_VISIBILITY_TIMEOUT_MS, UsageExportStatus.PENDING, this.configService.get('usageExport.batchSize')],
     )
   }
 


### PR DESCRIPTION
Follow-up to #1169. CodeRabbit raised two Major findings against the config
validation that merged in `cc02ebb3`; both are fixed here.

Neither defect can fire while `USAGE_EXPORT_ENABLED` is false, which it is on
every stage today — but both would fire immediately on the stage that turns it on.

## Call graph

```text
Before
  usageExportConfig      (config · apps/api/src/config/configuration.ts:71)   — rejects only an empty URL, so "commerce" is accepted
    └─ deliver           (UsageExportPublisherService · apps/api/src/usage/services/usage-export-publisher.service.ts:136) — axios fails every request
        └─ recordFailure (UsageExportPublisherService · apps/api/src/usage/services/usage-export-publisher.service.ts:174) — retry budget drains, batch blocks

  claimBatch             (UsageExportPublisherService · apps/api/src/usage/services/usage-export-publisher.service.ts:110) — hides a batch for a local 60s literal
    └─ deliver           (UsageExportPublisherService · apps/api/src/usage/services/usage-export-publisher.service.ts:136) — a >=60s timeout outlives that window; rows re-claim mid-flight

After
  usageExportConfig      (config · apps/api/src/config/configuration.ts:71)   — parses the URL, requires http(s), and rejects a timeout at or above the window
    └─ requiredHttpUrl   (config · apps/api/src/config/configuration.ts:53)   — NEW: absolute http(s) only, trailing slash trimmed, value never echoed
    └─ claimBatch        (UsageExportPublisherService · apps/api/src/usage/services/usage-export-publisher.service.ts:110) — reads the shared constant for the claim and its lock
```

**Key:** the window was a literal in the publisher with nothing tying it to the
timeout, so the two could drift apart; it is now one exported constant that the
validator checks against and the publisher reads.

## What each fix does

**`USAGE_EXPORT_URL` is parsed, not just measured.** Emptiness was the only
check, so `commerce` or an `ftp://` destination reached axios, failed every
request, drained the retry budget and blocked the batch — the same end state the
emptiness check exists to prevent. It now requires an absolute http(s) URL and
trims a trailing slash, since the publisher appends `/internal/usage-events`.

The rejection names the variable but does not echo the value: a URL is the one
setting that can carry credentials in its userinfo, and a boot log is the wrong
place for them.

**The HTTP timeout must stay below the claim window.** `claimBatch` hides a
claimed batch for 60s and the publish cron holds a lock for the same duration,
but the timeout accepted any positive integer — so a value at or above 60s let
rows become claimable while their request was still in flight. Duplicate delivery
is harmless (the receiver deduplicates on `eventKey`), but it doubles load
exactly when the receiver is already too slow to answer.

**Both rules apply only while export is enabled.** They describe how delivery
must behave, and delivery does not happen while the flag is off, so a stage may
leave a placeholder destination behind without failing to boot. Counts stay
checked in every state — a malformed number is malformed whether or not anything
reads it.

## Tests

`nx test api` → **58 suites, 380 tests, 0 skipped**, against real Postgres 16 and
Redis 7. 23 of those are new in `usage-export-config.spec.ts`:

- four malformed destinations, two rejected schemes, three accepted forms
- the trailing slash is trimmed
- the rejection does not echo a URL carrying credentials
- a timeout at and past the window is rejected; just below is accepted
- the shipped default sits inside the window (nothing enforces that at runtime)
- eight cases covering the disabled branch, including that the same placeholder
  becomes fatal once export is enabled

Both guards were mutation-checked: reverting them fails 9 cases, and removing the
enabled-gate makes the spec suite fail to *load*, because `configuration.ts`
evaluates `usageExportConfig()` at module scope — which is the boot abort the
gate exists to prevent, reproduced literally.

## Known gaps, not fixed here

- A destination carrying a query or fragment still passes and still cannot work,
  since `deliver` appends its own path.
- `USAGE_EXPORT_VISIBILITY_TIMEOUT_MS / 1000` is exact only while the constant
  stays a whole number of seconds; Redis rejects a fractional `EX`.
- The timeout bound applies to the axios timer, not claim-to-abort elapsed, so
  59,999ms plus claim overhead can still outrun the window. No in-flight safety
  is claimed — receiver-side dedup is the answer to a duplicate.
- About fifteen sibling URL settings in `configuration.ts` (`billingApiUrl`,
  `analyticsApiUrl`, `SVIX_SERVER_URL`, `DEFAULT_RUNNER_PROXY_URL`, others) are
  equally unvalidated. Out of scope for an expedited fix, and unlike usage export
  none of them wedges a durable queue — worth a separate pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved usage-export configuration validation for batch size, timeouts, retries, and delivery credentials.
  * Added validation for HTTP(S) destination URLs and normalized trailing slashes.
  * Prevented export timeouts from exceeding the visibility window.
  * Disabled exports now safely ignore irrelevant delivery settings while still validating core values.

* **Documentation**
  * Documented usage-export configuration requirements and startup validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->