### PR TITLE
chore(api): drop the orphaned observability audit target

### DIFF
--- a/apps/api/src/audit/enums/audit-target.enum.ts
+++ b/apps/api/src/audit/enums/audit-target.enum.ts
@@ -15,5 +15,4 @@ export enum AuditTarget {
   USER = 'user',
   VOLUME = 'volume',
   REGION = 'region',
-  OBSERVABILITY = 'observability',
 }

--- a/apps/api/src/audit/interceptors/audit.interceptor.spec.ts
+++ b/apps/api/src/audit/interceptors/audit.interceptor.spec.ts
@@ -16,14 +16,19 @@ import { CustomHeaders } from '../../common/constants/header.constants'
 jest.mock('uuid', () => ({ v4: () => 'uuid-test' }))
 
 describe('AuditInterceptor', () => {
-  it('records the BoxLite source header and structured metadata for audited admin reads', async () => {
+  // The context below is synthetic on purpose: since the admin observability
+  // controller was deleted, no route emits AuditAction.READ. Metadata keys are
+  // resolved generically (resolveRequestMetadata iterates the extractors), so
+  // `surface`/`query` cover nothing the production `body:` extractors miss —
+  // what this uniquely holds is READ and a composite targetIdFromRequest.
+  it('records the BoxLite source header and structured metadata for an audited request', async () => {
     const auditContext: AuditContext = {
       action: AuditAction.READ,
-      targetType: AuditTarget.OBSERVABILITY,
-      targetIdFromRequest: (req) => `traceId:${req.query.traceId}`,
+      targetType: AuditTarget.RUNNER,
+      targetIdFromRequest: (req) => `regionId:${req.query.regionId}`,
       requestMetadata: {
-        surface: () => 'admin_observability',
-        query: (req) => ({ traceId: req.query.traceId }),
+        surface: () => 'admin_runners',
+        query: (req) => ({ regionId: req.query.regionId }),
       },
     }
     const reflector = {
@@ -36,9 +41,9 @@ describe('AuditInterceptor', () => {
     const configService = { get: jest.fn() }
     const interceptor = new AuditInterceptor(reflector, auditService as any, configService as any)
     const request = {
-      url: '/admin/runners?traceId=trace-1',
+      url: '/admin/runners?regionId=region-1',
       ip: '127.0.0.1',
-      query: { traceId: 'trace-1' },
+      query: { regionId: 'region-1' },
       user: { userId: 'user-1', email: 'admin@example.com', organizationId: 'org-1' },
       get: jest.fn((name: string) => {
         if (name === CustomHeaders.SOURCE.name) return 'agent'
@@ -68,19 +73,19 @@ describe('AuditInterceptor', () => {
         actorEmail: 'admin@example.com',
         organizationId: 'org-1',
         action: AuditAction.READ,
-        targetType: AuditTarget.OBSERVABILITY,
-        targetId: 'traceId:trace-1',
+        targetType: AuditTarget.RUNNER,
+        targetId: 'regionId:region-1',
         source: 'agent',
         userAgent: 'boxlite-agent-test',
         metadata: {
-          surface: 'admin_observability',
-          query: { traceId: 'trace-1' },
+          surface: 'admin_runners',
+          query: { regionId: 'region-1' },
         },
       }),
     )
     expect(auditService.updateLog).toHaveBeenCalledWith('audit-1', {
       organizationId: 'org-1',
-      targetId: 'traceId:trace-1',
+      targetId: 'regionId:region-1',
       statusCode: 200,
     })
   })


### PR DESCRIPTION
## Summary

Follow-up to #1171. That PR deleted the admin observability console, which was the sole
producer of `AuditTarget.OBSERVABILITY`; the enum member and the one test fixture naming it
were left behind. This removes them.

## Call graph

Before

```
audited request
  intercept                 (AuditInterceptor · apps/api/src/audit/interceptors/audit.interceptor.ts:43)
    ├─ resolveTargetId      (AuditInterceptor · apps/api/src/audit/interceptors/audit.interceptor.ts:85)
    └─ resolveRequestMetadata (AuditInterceptor · apps/api/src/audit/interceptors/audit.interceptor.ts:89)
  OBSERVABILITY = 'observability'  (AuditTarget · apps/api/src/audit/enums/audit-target.enum.ts:18)
                                   ← orphaned by #1171: no production emitter
    └─ named only by the fixture   (spec · apps/api/src/audit/interceptors/audit.interceptor.spec.ts:24)
         targetType OBSERVABILITY, surface 'admin_observability', url /admin/observability/investigate
```

After

```
audited request
  intercept                 (AuditInterceptor · apps/api/src/audit/interceptors/audit.interceptor.ts:43)   — unchanged
    ├─ resolveTargetId      (AuditInterceptor · apps/api/src/audit/interceptors/audit.interceptor.ts:85)   — unchanged
    └─ resolveRequestMetadata (AuditInterceptor · apps/api/src/audit/interceptors/audit.interceptor.ts:89) — unchanged
  REGION = 'region'         (AuditTarget · apps/api/src/audit/enums/audit-target.enum.ts:17)  — now the last member
    └─ fixture retargeted   (spec · apps/api/src/audit/interceptors/audit.interceptor.spec.ts:27)
         targetType RUNNER, surface 'admin_runners', url /admin/runners?regionId=region-1
```

## Changes

- `audit-target.enum.ts` — removed `OBSERVABILITY = 'observability'`. All 10 surviving members
  have at least one production emitter.
- `audit.interceptor.spec.ts` — the fixture moves off the deleted member. Every assertion is
  preserved 1:1 (the same nine `createLog` keys and the same `updateLog` triple); only fixture
  values changed, on both the input and expectation sides.

The fixture stays synthetic and a comment now says so. Since #1171, nothing emits
`AuditAction.READ`, so there is no real audited read to mirror. Narrowing the fixture to an
audited runner mutation would have traded away this spec's coverage of `READ` and of a
composite `targetIdFromRequest`, so the synthetic context is kept deliberately.

## How to verify

Removing the enum member cannot affect stored rows:

| Path | Type | Consequence |
|---|---|---|
| `audit-log.entity.ts:34` | `@Column({nullable: true}) targetType?: string` | historical `'observability'` rows still decode |
| `audit-log.dto.ts:28` | `string` | read path never resolves through the enum |
| `list-audit-logs-query.dto.ts` | no `targetType` filter | nothing filters by it |
| `create-audit-log-internal.dto.ts:16` | `targetType?: AuditTarget` | the only enum-typed path, and it is a write |

No `@IsEnum(AuditTarget)` exists anywhere under `apps/api/src`.

| Check | Result |
|---|---|
| `yarn tsc -p api/tsconfig.json --noEmit` | 0 |
| `yarn nx test api --skip-nx-cache` | 50 suites passed / 2 skipped, 315 tests passed, 0 failed |
| `yarn nx test api --skip-nx-cache --testPathPatterns=audit.interceptor.spec` | 1 suite / 1 test passed |

## Risks / rollout

None. No migration, no config change, no wire-format change — `targetType` is and stays a plain
string on the wire and in the column. The only behavioural surface is that new code can no longer
write `'observability'` as an audit target, which is the intent.

`AuditAction.READ` is now unemitted by the same deletion and is deliberately kept: unlike
`OBSERVABILITY`, which named a deleted feature, `READ` is a reusable CRUD verb, and ~20 other
`AuditAction` members (`LOGIN`, `RESIZE`, `SET_DEFAULT`, every `TOOLBOX_*`) already have no
emitter — it is a vocabulary enum, not an orphan.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the deprecated observability audit target.
  * Updated audit tracking to use runner reads, including region details, target identifiers, metadata, and source header handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->