### PR TITLE
fix(api): reject a usage-export URL carrying a query or fragment

### DIFF
--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -45,7 +45,25 @@ function requiredCount(value: string | undefined, fallback: number, name: string
 export const USAGE_EXPORT_VISIBILITY_TIMEOUT_MS = 60_000
 
 /**
- * An absolute http(s) URL, or a hard failure.
+ * An absolute http(s) URL with no query or fragment, or a hard failure.
+ *
+ * The caller appends its own path to whatever comes back, so `…/api?x=1` would
+ * produce `…/api?x=1/internal/usage-events`, which reaches nothing. Such a
+ * value is rejected rather than stripped, because stripping it would deliver
+ * somewhere other than the configured destination. Rejecting it is also what
+ * keeps the trailing-slash trim below honest: on a raw string that trim would
+ * otherwise eat a slash inside a query value.
+ *
+ * The delimiters are looked for in the raw string rather than in `parsed.search`
+ * and `parsed.hash`, which are both empty for a bare `?` or `#`. Asking the
+ * parsed value would answer "no query" while the delimiter sits in the string
+ * this returns, and `…/api?` would go out as `…/api?/internal/usage-events`.
+ *
+ * Only the trailing slash is normalized. Returning `origin + pathname` instead
+ * would look equivalent and quietly drop userinfo, drop an explicit port and
+ * lowercase the host — and axios builds Basic auth from userinfo and then
+ * deletes the Authorization header, so dropping it would change which
+ * credential the publisher sends.
  *
  * The offending value is deliberately not echoed: a URL is the one setting that
  * can carry credentials in its userinfo, and a boot log is the wrong place to
@@ -60,6 +78,9 @@ function requiredHttpUrl(value: string, name: string): string {
   }
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
     throw new Error(`${name} must use http or https`)
+  }
+  if (value.includes('?') || value.includes('#')) {
+    throw new Error(`${name} must not carry a query or fragment`)
   }
   return value.replace(/\/+$/, '')
 }

--- a/apps/api/src/config/usage-export-config.spec.ts
+++ b/apps/api/src/config/usage-export-config.spec.ts
@@ -110,12 +110,44 @@ describe('usageExportConfig', () => {
     expect(usageExportConfig(enabled({ USAGE_EXPORT_URL: url }))).toEqual(expect.objectContaining({ url }))
   })
 
+  // The publisher appends its own path to whatever is stored, so a destination
+  // carrying a query or fragment could never reach the receiver. Rejecting beats
+  // trimming, which would deliver somewhere other than what was configured.
+  // A bare delimiter is the case that reads as absent: URL parses "…/api?" to an
+  // empty search, so asking the parsed value whether it has a query answers no
+  // while the "?" is still there in the string that gets stored — and the
+  // publisher then posts to "…/api?/internal/usage-events". A trailing "?" also
+  // hides the slash from the trim, since /\/+$/ cannot match it.
+  it.each([
+    ['a query', 'https://commerce.test/api?target=1'],
+    ['a fragment', 'https://commerce.test/api#section'],
+    ['a bare query delimiter', 'https://commerce.test/api?'],
+    ['a bare fragment delimiter', 'https://commerce.test/api#'],
+    ['a bare delimiter behind a trailing slash', 'https://commerce.test/api/?'],
+  ])('refuses a destination carrying %s', (_case, url) => {
+    expect(() => usageExportConfig(enabled({ USAGE_EXPORT_URL: url }))).toThrow(
+      /USAGE_EXPORT_URL must not carry a query or fragment/,
+    )
+  })
+
   // The publisher appends "/internal/usage-events", so a stored trailing slash
   // would produce a double slash in the path.
   it('trims a trailing slash from the destination', () => {
     expect(usageExportConfig(enabled({ USAGE_EXPORT_URL: 'https://commerce.test/' }))).toEqual(
       expect.objectContaining({ url: 'https://commerce.test' }),
     )
+  })
+
+  // Only the trailing slash may change. Rebuilding from origin + pathname looks
+  // equivalent and is not: it drops userinfo — which axios turns into Basic auth,
+  // deleting the publisher's Bearer header — drops an explicit port, and
+  // lowercases the host.
+  it.each([
+    ['userinfo', 'https://user:secret@commerce.test/api'],
+    ['an explicit port', 'https://commerce.test:443/api'],
+    ['host casing', 'https://Commerce.TEST/API'],
+  ])('stores the destination verbatim, preserving %s', (_case, url) => {
+    expect(usageExportConfig(enabled({ USAGE_EXPORT_URL: url }))).toEqual(expect.objectContaining({ url }))
   })
 
   // A request still in flight when its rows become claimable again is delivered


### PR DESCRIPTION
Fixes #1172. Follow-up to #1170, which listed this as a known gap; CodeRabbit
raised it as a Minor finding against `fc0217fc`.

`USAGE_EXPORT_ENABLED` is false on every stage today, so nothing here can fire
until the stage that turns it on.

## Call graph

```text
Before
  usageExportConfig    (config · apps/api/src/config/configuration.ts:98)  — parses, checks the scheme
    └─ requiredHttpUrl (config · apps/api/src/config/configuration.ts:72)  ← BUG: trims a trailing slash off the raw string, eating a slash inside a query value — https://commerce.test/api?target=/ is stored as …/api?target=
        └─ deliver     (UsageExportPublisherService · apps/api/src/usage/services/usage-export-publisher.service.ts:136)  — appends /internal/usage-events after the query, so the receiver is never reached either way

After
  usageExportConfig    (config · apps/api/src/config/configuration.ts:98)  — unchanged
    └─ requiredHttpUrl (config · apps/api/src/config/configuration.ts:72)  — NEW: rejects any "?" or "#" in the raw value (configuration.ts:83), so the trim below it only ever sees a path
        └─ deliver     (UsageExportPublisherService · apps/api/src/usage/services/usage-export-publisher.service.ts:136)  — unchanged; can now only receive a path-only destination
```

**Key:** the guard is what makes the trim below it correct. Once a delimiter
cannot reach that line, the raw trim has nothing to corrupt, so the trim itself
is unchanged.

## Why reject rather than strip

Such a destination could never have worked. `deliver` appends
`/internal/usage-events` to whatever is stored, which would land *after* the
query — so the request goes nowhere regardless. Stripping the query would send
usage to a destination other than the one configured, which is worse than
refusing to boot: the operator would get no signal their setting was overridden.

## Why the check reads the raw string

`parsed.search` and `parsed.hash` are both `''` for a *bare* delimiter, so a
parsed-value check answers "no query" while the `?` is still sitting in the
string that gets returned and stored:

```
new URL('https://commerce.test/api?').search  === ''
new URL('https://commerce.test/api#').hash    === ''
```

`https://commerce.test/api?` would therefore have been accepted, and the
publisher would post to `https://commerce.test/api?/internal/usage-events` —
path `/api`, query `/internal/usage-events`, receiver never reached. That is the
exact failure this change exists to prevent, so the delimiters are looked for in
the raw string, which is also the thing being returned.

`https://commerce.test/api/?` slipped the trailing-slash trim too, since
`/\/+$/` cannot match a string ending in `?`.

## What deliberately did not change

The return stays `value.replace(/\/+$/, '')`. Rebuilding it as
`` `${parsed.origin}${parsed.pathname}` `` looks equivalent and is not — it drops
userinfo, drops an explicit port, and lowercases the host. The userinfo loss is
not cosmetic: axios builds a Basic `Authorization` header from URL userinfo and
then deletes the one the publisher set
(`apps/node_modules/axios/lib/adapters/http.js:858-866` vs the Bearer set at
`usage-export-publisher.service.ts:146`), so dropping userinfo would silently
change which credential is sent.

Three cases pin that, so the tidier-looking rewrite cannot return unnoticed:
`stores the destination verbatim, preserving userinfo / an explicit port / host casing`.

## Tests

`usage-export-config.spec.ts` → **47 tests**, 8 new: five rejected destinations
(a query, a fragment, a bare `?`, a bare `#`, a bare `?` behind a trailing slash)
and the three verbatim-storage cases above.

Written failing-first — the three bare-delimiter cases were added against the
old guard and observed to fail with `Received function did not throw` before the
guard was changed.

Both directions were then mutation-checked, each reverted byte-exact afterwards:

- Removing the guard — which is the *complete* revert, since it is the only
  executable change in the diff — → `5 failed, 42 passed`, failing exactly the
  five refusal cases.
- Restoring the `origin + pathname` rewrite → `3 failed, 44 passed`, failing
  exactly the three verbatim-storage cases and nothing else.

**Not run:** the two DB-gated integration suites. The Docker daemon is down on
this machine, so real Postgres was unavailable. Neither suite calls
`usageExportConfig` — both stub `usageExport.url` directly — but that is
reasoning, not a run, and it is stated here rather than left implied. `nx test
api` in CI covers them.

Green on the changed bytes: 4 usage-export suites (114 tests), `tsc --noEmit`,
`eslint`, `prettier --check`.

## Known gaps, unchanged from #1170

- `USAGE_EXPORT_VISIBILITY_TIMEOUT_MS / 1000` is exact only while the constant
  stays a whole number of seconds; Redis rejects a fractional `EX`.
- The timeout bound applies to the axios timer, not claim-to-abort elapsed.
- About fifteen sibling URL settings in `configuration.ts` are equally
  unvalidated — worth a separate pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Usage-export destinations now reject URLs containing query strings or fragments.
  * URL validation handles edge cases such as bare delimiters and trailing slashes.
  * Valid configured URLs preserve user information, explicit ports, host casing, and their original format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->