### PR TITLE
chore(infra-local): drop dead runtime-pin and cache-patch workarounds

### DIFF
--- a/apps/infra-local/compose/_local_arm64.py
+++ b/apps/infra-local/compose/_local_arm64.py
@@ -8,8 +8,6 @@ Why these exist (gaps `compose up` otherwise assumes are pre-handled):
     they hit the anonymous Docker Hub rate limit / a private-ghcr 401 — the
     BoxLite puller does NOT read ~/.docker/config.json, so creds must be
     threaded in. The curated box base itself is public.
-  • the maturin *editable* SDK build does not embed boxlite-guest/shim into the
-    runtime cache, so box boot fails with "boxlite-guest not found".
   • the box base is pulled from the published multi-arch agent image
     (ghcr.io/boxlite-ai/boxlite-agent-base), which now carries linux/arm64 — so
     an arm64 Mac boots a usable box straight from ghcr, no local image build.
@@ -129,24 +127,6 @@ def export_ghcr_env() -> None:
         os.environ.setdefault("GHCR_TOKEN", t)
         os.environ.setdefault("BOXLITE_GHCR_USER", u)
         os.environ.setdefault("BOXLITE_GHCR_TOKEN", t)
-
-
-def fix_runtime_cache() -> None:
-    """maturin editable builds leave the SDK runtime cache missing the big
-    boxlite-guest/shim binaries; copy them from the cargo build output."""
-    base = Path.home() / "Library" / "Application Support" / "boxlite" / "runtimes"
-    caches = sorted(base.glob("v*"))
-    if not caches:
-        return
-    cache = caches[0]
-    if (cache / "boxlite-guest").is_file():
-        return
-    for d in REPO.glob("target/debug/build/boxlite-*/out/runtime"):
-        if (d / "boxlite-guest").is_file():
-            for f in ("boxlite-guest", "boxlite-shim"):
-                shutil.copy2(d / f, cache / f)
-            print(f"  patched runtime cache: boxlite-guest+shim -> {cache}")
-            return
 
 
 def ensure_shared_target() -> None:

--- a/apps/infra-local/compose/config.py
+++ b/apps/infra-local/compose/config.py
@@ -4,70 +4,8 @@ from __future__ import annotations
 
 import hashlib
 import os
-import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-
-
-def _platform_runtime_cache_dir() -> Path:
-    """Directory the BoxLite SDK extracts its embedded runtime into.
-
-    Mirrors the Rust `dirs::data_local_dir()` the SDK uses: macOS →
-    ~/Library/Application Support, Linux → $XDG_DATA_HOME or ~/.local/share.
-    """
-    if sys.platform == "darwin":
-        base = Path.home() / "Library" / "Application Support"
-    else:
-        xdg = os.environ.get("XDG_DATA_HOME")
-        base = Path(xdg) if xdg else Path.home() / ".local" / "share"
-    return base / "boxlite" / "runtimes"
-
-
-def pick_runtime_dir(runtimes_dir: Path, version: str | None) -> Path | None:
-    """Pick a usable extracted runtime: a `v{version}[-{hash}]` dir that actually
-    contains the `boxlite-guest` binary. Pure (no env/global reads) for testability.
-
-    Skips dirs that carry a `.complete` stamp but are missing `boxlite-guest`
-    (a partial or REST-only extraction the SDK's fast path would wrongly trust
-    and then fail on at `box.start()`). Prefers the hashless release dir, then
-    the most-recently-used.
-    """
-    if not runtimes_dir.is_dir():
-        return None
-    usable: list[Path] = []
-    for d in runtimes_dir.iterdir():
-        if not d.is_dir() or not d.name.startswith("v"):
-            continue
-        if version and not (d.name == f"v{version}" or d.name.startswith(f"v{version}-")):
-            continue
-        if not (d / "boxlite-guest").is_file():
-            continue
-        usable.append(d)
-    if not usable:
-        return None
-    # Hashless release ("v1.2.3") before debug ("v1.2.3-hash"); then newest mtime.
-    usable.sort(key=lambda d: ("-" in d.name, -d.stat().st_mtime))
-    return usable[0]
-
-
-def resolve_runtime_dir() -> Path | None:
-    """A complete extracted runtime to pin via BOXLITE_RUNTIME_DIR, or None.
-
-    Returns None (leave the SDK's own resolution untouched) when the user already
-    set BOXLITE_RUNTIME_DIR. Otherwise locates a `boxlite-guest`-bearing cache dir
-    matching the installed SDK version — working around a stale/partial embedded
-    cache, or an SDK installed from another worktree without an embedded guest,
-    which the SDK would otherwise fail on at box start.
-    """
-    if os.environ.get("BOXLITE_RUNTIME_DIR"):
-        return None
-    try:
-        import boxlite
-
-        version = getattr(boxlite, "__version__", None)
-    except Exception:
-        version = None
-    return pick_runtime_dir(_platform_runtime_cache_dir(), version)
 
 
 def find_repo_root_from(here: Path) -> Path:

--- a/apps/infra-local/compose/native.py
+++ b/apps/infra-local/compose/native.py
@@ -209,7 +209,7 @@ class _Component:
     timeout_s: int
     argv: list[str]
     cwd: Path | None
-    env: dict[str, str | None]   # extra env layered on top of os.environ; None unsets
+    env: dict[str, str]   # extra env layered on top of os.environ
     pkill_pattern: str    # orphan-sweep fallback (matches the bash pkill -f)
 
 
@@ -245,11 +245,6 @@ def _components(p: _Paths) -> dict[str, _Component]:
                 "AWS_REGION": "us-east-1",
                 "OTEL_TRACING_ENABLED": "true",
                 "OTEL_EXPORTER_OTLP_ENDPOINT": _OTEL_OTLP_HTTP_URL,
-                # The runner links the locally-built core, whose embedded guest
-                # may differ from the PyPI SDK version that ensure_runtime_env()
-                # pins for L1. Unset that pin so the runner resolves the runtime
-                # matching its OWN core (avoids "Guest binary hash mismatch").
-                "BOXLITE_RUNTIME_DIR": None,
             },
             "boxlite-runner$",
         ),
@@ -297,9 +292,7 @@ def start_component(p: _Paths, comp: _Component) -> bool:
         proc = subprocess.Popen(
             comp.argv,
             cwd=str(comp.cwd) if comp.cwd else None,
-            # A None value in comp.env unsets an inherited var (e.g. the L1
-            # BOXLITE_RUNTIME_DIR pin must not leak to the runner — see below).
-            env={k: v for k, v in {**os.environ, **comp.env}.items() if v is not None},
+            env={**os.environ, **comp.env},
             stdout=logf,
             stderr=subprocess.STDOUT,
             start_new_session=True,  # detach: survives our exit + own process group
@@ -517,14 +510,12 @@ def up(cfg: InfraConfig, components: list[str] | None = None) -> int:
             err(f"unknown component: {name} (valid: {' '.join(ALL_COMPONENTS)})")
             return 2
     # 0. Apple-Silicon bootstrap (idempotent no-ops once done): thread docker.io
-    # + ghcr.io creds through to L1 + runner, build the native lib, fix the
-    # runtime cache.
+    # + ghcr.io creds through to L1 + runner, build the native lib.
     _local_arm64.ensure_tools_on_path()
     _local_arm64.export_dockerhub_env()
     _local_arm64.export_ghcr_env()
     _ensure_installed(p)
     _local_arm64.ensure_native_lib()
-    _local_arm64.fix_runtime_cache()
 
     # 1. ensure L1 boxes (single asyncio.run; brings L1 up if postgres is down)
     l1_recreated = asyncio.run(_ensure_l1_async(cfg))

--- a/apps/infra-local/compose/orchestrator.py
+++ b/apps/infra-local/compose/orchestrator.py
@@ -17,7 +17,7 @@ from graphlib import TopologicalSorter
 from pathlib import Path
 
 from ._sdk import import_sdk
-from .config import InfraConfig, resolve_runtime_dir
+from .config import InfraConfig
 from .doctor import doctor
 from .services import HealthCheck, ServiceSpec
 
@@ -99,19 +99,6 @@ def _build_box_options_with_volumes(spec: ServiceSpec, config: InfraConfig, volu
     )
 
 
-def ensure_runtime_env() -> None:
-    """Pin BOXLITE_RUNTIME_DIR to a complete extracted runtime when the SDK's own
-    default resolution would otherwise fail — a stale/partial embedded cache (a
-    `.complete` dir missing boxlite-guest), or an SDK installed from another
-    worktree without an embedded guest. No-op if the user already set
-    BOXLITE_RUNTIME_DIR or no usable cached runtime is found. Idempotent.
-    """
-    runtime_dir = resolve_runtime_dir()
-    if runtime_dir is not None:
-        os.environ["BOXLITE_RUNTIME_DIR"] = str(runtime_dir)
-        print(f"  pinned BOXLITE_RUNTIME_DIR to cached runtime: {runtime_dir}")
-
-
 def ensure_home_env(config: InfraConfig) -> None:
     """Export BOXLITE_HOME from config so the SDK uses the repo-scoped home.
 
@@ -124,7 +111,6 @@ def ensure_home_env(config: InfraConfig) -> None:
 
 
 def get_runtime():
-    ensure_runtime_env()
     Boxlite, _ = import_sdk()
     # Local override: authenticate docker.io pulls when creds are supplied via
     # env, so L1 image pulls don't hit the anonymous Docker Hub rate limit.
@@ -378,11 +364,9 @@ async def up(
     only: list[str] | None = None,
     skip_doctor: bool = False,
 ) -> None:
-    # Pin home + runtime dir before anything builds a Boxlite.default()
-    # singleton (doctor below does), so box starts hit the repo-scoped home
-    # and find boxlite-guest deterministically.
+    # Pin home before anything builds a Boxlite.default() singleton (doctor
+    # below does), so box starts hit the repo-scoped home.
     ensure_home_env(config)
-    ensure_runtime_env()
     if not skip_doctor:
         await doctor(config, services, strict=True)
     else:


### PR DESCRIPTION
## Summary

Delete two infra-local workaround families whose guarded failure modes no longer exist — and which had turned actively harmful: the `BOXLITE_RUNTIME_DIR` pin chain repeatedly pinned stale runtime caches (booting boxes with shims that predate the engine's config schema), and `fix_runtime_cache` copied guest/shim binaries from arbitrary `boxlite-*` build dirs in the machine-shared cargo cache, reintroducing exactly the stale artifacts it meant to fix.

## Call graph

```text
Before
  up                       (compose/native.py)
  ├─ _local_arm64.fix_runtime_cache            — copies guest+shim from an ARBITRARY target/debug/build/boxlite-* dir  ← BUG: shared-cache staleness reinjected
  └─ orchestrator.up / get_runtime
     └─ ensure_runtime_env                     (compose/orchestrator.py)
        └─ resolve_runtime_dir → pick_runtime_dir  (compose/config.py) — pins BOXLITE_RUNTIME_DIR to a globbed cache dir  ← BUG: pins stale runtimes
  start_component          (compose/native.py) — None-filter env merge; runner env carries BOXLITE_RUNTIME_DIR: None to shield the runner from the pin

After
  up                       (compose/native.py) — Apple-Silicon bootstrap without the cache patch
  └─ orchestrator.up / get_runtime — no pin; the SDK self-resolves its embedded runtime
  start_component          (compose/native.py) — plain {**os.environ, **comp.env}; env is dict[str, str]
```

## Why they are dead

- The SDK reliably self-extracts its embedded runtime: three maturin rebuild + cold-extraction cycles observed, each producing a complete `boxlite-guest`-bearing runtime dir with no patching.
- Validated end to end: with the removal in place, runtime cache dirs deleted, `make nuke` then `make up` — all L1 boxes healthy purely on SDK resolution (zero pin lines logged), full stack up on retry, all three services (`boxlite-api`, `boxlite-runner`, `boxlite-proxy`) visible in the local Jaeger. The one first-boot failure (pgadmin healthcheck window) reproduces identically with the workarounds still present, so it is unrelated.

## Behavior note

With the None-unset machinery gone, a developer-exported `BOXLITE_RUNTIME_DIR` now reaches the runner instead of being silently scrubbed — correct env semantics; only relevant if you hand-pin a runtime dir that mismatches the runner's locally built core.

https://claude.ai/code/session_0196vDXG3fbDtna9c7UTFfPf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Simplified local runtime setup by removing automatic runtime-cache repair and directory selection.
  * Local services now use the configured runtime home without pinning a separate cached runtime.
  * Improved environment handling so inherited variables are preserved when launching components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->