### PR TITLE
fix(api): add owner-safe usage lock leases

### DIFF
--- a/apps/api/src/box/common/redis-lock.provider.spec.ts
+++ b/apps/api/src/box/common/redis-lock.provider.spec.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { LockCode, RedisLockProvider, withRedisLockLease } from './redis-lock.provider'
+
+describe('RedisLockProvider leases', () => {
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('releases only the owner that acquired the lease', async () => {
+    const redis = {
+      set: jest.fn().mockResolvedValue('OK'),
+      eval: jest.fn().mockResolvedValue(1),
+    }
+    const provider = new RedisLockProvider(redis as any)
+
+    const lease = await provider.acquireLease('usage-period-box-1', 10)
+    const owner = redis.set.mock.calls[0][1]
+    await lease?.release()
+
+    expect(owner).not.toBe('1')
+    expect(redis.eval).toHaveBeenCalledWith(
+      expect.stringContaining("redis.call('del', KEYS[1])"),
+      1,
+      'usage-period-box-1',
+      owner,
+    )
+  })
+
+  it('does not let an expired owner delete a replacement owner', async () => {
+    let currentOwner = 'replacement-owner'
+    const redis = {
+      eval: jest.fn(async (_script: string, _keys: number, _key: string, owner: string) => {
+        if (currentOwner === owner) {
+          currentOwner = ''
+          return 1
+        }
+        return 0
+      }),
+    }
+    const provider = new RedisLockProvider(redis as any)
+    const warn = jest.spyOn((provider as any).logger, 'warn').mockImplementation()
+
+    await provider.releaseLease('shared-key', new LockCode('expired-owner'))
+
+    expect(currentOwner).toBe('replacement-owner')
+    expect(redis.eval).toHaveBeenCalledWith(
+      expect.stringContaining("if redis.call('get', KEYS[1]) == ARGV[1]"),
+      1,
+      'shared-key',
+      'expired-owner',
+    )
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('shared-key'))
+  })
+
+  it('renews an acquired lease before its TTL expires', async () => {
+    jest.useFakeTimers()
+    const redis = {
+      set: jest.fn().mockResolvedValue('OK'),
+      eval: jest.fn().mockResolvedValue(1),
+    }
+    const provider = new RedisLockProvider(redis as any)
+
+    const lease = await provider.acquireLease('archive-usage-periods', 10)
+    await jest.advanceTimersByTimeAsync(5_000)
+
+    expect(redis.eval).toHaveBeenCalledWith(
+      expect.stringContaining("redis.call('expire', KEYS[1], ARGV[2])"),
+      1,
+      'archive-usage-periods',
+      expect.any(String),
+      10,
+    )
+    await lease?.release()
+  })
+
+  it('aborts before expiry when a renewal command never settles', async () => {
+    jest.useFakeTimers()
+    const redis = {
+      set: jest.fn().mockResolvedValue('OK'),
+      eval: jest.fn(() => new Promise(() => undefined)),
+    }
+    const provider = new RedisLockProvider(redis as any)
+    const lease = await provider.acquireLease('stalled-renewal', 2)
+
+    await jest.advanceTimersByTimeAsync(1_800)
+
+    expect(lease?.signal.aborted).toBe(true)
+    expect(lease?.signal.reason).toEqual(expect.objectContaining({ message: expect.stringContaining('timed out') }))
+    const release = expect(lease?.release()).rejects.toThrow('renewal timed out')
+    await jest.advanceTimersByTimeAsync(250)
+    await release
+  })
+
+  it('preserves the operation error when release also fails', async () => {
+    const operationError = new Error('operation failed')
+    const releaseError = new Error('release failed')
+    const onSuppressedReleaseError = jest.fn()
+    const lease = {
+      signal: new AbortController().signal,
+      release: jest.fn().mockRejectedValue(releaseError),
+    }
+
+    await expect(
+      withRedisLockLease(
+        lease as any,
+        async () => {
+          throw operationError
+        },
+        onSuppressedReleaseError,
+      ),
+    ).rejects.toBe(operationError)
+    expect(onSuppressedReleaseError).toHaveBeenCalledWith(releaseError)
+  })
+
+  it('cancels an in-flight wait and releases a lease that arrives afterward', async () => {
+    const provider = new RedisLockProvider({} as any)
+    const controller = new AbortController()
+    let finishRelease!: () => void
+    const released = new Promise<void>((resolve) => {
+      finishRelease = resolve
+    })
+    const lease = { release: jest.fn().mockImplementation(async () => finishRelease()) }
+    let finishAcquire!: (lease: any) => void
+    jest.spyOn(provider, 'acquireLease').mockReturnValue(
+      new Promise((resolve) => {
+        finishAcquire = resolve
+      }),
+    )
+
+    const waiting = expect(
+      provider.waitForLease('usage-period-box-1', 60, controller.signal),
+    ).rejects.toThrow('service is shutting down')
+    controller.abort(new Error('service is shutting down'))
+    await waiting
+
+    finishAcquire(lease)
+    await released
+    expect(lease.release).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/api/src/box/common/redis-lock.provider.ts
+++ b/apps/api/src/box/common/redis-lock.provider.ts
@@ -5,8 +5,10 @@
  */
 
 import { InjectRedis } from '@nestjs-modules/ioredis'
-import { Injectable } from '@nestjs/common'
+import { Injectable, Logger } from '@nestjs/common'
 import { Redis } from 'ioredis'
+import { randomUUID } from 'crypto'
+import { setTimeout as sleep } from 'timers/promises'
 
 type Acquired = boolean
 
@@ -18,14 +20,220 @@ export class LockCode {
   }
 }
 
+export class LockOwnershipLostError extends Error {}
+
+export class RedisLockLease {
+  private readonly abortController = new AbortController()
+  private renewalTimer: ReturnType<typeof setTimeout> | null = null
+  private renewal: Promise<void> = Promise.resolve()
+  private renewalError: unknown
+  private isReleased = false
+
+  constructor(
+    private readonly provider: RedisLockProvider,
+    private readonly key: string,
+    private readonly ttl: number,
+    private readonly owner: LockCode,
+  ) {
+    this.scheduleRenewal()
+  }
+
+  get signal(): AbortSignal {
+    return this.abortController.signal
+  }
+
+  async release(): Promise<void> {
+    if (this.isReleased) {
+      return
+    }
+    this.isReleased = true
+    if (this.renewalTimer) {
+      clearTimeout(this.renewalTimer)
+    }
+    await this.renewal
+
+    let releaseError: unknown
+    try {
+      await this.withTimeout(
+        this.provider.releaseLease(this.key, this.owner),
+        this.operationTimeoutMs,
+        `Redis lock release timed out for ${this.key}`,
+      )
+    } catch (error) {
+      releaseError = error
+    }
+
+    if (this.renewalError) {
+      throw this.renewalError
+    }
+    if (releaseError) {
+      throw releaseError
+    }
+  }
+
+  private get operationTimeoutMs(): number {
+    // Two renewal attempts and the delay between them finish by 7/8 TTL.
+    return Math.min((this.ttl * 1000) / 8, 1000)
+  }
+
+  private scheduleRenewal(): void {
+    this.renewalTimer = setTimeout(() => {
+      this.renewal = this.renewWithTimeout()
+        .catch((error) => {
+          if (error instanceof LockOwnershipLostError) {
+            throw error
+          }
+          if (this.isReleased) {
+            return
+          }
+          return new Promise<void>((resolve) => setTimeout(resolve, this.operationTimeoutMs)).then(() => {
+            if (!this.isReleased) {
+              return this.renewWithTimeout()
+            }
+          })
+        })
+        .catch((error) => {
+          this.renewalError = error
+          this.abortController.abort(error)
+        })
+        .then(() => {
+          if (!this.isReleased && !this.renewalError) {
+            this.scheduleRenewal()
+          }
+        })
+    }, (this.ttl * 1000) / 2)
+  }
+
+  private async renewWithTimeout(): Promise<void> {
+    await this.withTimeout(
+      this.provider.renewLease(this.key, this.ttl, this.owner),
+      this.operationTimeoutMs,
+      `Redis lock renewal timed out for ${this.key}`,
+    )
+  }
+
+  private async withTimeout(operation: Promise<void>, timeoutMs: number, timeoutMessage: string): Promise<void> {
+    let timeout: ReturnType<typeof setTimeout>
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeout = setTimeout(() => reject(new Error(timeoutMessage)), timeoutMs)
+    })
+
+    try {
+      await Promise.race([operation, timeoutPromise])
+    } finally {
+      clearTimeout(timeout)
+    }
+  }
+}
+
+export async function withRedisLockLease<T>(
+  lease: RedisLockLease,
+  operation: (signal: AbortSignal) => Promise<T>,
+  onSuppressedReleaseError?: (error: unknown) => void,
+): Promise<T> {
+  const signal = lease.signal
+  let result: T
+  try {
+    result = await operation(signal)
+    signal.throwIfAborted()
+  } catch (error) {
+    try {
+      await lease.release()
+    } catch (releaseError) {
+      onSuppressedReleaseError?.(releaseError)
+    }
+    throw error
+  }
+
+  await lease.release()
+  return result
+}
+
 @Injectable()
 export class RedisLockProvider {
+  private readonly logger = new Logger(RedisLockProvider.name)
+
   constructor(@InjectRedis() private readonly redis: Redis) {}
 
   async lock(key: string, ttl: number, code?: LockCode | null): Promise<Acquired> {
     const keyValue = code ? code.getCode() : '1'
     const acquired = await this.redis.set(key, keyValue, 'EX', ttl, 'NX')
     return !!acquired
+  }
+
+  async acquireLease(key: string, ttl: number): Promise<RedisLockLease | null> {
+    const owner = new LockCode(randomUUID())
+    if (!(await this.lock(key, ttl, owner))) {
+      return null
+    }
+    return new RedisLockLease(this, key, ttl, owner)
+  }
+
+  async renewLease(key: string, ttl: number, owner: LockCode): Promise<void> {
+    const renewed = (await this.redis.eval(
+      `if redis.call('get', KEYS[1]) == ARGV[1] then
+        return redis.call('expire', KEYS[1], ARGV[2])
+      end
+      return 0`,
+      1,
+      key,
+      owner.getCode(),
+      ttl,
+    )) as number
+    if (renewed !== 1) {
+      throw new LockOwnershipLostError(`Cannot renew Redis lock lease for ${key}: ownership was lost`)
+    }
+  }
+
+  async releaseLease(key: string, owner: LockCode): Promise<void> {
+    const released = (await this.redis.eval(
+      `if redis.call('get', KEYS[1]) == ARGV[1] then
+        return redis.call('del', KEYS[1])
+      end
+      return 0`,
+      1,
+      key,
+      owner.getCode(),
+    )) as number
+    if (released !== 1) {
+      this.logger.warn(`Redis lock lease for ${key} was no longer owned when released`)
+    }
+  }
+
+  async waitForLease(key: string, ttl: number, signal: AbortSignal): Promise<RedisLockLease> {
+    while (true) {
+      signal.throwIfAborted()
+      const acquisition = this.acquireLease(key, ttl)
+      let onAbort!: () => void
+      const cancelled = new Promise<never>((_, reject) => {
+        onAbort = () => reject(signal.reason)
+        signal.addEventListener('abort', onAbort, { once: true })
+      })
+
+      try {
+        const lease = await Promise.race([acquisition, cancelled])
+        signal.throwIfAborted()
+        if (lease) return lease
+      } catch (error) {
+        if (signal.aborted) {
+          void acquisition
+            .then((lease) => lease?.release())
+            .catch((releaseError) =>
+              this.logger.error(`Error cleaning up cancelled Redis lock wait for ${key}`, releaseError),
+            )
+        }
+        throw error
+      } finally {
+        signal.removeEventListener('abort', onAbort)
+      }
+
+      try {
+        await sleep(50, undefined, { signal })
+      } catch (error) {
+        signal.throwIfAborted()
+        throw error
+      }
+    }
   }
 
   async getCode(key: string): Promise<LockCode | null> {

--- a/apps/api/src/common/decorators/track-job-execution.decorator.spec.ts
+++ b/apps/api/src/common/decorators/track-job-execution.decorator.spec.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { TrackJobExecution } from './track-job-execution.decorator'
+
+describe('TrackJobExecution', () => {
+  it('tracks concurrent calls of the same method independently', async () => {
+    const completions: Array<() => void> = []
+
+    class Worker {
+      activeJobs = new Set<string>()
+
+      @TrackJobExecution()
+      async run() {
+        await new Promise<void>((resolve) => completions.push(resolve))
+      }
+    }
+
+    const worker = new Worker()
+    const first = worker.run()
+    const second = worker.run()
+    expect(worker.activeJobs.size).toBe(2)
+
+    completions[0]()
+    await first
+    expect(worker.activeJobs.size).toBe(1)
+
+    completions[1]()
+    await second
+    expect(worker.activeJobs.size).toBe(0)
+  })
+})

--- a/apps/api/src/common/decorators/track-job-execution.decorator.ts
+++ b/apps/api/src/common/decorators/track-job-execution.decorator.ts
@@ -8,6 +8,8 @@
  * Track job execution in activeJobs set.
  * @returns A decorator function that tracks execution of a job.
  */
+let nextExecutionId = 0
+
 export function TrackJobExecution() {
   return function (target: any, propertyKey: string, descriptor: PropertyDescriptor) {
     const original = descriptor.value
@@ -17,11 +19,12 @@ export function TrackJobExecution() {
         throw new Error(`@TrackExecution requires 'activeJobs' property on ${target.constructor.name}`)
       }
 
-      this.activeJobs.add(propertyKey)
+      const execution = `${propertyKey}:${nextExecutionId++}`
+      this.activeJobs.add(execution)
       try {
         return await original.apply(this, args)
       } finally {
-        this.activeJobs.delete(propertyKey)
+        this.activeJobs.delete(execution)
       }
     }
   }

--- a/apps/api/src/usage/services/usage.service.spec.ts
+++ b/apps/api/src/usage/services/usage.service.spec.ts
@@ -44,17 +44,30 @@ const satisfies = (actual: unknown, condition: unknown): boolean => {
 }
 
 const makeService = (stored: BoxUsagePeriod[] = []) => {
+  const lease = {
+    signal: new AbortController().signal,
+    release: jest.fn().mockResolvedValue(undefined),
+  }
+  const transactionalEntityManager = {
+    find: jest.fn().mockResolvedValue([]),
+    delete: jest.fn().mockResolvedValue(undefined),
+    save: jest.fn().mockImplementation(async (value) => value),
+  }
   const usagePeriodRepository = {
     findOne: jest.fn(async ({ where }: any) =>
       stored.find((period) =>
         Object.entries(where).every(([column, condition]) => satisfies((period as any)[column], condition)),
       ),
     ),
+    find: jest.fn().mockResolvedValue([]),
     save: jest.fn().mockImplementation(async (period) => period),
+    manager: {
+      transaction: jest.fn(async (callback) => callback(transactionalEntityManager)),
+    },
   }
   const redisLockProvider = {
-    lock: jest.fn().mockResolvedValue(true),
-    unlock: jest.fn().mockResolvedValue(undefined),
+    acquireLease: jest.fn().mockResolvedValue(lease),
+    waitForLease: jest.fn().mockResolvedValue(lease),
   }
   const boxRepository = { findOne: jest.fn() }
   const usageExportOutboxService = { enqueue: jest.fn().mockResolvedValue(0) }
@@ -66,7 +79,14 @@ const makeService = (stored: BoxUsagePeriod[] = []) => {
     usageExportOutboxService as any,
   )
 
-  return { service, usagePeriodRepository, redisLockProvider, usageExportOutboxService }
+  return {
+    service,
+    usagePeriodRepository,
+    redisLockProvider,
+    usageExportOutboxService,
+    lease,
+    transactionalEntityManager,
+  }
 }
 
 const OTHER_BOX_ID = 'box-2'
@@ -88,6 +108,23 @@ describe('UsageService event subscriptions', () => {
 })
 
 describe('UsageService.handleBoxStateUpdate', () => {
+  it('cancels a pending lock wait during application shutdown', async () => {
+    const { service, redisLockProvider } = makeService()
+    redisLockProvider.waitForLease.mockImplementation(
+      (_key: string, _ttl: number, signal: AbortSignal) =>
+        new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason), { once: true })
+        }),
+    )
+
+    const handling = service.handleBoxStateUpdate(event(BoxState.STARTING)).catch((error) => error)
+    await Promise.resolve()
+    await service.onApplicationShutdown()
+
+    await expect(handling).resolves.toEqual(expect.objectContaining({ message: 'UsageService is shutting down' }))
+    expect(service.activeJobs.size).toBe(0)
+  })
+
   it('opens a full-resource period when the box starts', async () => {
     const { service, usagePeriodRepository } = makeService()
 
@@ -237,11 +274,29 @@ describe('UsageService.handleBoxStateUpdate', () => {
   })
 
   it('releases the per-box lock even when the transition is not billable', async () => {
-    const { service, redisLockProvider } = makeService()
+    const { service, lease } = makeService()
 
     await service.handleBoxStateUpdate(event(BoxState.STARTING))
 
-    expect(redisLockProvider.unlock).toHaveBeenCalledWith(`usage-period-${box.id}`)
+    expect(lease.release).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not reopen a period after lease ownership is lost while closing it', async () => {
+    const open = openPeriod()
+    const { service, usagePeriodRepository, lease } = makeService([open])
+    const ownershipError = new Error('ownership was lost')
+    const controller = new AbortController()
+    lease.signal = controller.signal
+    usagePeriodRepository.save.mockImplementationOnce(async (period) => {
+      controller.abort(ownershipError)
+      return period
+    })
+
+    await expect(service.handleBoxStateUpdate(event(BoxState.STARTED))).rejects.toBe(ownershipError)
+
+    expect(usagePeriodRepository.save).toHaveBeenCalledTimes(1)
+    expect(usagePeriodRepository.save).toHaveBeenCalledWith(open)
+    expect(lease.release).toHaveBeenCalledTimes(1)
   })
 })
 
@@ -269,12 +324,51 @@ describe('UsageService.handleBoxDesiredStateUpdate', () => {
   })
 
   it('releases the per-box lock it took', async () => {
-    const { service, redisLockProvider } = makeService([openPeriod()])
+    const { service, lease } = makeService([openPeriod()])
 
     await service.handleBoxDesiredStateUpdate(
       new BoxDesiredStateUpdatedEvent(box, BoxDesiredState.STARTED, BoxDesiredState.DESTROYED),
     )
 
-    expect(redisLockProvider.unlock).toHaveBeenCalledWith(`usage-period-${box.id}`)
+    expect(lease.release).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('UsageService lease lifecycle', () => {
+  it('releases the archive lease when the transaction fails', async () => {
+    const { service, usagePeriodRepository, lease } = makeService()
+    const transactionError = new Error('archive transaction failed')
+    usagePeriodRepository.manager.transaction.mockRejectedValue(transactionError)
+
+    await expect(service.archiveUsagePeriods()).rejects.toBe(transactionError)
+
+    expect(lease.release).toHaveBeenCalledTimes(1)
+  })
+
+  it('rolls back archive writes when lease ownership is lost before commit', async () => {
+    const { service, usagePeriodRepository, usageExportOutboxService, lease, transactionalEntityManager } =
+      makeService()
+    const ownershipError = new Error('ownership was lost')
+    const controller = new AbortController()
+    lease.signal = controller.signal
+    const period = { id: 'period-1' } as BoxUsagePeriod
+    transactionalEntityManager.find.mockResolvedValue([period])
+    usageExportOutboxService.enqueue.mockImplementation(async () => {
+      controller.abort(ownershipError)
+    })
+    let committed = false
+    usagePeriodRepository.manager.transaction.mockImplementation(async (callback) => {
+      const result = await callback(transactionalEntityManager)
+      committed = true
+      return result
+    })
+
+    await expect(service.archiveUsagePeriods()).rejects.toBe(ownershipError)
+
+    expect(transactionalEntityManager.delete).toHaveBeenCalledWith(BoxUsagePeriod, [period.id])
+    expect(transactionalEntityManager.save).toHaveBeenCalledTimes(1)
+    expect(usageExportOutboxService.enqueue).toHaveBeenCalledTimes(1)
+    expect(committed).toBe(false)
+    expect(lease.release).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/api/src/usage/services/usage.service.ts
+++ b/apps/api/src/usage/services/usage.service.ts
@@ -15,7 +15,7 @@ import { BoxState } from '../../box/enums/box-state.enum'
 import { BoxDesiredState } from '../../box/enums/box-desired-state.enum'
 import { BoxEvents } from './../../box/constants/box-events.constants'
 import { Cron, CronExpression } from '@nestjs/schedule'
-import { RedisLockProvider } from '../../box/common/redis-lock.provider'
+import { RedisLockLease, RedisLockProvider, withRedisLockLease } from '../../box/common/redis-lock.provider'
 import { BOX_WARM_POOL_UNASSIGNED_ORGANIZATION } from '../../box/constants/box.constants'
 import { BoxUsagePeriodArchive } from '../entities/box-usage-period-archive.entity'
 import { TrackableJobExecutions } from '../../common/interfaces/trackable-job-executions'
@@ -30,6 +30,7 @@ import { UsageExportOutboxService } from './usage-export-outbox.service'
 export class UsageService implements TrackableJobExecutions, OnApplicationShutdown {
   activeJobs = new Set<string>()
   private readonly logger = new Logger(UsageService.name)
+  private readonly shutdownController = new AbortController()
 
   constructor(
     @InjectRepository(BoxUsagePeriod)
@@ -40,6 +41,7 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
   ) {}
 
   async onApplicationShutdown() {
+    this.shutdownController.abort(new Error('UsageService is shutting down'))
     //  wait for all active jobs to finish
     while (this.activeJobs.size > 0) {
       this.logger.log(`Waiting for ${this.activeJobs.size} active jobs to finish`)
@@ -50,31 +52,30 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
   @OnEvent(BoxEvents.DESIRED_STATE_UPDATED)
   @TrackJobExecution()
   async handleBoxDesiredStateUpdate(event: BoxDesiredStateUpdatedEvent) {
-    await this.waitForLock(event.box.id)
+    const lease = await this.waitForLock(event.box.id)
 
-    try {
+    await this.withLease(lease, async (signal) => {
+      signal.throwIfAborted()
       switch (event.newDesiredState) {
         case BoxDesiredState.DESTROYED: {
           await this.closeUsagePeriod(event.box.id)
           break
         }
       }
-    } finally {
-      this.releaseLock(event.box.id).catch((error) => {
-        this.logger.error(`Error releasing lock for box ${event.box.id}`, error)
-      })
-    }
+    }, `box ${event.box.id}`)
   }
 
   @OnEvent(BoxEvents.STATE_UPDATED)
   @TrackJobExecution()
   async handleBoxStateUpdate(event: BoxStateUpdatedEvent) {
-    await this.waitForLock(event.box.id)
+    const lease = await this.waitForLock(event.box.id)
 
-    try {
+    await this.withLease(lease, async (signal) => {
+      signal.throwIfAborted()
       switch (event.newState) {
         case BoxState.STARTED: {
           await this.closeUsagePeriod(event.box.id)
+          signal.throwIfAborted()
           await this.createUsagePeriod(event)
           break
         }
@@ -85,6 +86,7 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
         // decision.
         case BoxState.STOPPING:
           await this.closeUsagePeriod(event.box.id)
+          signal.throwIfAborted()
           await this.createUsagePeriod(event, true)
           break
         // Safeguards if STOPPING state is skipped
@@ -96,8 +98,10 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
               cpu: Not(0),
             },
           })
+          signal.throwIfAborted()
           if (cpuUsagePeriod) {
             await this.closeUsagePeriod(event.box.id)
+            signal.throwIfAborted()
             await this.createUsagePeriod(event, true)
           }
           break
@@ -110,11 +114,7 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
           break
         }
       }
-    } finally {
-      this.releaseLock(event.box.id).catch((error) => {
-        this.logger.error(`Error releasing lock for box ${event.box.id}`, error)
-      })
-    }
+    }, `box ${event.box.id}`)
   }
 
   private async createUsagePeriod(event: BoxStateUpdatedEvent, diskOnly = false) {
@@ -157,66 +157,70 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
   @LogExecution('close-and-reopen-usage-periods')
   @WithInstrumentation()
   async closeAndReopenUsagePeriods() {
-    if (!(await this.redisLockProvider.lock('close-and-reopen-usage-periods', 60))) {
+    const lockKey = 'close-and-reopen-usage-periods'
+    const lease = await this.redisLockProvider.acquireLease(lockKey, 60)
+    if (!lease) {
       return
     }
 
-    const usagePeriods = await this.boxUsagePeriodRepository.find({
-      where: {
-        endAt: IsNull(),
-        // 1 day ago
-        startAt: LessThan(new Date(Date.now() - 1000 * 60 * 60 * 24)),
-        organizationId: Not(BOX_WARM_POOL_UNASSIGNED_ORGANIZATION),
-      },
-      order: {
-        startAt: 'ASC',
-      },
-      take: 100,
-    })
+    await this.withLease(lease, async (signal) => {
+      const usagePeriods = await this.boxUsagePeriodRepository.find({
+        where: {
+          endAt: IsNull(),
+          // 1 day ago
+          startAt: LessThan(new Date(Date.now() - 1000 * 60 * 60 * 24)),
+          organizationId: Not(BOX_WARM_POOL_UNASSIGNED_ORGANIZATION),
+        },
+        order: {
+          startAt: 'ASC',
+        },
+        take: 100,
+      })
 
-    for (const usagePeriod of usagePeriods) {
-      if (!(await this.aquireLock(usagePeriod.boxId))) {
-        continue
-      }
+      for (const usagePeriod of usagePeriods) {
+        signal.throwIfAborted()
+        const boxLease = await this.acquireLease(usagePeriod.boxId)
+        if (!boxLease) {
+          continue
+        }
 
-      // validate that the usage period should remain active just in case
-      try {
-        const box = await this.boxRepository.findOne({
-          where: {
-            id: usagePeriod.boxId,
-          },
-        })
+        // validate that the usage period should remain active just in case
+        await this.withLease(boxLease, async (boxSignal) => {
+          const box = await this.boxRepository.findOne({
+            where: {
+              id: usagePeriod.boxId,
+            },
+          })
 
-        await this.boxUsagePeriodRepository.manager.transaction(async (transactionalEntityManager) => {
-          // Close usage period
-          const closeTime = new Date()
-          usagePeriod.endAt = closeTime
-          await transactionalEntityManager.save(usagePeriod)
+          await this.boxUsagePeriodRepository.manager.transaction(async (transactionalEntityManager) => {
+            boxSignal.throwIfAborted()
+            // Close usage period
+            const closeTime = new Date()
+            usagePeriod.endAt = closeTime
+            await transactionalEntityManager.save(usagePeriod)
 
-          if (
-            box &&
-            (box.state === BoxState.STARTED || box.state === BoxState.STOPPED || box.state === BoxState.STOPPING)
-          ) {
-            // Create new usage period
-            const newUsagePeriod = BoxUsagePeriod.fromUsagePeriod(usagePeriod)
-            newUsagePeriod.startAt = closeTime
-            newUsagePeriod.endAt = null
-            if (box.state === BoxState.STOPPED) {
-              newUsagePeriod.cpu = 0
-              newUsagePeriod.gpu = 0
-              newUsagePeriod.mem = 0
+            if (
+              box &&
+              (box.state === BoxState.STARTED || box.state === BoxState.STOPPED || box.state === BoxState.STOPPING)
+            ) {
+              // Create new usage period
+              const newUsagePeriod = BoxUsagePeriod.fromUsagePeriod(usagePeriod)
+              newUsagePeriod.startAt = closeTime
+              newUsagePeriod.endAt = null
+              if (box.state === BoxState.STOPPED) {
+                newUsagePeriod.cpu = 0
+                newUsagePeriod.gpu = 0
+                newUsagePeriod.mem = 0
+              }
+              await transactionalEntityManager.save(newUsagePeriod)
             }
-            await transactionalEntityManager.save(newUsagePeriod)
-          }
+            boxSignal.throwIfAborted()
+          })
+        }, `usage period ${usagePeriod.boxId}`).catch((error) => {
+          this.logger.error(`Error closing and reopening usage period ${usagePeriod.boxId}`, error)
         })
-      } catch (error) {
-        this.logger.error(`Error closing and reopening usage period ${usagePeriod.boxId}`, error)
-      } finally {
-        await this.releaseLock(usagePeriod.boxId)
       }
-    }
-
-    await this.redisLockProvider.unlock('close-and-reopen-usage-periods')
+    }, lockKey)
   }
 
   @Cron(CronExpression.EVERY_MINUTE, { name: 'archive-usage-periods' })
@@ -225,51 +229,57 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
   @WithInstrumentation()
   async archiveUsagePeriods() {
     const lockKey = 'archive-usage-periods'
-    if (!(await this.redisLockProvider.lock(lockKey, 60))) {
+    const lease = await this.redisLockProvider.acquireLease(lockKey, 60)
+    if (!lease) {
       return
     }
 
-    await this.boxUsagePeriodRepository.manager.transaction(async (transactionalEntityManager) => {
-      const usagePeriods = await transactionalEntityManager.find(BoxUsagePeriod, {
-        where: {
-          endAt: Not(IsNull()),
-        },
-        order: {
-          startAt: 'ASC',
-        },
-        take: 1000,
+    await this.withLease(lease, async (signal) => {
+      await this.boxUsagePeriodRepository.manager.transaction(async (transactionalEntityManager) => {
+        signal.throwIfAborted()
+        const usagePeriods = await transactionalEntityManager.find(BoxUsagePeriod, {
+          where: {
+            endAt: Not(IsNull()),
+          },
+          order: {
+            startAt: 'ASC',
+          },
+          take: 1000,
+        })
+
+        if (usagePeriods.length === 0) {
+          return
+        }
+
+        this.logger.debug(`Found ${usagePeriods.length} usage periods to archive`)
+
+        await transactionalEntityManager.delete(
+          BoxUsagePeriod,
+          usagePeriods.map((usagePeriod) => usagePeriod.id),
+        )
+        await transactionalEntityManager.save(usagePeriods.map(BoxUsagePeriodArchive.fromUsagePeriod))
+        // Same transaction as the archive write, so a usage period can never be
+        // archived without an export intent, nor an intent survive a rollback.
+        await this.usageExportOutboxService.enqueue(transactionalEntityManager, usagePeriods)
+        signal.throwIfAborted()
       })
+    }, lockKey)
+  }
 
-      if (usagePeriods.length === 0) {
-        return
-      }
+  private async waitForLock(boxId: string): Promise<RedisLockLease> {
+    // Box state events are not durable or replayed, so a normal-operation
+    // deadline would permanently drop a billing transition. Only shutdown
+    // cancels the wait; acquired leases still stop on ownership loss.
+    return this.redisLockProvider.waitForLease(`usage-period-${boxId}`, 60, this.shutdownController.signal)
+  }
 
-      this.logger.debug(`Found ${usagePeriods.length} usage periods to archive`)
+  private async acquireLease(boxId: string): Promise<RedisLockLease | null> {
+    return this.redisLockProvider.acquireLease(`usage-period-${boxId}`, 60)
+  }
 
-      await transactionalEntityManager.delete(
-        BoxUsagePeriod,
-        usagePeriods.map((usagePeriod) => usagePeriod.id),
-      )
-      await transactionalEntityManager.save(usagePeriods.map(BoxUsagePeriodArchive.fromUsagePeriod))
-      // Same transaction as the archive write, so a usage period can never be
-      // archived without an export intent, nor an intent survive a rollback.
-      await this.usageExportOutboxService.enqueue(transactionalEntityManager, usagePeriods)
+  private withLease<T>(lease: RedisLockLease, operation: (signal: AbortSignal) => Promise<T>, context: string) {
+    return withRedisLockLease(lease, operation, (releaseError) => {
+      this.logger.error(`Error releasing Redis lock lease after ${context} operation failed`, releaseError)
     })
-
-    await this.redisLockProvider.unlock(lockKey)
-  }
-
-  private async waitForLock(boxId: string) {
-    while (!(await this.aquireLock(boxId))) {
-      await new Promise((resolve) => setTimeout(resolve, 500))
-    }
-  }
-
-  private async aquireLock(boxId: string): Promise<boolean> {
-    return await this.redisLockProvider.lock(`usage-period-${boxId}`, 60)
-  }
-
-  private async releaseLock(boxId: string) {
-    await this.redisLockProvider.unlock(`usage-period-${boxId}`)
   }
 }


### PR DESCRIPTION
## Summary
Replace UsageService's fixed-TTL Redis locks with renewable, owner-specific leases. Stale owners stop protected work, pending lock waits are cancelled during shutdown, and already-running jobs are drained.

## Call graph
Before

```text
handleBoxStateUpdate    
  └─ waitForLock        
       └─ lock            
  └─ releaseLock           
       └─ unlock        

closeAndReopenUsagePeriods
  └─ transaction     

archiveUsagePeriods  
  └─ transaction    

onApplicationShutdown      
  └─ handleBoxStateUpdate  
       └─ waitForLock      
```

After

```text
handleBoxStateUpdate        
  └─ waitForLock       
       └─ waitForLease     
  └─ withLease          
       └─ withRedisLockLease 

closeAndReopenUsagePeriods
  ├─ acquireLease       
  └─ withLease             
       └─ transaction     

archiveUsagePeriods       
  ├─ acquireLease         
  └─ withLease             
       └─ transaction      

onApplicationShutdown      
  └─ handleBoxStateUpdate  
       └─ waitForLock      
            └─ waitForLease
```

## Changes
- Add renewable Redis leases with UUID ownership and compare-owner renewal/release.
- Stop protected UsageService work after ownership loss and preserve primary errors during cleanup.
- Cancel pending usage lock waits during shutdown and release leases acquired after cancellation.
- Track concurrent job invocations independently so shutdown waits for every job.

## How to verify
- `make test:apps FILTER=UsageService`
- `make test:apps FILTER=RedisLockProvider`
- `make test:apps FILTER=TrackJobExecution`
- `make lint:apps`

## Risks / rollout
- Only UsageService lock callers are migrated; the shared tracking decorator now records every invocation independently for all callers.
- Normal lock contention remains unbounded because box state events have no durable replay path; only shutdown cancels the wait.

## Summary by CodeRabbit

- **New Features**
  - Added safer lease-based coordination for usage processing, helping prevent concurrent operations from interfering with one another.
  - Added automatic lease renewal and ownership-loss detection.
  - Added cancellation handling so interrupted operations can stop safely.
  - Improved tracking of concurrent background jobs.

- **Bug Fixes**
  - Improved cleanup and rollback when processing or archival operations fail.
  - Preserved original operation errors when cleanup also fails.
  - Added safeguards for pending operations during application shutdown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of background processing when multiple operations run concurrently.
  * Prevented stale or lost coordination from allowing conflicting work to continue.
  * Improved cleanup when operations are cancelled, shut down, or encounter errors.
  * Preserved the original operation error when cleanup also fails.

* **Reliability**
  * Added automatic coordination renewal for longer-running tasks.
  * Improved handling of interrupted archive, billing, and scheduled processing workflows.
  * Ensured concurrent job executions are tracked independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->