### PR TITLE
fix(sdk): SimpleBox auto_remove leaks boxes over REST (Python + Node)

### DIFF
--- a/apps/e2e/cases/test_node_simplebox_lifecycle.py
+++ b/apps/e2e/cases/test_node_simplebox_lifecycle.py
@@ -1,0 +1,63 @@
+"""REST E2E coverage for the Node SDK's SimpleBox exit-time cleanup contract.
+
+Mirrors test_simplebox_lifecycle.py: SimpleBox.stop() (sdks/node/lib/simplebox.ts)
+must delete the box when autoRemove is true, not just stop it - the same
+gap fixed on the Python side in #1186.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "lib"))
+from e2e_auth import auth_context
+from images import default_image
+
+
+REPO = Path(__file__).resolve().parents[3]
+NODE_SDK = REPO / "sdks/node"
+DRIVER = REPO / "apps/e2e/sdks/node/e2e_simplebox_lifecycle.ts"
+
+
+def _has_node_napi_build() -> bool:
+    return any(
+        directory.exists() and any(directory.rglob("*.node"))
+        for directory in (NODE_SDK / "native", NODE_SDK / "dist", NODE_SDK / "npm")
+    )
+
+
+@pytest.fixture(scope="module")
+def node_env():
+    if auth_context().auth != "api-key":
+        pytest.skip("Node SDK E2E only supports API-key credentials today")
+    if not shutil.which("npx"):
+        pytest.skip("npx not installed")
+    if not _has_node_napi_build():
+        pytest.skip("Node SDK napi binding not built")
+    ctx = auth_context()
+    return {
+        **os.environ,
+        **ctx.api_key_sdk_env(),
+        "BOXLITE_E2E_IMAGE": default_image(),
+    }
+
+
+def test_node_sdk_simplebox_lifecycle(node_env):
+    result = subprocess.run(
+        ["npx", "--yes", "tsx", str(DRIVER)],
+        env=node_env,
+        timeout=60,
+        capture_output=True,
+        text=True,
+        cwd=str(NODE_SDK),
+    )
+    assert result.returncode == 0, (
+        f"exit={result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "AUTOREMOVE_TRUE_DELETES=ok" in result.stdout
+    assert "AUTOREMOVE_FALSE_KEEPS=ok" in result.stdout

--- a/apps/e2e/cases/test_simplebox_lifecycle.py
+++ b/apps/e2e/cases/test_simplebox_lifecycle.py
@@ -23,16 +23,24 @@ async def _box_gone(rt, box_id: str, *, timeout: float = 15.0) -> bool:
     """Poll until get_info reports the box missing, or the timeout elapses.
 
     The Python SDK has no typed NotFound exception over REST (`map_err`
-    collapses every server error to a generic RuntimeError), so - like the
-    rest of this suite - absence is detected by catching the call failing
-    rather than by an `is None` / typed-error check.
+    collapses every server error to a generic RuntimeError), so absence is
+    detected by matching the REST 404 wording in the message rather than an
+    `is None` / typed-error check. Any other failure (pending state,
+    transport blip, ...) is retried instead of being treated as proof of
+    deletion - a false "not found" would hide the real leak this test
+    exists to catch.
     """
     deadline = time.monotonic() + timeout
     while True:
         try:
             await rt.get_info(box_id)
-        except Exception:
-            return True
+        except Exception as exc:
+            if "not found" in str(exc).lower():
+                return True
+            if time.monotonic() > deadline:
+                raise
+            await asyncio.sleep(1.0)
+            continue
         if time.monotonic() > deadline:
             return False
         await asyncio.sleep(1.0)

--- a/apps/e2e/cases/test_simplebox_lifecycle.py
+++ b/apps/e2e/cases/test_simplebox_lifecycle.py
@@ -1,0 +1,70 @@
+"""REST E2E coverage for SimpleBox's exit-time cleanup contract.
+
+`Box.__aexit__` (the Rust FFI layer) only stops the VM. `BoxOptions.auto_remove`
+is a deprecated field that REST runtimes silently ignore (see the
+`auto_remove` docs on `BoxOptions` in `src/boxlite/src/runtime/options.rs`) -
+local runtimes still self-delete on stop when it's set, which is why this
+only leaks remotely. If `SimpleBox` doesn't explicitly delete the box itself
+on exit, `auto_remove=True` deletes nothing and the box is left `Stopped`
+forever on the remote server. This is a regression test for exactly that
+leak: every box `test_sdk_tunnel.py` created via `SimpleBox` survived the
+whole e2e suite on the dev cloud environment.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+
+import boxlite
+import pytest
+
+
+async def _box_gone(rt, box_id: str, *, timeout: float = 15.0) -> bool:
+    """Poll until get_info reports the box missing, or the timeout elapses.
+
+    The Python SDK has no typed NotFound exception over REST (`map_err`
+    collapses every server error to a generic RuntimeError), so - like the
+    rest of this suite - absence is detected by catching the call failing
+    rather than by an `is None` / typed-error check.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            await rt.get_info(box_id)
+        except Exception:
+            return True
+        if time.monotonic() > deadline:
+            return False
+        await asyncio.sleep(1.0)
+
+
+@pytest.mark.asyncio
+async def test_simplebox_auto_remove_deletes_on_exit(rt, image):
+    """auto_remove=True must delete the box on exit, not just stop it."""
+    box = boxlite.SimpleBox(image=image, runtime=rt, auto_remove=True)
+    async with box:
+        pass
+
+    assert await _box_gone(rt, box.id), (
+        f"box {box.id} is still present after SimpleBox exited with "
+        "auto_remove=True; Box.__aexit__ only stops the VM, so SimpleBox "
+        "itself must issue the delete"
+    )
+
+
+@pytest.mark.asyncio
+async def test_simplebox_auto_remove_false_keeps_box(rt, image):
+    """auto_remove=False must leave the box stopped, not deleted, on exit."""
+    box = boxlite.SimpleBox(image=image, runtime=rt, auto_remove=False)
+    async with box:
+        pass
+    try:
+        info = await rt.get_info(box.id)
+        assert info is not None, "box was deleted despite auto_remove=False"
+    finally:
+        # stop() (run by the `async with` above) leaves the box briefly
+        # `pending` server-side; give that a moment to clear before the
+        # cleanup remove() below, same as test_lifecycle_comprehensive.py's
+        # stop -> sleep(1) -> next-operation pattern.
+        await asyncio.sleep(1)
+        await rt.remove(box.id, force=True)

--- a/apps/e2e/sdks/node/e2e_simplebox_lifecycle.ts
+++ b/apps/e2e/sdks/node/e2e_simplebox_lifecycle.ts
@@ -13,15 +13,30 @@ function env(name: string, fallback: string): string {
   return value && value.length ? value : fallback
 }
 
-/** Polls until getInfo reports the box missing, or the timeout elapses. */
+function isNotFound(error: unknown): boolean {
+  return error instanceof Error && error.message.toLowerCase().includes('not found')
+}
+
+/**
+ * Polls until getInfo reports the box missing, or the timeout elapses.
+ *
+ * The Node SDK has no typed not-found error over REST, so absence is
+ * detected by matching the REST 404 wording in the message rather than a
+ * `null` / typed-error check. Any other failure (pending state, transport
+ * blip, ...) is retried instead of being treated as proof of deletion - a
+ * false "not found" would hide the real leak this driver exists to catch.
+ */
 async function boxGone(runtime: JsBoxlite, id: string, timeoutMs = 15_000): Promise<boolean> {
   const deadline = Date.now() + timeoutMs
   while (true) {
     try {
       const info = await runtime.getInfo(id)
       if (info == null) return true
-    } catch {
-      return true
+    } catch (error) {
+      if (isNotFound(error)) return true
+      if (Date.now() > deadline) throw error
+      await delay(1_000)
+      continue
     }
     if (Date.now() > deadline) return false
     await delay(1_000)
@@ -53,11 +68,12 @@ async function main(): Promise<void> {
     const info = await runtime.getInfo(keptId)
     if (info == null) throw new Error(`box ${keptId} was deleted despite autoRemove=false`)
   } finally {
-    // stop() above can leave the box briefly `pending` server-side; give
-    // that a moment to clear before this cleanup remove(), same as the
-    // retry inside SimpleBox.stop() itself.
+    // stop() above can leave the box briefly `pending` server-side; retry
+    // once past that window, same as the retry inside SimpleBox.stop()
+    // itself. A failure here would leak this box, so it's rethrown rather
+    // than swallowed.
     await delay(1_000)
-    await runtime.remove(keptId, true).catch(() => undefined)
+    await runtime.remove(keptId, true)
   }
   console.log('AUTOREMOVE_FALSE_KEEPS=ok')
 }

--- a/apps/e2e/sdks/node/e2e_simplebox_lifecycle.ts
+++ b/apps/e2e/sdks/node/e2e_simplebox_lifecycle.ts
@@ -1,0 +1,68 @@
+// REST E2E regression: SimpleBox.stop() must delete the box when
+// autoRemove is true, not just stop it. `autoRemove` on BoxOptions is a
+// deprecated field REST runtimes silently ignore (local runtimes still
+// self-delete on stop, which is why this only leaks remotely) - see
+// sdks/node/lib/simplebox.ts SimpleBox.stop().
+
+import { ApiKeyCredential, BoxliteRestOptions, JsBoxlite, SimpleBox } from '../../../../sdks/node'
+import { DEFAULT_BOX_IMAGE } from '../../../../scripts/test/image.js'
+import { setTimeout as delay } from 'node:timers/promises'
+
+function env(name: string, fallback: string): string {
+  const value = process.env[name]
+  return value && value.length ? value : fallback
+}
+
+/** Polls until getInfo reports the box missing, or the timeout elapses. */
+async function boxGone(runtime: JsBoxlite, id: string, timeoutMs = 15_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (true) {
+    try {
+      const info = await runtime.getInfo(id)
+      if (info == null) return true
+    } catch {
+      return true
+    }
+    if (Date.now() > deadline) return false
+    await delay(1_000)
+  }
+}
+
+async function main(): Promise<void> {
+  const runtime = JsBoxlite.rest(
+    new BoxliteRestOptions({
+      url: env('BOXLITE_E2E_URL', 'http://localhost:3000/api'),
+      credential: new ApiKeyCredential(env('BOXLITE_E2E_API_KEY', 'devkey')),
+      pathPrefix: env('BOXLITE_E2E_PREFIX', ''),
+    }),
+  )
+  const image = env('BOXLITE_E2E_IMAGE', DEFAULT_BOX_IMAGE)
+
+  const removedBox = new SimpleBox({ image, runtime, autoRemove: true })
+  const removedId = await removedBox.getId()
+  await removedBox.stop()
+  if (!(await boxGone(runtime, removedId))) {
+    throw new Error(`box ${removedId} is still present after stop() with autoRemove=true`)
+  }
+  console.log('AUTOREMOVE_TRUE_DELETES=ok')
+
+  const keptBox = new SimpleBox({ image, runtime, autoRemove: false })
+  const keptId = await keptBox.getId()
+  await keptBox.stop()
+  try {
+    const info = await runtime.getInfo(keptId)
+    if (info == null) throw new Error(`box ${keptId} was deleted despite autoRemove=false`)
+  } finally {
+    // stop() above can leave the box briefly `pending` server-side; give
+    // that a moment to clear before this cleanup remove(), same as the
+    // retry inside SimpleBox.stop() itself.
+    await delay(1_000)
+    await runtime.remove(keptId, true).catch(() => undefined)
+  }
+  console.log('AUTOREMOVE_FALSE_KEEPS=ok')
+}
+
+void main().catch((error: unknown) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/sdks/node/lib/simplebox.ts
+++ b/sdks/node/lib/simplebox.ts
@@ -33,6 +33,7 @@ interface BoxRuntime {
     options: JsBoxOptions,
     name?: string | null,
   ): Promise<{ readonly created: boolean; readonly box: BoxLike }>;
+  remove(idOrName: string, force?: boolean | null): Promise<void>;
 }
 
 /**
@@ -770,6 +771,41 @@ export class SimpleBox {
       return;
     }
     await this._box.stop();
+    // `stop()` only stops the VM. `autoRemove` on JsBoxOptions is a
+    // deprecated field REST runtimes silently ignore (local runtimes still
+    // self-delete on stop, which is why this only leaks remotely) - the
+    // explicit remove() below is what actually deletes the box over REST.
+    // Only a box this instance created is removed; one reused via
+    // `reuseExisting: true` may still be open in an outer session.
+    if (this._boxOpts.autoRemove && this._created) {
+      await this._removeAfterStop();
+    }
+  }
+
+  /**
+   * Delete `this._box`, retrying once if the stop() above is still
+   * finalizing server-side (`Box state change in progress`).
+   */
+  private async _removeAfterStop(): Promise<void> {
+    const box = this._box;
+    if (!box) {
+      return;
+    }
+    for (const [attempt, delayMs] of [0, 1000].entries()) {
+      if (delayMs) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
+      try {
+        await this._runtime.remove(box.id, true);
+        return;
+      } catch (err) {
+        if (attempt === 1) {
+          // Local runtimes already deleted it as part of stop() above, so
+          // "not found" here is the expected, already-clean case.
+          console.debug(`autoRemove cleanup for box ${box.id}:`, err);
+        }
+      }
+    }
   }
 
   /**

--- a/sdks/python/boxlite/simplebox.py
+++ b/sdks/python/boxlite/simplebox.py
@@ -130,6 +130,7 @@ class SimpleBox:
             **kwargs,
         )
         self._name = name
+        self._auto_remove = auto_remove
         self._reuse_existing = reuse_existing
         self._box = None
         self._started = False
@@ -182,8 +183,41 @@ class SimpleBox:
         return await self.__aenter__()
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        """Async context manager exit - delegates to Box.__aexit__ (returns awaitable)."""
-        return await self._box.__aexit__(exc_type, exc_val, exc_tb)
+        """Async context manager exit - stops the box, then deletes it if
+        auto_remove was requested.
+
+        `Box.__aexit__` only stops the VM. Deletion used to be implied by
+        passing `auto_remove=True` into `BoxOptions`, but that field is
+        deprecated and REST runtimes silently ignore it (local runtimes
+        still self-delete on stop, which is why this only leaks remotely).
+        The explicit `remove()` call below is what actually deletes the box
+        over REST. Only a box this instance created is removed - one
+        reused via `reuse_existing=True` may still be open in an outer
+        session, so exiting an inner session must not delete it out from
+        under that session.
+        """
+        result = await self._box.__aexit__(exc_type, exc_val, exc_tb)
+        if self._auto_remove and self._created:
+            await self._remove_after_stop()
+        return result
+
+    async def _remove_after_stop(self) -> None:
+        """Delete `self._box`, retrying once if the stop() above is still
+        finalizing server-side (`Box state change in progress`)."""
+        for attempt, delay in enumerate((0, 1)):
+            if delay:
+                await asyncio.sleep(delay)
+            try:
+                await self._runtime.remove(self._box.id, force=True)
+                return
+            except Exception:
+                if attempt == 1:
+                    # Local runtimes already deleted it as part of stop()
+                    # above, so "not found" here is the expected,
+                    # already-clean case.
+                    logger.debug(
+                        "auto_remove cleanup for box %s", self._box.id, exc_info=True
+                    )
 
     @property
     def id(self) -> str:

--- a/sdks/python/boxlite/sync_api/_simplebox.py
+++ b/sdks/python/boxlite/sync_api/_simplebox.py
@@ -7,6 +7,7 @@ Async-only metadata retrieval is not exposed.
 
 import asyncio
 import logging
+import time
 from typing import TYPE_CHECKING, Optional
 
 from ..exec import ExecResult
@@ -96,6 +97,7 @@ class SyncSimpleBox:
 
         # Store for lazy creation in __enter__
         self._name = name
+        self._auto_remove = auto_remove
         self._reuse_existing = reuse_existing
         self._box: SyncBox | None = None
         self._created: bool | None = None
@@ -121,14 +123,42 @@ class SyncSimpleBox:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
-        """Exit context - stops the box, then stops runtime if owned."""
-        # Stop the box (SyncBox.stop() is already sync)
+        """Exit context - stops the box, deletes it if auto_remove was
+        requested, then stops runtime if owned.
+
+        `SyncBox.stop()` only stops the VM. Deletion used to be implied by
+        `auto_remove=True`, but that field is deprecated and REST runtimes
+        silently ignore it (local runtimes still self-delete on stop, which
+        is why this only leaks remotely). The explicit `remove()` call below
+        is what actually deletes the box over REST. Only a box this instance
+        created is removed - one reused via `reuse_existing=True` may still
+        be open in an outer session.
+        """
         if self._box is not None:
             self._box.stop()
+            if self._auto_remove and self._created:
+                self._remove_after_stop()
 
         # Stop runtime if we own it
         if self._owns_runtime:
             self._runtime.stop()
+
+    def _remove_after_stop(self) -> None:
+        """Delete `self._box`, retrying once if the stop() above is still
+        finalizing server-side (`Box state change in progress`)."""
+        for attempt, delay in enumerate((0, 1)):
+            if delay:
+                time.sleep(delay)
+            try:
+                self._runtime.remove(self._box.id, force=True)
+                return
+            except Exception:
+                if attempt == 1:
+                    # Local runtimes already deleted it as part of stop()
+                    # above, so "not found" here is expected and already clean.
+                    logger.debug(
+                        "auto_remove cleanup for box %s", self._box.id, exc_info=True
+                    )
 
     @property
     def id(self) -> str:


### PR DESCRIPTION
`SimpleBox` (Python and Node) now deletes the box on exit when `auto_remove`/`autoRemove` is true, instead of only stopping it (a no-op over REST that left every such box `Stopped` forever on the dev cloud environment).

Test plan:
- [x] `apps/e2e/cases/test_simplebox_lifecycle.py` against the dev cloud API — fails on the pre-fix Python code, passes after
- [x] `apps/e2e/cases/test_node_simplebox_lifecycle.py` against the dev cloud API — fails on the pre-fix Node code, passes after
- [x] `apps/e2e/cases/test_sdk_tunnel.py` against the dev cloud API — dev box count returns to 0 after the run
- [x] `cd sdks/node && npx tsc --noEmit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic cleanup for boxes created with auto-removal enabled when their lifecycle ends.
  - Added explicit box removal support to the Node SDK.
  - Preserved boxes configured with auto-removal disabled for inspection and manual cleanup.
  - Reused boxes are not removed unintentionally.

- **Bug Fixes**
  - Improved cleanup reliability by retrying removal during shutdown and tolerating already-removed boxes.

- **Tests**
  - Added end-to-end coverage for Python and Node box lifecycle and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->