### PR TITLE
fix(infra): keep Jaeger OTLP ingest off the internet-facing ALB

### DIFF
--- a/apps/infra/.env.example
+++ b/apps/infra/.env.example
@@ -206,8 +206,10 @@ OIDC_AUDIENCE=https://dev.example.com/api
 #   PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED=True
 # Jaeger (trace UI) is internal-only by default — unauthenticated and exposing
 # sensitive spans, so reach it via VPN / bastion / SSM. Opt into an internet-facing
-# ALB only if you understand the exposure:
-#   JAEGER_PUBLIC=true                       # NOT recommended (no auth)
+# ALB only if you understand the exposure. Public mode also detaches the OTLP
+# ingest listener (never rides a public ALB), so NEW traces stop reaching Jaeger:
+# the UI shows only what arrived while internal.
+#   JAEGER_PUBLIC=true                       # NOT recommended (no auth, frozen traces)
 # MailDev (mail catcher) is internal-only with NO public option: it has no built-in
 # auth, so MAILDEV_PUBLIC=true is rejected at deploy time (fail loud, not silent).
 # The OtelCollector OTLP endpoint is internal-only with no toggle: every emitter

--- a/apps/infra/.env.example
+++ b/apps/infra/.env.example
@@ -204,12 +204,9 @@ OIDC_AUDIENCE=https://dev.example.com/api
 #   PGADMIN_DEFAULT_PASSWORD=                # default: auto-generated
 #   PGADMIN_CONFIG_SERVER_MODE=True          # False disables the login screen (desktop mode)
 #   PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED=True
-# Jaeger (trace UI) is internal-only by default — unauthenticated and exposing
-# sensitive spans, so reach it via VPN / bastion / SSM. Opt into an internet-facing
-# ALB only if you understand the exposure. Public mode also detaches the OTLP
-# ingest listener (never rides a public ALB), so NEW traces stop reaching Jaeger:
-# the UI shows only what arrived while internal.
-#   JAEGER_PUBLIC=true                       # NOT recommended (no auth, frozen traces)
+# Jaeger (trace UI) is internal-only with NO public option, same as MailDev: it
+# has no built-in auth and serves plain HTTP, so JAEGER_PUBLIC=true is rejected
+# at deploy time (fail loud, not silent). Reach it via VPN / bastion / SSM.
 # MailDev (mail catcher) is internal-only with NO public option: it has no built-in
 # auth, so MAILDEV_PUBLIC=true is rejected at deploy time (fail loud, not silent).
 # The OtelCollector OTLP endpoint is internal-only with no toggle: every emitter

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -174,10 +174,15 @@ export default $config({
     }
     const collectorExporters = clickHouseExporterEnabled ? '[boxlite_exporter,clickhouse]' : '[boxlite_exporter]'
     // Traces additionally fan out to Jaeger; metrics/logs stay off it (Jaeger
-    // ingests traces only).
-    const collectorTraceExporters = clickHouseExporterEnabled
-      ? '[boxlite_exporter,clickhouse,otlphttp/jaeger]'
-      : '[boxlite_exporter,otlphttp/jaeger]'
+    // ingests traces only). Public-Jaeger mode drops the OTLP listener from the
+    // ALB (see the Jaeger service), so the exporter is dropped with it — else
+    // the collector would retry into a listener that no longer exists.
+    const jaegerPublic = envOr('JAEGER_PUBLIC', 'false') === 'true'
+    const collectorTraceExporters = jaegerPublic
+      ? collectorExporters
+      : clickHouseExporterEnabled
+        ? '[boxlite_exporter,clickhouse,otlphttp/jaeger]'
+        : '[boxlite_exporter,otlphttp/jaeger]'
 
     // HTTPS everywhere: the Router CloudFront Function deletes customOriginConfig
     // for http origins and CF then falls back to match-viewer (→ tries HTTPS on a
@@ -357,9 +362,10 @@ export default $config({
     // Internal ALB by default: the trace UI exposes every span (URLs, headers,
     // IDs, SQL, error bodies) with no auth, and nothing outside the VPC needs
     // to read it. Reach it via VPN / bastion / `aws ssm start-session`.
-    // JAEGER_PUBLIC=true opts into an internet-facing ALB — which then also
-    // exposes the unauthenticated OTLP ingest listener below.
-    const jaegerPublic = envOr('JAEGER_PUBLIC', 'false') === 'true'
+    // JAEGER_PUBLIC=true opts the UI into an internet-facing ALB; the OTLP
+    // ingest listener never rides it (unauthenticated span injection / DoS),
+    // so public mode also stops new traces from reaching Jaeger — it shows
+    // only what arrived while internal.
     const jaeger = new sst.aws.Service('Jaeger', {
       cluster,
       image: IMAGES.jaeger,
@@ -367,14 +373,19 @@ export default $config({
         public: jaegerPublic,
         rules: [
           { listen: '80/http', forward: `${PORTS.JAEGER_UI}/http` },
-          // OTLP HTTP ingest, fed by the OtelCollector's otlphttp/jaeger exporter.
-          { listen: `${PORTS.OTLP_HTTP}/http`, forward: `${PORTS.OTLP_HTTP}/http` },
+          // OTLP HTTP ingest, fed by the OtelCollector's otlphttp/jaeger
+          // exporter — internal mode only, see the JAEGER_PUBLIC note above.
+          ...(jaegerPublic ? [] : [{ listen: `${PORTS.OTLP_HTTP}/http`, forward: `${PORTS.OTLP_HTTP}/http` }]),
         ],
-        health: {
-          // The OTLP receiver returns a client-error status for a bare
-          // health-check GET, which still proves the receiver is listening.
-          [`${PORTS.OTLP_HTTP}/http`]: httpHealth('/', { successCodes: '200-499' }),
-        },
+        ...(jaegerPublic
+          ? {}
+          : {
+              health: {
+                // The OTLP receiver returns a client-error status for a bare
+                // health-check GET, which still proves the receiver is listening.
+                [`${PORTS.OTLP_HTTP}/http`]: httpHealth('/', { successCodes: '200-499' }),
+              },
+            }),
       },
       environment: { COLLECTOR_OTLP_ENABLED: 'true' },
     })

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -174,15 +174,10 @@ export default $config({
     }
     const collectorExporters = clickHouseExporterEnabled ? '[boxlite_exporter,clickhouse]' : '[boxlite_exporter]'
     // Traces additionally fan out to Jaeger; metrics/logs stay off it (Jaeger
-    // ingests traces only). Public-Jaeger mode drops the OTLP listener from the
-    // ALB (see the Jaeger service), so the exporter is dropped with it — else
-    // the collector would retry into a listener that no longer exists.
-    const jaegerPublic = envOr('JAEGER_PUBLIC', 'false') === 'true'
-    const collectorTraceExporters = jaegerPublic
-      ? collectorExporters
-      : clickHouseExporterEnabled
-        ? '[boxlite_exporter,clickhouse,otlphttp/jaeger]'
-        : '[boxlite_exporter,otlphttp/jaeger]'
+    // ingests traces only).
+    const collectorTraceExporters = clickHouseExporterEnabled
+      ? '[boxlite_exporter,clickhouse,otlphttp/jaeger]'
+      : '[boxlite_exporter,otlphttp/jaeger]'
 
     // HTTPS everywhere: the Router CloudFront Function deletes customOriginConfig
     // for http origins and CF then falls back to match-viewer (→ tries HTTPS on a
@@ -359,33 +354,33 @@ export default $config({
     // Created before Api so API, runner, host, and box can all emit OTLP to the
     // same Collector. ClickHouse is external/managed only; no in-cluster
     // ClickHouseSpike fallback is part of the target architecture.
-    // Internal ALB by default: the trace UI exposes every span (URLs, headers,
-    // IDs, SQL, error bodies) with no auth, and nothing outside the VPC needs
-    // to read it. Reach it via VPN / bastion / `aws ssm start-session`.
-    // JAEGER_PUBLIC=true opts the UI into an internet-facing ALB; the OTLP
-    // ingest listener never rides it (unauthenticated span injection / DoS),
-    // so public mode also stops new traces from reaching Jaeger — it shows
-    // only what arrived while internal.
+    // Jaeger is VPC-internal only: the trace UI exposes every span (URLs,
+    // headers, IDs, SQL, error bodies) with no auth over plain HTTP, and its
+    // OTLP ingest is equally unauthenticated — reach the UI via VPN / bastion /
+    // `aws ssm start-session`. JAEGER_PUBLIC is rejected (fail loud) like
+    // MAILDEV_PUBLIC: no auth gate or TLS story makes public exposure safe.
+    if (envOr('JAEGER_PUBLIC', 'false') === 'true') {
+      throw new Error(
+        'JAEGER_PUBLIC is not supported: Jaeger has no auth and its UI is plain HTTP, so ' +
+          'it cannot be safely exposed to the internet. Reach it via VPN / bastion / ' +
+          '`aws ssm start-session`.',
+      )
+    }
     const jaeger = new sst.aws.Service('Jaeger', {
       cluster,
       image: IMAGES.jaeger,
       loadBalancer: {
-        public: jaegerPublic,
+        public: false,
         rules: [
           { listen: '80/http', forward: `${PORTS.JAEGER_UI}/http` },
-          // OTLP HTTP ingest, fed by the OtelCollector's otlphttp/jaeger
-          // exporter — internal mode only, see the JAEGER_PUBLIC note above.
-          ...(jaegerPublic ? [] : [{ listen: `${PORTS.OTLP_HTTP}/http`, forward: `${PORTS.OTLP_HTTP}/http` }]),
+          // OTLP HTTP ingest, fed by the OtelCollector's otlphttp/jaeger exporter.
+          { listen: `${PORTS.OTLP_HTTP}/http`, forward: `${PORTS.OTLP_HTTP}/http` },
         ],
-        ...(jaegerPublic
-          ? {}
-          : {
-              health: {
-                // The OTLP receiver returns a client-error status for a bare
-                // health-check GET, which still proves the receiver is listening.
-                [`${PORTS.OTLP_HTTP}/http`]: httpHealth('/', { successCodes: '200-499' }),
-              },
-            }),
+        health: {
+          // The OTLP receiver returns a client-error status for a bare
+          // health-check GET, which still proves the receiver is listening.
+          [`${PORTS.OTLP_HTTP}/http`]: httpHealth('/', { successCodes: '200-499' }),
+        },
       },
       environment: { COLLECTOR_OTLP_ENABLED: 'true' },
     })


### PR DESCRIPTION
## Summary

Follow-up to #1175's review. CodeRabbit raised two Major findings; one is real and fixed here, the other was refuted by verification and deliberately left unchanged.

**Fixed — OTLP ingest off the public ALB.** `JAEGER_PUBLIC=true` used to expose the unauthenticated `4318` OTLP listener on the same internet-facing ALB as the UI: open span injection and resource abuse. The listener and its health check now attach only in internal mode, and the collector's traces pipeline drops the `otlphttp/jaeger` exporter with them instead of retrying into a listener that no longer exists. `.env.example` documents the trade-off (public mode freezes Jaeger's view; new traces stop arriving).

**Refuted — proxy propagator ordering.** The claim was that `otelhttp.NewTransport` built in `GetConfig` before `InitTracer` captures a noop propagator and never injects `traceparent`. Against the pinned versions (otelhttp v0.67.0, otel v1.43.0) this does not hold: otel's global propagator is a delegating handle (`internal/global/state.go:114-122`) — the first `SetTextMapPropagator` call delegates into the pre-captured default, so a pre-init transport injects identically. Verified with an isolated two-process probe (both orderings inject a `traceparent` carrying the parent span's trace id). No code change; a reply on the review thread carries the same analysis.

## Call graph

```text
Before
  jaegerPublic = envOr('JAEGER_PUBLIC')           (apps/infra/sst.config.ts)
  └─ Jaeger loadBalancer { public: jaegerPublic,
       rules: [80→UI, 4318→OTLP] }                ← BUG: public mode exposes unauthenticated OTLP ingest
  collectorTraceExporters = [..., otlphttp/jaeger]  (unconditional)

After
  jaegerPublic (hoisted above the exporter split)
  ├─ Jaeger loadBalancer rules: [80→UI, ...(internal ? [4318→OTLP] : [])]
  │    health: internal-only for the OTLP target
  └─ collectorTraceExporters: internal → [..., otlphttp/jaeger]
                              public   → collectorExporters (no jaeger — nothing to reach)
```

## Verification

- `npx esbuild --loader:.ts=ts apps/infra/sst.config.ts` — clean parse (no local SST typecheck exists).
- Default (internal) path is behavior-identical to merged #1175 — same rules, health, and pipeline as before this change.
- Residual risk: the `JAEGER_PUBLIC=true` branch is deploy-time-unverified (flag defaults false, dev never sets it); flipping it likely also replaces the ALB and recycles the in-memory Jaeger task, so the "frozen view" may be an empty one.

https://claude.ai/code/session_0196vDXG3fbDtna9c7UTFfPf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changes**
  - Jaeger is now always available only within the private network.
  - Deployments configured with `JAEGER_PUBLIC=true` are rejected with a clear safety error.
  - Trace ingestion, health checks, and trace exporting continue to work as before.

- **Documentation**
  - Updated configuration guidance to clarify that Jaeger does not support public access and must remain internal-only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->