### PR TITLE
fix(disk): silent debugfs failures, xattr loss, image capacity

### DIFF
--- a/.githooks/githooks.test.sh
+++ b/.githooks/githooks.test.sh
@@ -97,9 +97,17 @@ write_ref_updates_file() {  # repo remote local_ref remote_ref output_file
   printf '%s %s %s %s\n' "$local_ref" "$local_sha" "$remote_ref" "$remote_sha" > "$output_file"
 }
 
+# Extracted from the real pre-push, not hand-duplicated: a second copy of this
+# selection algorithm is exactly how it went stale before (see new_ref_base_sha's
+# own history) — a fix applied to only one copy leaves the other asserting
+# against a base the real hook no longer picks.
+eval "$(sed -n '/^new_ref_base_sha() {/,/^}/p' "$REPO_ROOT/.githooks/pre-push" | \
+  sed -e 's|\${repo_root}|${repo}|g' -e 's|\$repo_root|\$repo|g' \
+      -e 's|\${remote_name}|${remote}|g' -e 's|\$remote_name|\$remote|g')"
+
 pushed_diff_hash_for() {  # repo remote ref_updates_file
   local repo="$1" remote="$2" ref_updates_file="$3"
-  local empty_tree local_ref local_sha remote_ref remote_sha base_sha candidate
+  local empty_tree local_ref local_sha remote_ref remote_sha base_sha
   empty_tree="$(git -C "$repo" hash-object -t tree /dev/null)"
   while read -r local_ref local_sha remote_ref remote_sha; do
     [[ -n "${local_ref:-}" ]] || continue
@@ -107,14 +115,7 @@ pushed_diff_hash_for() {  # repo remote ref_updates_file
     if [[ "$local_sha" =~ ^0+$ ]]; then
       printf 'deleted %s at %s\n' "$remote_ref" "$remote_sha"
     elif [[ "$remote_sha" =~ ^0+$ ]]; then
-      base_sha=""
-      while IFS= read -r candidate; do
-        [[ -n "$candidate" ]] || continue
-        if git -C "$repo" merge-base --is-ancestor "$candidate" "$local_sha" 2>/dev/null; then
-          base_sha="$candidate"
-          break
-        fi
-      done < <(git -C "$repo" for-each-ref --format='%(objectname)' "refs/remotes/${remote}" 2>/dev/null)
+      base_sha="$(new_ref_base_sha "$local_sha" || true)"
       if [[ -n "$base_sha" ]]; then
         git -C "$repo" log --format='commit-subject %H %s' "$base_sha..$local_sha" 2>/dev/null || true
         git -C "$repo" diff --no-ext-diff "$base_sha" "$local_sha" 2>/dev/null || true
@@ -514,6 +515,129 @@ check_eq "Codex delegated new-ref push self-audits from remote base" "$?" 0
 grep -q '+new ref' "$R/new-ref-prompt.txt" && grep -q 'commit-subject .*test(hooks): new ref audit' "$R/new-ref-prompt.txt" && ! grep -q 'commit-subject .*base' "$R/new-ref-prompt.txt" && new_ref_context=yes || new_ref_context=no
 check_eq "new-ref audit excludes unchanged base history" "$new_ref_context" "yes"
 rm -rf "$R" "$B"
+
+# new_ref_base_sha must pick the CLOSEST ancestor among remote-tracking refs,
+# not the first one for-each-ref happens to list. "aaa-early" sorts before
+# "zzz-late" alphabetically and IS also an ancestor of the new branch (it's
+# zzz-late's own ancestor) — a scan that stops at the first match would pick
+# aaa-early's far older commit as the base and drag its whole history into
+# the audited diff. Neither branch is named main/master, so this exercises
+# the fallback scan specifically, not the default-branch fast path.
+R="$(setup)"
+B="$(mktemp -d)"; git init -q --bare "$B"; git -C "$R" remote add origin "$B"
+git -C "$R" checkout -qb aaa-early
+( cd "$R" && env -i PATH="$PATH" HOME="$HOME" git push -q origin aaa-early:aaa-early >/dev/null 2>"$R/err.txt" )
+git -C "$R" checkout -qb zzz-late
+printf 'late 1\n' >> "$R/f"; git -C "$R" add -A; git -C "$R" commit -qm 'test(hooks): zzz-late c1'
+printf 'late 2\n' >> "$R/f"; git -C "$R" add -A; git -C "$R" commit -qm 'test(hooks): zzz-late c2'
+( cd "$R" && env -i PATH="$PATH" HOME="$HOME" git push -q origin zzz-late:zzz-late >/dev/null 2>"$R/err.txt" )
+git -C "$R" fetch -q origin
+git -C "$R" checkout -qb closest-base-test zzz-late
+printf 'newest\n' >> "$R/f"; git -C "$R" add -A; git -C "$R" commit -qm 'test(hooks): closest base new commit'
+mkdir -p "$R/bin"
+cat > "$R/bin/codex" <<'CLOSEST_BASE_FAKE_CODEX'
+#!/usr/bin/env bash
+set -eu
+if [[ "${1:-}" == "--version" ]]; then
+  printf 'codex-cli fake\n'
+  exit 0
+fi
+cd_arg=""; output=""; prompt=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cd) cd_arg="$2"; shift 2 ;;
+    --output-last-message|-o) output="$2"; shift 2 ;;
+    -) prompt="$(cat)"; shift ;;
+    --ask-for-approval|--disable|--sandbox|--output-schema) shift 2 ;;
+    exec|--ephemeral) shift ;;
+    *) shift ;;
+  esac
+done
+printf '%s\n' "$prompt" > "$cd_arg/closest-base-prompt.txt"
+branch="$(git -C "$cd_arg" branch --show-current)"
+head="$(git -C "$cd_arg" rev-parse HEAD)"
+diff_hash="$(printf '%s\n' "$prompt" | sed -n 's/^Expected diff hash: //p')"
+command_hash="$(printf '%s\n' "$prompt" | sed -n 's/^Expected command hash: //p')"
+jq -nc --arg b "$branch" --arg h "$head" --arg dh "$diff_hash" --arg ch "$command_hash" \
+  '{branch:$b, head:$h, command_kind:"push", diff_hash:$dh, command_hash:$ch, commit_subject_hash:"", verdict:"PASS", findings:[]}' \
+  > "$output"
+CLOSEST_BASE_FAKE_CODEX
+chmod +x "$R/bin/codex"
+( cd "$R" && env -i PATH="$PATH" HOME="$HOME" CODEX_SANDBOX=seatbelt CODEX_BIN="$R/bin/codex" git push -q origin "refs/heads/closest-base-test:refs/heads/closest-base-test" >/dev/null 2>"$R/err.txt" )
+check_eq "Codex delegated closest-base push self-audits" "$?" 0
+grep -q 'commit-subject .*closest base new commit' "$R/closest-base-prompt.txt" \
+  && ! grep -q 'commit-subject .*zzz-late c1' "$R/closest-base-prompt.txt" \
+  && ! grep -q 'commit-subject .*zzz-late c2' "$R/closest-base-prompt.txt" \
+  && closest_base_context=yes || closest_base_context=no
+check_eq "new-ref base picks closest ancestor, not first in ref order" "$closest_base_context" "yes"
+rm -rf "$R" "$B"
+
+# new_ref_base_sha must use merge-base, not is-ancestor: by the time a branch
+# is pushed, the default branch has often moved on with unrelated commits, so
+# its current tip is no longer a strict ancestor of the pushed commit at all
+# (is-ancestor returns false) even though the real fork point is easy to find.
+# A candidate-selection fix that still gates on is-ancestor would exclude
+# main entirely here and fall through to whatever unrelated ref the scan
+# finds first — reproducing the same wrong-base bug from a different angle.
+# Stderr from every push in this test goes to a file OUTSIDE the repo: this
+# test (unlike its siblings) checks out backward to a PREVIOUS branch after
+# committing forward, and a redirect target inside $R gets caught by the next
+# `git add -A`, tracked with whatever content it held at that moment, then
+# silently rewritten (dirtied) by a later push's redirect without a matching
+# commit — so the following checkout to a branch with a DIFFERENT committed
+# version of that same path fails with "would be overwritten by checkout".
+moved_on_err="$(mktemp)"
+R="$(setup)"
+B="$(mktemp -d)"; git init -q --bare "$B"; git -C "$R" remote add origin "$B"
+branch_ref="$(current_branch_ref "$R")"
+( cd "$R" && env -i PATH="$PATH" HOME="$HOME" git push -q origin "$branch_ref:$branch_ref" >/dev/null 2>"$moved_on_err" )
+git -C "$R" checkout -qb moved-on-feature
+printf 'feature 1\n' >> "$R/f"; git -C "$R" add -A; git -C "$R" commit -qm 'test(hooks): feature before main moves on'
+git -C "$R" checkout -q "${branch_ref#refs/heads/}"
+printf 'main moved on 1\n' >> "$R/f"; git -C "$R" add -A; git -C "$R" commit -qm 'test(hooks): main moved on c1'
+printf 'main moved on 2\n' >> "$R/f2"; git -C "$R" add -A; git -C "$R" commit -qm 'test(hooks): main moved on c2'
+( cd "$R" && env -i PATH="$PATH" HOME="$HOME" git push -q origin "$branch_ref:$branch_ref" >/dev/null 2>"$moved_on_err" )
+git -C "$R" fetch -q origin
+git -C "$R" checkout -q moved-on-feature
+printf 'feature 2\n' >> "$R/f"; git -C "$R" add -A; git -C "$R" commit -qm 'test(hooks): feature after main moved on'
+mkdir -p "$R/bin"
+cat > "$R/bin/codex" <<'MOVED_ON_FAKE_CODEX'
+#!/usr/bin/env bash
+set -eu
+if [[ "${1:-}" == "--version" ]]; then
+  printf 'codex-cli fake\n'
+  exit 0
+fi
+cd_arg=""; output=""; prompt=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cd) cd_arg="$2"; shift 2 ;;
+    --output-last-message|-o) output="$2"; shift 2 ;;
+    -) prompt="$(cat)"; shift ;;
+    --ask-for-approval|--disable|--sandbox|--output-schema) shift 2 ;;
+    exec|--ephemeral) shift ;;
+    *) shift ;;
+  esac
+done
+printf '%s\n' "$prompt" > "$cd_arg/moved-on-prompt.txt"
+branch="$(git -C "$cd_arg" branch --show-current)"
+head="$(git -C "$cd_arg" rev-parse HEAD)"
+diff_hash="$(printf '%s\n' "$prompt" | sed -n 's/^Expected diff hash: //p')"
+command_hash="$(printf '%s\n' "$prompt" | sed -n 's/^Expected command hash: //p')"
+jq -nc --arg b "$branch" --arg h "$head" --arg dh "$diff_hash" --arg ch "$command_hash" \
+  '{branch:$b, head:$h, command_kind:"push", diff_hash:$dh, command_hash:$ch, commit_subject_hash:"", verdict:"PASS", findings:[]}' \
+  > "$output"
+MOVED_ON_FAKE_CODEX
+chmod +x "$R/bin/codex"
+( cd "$R" && env -i PATH="$PATH" HOME="$HOME" CODEX_SANDBOX=seatbelt CODEX_BIN="$R/bin/codex" git push -q origin "refs/heads/moved-on-feature:refs/heads/moved-on-feature" >/dev/null 2>"$moved_on_err" )
+check_eq "Codex delegated moved-on-base push self-audits" "$?" 0
+grep -q 'commit-subject .*feature before main moves on' "$R/moved-on-prompt.txt" \
+  && grep -q 'commit-subject .*feature after main moved on' "$R/moved-on-prompt.txt" \
+  && ! grep -q 'commit-subject .*main moved on c1' "$R/moved-on-prompt.txt" \
+  && ! grep -q 'commit-subject .*main moved on c2' "$R/moved-on-prompt.txt" \
+  && moved_on_context=yes || moved_on_context=no
+check_eq "new-ref base finds real fork point after default branch moves on" "$moved_on_context" "yes"
+rm -rf "$R" "$B" "$moved_on_err"
 
 R="$(setup)"
 B="$(mktemp -d)"; git init -q --bare "$B"; git -C "$R" remote add origin "$B"

--- a/.githooks/githooks.test.sh
+++ b/.githooks/githooks.test.sh
@@ -101,9 +101,14 @@ write_ref_updates_file() {  # repo remote local_ref remote_ref output_file
 # selection algorithm is exactly how it went stale before (see new_ref_base_sha's
 # own history) — a fix applied to only one copy leaves the other asserting
 # against a base the real hook no longer picks.
+# shellcheck disable=SC2016  # sed scripts are literal; expansion must not happen here.
 eval "$(sed -n '/^new_ref_base_sha() {/,/^}/p' "$REPO_ROOT/.githooks/pre-push" | \
   sed -e 's|\${repo_root}|${repo}|g' -e 's|\$repo_root|\$repo|g' \
       -e 's|\${remote_name}|${remote}|g' -e 's|\$remote_name|\$remote|g')"
+declare -F new_ref_base_sha >/dev/null || {
+  printf 'FATAL: could not extract new_ref_base_sha from .githooks/pre-push\n' >&2
+  exit 1
+}
 
 pushed_diff_hash_for() {  # repo remote ref_updates_file
   local repo="$1" remote="$2" ref_updates_file="$3"
@@ -525,12 +530,17 @@ rm -rf "$R" "$B"
 # the fallback scan specifically, not the default-branch fast path.
 R="$(setup)"
 B="$(mktemp -d)"; git init -q --bare "$B"; git -C "$R" remote add origin "$B"
+# Outside $R, not "$R/err.txt": the checkouts below cross branches after a
+# `git add -A`, which would otherwise sweep a same-named file into history
+# and then dirty the working tree on the next redirect — the exact hazard
+# the "moved_on_err" test below documents.
+aaa_zzz_err="$(mktemp)"
 git -C "$R" checkout -qb aaa-early
-( cd "$R" && env -i PATH="$PATH" HOME="$HOME" git push -q origin aaa-early:aaa-early >/dev/null 2>"$R/err.txt" )
+( cd "$R" && env -i PATH="$PATH" HOME="$HOME" git push -q origin aaa-early:aaa-early >/dev/null 2>"$aaa_zzz_err" )
 git -C "$R" checkout -qb zzz-late
 printf 'late 1\n' >> "$R/f"; git -C "$R" add -A; git -C "$R" commit -qm 'test(hooks): zzz-late c1'
 printf 'late 2\n' >> "$R/f"; git -C "$R" add -A; git -C "$R" commit -qm 'test(hooks): zzz-late c2'
-( cd "$R" && env -i PATH="$PATH" HOME="$HOME" git push -q origin zzz-late:zzz-late >/dev/null 2>"$R/err.txt" )
+( cd "$R" && env -i PATH="$PATH" HOME="$HOME" git push -q origin zzz-late:zzz-late >/dev/null 2>"$aaa_zzz_err" )
 git -C "$R" fetch -q origin
 git -C "$R" checkout -qb closest-base-test zzz-late
 printf 'newest\n' >> "$R/f"; git -C "$R" add -A; git -C "$R" commit -qm 'test(hooks): closest base new commit'
@@ -570,7 +580,7 @@ grep -q 'commit-subject .*closest base new commit' "$R/closest-base-prompt.txt" 
   && ! grep -q 'commit-subject .*zzz-late c2' "$R/closest-base-prompt.txt" \
   && closest_base_context=yes || closest_base_context=no
 check_eq "new-ref base picks closest ancestor, not first in ref order" "$closest_base_context" "yes"
-rm -rf "$R" "$B"
+rm -rf "$R" "$B" "$aaa_zzz_err"
 
 # new_ref_base_sha must use merge-base, not is-ancestor: by the time a branch
 # is pushed, the default branch has often moved on with unrelated commits, so

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -51,15 +51,41 @@ is_zero_sha() {
 }
 
 new_ref_base_sha() {
-  local local_sha="$1" candidate
+  local local_sha="$1" candidate merge_base best_base="" best_distance="" distance
+
+  # The overwhelming majority of new branches fork from the remote's default
+  # branch — check it first, cheaply. Uses merge-base, not is-ancestor: by the
+  # time this push happens the default branch has often moved past the actual
+  # fork point (more commits landed on it after this branch was cut), so its
+  # current tip may no longer be a strict ancestor of local_sha at all — but
+  # merge-base still finds the real divergence point either way.
+  for candidate in "refs/remotes/${remote_name}/HEAD" "refs/remotes/${remote_name}/main" \
+                   "refs/remotes/${remote_name}/master"; do
+    candidate="$(git -C "$repo_root" rev-parse --verify "$candidate" 2>/dev/null)" || continue
+    merge_base="$(git -C "$repo_root" merge-base "$candidate" "$local_sha" 2>/dev/null)" || continue
+    printf '%s\n' "$merge_base"
+    return 0
+  done
+
+  # Fall back to the closest common ancestor among every remote-tracking ref:
+  # whichever candidate's merge-base needs the fewest commits to reach
+  # local_sha, not the first ref found in ref-name order. Any sufficiently old
+  # branch tip shares SOME common history with local_sha, so "first match in
+  # for-each-ref's alphabetical order" can silently pick a divergence point
+  # from years-old, unrelated history instead of the branch's actual starting
+  # point.
   while IFS= read -r candidate; do
     [[ -n "$candidate" ]] || continue
-    if git -C "$repo_root" merge-base --is-ancestor "$candidate" "$local_sha" 2>/dev/null; then
-      printf '%s\n' "$candidate"
-      return 0
+    merge_base="$(git -C "$repo_root" merge-base "$candidate" "$local_sha" 2>/dev/null)" || continue
+    distance="$(git -C "$repo_root" rev-list --count "${merge_base}..${local_sha}" 2>/dev/null)" || continue
+    if [[ -z "$best_distance" || "$distance" -lt "$best_distance" ]]; then
+      best_base="$merge_base"
+      best_distance="$distance"
     fi
   done < <(git -C "$repo_root" for-each-ref --format='%(objectname)' "refs/remotes/${remote_name}" 2>/dev/null)
-  return 1
+
+  [[ -n "$best_base" ]] || return 1
+  printf '%s\n' "$best_base"
 }
 
 write_pushed_diff() {

--- a/src/boxlite/src/disk/ext4.rs
+++ b/src/boxlite/src/disk/ext4.rs
@@ -428,6 +428,42 @@ pub fn create_ext4_from_dir(source: &Path, output_path: &Path) -> BoxliteResult<
     Ok(disk)
 }
 
+/// Check a `debugfs -w -f -` batch-script invocation actually succeeded,
+/// including per-command failures the process exit code alone can't see.
+///
+/// `debugfs -f -` logs a per-command failure (e.g. `sif` on a path it can't
+/// resolve, or `write` on a source file that vanished — both via `com_err`) to
+/// the same stderr stream as its one-line startup banner, then continues to
+/// the next command rather than aborting. So a clean exit code isn't proof
+/// every command landed; anything beyond that first banner line means a
+/// command failed silently. `what` names the operation for the error message
+/// (e.g. `"normalizing {path}"`, `"injecting {src} -> {dst}"`).
+fn check_debugfs_output(what: &str, output: &std::process::Output) -> BoxliteResult<()> {
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(BoxliteError::Storage(format!(
+            "debugfs failed (exit {:?}) while {}: {}",
+            output.status.code(),
+            what,
+            stderr
+        )));
+    }
+
+    let after_banner = match output.stderr.iter().position(|&b| b == b'\n') {
+        Some(newline) => &output.stderr[newline + 1..],
+        None => &output.stderr[..],
+    };
+    if !after_banner.is_empty() {
+        return Err(BoxliteError::Storage(format!(
+            "debugfs reported unexpected output while {}: {}",
+            what,
+            String::from_utf8_lossy(after_banner)
+        )));
+    }
+
+    Ok(())
+}
+
 /// Normalize inode metadata in the ext4 image via debugfs: give every file the
 /// ownership its layer declared (0:0 when none was recorded), and restore the
 /// original mode on any entry whose owner-read bit was temporarily widened so
@@ -500,15 +536,7 @@ fn normalize_inodes_with_debugfs(
     // This is the only pass that writes the original 0000 modes back into the
     // image, so a failure must abort the build rather than yield an image with
     // wrong inode metadata.
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(BoxliteError::Storage(format!(
-            "debugfs inode normalization failed (exit {:?}) on {}: {}",
-            output.status.code(),
-            image_path.display(),
-            stderr
-        )));
-    }
+    check_debugfs_output(&format!("normalizing {}", image_path.display()), &output)?;
 
     tracing::info!(
         "Normalized {} inodes ({} without recorded ownership → 0:0, {} mode-restored) in {:?}",
@@ -564,15 +592,10 @@ pub fn inject_file_into_ext4(
         .wait_with_output()
         .map_err(|e| BoxliteError::Storage(format!("Failed to wait for debugfs: {}", e)))?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(BoxliteError::Storage(format!(
-            "debugfs injection failed for {} -> {}: {}",
-            host_file.display(),
-            guest_path,
-            stderr
-        )));
-    }
+    check_debugfs_output(
+        &format!("injecting {} -> {}", host_file.display(), guest_path),
+        &output,
+    )?;
 
     tracing::debug!(
         "Injected {} into ext4 image at /{}",
@@ -626,6 +649,58 @@ fn build_inject_commands(host_file_str: &str, guest_path: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A `sif` command targeting a path debugfs cannot resolve makes the whole
+    /// batch script exit 0 — e2fsprogs's `-f -` mode logs the failure via
+    /// `com_err` to the same stderr stream as the one-line startup banner, and
+    /// moves on to the next command rather than aborting. The doc comment on
+    /// `normalize_inodes_with_debugfs` states "a failure must abort the build",
+    /// but checking only `output.status.success()` cannot see this class of
+    /// failure at all.
+    ///
+    /// Verified empirically before writing this test: 20 failing `sif` commands
+    /// against a real image still produced `exit=0`, with each failure adding a
+    /// `"<path>: File not found by ext2_lookup"` line to stderr, after the fixed
+    /// one-line banner.
+    #[test]
+    fn normalize_inodes_with_debugfs_fails_on_unresolvable_path() {
+        if util::find_binary("mke2fs").is_err() || util::find_binary("debugfs").is_err() {
+            eprintln!("skipping: mke2fs/debugfs not found (run `make runtime:debug`)");
+            return;
+        }
+        if unsafe { libc::geteuid() } == 0 {
+            eprintln!("skipping: root skips debugfs normalization entirely");
+            return;
+        }
+
+        let src_root = tempfile::tempdir().expect("source tempdir");
+        let src = src_root.path().join("rootfs");
+        std::fs::create_dir_all(&src).expect("mkdir rootfs");
+        std::fs::write(src.join("real"), b"x").expect("write real");
+
+        let out_root = tempfile::tempdir().expect("output tempdir");
+        let out = out_root.path().join("rootfs.ext4");
+        let _disk = create_ext4_from_dir(&src, &out).expect("ext4 build must succeed");
+
+        // A path that does not exist in the image just built.
+        let scan = SourceScan {
+            owners: vec![InodeOwner {
+                ext4_path: "/does-not-exist".to_string(),
+                uid: 1001,
+                gid: 1001,
+            }],
+            unrecorded: 0,
+            total_blocks: 0,
+            entry_count: 0,
+        };
+
+        let result = normalize_inodes_with_debugfs(&out, &scan, &[]);
+        assert!(
+            result.is_err(),
+            "an unresolvable sif target must fail the build, not silently succeed \
+             with the image left partially unnormalized"
+        );
+    }
 
     /// A tree larger than `MIN_DISK_SIZE_BYTES` must still build when it
     /// contains an unreadable (mode `0000`) directory.
@@ -1039,6 +1114,41 @@ mod tests {
 
         // Make the tree removable so TempDir can clean up.
         std::fs::set_permissions(&secret_dir, std::fs::Permissions::from_mode(0o700)).ok();
+    }
+
+    /// `inject_file_into_ext4` runs the same `debugfs -w -f -` batch-script
+    /// pattern as `normalize_inodes_with_debugfs`, and has the identical gap: a
+    /// failing `write` (e.g. the host source file vanished) makes every
+    /// subsequent `sif` on that never-created guest path fail too, but the
+    /// whole script still exits 0.
+    ///
+    /// Verified empirically before writing this test: `write` on a nonexistent
+    /// host path produces `"do_write_internal: No such file or directory..."` on
+    /// stderr, followed by three `"File not found by ext2_lookup"` lines (one per
+    /// cascading `sif`), with the process still exiting 0.
+    #[test]
+    fn inject_file_into_ext4_fails_on_missing_host_file() {
+        if util::find_binary("mke2fs").is_err() || util::find_binary("debugfs").is_err() {
+            eprintln!("skipping: mke2fs/debugfs not found (run `make runtime:debug`)");
+            return;
+        }
+
+        let src_root = tempfile::tempdir().expect("source tempdir");
+        let src = src_root.path().join("rootfs");
+        std::fs::create_dir_all(&src).expect("mkdir rootfs");
+        std::fs::write(src.join("real"), b"x").expect("write real");
+
+        let out_root = tempfile::tempdir().expect("output tempdir");
+        let out = out_root.path().join("rootfs.ext4");
+        let _disk = create_ext4_from_dir(&src, &out).expect("ext4 build must succeed");
+
+        let missing_host_file = src_root.path().join("does-not-exist-on-host");
+        let result = inject_file_into_ext4(&out, &missing_host_file, "injected");
+        assert!(
+            result.is_err(),
+            "a missing host source file must fail the injection, not silently \
+             succeed with the guest path never actually written"
+        );
     }
 
     #[test]

--- a/src/boxlite/src/disk/ext4.rs
+++ b/src/boxlite/src/disk/ext4.rs
@@ -161,24 +161,27 @@ impl SourceScan {
     /// header's uid/gid in the `override_stat` xattr and `mke2fs -d` records the
     /// *host* uid instead. Entries with no record — the guest rootfs, injected
     /// binaries — stay 0:0, which is what those paths require.
-    fn record_owner(&mut self, source_root: &Path, path: &Path) {
+    ///
+    /// A *present-but-malformed* record is different: it is the only copy of
+    /// that file's real ownership, so it must abort the build rather than
+    /// silently default to 0:0 like a genuinely absent one — see
+    /// `OverrideStat::read_xattr`'s doc comment for why `Ok(None)` and `Err`
+    /// are deliberately distinct.
+    fn record_owner(&mut self, source_root: &Path, path: &Path) -> BoxliteResult<()> {
         let rel = path.strip_prefix(source_root).unwrap_or(path);
         if rel.as_os_str().is_empty() {
-            return; // the source root maps to the image root
+            return Ok(()); // the source root maps to the image root
         }
 
-        let (uid, gid) = match OverrideStat::read_xattr(path) {
-            Ok(Some(stat)) => (stat.uid, stat.gid),
-            Ok(None) => {
-                self.unrecorded += 1;
-                (0, 0)
-            }
-            Err(e) => {
-                tracing::warn!(
-                    "Failed to read ownership xattr on {}, defaulting to 0:0: {}",
-                    path.display(),
-                    e
-                );
+        let (uid, gid) = match OverrideStat::read_xattr(path).map_err(|e| {
+            BoxliteError::Storage(format!(
+                "Failed to read ownership xattr on {}: {}",
+                path.display(),
+                e
+            ))
+        })? {
+            Some(stat) => (stat.uid, stat.gid),
+            None => {
                 self.unrecorded += 1;
                 (0, 0)
             }
@@ -190,6 +193,7 @@ impl SourceScan {
             uid,
             gid,
         });
+        Ok(())
     }
 }
 
@@ -243,7 +247,7 @@ fn scan_dir_recursive(
         record_and_widen(source_root, dir, dir_mode, dir_mode | 0o500, widened)?;
     }
     scan.account(&dir_meta);
-    scan.record_owner(source_root, dir);
+    scan.record_owner(source_root, dir)?;
 
     let entries = std::fs::read_dir(dir).map_err(|e| {
         BoxliteError::Storage(format!("Failed to read dir {}: {}", dir.display(), e))
@@ -274,7 +278,7 @@ fn scan_dir_recursive(
             )?;
         }
         scan.account(&meta);
-        scan.record_owner(source_root, &path);
+        scan.record_owner(source_root, &path)?;
     }
     Ok(())
 }
@@ -1016,6 +1020,41 @@ mod tests {
             image_owner(&out, "/etc/passwd"),
             ("0".to_string(), "0".to_string()),
             "an entry with no recorded ownership must still normalize to 0:0"
+        );
+    }
+
+    /// A malformed `override_stat` xattr must abort the scan, not silently
+    /// default to 0:0.
+    ///
+    /// `OverrideStat::read_xattr` distinguishes a genuinely absent xattr
+    /// (`Ok(None)`, correctly defaults to 0:0) from a present-but-unparseable
+    /// one (`Err`) — but `record_owner` treated both the same, logging a
+    /// warning and defaulting to 0:0 either way. Unprivileged extraction
+    /// can't `chown`, so a layer-declared xattr is the *only* copy of that
+    /// file's real ownership; silently discarding a corrupt one is exactly
+    /// the silent-failure class this file's `check_debugfs_output` already
+    /// guards against one layer down — the scan itself must not repeat it.
+    #[test]
+    fn scan_source_tree_fails_on_malformed_override_stat() {
+        // Matches OverrideStat::CONTAINERS_OVERRIDE_XATTR (private to
+        // images::archive::override_stat) — the containers/storage xattr name,
+        // not expected to ever change.
+        const CONTAINERS_OVERRIDE_XATTR: &str = "user.containers.override_stat";
+
+        let root = tempfile::tempdir().expect("tempdir");
+        let src = root.path().join("rootfs");
+        std::fs::create_dir_all(&src).expect("mkdir rootfs");
+        let f = src.join("file");
+        std::fs::write(&f, b"x").expect("write file");
+        xattr::set(&f, CONTAINERS_OVERRIDE_XATTR, b"not-a-valid-record")
+            .expect("seed malformed xattr");
+
+        let mut widened = Vec::new();
+        let result = scan_source_tree(&src, &mut widened);
+        assert!(
+            result.is_err(),
+            "a malformed override_stat xattr is the only copy of a layer's \
+             declared ownership; the scan must fail, not silently default to 0:0"
         );
     }
 

--- a/src/boxlite/src/disk/ext4.rs
+++ b/src/boxlite/src/disk/ext4.rs
@@ -61,8 +61,11 @@ fn calculate_dir_size(dir: &Path) -> BoxliteResult<u64> {
 }
 
 /// Calculate appropriate disk size with ext4 overhead.
-fn calculate_disk_size(source: &Path) -> u64 {
-    disk_size_with_overhead(calculate_dir_size(source).unwrap_or(DEFAULT_DIR_SIZE_BYTES))
+fn calculate_disk_size(source: &Path, reserve_bytes: u64) -> u64 {
+    disk_size_with_overhead(
+        calculate_dir_size(source).unwrap_or(DEFAULT_DIR_SIZE_BYTES),
+        reserve_bytes,
+    )
 }
 
 /// Apply ext4 overhead to a measured tree size and clamp to the minimum image.
@@ -70,22 +73,32 @@ fn calculate_disk_size(source: &Path) -> u64 {
 /// Split from [`calculate_disk_size`] so the unprivileged path — which measures
 /// the tree during its own single scan — shares one definition of the sizing
 /// policy instead of restating the arithmetic.
-fn disk_size_with_overhead(dir_size: u64) -> u64 {
+///
+/// `reserve_bytes` is extra room for content the *caller* adds to the image
+/// after it is built (e.g. `GuestRootfsManager` injects the `boxlite-guest`
+/// binary into a copy of this image once it exists — an unstripped debug
+/// build runs ~231 MiB, well over the free space a floor-sized image
+/// otherwise has). Added once, verbatim, after the tree-size overhead
+/// multiplier: it's an exact byte count, not an estimate that needs the same
+/// safety margin as the measured tree.
+fn disk_size_with_overhead(dir_size: u64, reserve_bytes: u64) -> u64 {
     // ext4 overhead:
     // - Metadata (superblock, block groups, inode tables): ~1-5%
     // - Journal: 64MB
     // - We set reserved blocks to 0% via mke2fs
     // Use 1.1x multiplier (10% overhead) plus 64MB for journal
     // Testing showed ~0.5% overhead needed, 10% provides safety margin
-    let size_with_overhead =
-        dir_size * SIZE_MULTIPLIER_NUM / SIZE_MULTIPLIER_DEN + JOURNAL_OVERHEAD_BYTES;
+    let size_with_overhead = dir_size * SIZE_MULTIPLIER_NUM / SIZE_MULTIPLIER_DEN
+        + JOURNAL_OVERHEAD_BYTES
+        + reserve_bytes;
 
     // Minimum 256MB for small images
     let final_size = size_with_overhead.max(MIN_DISK_SIZE_BYTES);
 
     tracing::debug!(
-        "Calculated disk size: dir_size={}MB, with_overhead={}MB, final={}MB",
+        "Calculated disk size: dir_size={}MB, reserve={}MB, with_overhead={}MB, final={}MB",
         dir_size / (1024 * 1024),
+        reserve_bytes / (1024 * 1024),
         size_with_overhead / (1024 * 1024),
         final_size / (1024 * 1024)
     );
@@ -333,10 +346,16 @@ impl Drop for SourceModeGuard {
 /// from a source directory, which is much simpler than using libext2fs.
 ///
 /// Size is automatically calculated based on directory contents with
-/// appropriate overhead for ext4 metadata, journal, and reserved blocks.
+/// appropriate overhead for ext4 metadata, journal, and reserved blocks, plus
+/// `reserve_bytes` of extra headroom for whatever the caller injects into the
+/// image afterward (0 when nothing will be).
 ///
 /// Returns a non-persistent Disk (will be cleaned up on drop).
-pub fn create_ext4_from_dir(source: &Path, output_path: &Path) -> BoxliteResult<Disk> {
+pub fn create_ext4_from_dir(
+    source: &Path,
+    output_path: &Path,
+    reserve_bytes: u64,
+) -> BoxliteResult<Disk> {
     let output_str = output_path.to_str().ok_or_else(|| {
         BoxliteError::Storage(format!("Invalid output path: {}", output_path.display()))
     })?;
@@ -367,8 +386,8 @@ pub fn create_ext4_from_dir(source: &Path, output_path: &Path) -> BoxliteResult<
     // measurement for the whole tree, not just the unreadable subtree, and
     // under-sizing the image for `mke2fs`.
     let size_bytes = match &scan {
-        Some(scan) => disk_size_with_overhead(scan.dir_size()),
-        None => calculate_disk_size(source),
+        Some(scan) => disk_size_with_overhead(scan.dir_size(), reserve_bytes),
+        None => calculate_disk_size(source, reserve_bytes),
     };
 
     // With -b 4096, mke2fs expects size in 4KB blocks
@@ -680,7 +699,7 @@ mod tests {
 
         let out_root = tempfile::tempdir().expect("output tempdir");
         let out = out_root.path().join("rootfs.ext4");
-        let _disk = create_ext4_from_dir(&src, &out).expect("ext4 build must succeed");
+        let _disk = create_ext4_from_dir(&src, &out, 0).expect("ext4 build must succeed");
 
         // A path that does not exist in the image just built.
         let scan = SourceScan {
@@ -748,7 +767,7 @@ mod tests {
 
         let out_root = tempfile::tempdir().expect("output tempdir");
         let out = out_root.path().join("rootfs.ext4");
-        let built = create_ext4_from_dir(&src, &out);
+        let built = create_ext4_from_dir(&src, &out, 0);
 
         // Restore before asserting so TempDir::drop can always recurse.
         let _ = std::fs::set_permissions(&secret, std::fs::Permissions::from_mode(0o755));
@@ -808,7 +827,7 @@ mod tests {
 
         // Pre-fix this returns Err (mke2fs aborts on the 0000 file). Bind the
         // returned Disk: it is non-persistent and deletes the image on drop.
-        let _disk = create_ext4_from_dir(&src, &out)
+        let _disk = create_ext4_from_dir(&src, &out, 0)
             .expect("ext4 build must tolerate a 0000-mode source file");
 
         // The image must carry the ORIGINAL 0000 mode (data crosses the
@@ -888,7 +907,7 @@ mod tests {
 
         let out_root = tempfile::tempdir().expect("output tempdir");
         let out = out_root.path().join("rootfs.ext4");
-        let _disk = create_ext4_from_dir(&src, &out).expect("ext4 build must succeed");
+        let _disk = create_ext4_from_dir(&src, &out, 0).expect("ext4 build must succeed");
 
         // The dir restores fine even with the bug (it's restored first).
         assert_eq!(
@@ -981,7 +1000,7 @@ mod tests {
 
         let out_root = tempfile::tempdir().expect("output tempdir");
         let out = out_root.path().join("rootfs.ext4");
-        let _disk = create_ext4_from_dir(&src, &out).expect("ext4 build must succeed");
+        let _disk = create_ext4_from_dir(&src, &out, 0).expect("ext4 build must succeed");
 
         assert_eq!(
             image_owner(&out, "/var/dex"),
@@ -1140,7 +1159,7 @@ mod tests {
 
         let out_root = tempfile::tempdir().expect("output tempdir");
         let out = out_root.path().join("rootfs.ext4");
-        let _disk = create_ext4_from_dir(&src, &out).expect("ext4 build must succeed");
+        let _disk = create_ext4_from_dir(&src, &out, 0).expect("ext4 build must succeed");
 
         let missing_host_file = src_root.path().join("does-not-exist-on-host");
         let result = inject_file_into_ext4(&out, &missing_host_file, "injected");
@@ -1148,6 +1167,82 @@ mod tests {
             result.is_err(),
             "a missing host source file must fail the injection, not silently \
              succeed with the guest path never actually written"
+        );
+    }
+
+    /// Write `len` non-zero, non-repeating bytes to `path`.
+    ///
+    /// `debugfs write` (verified empirically before writing this test, against
+    /// a real image) treats a long run of *zero* bytes in the source file as
+    /// sparse and allocates no real ext4 blocks for it at all — a same-length
+    /// all-zero stand-in file would consume no free space and make the
+    /// reproducer below tautologically green regardless of how little room
+    /// the image actually has.
+    fn write_random_file(path: &Path, len: u64) {
+        use std::io::Read;
+
+        let mut urandom = std::fs::File::open("/dev/urandom").expect("open /dev/urandom");
+        let mut limited = (&mut urandom).take(len);
+        let mut out = std::fs::File::create(path).expect("create random payload file");
+        std::io::copy(&mut limited, &mut out).expect("write random payload");
+    }
+
+    /// A guest binary injected *after* the image is built must actually fit.
+    ///
+    /// `create_ext4_from_dir` sizes the image purely from the source tree it
+    /// is given — a near-empty tree lands at the `MIN_DISK_SIZE_BYTES` floor,
+    /// with no headroom budgeted for anything injected afterward. But
+    /// `GuestRootfsManager::build_and_install` (rootfs/guest.rs) copies
+    /// exactly that image and then injects the `boxlite-guest` binary into
+    /// it — an unstripped debug build runs ~231 MiB, well over the ~223 MiB
+    /// of free space a floor-sized image has once mke2fs/journal overhead is
+    /// accounted for (measured empirically against a real image before
+    /// writing this test).
+    ///
+    /// Pre-fix, this fails: `create_ext4_from_dir` has no way to reserve
+    /// headroom, so a same-shape oversized payload cannot fit and
+    /// `inject_file_into_ext4` correctly reports `Err` (`check_debugfs_output`
+    /// above already catches the underlying `debugfs` silent-failure class) —
+    /// proving this is a real, present-day capacity bug, not a hypothetical
+    /// one.
+    #[test]
+    fn create_ext4_from_dir_reserves_headroom_for_post_build_injection() {
+        if util::find_binary("mke2fs").is_err() || util::find_binary("debugfs").is_err() {
+            eprintln!("skipping: mke2fs/debugfs not found (run `make runtime:debug`)");
+            return;
+        }
+
+        let src_root = tempfile::tempdir().expect("source tempdir");
+        let src = src_root.path().join("rootfs");
+        std::fs::create_dir_all(&src).expect("mkdir rootfs");
+        std::fs::write(src.join("real"), b"x").expect("write real");
+
+        // Larger than the ~223 MiB of free space measured on a floor-sized
+        // image with no reserve — comfortably over, well under a real debug
+        // guest binary (~231 MiB).
+        let payload_len = 235 * 1024 * 1024u64;
+        let payload_root = tempfile::tempdir().expect("payload tempdir");
+        let payload = payload_root.path().join("guest-binary-stand-in");
+        write_random_file(&payload, payload_len);
+
+        let out_root = tempfile::tempdir().expect("output tempdir");
+        let out = out_root.path().join("rootfs.ext4");
+        // Exercises the reserve_bytes mechanism itself, at this function's
+        // own level — not the specific value runtime/rt_impl.rs picks (a
+        // fixed constant; see IMAGE_DISK_GUEST_BINARY_HEADROOM_BYTES there).
+        // Sized to the payload plus a small fixed margin, not a percentage of
+        // it: the payload length is already exact, unlike the tree-size
+        // estimate `disk_size_with_overhead`'s multiplier compensates for.
+        let reserve_bytes = payload_len + 8 * 1024 * 1024;
+        let _disk =
+            create_ext4_from_dir(&src, &out, reserve_bytes).expect("ext4 build must succeed");
+
+        let result = inject_file_into_ext4(&out, &payload, "boxlite/bin/boxlite-guest");
+        assert!(
+            result.is_ok(),
+            "a guest binary must always fit in the image it is injected into, \
+             but injection into an unpadded floor-sized image failed: {:?}",
+            result.err()
         );
     }
 

--- a/src/boxlite/src/images/archive/override_stat.rs
+++ b/src/boxlite/src/images/archive/override_stat.rs
@@ -145,12 +145,23 @@ impl OverrideStat {
     }
 
     /// Read override stat from xattr on the given path.
+    ///
+    /// `Ok(None)` means the xattr is genuinely absent. A present-but-malformed
+    /// value — invalid UTF-8, or valid UTF-8 that doesn't match `parse`'s
+    /// expected shape — is `Err`, same as any other unreadable-record case, so
+    /// callers can't conflate "nothing was ever recorded" with "a record exists
+    /// but couldn't be honored".
     pub fn read_xattr(path: &Path) -> std::io::Result<Option<Self>> {
         match xattr::get(path, CONTAINERS_OVERRIDE_XATTR)? {
             Some(value) => {
                 let s = std::str::from_utf8(&value)
                     .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-                Ok(Self::parse(s))
+                Self::parse(s).map(Some).ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("malformed {CONTAINERS_OVERRIDE_XATTR} value: {s:?}"),
+                    )
+                })
             }
             None => Ok(None),
         }
@@ -240,5 +251,35 @@ mod tests {
         assert!(OverrideStat::parse("").is_none());
         assert!(OverrideStat::parse("1000:1000").is_none());
         assert!(OverrideStat::parse("invalid:invalid:invalid:invalid").is_none());
+    }
+
+    /// `read_xattr` must not conflate "no ownership was ever recorded" with
+    /// "a record exists but is corrupt or in a format this build can't parse".
+    /// Every caller (the ext4 builder, `fix_rootfs_permissions`) treats `Ok(None)`
+    /// as "default to 0:0, nothing lost" — correct for a genuinely absent xattr,
+    /// wrong for a present-but-unparseable one, since that value is the *only*
+    /// copy of a layer's declared ownership (unprivileged extraction can't
+    /// `chown`). A non-UTF-8 value already surfaces as `Err` via the `str::from_utf8`
+    /// conversion; a valid-UTF-8-but-wrong-format value must too, for the same
+    /// reason — both indicate someone (or something) marked this file specially
+    /// and the record can't be honored.
+    #[test]
+    fn read_xattr_distinguishes_absent_from_malformed() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("f");
+        std::fs::write(&path, b"x").expect("write f");
+
+        assert!(
+            matches!(OverrideStat::read_xattr(&path), Ok(None)),
+            "genuinely absent xattr must read as Ok(None)"
+        );
+
+        // Valid UTF-8, wrong shape (missing the mode/type fields OverrideStat::parse requires).
+        xattr::set(&path, CONTAINERS_OVERRIDE_XATTR, b"1001:1001")
+            .expect("seed malformed xattr value");
+        assert!(
+            OverrideStat::read_xattr(&path).is_err(),
+            "a present-but-unparseable xattr must not read the same as absent"
+        );
     }
 }

--- a/src/boxlite/src/images/image_disk.rs
+++ b/src/boxlite/src/images/image_disk.rs
@@ -33,13 +33,25 @@ use super::ImageObject;
 pub struct ImageDiskManager {
     cache_dir: PathBuf,
     temp_dir: PathBuf,
+    /// Extra headroom baked into every image disk this manager builds.
+    ///
+    /// The cache key is the image digest alone, and `GuestRootfsManager`
+    /// injects the `boxlite-guest` binary into a *copy* of whatever this
+    /// manager cached — so the headroom that copy needs must be decided once,
+    /// here, rather than per `get_or_create` call: `container_rootfs.rs`'s
+    /// `prepare_disk_rootfs` uses the same cached disk directly with no
+    /// injection, and if headroom were instead a per-call choice, whichever
+    /// caller happened to build a given digest first would decide the size
+    /// for every later caller of that digest too.
+    reserve_bytes: u64,
 }
 
 impl ImageDiskManager {
-    pub fn new(cache_dir: PathBuf, temp_dir: PathBuf) -> Self {
+    pub fn new(cache_dir: PathBuf, temp_dir: PathBuf, reserve_bytes: u64) -> Self {
         Self {
             cache_dir,
             temp_dir,
+            reserve_bytes,
         }
     }
 
@@ -86,12 +98,12 @@ impl ImageDiskManager {
         let temp_disk_path = temp.path().join("image.ext4");
         let prepared_path = prepared.path.clone();
         let disk_clone = temp_disk_path.clone();
-        let temp_disk =
-            tokio::task::spawn_blocking(move || create_ext4_from_dir(&prepared_path, &disk_clone))
-                .await
-                .map_err(|e| {
-                    BoxliteError::Internal(format!("Disk creation task failed: {}", e))
-                })??;
+        let reserve_bytes = self.reserve_bytes;
+        let temp_disk = tokio::task::spawn_blocking(move || {
+            create_ext4_from_dir(&prepared_path, &disk_clone, reserve_bytes)
+        })
+        .await
+        .map_err(|e| BoxliteError::Internal(format!("Disk creation task failed: {}", e)))??;
 
         // Atomically install staged disk to cache
         self.install(digest, temp_disk)
@@ -138,8 +150,6 @@ impl ImageDiskManager {
     }
 
     /// Compute the cache path for a given image digest.
-    ///
-    /// Format matches `storage.rs:disk_image_path()`: `{digest}.ext4`
     fn disk_path(&self, digest: &str) -> PathBuf {
         let filename = digest.replace(':', "-");
         self.cache_dir.join(format!("{}.ext4", filename))
@@ -152,7 +162,11 @@ mod tests {
 
     #[test]
     fn test_disk_path_replaces_colon() {
-        let mgr = ImageDiskManager::new(PathBuf::from("/cache/disk-images"), PathBuf::from("/tmp"));
+        let mgr = ImageDiskManager::new(
+            PathBuf::from("/cache/disk-images"),
+            PathBuf::from("/tmp"),
+            0,
+        );
         let path = mgr.disk_path("sha256:abc123def456");
         assert_eq!(
             path,
@@ -162,7 +176,7 @@ mod tests {
 
     #[test]
     fn test_disk_path_no_colon() {
-        let mgr = ImageDiskManager::new(PathBuf::from("/cache"), PathBuf::from("/tmp"));
+        let mgr = ImageDiskManager::new(PathBuf::from("/cache"), PathBuf::from("/tmp"), 0);
         let path = mgr.disk_path("plaindigest");
         assert_eq!(path, PathBuf::from("/cache/plaindigest.ext4"));
     }
@@ -170,7 +184,7 @@ mod tests {
     #[test]
     fn test_find_returns_none_when_missing() {
         let dir = tempfile::TempDir::new().unwrap();
-        let mgr = ImageDiskManager::new(dir.path().to_path_buf(), dir.path().to_path_buf());
+        let mgr = ImageDiskManager::new(dir.path().to_path_buf(), dir.path().to_path_buf(), 0);
 
         assert!(mgr.find("sha256:nonexistent").is_none());
     }
@@ -178,10 +192,10 @@ mod tests {
     #[test]
     fn test_find_returns_disk_when_cached() {
         let dir = tempfile::TempDir::new().unwrap();
-        let mgr = ImageDiskManager::new(dir.path().to_path_buf(), dir.path().to_path_buf());
+        let mgr = ImageDiskManager::new(dir.path().to_path_buf(), dir.path().to_path_buf(), 0);
 
         // Create a fake cached disk
-        let cached = dir.path().join("sha256-abc123.ext4");
+        let cached = mgr.disk_path("sha256:abc123");
         std::fs::write(&cached, "fake disk").unwrap();
 
         let disk = mgr.find("sha256:abc123");
@@ -196,7 +210,7 @@ mod tests {
     fn test_install_creates_dir_and_moves_file() {
         let dir = tempfile::TempDir::new().unwrap();
         let cache_dir = dir.path().join("disk-images");
-        let mgr = ImageDiskManager::new(cache_dir.clone(), dir.path().to_path_buf());
+        let mgr = ImageDiskManager::new(cache_dir.clone(), dir.path().to_path_buf(), 0);
 
         // Create staged file
         let staged_path = dir.path().join("staged.ext4");
@@ -204,7 +218,7 @@ mod tests {
         let staged_disk = Disk::new(staged_path, DiskFormat::Ext4, false);
 
         let result = mgr.install("sha256:test", staged_disk).unwrap();
-        let expected = cache_dir.join("sha256-test.ext4");
+        let expected = mgr.disk_path("sha256:test");
 
         assert!(expected.exists());
         assert_eq!(result.path(), expected);
@@ -216,10 +230,10 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let cache_dir = dir.path().join("disk-images");
         std::fs::create_dir_all(&cache_dir).unwrap();
-        let mgr = ImageDiskManager::new(cache_dir.clone(), dir.path().to_path_buf());
+        let mgr = ImageDiskManager::new(cache_dir.clone(), dir.path().to_path_buf(), 0);
 
         // Pre-create target (another process won the race)
-        let target = cache_dir.join("sha256-raced.ext4");
+        let target = mgr.disk_path("sha256:raced");
         std::fs::write(&target, "first").unwrap();
 
         // Try to install over it

--- a/src/boxlite/src/images/image_disk.rs
+++ b/src/boxlite/src/images/image_disk.rs
@@ -16,7 +16,10 @@ use super::ImageObject;
 /// Builds and caches ext4 disk images from OCI images.
 ///
 /// Image disks are pure: only OCI image content, no guest binary injected.
-/// Cache key is the image digest (SHA256 of layer digests).
+/// Cache key is the image digest (SHA256 of layer digests) plus the
+/// manager's `reserve_bytes` — see the field doc — so a disk cached by an
+/// older build (before headroom existed, or under a smaller budget) is never
+/// mistaken for one sized under the current budget.
 ///
 /// Follows the staged install pattern: build in temp → atomic rename to cache.
 /// No half-written files ever appear in the cache directory.
@@ -33,16 +36,28 @@ use super::ImageObject;
 pub struct ImageDiskManager {
     cache_dir: PathBuf,
     temp_dir: PathBuf,
-    /// Extra headroom baked into every image disk this manager builds.
+    /// Extra headroom baked into every image disk this manager builds, and
+    /// folded into its cache key (`disk_path`).
     ///
-    /// The cache key is the image digest alone, and `GuestRootfsManager`
-    /// injects the `boxlite-guest` binary into a *copy* of whatever this
-    /// manager cached — so the headroom that copy needs must be decided once,
-    /// here, rather than per `get_or_create` call: `container_rootfs.rs`'s
-    /// `prepare_disk_rootfs` uses the same cached disk directly with no
-    /// injection, and if headroom were instead a per-call choice, whichever
-    /// caller happened to build a given digest first would decide the size
-    /// for every later caller of that digest too.
+    /// `GuestRootfsManager` injects the `boxlite-guest` binary into a *copy*
+    /// of whatever this manager cached — so the headroom that copy needs
+    /// must be decided once, here, rather than per `get_or_create` call:
+    /// `container_rootfs.rs`'s `prepare_disk_rootfs` uses the same cached
+    /// disk directly with no injection, and if headroom were instead a
+    /// per-call choice, whichever caller happened to build a given digest
+    /// first would decide the size for every later caller of that digest too.
+    ///
+    /// In production this is a fixed constant
+    /// (`IMAGE_DISK_GUEST_BINARY_HEADROOM_BYTES` in `runtime/rt_impl.rs`),
+    /// not derived from the guest binary's live size — so, unlike a value
+    /// that changed on every guest-binary rebuild, folding it into the cache
+    /// key doesn't orphan a cache entry on every rebuild; it only creates a
+    /// new one on the rare, deliberate occasions the constant itself changes
+    /// (this manager has no GC, so that distinction is load-bearing — see
+    /// the constant's own doc comment). It still MUST be in the cache key:
+    /// an older build with no headroom budgeted at all (or a smaller one)
+    /// would otherwise be reused as-is, silently reproducing the exact
+    /// ENOSPC-on-injection failure this field exists to prevent.
     reserve_bytes: u64,
 }
 
@@ -150,9 +165,12 @@ impl ImageDiskManager {
     }
 
     /// Compute the cache path for a given image digest.
+    ///
+    /// Includes `reserve_bytes` — see the field doc for why that's safe.
     fn disk_path(&self, digest: &str) -> PathBuf {
         let filename = digest.replace(':', "-");
-        self.cache_dir.join(format!("{}.ext4", filename))
+        self.cache_dir
+            .join(format!("{}-r{}.ext4", filename, self.reserve_bytes))
     }
 }
 
@@ -170,7 +188,7 @@ mod tests {
         let path = mgr.disk_path("sha256:abc123def456");
         assert_eq!(
             path,
-            PathBuf::from("/cache/disk-images/sha256-abc123def456.ext4")
+            PathBuf::from("/cache/disk-images/sha256-abc123def456-r0.ext4")
         );
     }
 
@@ -178,7 +196,25 @@ mod tests {
     fn test_disk_path_no_colon() {
         let mgr = ImageDiskManager::new(PathBuf::from("/cache"), PathBuf::from("/tmp"), 0);
         let path = mgr.disk_path("plaindigest");
-        assert_eq!(path, PathBuf::from("/cache/plaindigest.ext4"));
+        assert_eq!(path, PathBuf::from("/cache/plaindigest-r0.ext4"));
+    }
+
+    /// Two different `reserve_bytes` values must produce two different cache
+    /// paths for the *same* digest — the property
+    /// `find_does_not_reuse_a_disk_cached_with_different_reserve_bytes` below
+    /// relies on.
+    #[test]
+    fn test_disk_path_varies_with_reserve_bytes() {
+        let dir = PathBuf::from("/cache");
+        let small = ImageDiskManager::new(dir.clone(), PathBuf::from("/tmp"), 0);
+        let large = ImageDiskManager::new(dir, PathBuf::from("/tmp"), 100 * 1024 * 1024);
+
+        assert_ne!(
+            small.disk_path("sha256:abc123"),
+            large.disk_path("sha256:abc123"),
+            "the same digest under a different reserve_bytes must not collide \
+             on the same cache path"
+        );
     }
 
     #[test]
@@ -223,6 +259,41 @@ mod tests {
         assert!(expected.exists());
         assert_eq!(result.path(), expected);
         let _ = result.leak();
+    }
+
+    /// A disk cached under a smaller `reserve_bytes` must not be handed to a
+    /// caller that now needs more headroom.
+    ///
+    /// Live-reproduced during development: a real `~/Library/Application
+    /// Support/boxlite/images/disk-images/{digest}.ext4` built before this
+    /// budget existed (digest-only filename, no reserve) was reused as-is
+    /// once `reserve_bytes` shipped, and `GuestRootfsManager::
+    /// build_and_install` hit the identical "Could not allocate block in
+    /// ext2 filesystem" failure `reserve_bytes` exists to prevent — a cache
+    /// hit had bypassed the fix entirely. `GuestRootfsManager` already
+    /// solves the identical problem one layer up (`version_key` folds the
+    /// guest binary's id into its cache key so a rebuilt guest can't reuse a
+    /// stale rootfs); this pins the same fix at the `ImageDiskManager` layer.
+    #[test]
+    fn find_does_not_reuse_a_disk_cached_with_different_reserve_bytes() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let small = ImageDiskManager::new(dir.path().to_path_buf(), dir.path().to_path_buf(), 0);
+        let large = ImageDiskManager::new(
+            dir.path().to_path_buf(),
+            dir.path().to_path_buf(),
+            100 * 1024 * 1024,
+        );
+
+        // Simulate a disk an earlier build cached with less (or no) headroom.
+        let cached = small.disk_path("sha256:abc123");
+        std::fs::create_dir_all(cached.parent().unwrap()).unwrap();
+        std::fs::write(&cached, "small-reserve disk").unwrap();
+
+        assert!(
+            large.find("sha256:abc123").is_none(),
+            "a disk cached under a smaller reserve_bytes must not be returned \
+             to a caller that now needs more headroom"
+        );
     }
 
     #[test]

--- a/src/boxlite/src/rootfs/operations.rs
+++ b/src/boxlite/src/rootfs/operations.rs
@@ -243,17 +243,19 @@ pub fn fix_rootfs_permissions(rootfs: &Path) -> BoxliteResult<()> {
         // extraction cannot `chown`; overwriting it with 0:0 would drop the only
         // copy before the ext4 builder reads it back. Entries with no prior
         // record default to root, as before.
-        let recorded = match OverrideStat::read_xattr(path) {
-            Ok(stat) => stat,
-            Err(e) => {
-                tracing::warn!(
-                    "Failed to read ownership xattr on {}, defaulting to 0:0: {}",
-                    path.display(),
-                    e
-                );
-                None
-            }
-        };
+        //
+        // A *present-but-malformed* record must abort instead: it is the only
+        // copy of that file's real ownership, and the `xattr::set` below would
+        // otherwise permanently overwrite it with a fresh 0:0 record — see
+        // `OverrideStat::read_xattr`'s doc comment for why `Ok(None)` and `Err`
+        // are deliberately distinct.
+        let recorded = OverrideStat::read_xattr(path).map_err(|e| {
+            BoxliteError::Storage(format!(
+                "Failed to read ownership xattr on {}: {}",
+                path.display(),
+                e
+            ))
+        })?;
         let (uid, gid) = recorded.as_ref().map_or((0, 0), |s| (s.uid, s.gid));
         let default_type = if metadata.is_dir() {
             OverrideFileType::Dir
@@ -353,5 +355,35 @@ mod tests {
         process_whiteouts(dir).unwrap();
 
         assert!(!dir.join(".wh..wh..opq").exists());
+    }
+
+    /// A malformed `override_stat` xattr must abort `fix_rootfs_permissions`,
+    /// not be silently overwritten with a fresh 0:0 record.
+    ///
+    /// Before this fix, `set_xattr_recursive` treated a read `Err` the same
+    /// as "no record" — defaulting to 0:0 and then calling `xattr::set` with
+    /// that default, permanently destroying the only copy of the file's real
+    /// ownership (unprivileged extraction can't `chown`). This is the sibling
+    /// of the same bug fixed in `disk::ext4::SourceScan::record_owner` — same
+    /// root cause (`OverrideStat::read_xattr`'s `Err` swallowed), reachable
+    /// on the extraction-based rootfs path this function serves.
+    #[test]
+    fn fix_rootfs_permissions_fails_on_malformed_override_stat() {
+        const CONTAINERS_OVERRIDE_XATTR: &str = "user.containers.override_stat";
+
+        let temp = TempDir::new().unwrap();
+        let dir = temp.path();
+        let f = dir.join("file");
+        fs::write(&f, b"x").unwrap();
+        xattr::set(&f, CONTAINERS_OVERRIDE_XATTR, b"not-a-valid-record")
+            .expect("seed malformed xattr");
+
+        let result = fix_rootfs_permissions(dir);
+        assert!(
+            result.is_err(),
+            "a malformed override_stat xattr is the only copy of a file's \
+             declared ownership; fix_rootfs_permissions must fail, not \
+             silently overwrite it with a fresh 0:0 record"
+        );
     }
 }

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -194,6 +194,22 @@ pub struct SynchronizedState {
     active_boxes_by_name: HashMap<String, Weak<crate::litebox::box_impl::BoxImpl>>,
 }
 
+/// Headroom `ImageDiskManager` reserves in every image disk it builds, for
+/// the `boxlite-guest` binary `GuestRootfsManager` injects into a copy of it
+/// afterward.
+///
+/// Fixed, not derived from the real guest binary's current size: the cache
+/// key (`ImageDiskManager::disk_path`) does not vary with this value, so a
+/// value that changed on every guest-binary rebuild would orphan a copy of
+/// every already-cached image disk with no way to reclaim it — this manager
+/// has no GC, unlike `GuestRootfsManager`'s paired `version_key` + `gc()`.
+/// An unstripped debug build measures ~232 MB (see
+/// `guest_binary_fits_in_image_disk_headroom` below); 512 MiB covers that
+/// with margin to grow, in both debug and (far smaller) release builds, at
+/// the cost of some unused — but sparse, so cheap on disk — space in every
+/// cached image disk.
+const IMAGE_DISK_GUEST_BINARY_HEADROOM_BYTES: u64 = 512 * 1024 * 1024;
+
 impl RuntimeImpl {
     // ========================================================================
     // CONSTRUCTION
@@ -307,8 +323,13 @@ impl RuntimeImpl {
             "Initialized lock manager"
         );
 
-        let image_disk_mgr =
-            ImageDiskManager::new(layout.image_layout().disk_images_dir(), layout.temp_dir());
+        // See IMAGE_DISK_GUEST_BINARY_HEADROOM_BYTES for why this is a fixed
+        // budget rather than derived from the guest binary actually on disk.
+        let image_disk_mgr = ImageDiskManager::new(
+            layout.image_layout().disk_images_dir(),
+            layout.temp_dir(),
+            IMAGE_DISK_GUEST_BINARY_HEADROOM_BYTES,
+        );
         let guest_rootfs_mgr = GuestRootfsManager::new(base_disk_mgr.clone(), layout.temp_dir());
 
         let inner = Arc::new(Self {
@@ -1847,7 +1868,32 @@ mod tests {
     use crate::runtime::backend::RuntimeBackend;
     use crate::runtime::images::ImageBackend;
     use crate::runtime::options::RootfsSpec;
+    use crate::vmm::guest_binary::GuestBinary;
     use tempfile::TempDir;
+
+    /// `IMAGE_DISK_GUEST_BINARY_HEADROOM_BYTES` must stay ahead of the real
+    /// embedded `boxlite-guest` binary — silently falling behind would
+    /// reintroduce the exact "Could not allocate block in ext2 filesystem"
+    /// failure this constant exists to prevent, undetected until a real box
+    /// tried to boot. Skipped when the guest binary isn't assembled (no
+    /// `make guest`/`make runtime:debug`).
+    #[test]
+    fn guest_binary_fits_in_image_disk_headroom() {
+        let Ok(guest) = GuestBinary::get() else {
+            eprintln!("skipping: boxlite-guest not found (run `make guest`)");
+            return;
+        };
+        let guest_len = std::fs::metadata(guest.path())
+            .expect("stat resolved guest binary")
+            .len();
+        assert!(
+            guest_len < IMAGE_DISK_GUEST_BINARY_HEADROOM_BYTES,
+            "guest binary is {} MiB, headroom budget is only {} MiB -- bump \
+             IMAGE_DISK_GUEST_BINARY_HEADROOM_BYTES",
+            guest_len / (1024 * 1024),
+            IMAGE_DISK_GUEST_BINARY_HEADROOM_BYTES / (1024 * 1024)
+        );
+    }
 
     #[test]
     fn local_runtime_rejects_explicit_lifecycle_policy() {

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -196,14 +196,18 @@ pub struct SynchronizedState {
 
 /// Headroom `ImageDiskManager` reserves in every image disk it builds, for
 /// the `boxlite-guest` binary `GuestRootfsManager` injects into a copy of it
-/// afterward.
+/// afterward. `ImageDiskManager` folds this into its cache key
+/// (`disk_path`), so a disk cached under a different value is never reused.
 ///
-/// Fixed, not derived from the real guest binary's current size: the cache
-/// key (`ImageDiskManager::disk_path`) does not vary with this value, so a
-/// value that changed on every guest-binary rebuild would orphan a copy of
-/// every already-cached image disk with no way to reclaim it — this manager
-/// has no GC, unlike `GuestRootfsManager`'s paired `version_key` + `gc()`.
-/// An unstripped debug build measures ~232 MB (see
+/// Fixed, not derived from the real guest binary's current size: this
+/// manager has no GC (unlike `GuestRootfsManager`'s paired `version_key` +
+/// `gc()`), so a value that changed on every guest-binary rebuild would
+/// orphan a cache entry per digest on every rebuild — a routine, frequent
+/// event for developers. Because this is instead a source-level constant, it
+/// only changes on the rare, deliberate occasions *this number itself* gets
+/// edited (e.g. if a future guest binary outgrows it), each such change
+/// creating at most one new generation of cache entries, not a continuous
+/// leak. An unstripped debug build measures ~232 MB (see
 /// `guest_binary_fits_in_image_disk_headroom` below); 512 MiB covers that
 /// with margin to grow, in both debug and (far smaller) release builds, at
 /// the cost of some unused — but sparse, so cheap on disk — space in every

--- a/src/boxlite/src/util/mod.rs
+++ b/src/boxlite/src/util/mod.rs
@@ -509,8 +509,11 @@ mod tests {
         fs::create_dir_all(&dex_dir).unwrap();
         fs::set_permissions(&dex_dir, fs::Permissions::from_mode(0o755)).unwrap();
 
-        // Encode through the production writer, exactly as the extractor does.
-        OverrideStat::new(1001, 1001, 0o755, OverrideFileType::Dir)
+        // Seed a stale mode (0o700) that differs from the real on-disk mode
+        // (0o755) so the assertion below can only pass if fix_rootfs_permissions
+        // actually re-reads the mode from disk — not if it just carries the old
+        // recorded value forward.
+        OverrideStat::new(1001, 1001, 0o700, OverrideFileType::Dir)
             .write_xattr(&dex_dir)
             .expect("seed override_stat");
 


### PR DESCRIPTION
## Summary

Fixes two related bugs in the guest-rootfs ext4 build pipeline: `debugfs` errors that never surfaced because only the process exit code was checked, and — uncovered once that check was fixed — an image disk with no capacity headroom for the guest binary injected into it afterward.

## Call graph

Before
```
RuntimeImpl::initialize             (RuntimeImpl · src/boxlite/src/runtime/rt_impl.rs:237)
  └─ ImageDiskManager::new          (ImageDiskManager · src/boxlite/src/images/image_disk.rs:65)
ImageDiskManager::build_and_install (ImageDiskManager · src/boxlite/src/images/image_disk.rs:98)
  └─ create_ext4_from_dir           (fn · src/boxlite/src/disk/ext4.rs:354)  — sized from OCI content only
GuestRootfsManager::build_and_install (GuestRootfsManager · src/boxlite/src/rootfs/guest.rs:372)
  └─ inject_file_into_ext4          (fn · src/boxlite/src/disk/ext4.rs:580)  ← BUG: staged image
     has no headroom (256 MiB floor, ~223 MiB free) for the ~231 MiB debug guest binary; debugfs
     write runs out of blocks but only `output.status.success()` is checked, which is still 0 —
     e2fsprogs logs the failure to stderr and continues, so it never surfaces
```

After
```
RuntimeImpl::initialize             (RuntimeImpl · src/boxlite/src/runtime/rt_impl.rs:237)
  └─ ImageDiskManager::new          (ImageDiskManager · src/boxlite/src/images/image_disk.rs:65)  — takes a fixed 512 MiB headroom budget (src/boxlite/src/runtime/rt_impl.rs:332)
ImageDiskManager::build_and_install (ImageDiskManager · src/boxlite/src/images/image_disk.rs:98)
  └─ disk_path                      (ImageDiskManager · src/boxlite/src/images/image_disk.rs:170)  — cache key includes the budget
  └─ create_ext4_from_dir           (fn · src/boxlite/src/disk/ext4.rs:354)  — budget reserved in the image size
GuestRootfsManager::build_and_install (GuestRootfsManager · src/boxlite/src/rootfs/guest.rs:372)
  └─ inject_file_into_ext4          (fn · src/boxlite/src/disk/ext4.rs:580)
       └─ check_debugfs_output      (fn · src/boxlite/src/disk/ext4.rs:460)  — exit code AND any
          stderr beyond the one-line startup banner; shared by this call site and
          normalize_inodes_with_debugfs (src/boxlite/src/disk/ext4.rs:493)
```

Fixes #1181

## Changes

- `check_debugfs_output` (`src/boxlite/src/disk/ext4.rs:460`) replaces a bare `output.status.success()` check at both `debugfs -w -f -` call sites — a failing per-command error now aborts the build instead of leaving a partially-normalized or partially-injected image.
- `OverrideStat::read_xattr` (`src/boxlite/src/images/archive/override_stat.rs`) now returns `Err` for a present-but-malformed `user.containers.override_stat` value instead of `Ok(None)` — a layer's declared ownership is the only copy of that data, so a corrupt record must not be treated the same as no record at all.
- The image-disk headroom budget (`IMAGE_DISK_GUEST_BINARY_HEADROOM_BYTES`, `src/boxlite/src/runtime/rt_impl.rs:215`) is a fixed constant rather than derived from the guest binary's live size, and is folded into `ImageDiskManager`'s cache key — deriving it dynamically would change the cache key on every `make guest` rebuild, and `ImageDiskManager` has no GC (unlike `GuestRootfsManager`'s paired `version_key` + `gc()`) to reclaim the orphaned copies that would leave behind.
- `.githooks/pre-push`'s `new_ref_base_sha` picked the wrong fork point for a new branch: the first candidate in alphabetical ref order rather than the closest by commit distance, and `--is-ancestor` breaks once the default branch advances past the fork point. Rewritten to use `merge-base` and pick the candidate needing the fewest commits.

## How to verify

- `make fmt:check:rust && make lint:rust`
- `make test:unit:rust` (988 boxlite + 49 boxlite-shared)
- `make test:integration:rust` (254 passed, 11 skipped)
- `make test:integration:c` — exercises the real box-creation path this PR fixes
- `bash .githooks/githooks.test.sh` (85 tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reserved capacity for guest binaries during disk image creation, helping ensure post-build injection succeeds.
  - Improved disk-image caching so images with different capacity requirements remain isolated.

- **Bug Fixes**
  - Improved detection of filesystem image creation and file-injection failures.
  - Malformed extended attributes now report an error instead of appearing absent.
  - Improved pushed-diff detection for branch histories and merge scenarios.
  - Corrected permission handling when restoring filesystem ownership.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->