### PR TITLE
fix(infra): give the usage exporter the settings it waits for

### DIFF
--- a/apps/infra/.env.example
+++ b/apps/infra/.env.example
@@ -237,6 +237,20 @@ OIDC_AUDIENCE=https://dev.example.com/api
 # instead of advertising a service that would fail every request. Suspension
 # does not key off it (REQUIRE_PAYMENT_METHOD does).
 # BILLING_API_URL=https://billing.example.com/api/billing
+#   Setting it also arms usage export to that same service, since a stage with
+#   somewhere to bill has somewhere to send usage. USAGE_EXPORT_URL defaults to
+#   BILLING_API_URL's origin and rarely needs setting: the publisher appends
+#   /internal/usage-events, which the billing service serves off its bare origin
+#   because that route authenticates a service rather than a user, so the
+#   /api/billing value would 404 every batch. Override only if the two live at
+#   different origins.
+# USAGE_EXPORT_URL=https://billing.example.com
+#   [required SST secret to export] USAGE_EXPORT_TOKEN is what turns delivery on:
+#   until the stage's secret store holds one, the exporter stays off and writes no
+#   outbox rows. It must equal the string the billing service reads as
+#   USAGE_INGEST_TOKEN — for boxlite-commerce, the value its own stack keeps in
+#   Secrets Manager under boxlite-commerce/<stage>/usage-ingest-token. Use the
+#   non-echoing stdin procedure in README.md; never put the value in process argv.
 
 # 4k. Observability backend — ClickHouse (trace/metric/log storage). All [optional];
 # unset = the OtelCollector targets a disabled endpoint and the API's observability

--- a/apps/infra/README.md
+++ b/apps/infra/README.md
@@ -241,7 +241,7 @@ each stage you run.
 
 | What | Stored in | Set by |
 | --- | --- | --- |
-| App secrets (`OIDC_CLIENT_ID`, Auth0 Management API, Svix, PostHog) | SST secret store | `npm run bootstrap`; others via `npm run sst -- secret set <NAME> --stage <stage>` reading stdin |
+| App secrets (`OIDC_CLIENT_ID`, Auth0 Management API, Svix, PostHog, `USAGE_EXPORT_TOKEN`) | SST secret store | `npm run bootstrap`; others via `npm run sst -- secret set <NAME> --stage <stage>` reading stdin |
 | Cloudflare creds (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_DEFAULT_ACCOUNT_ID`) | AWS SSM SecureString, or GitHub Environment secrets (which win) | `npm run bootstrap` |
 | Stage config (`STACK_DOMAIN`, `OIDC_*`, toggles) | GitHub Environment secret `DEPLOY_ENV` | `npm run bootstrap` |
 

--- a/apps/infra/scripts/sst-config-contract.test.mjs
+++ b/apps/infra/scripts/sst-config-contract.test.mjs
@@ -408,7 +408,12 @@ test('organization suspension is gated on its own flag, not on BILLING_API_URL',
 // 404s. The producing and consuming sides sit in different packages: nothing but a cross-file
 // guard notices when one of them moves.
 test('a billing URL is advertised only where a billing service answers', () => {
-  assert.match(liveConfig, /\.\.\.\(process\.env\.BILLING_API_URL && \{ BILLING_API_URL: process\.env\.BILLING_API_URL \}\)/)
+  // Shape, not formatting: the block gained usage-export settings on the same gate, so pinning
+  // the one-line spelling would fail on a change that keeps the guarantee exactly. What matters
+  // is that the gate is the env var and the value is passed through with no default behind it.
+  assert.match(liveConfig, /\.\.\.\(process\.env\.BILLING_API_URL && \{/)
+  assert.match(liveConfig, /BILLING_API_URL: process\.env\.BILLING_API_URL,/)
+  assert.doesNotMatch(liveConfig, /BILLING_API_URL: envOr\(/)
 
   // Wallet, plan and usage are sections of one /dashboard/billing page, so the gate moved from
   // the route table into that page: it must refuse to render any section — none of which can
@@ -441,4 +446,36 @@ test('a billing URL is advertised only where a billing service answers', () => {
   for (const route of redirectedRoutes) {
     assert.doesNotMatch(hiddenRoutes, new RegExp(route))
   }
+})
+
+// Where usage is shipped and where the dashboard calls are one letter apart in intent and a whole
+// route apart in fact: the publisher appends /internal/usage-events, which the billing service
+// serves off its bare origin because that route authenticates a service rather than a user, so it
+// sits outside the /api/billing prefix (boxlite-commerce src/http.ts). Handing the exporter
+// BILLING_API_URL's value is the plausible edit that 404s every batch, silently, for as long as
+// nobody reads the outbox — and the two sides sit in different repositories, where no type checks
+// the seam. Deriving the origin is what makes the two impossible to point apart by accident.
+test('usage is exported to the ingest origin, never to the dashboard billing URL', () => {
+  assert.match(
+    liveConfig,
+    /USAGE_EXPORT_URL: envOr\('USAGE_EXPORT_URL', new URL\(process\.env\.BILLING_API_URL\)\.origin\)/,
+  )
+  assert.doesNotMatch(liveConfig, /USAGE_EXPORT_URL: envOr\([^)]*\/api\/billing/)
+
+  // Delivery is gated on the credential, not asserted alongside it: configuration.ts throws when
+  // export is enabled without a token, so a stage pointed at a billing service but holding no
+  // secret must come up exporting nothing rather than crash-loop on boot.
+  assert.match(liveConfig, /USAGE_EXPORT_TOKEN: usageExportToken\.value/)
+  assert.match(
+    liveConfig,
+    /USAGE_EXPORT_ENABLED: usageExportToken\.value\.apply\(\(token\) => \(token\.trim\(\) \? 'true' : 'false'\)\)/,
+  )
+  assert.match(liveConfig, /const usageExportToken = new sst\.Secret\('USAGE_EXPORT_TOKEN', ''\)/)
+
+  // Nothing here can discover the receiving half — it belongs to the billing service's own stack —
+  // so the note naming the value to set is the only thing between an operator and a stage that
+  // 401s every batch, and it must keep naming it.
+  assert.match(environmentExample, /^# USAGE_EXPORT_URL=/m)
+  assert.match(environmentExample, /boxlite-commerce\/<stage>\/usage-ingest-token/)
+  assert.doesNotMatch(environmentExample, /^USAGE_EXPORT_TOKEN=/m)
 })

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -203,6 +203,23 @@ export default $config({
     const oidcMgmtClientSecret = new sst.Secret('OIDC_MANAGEMENT_API_CLIENT_SECRET')
     const posthogApiKey = new sst.Secret('POSTHOG_API_KEY', '')
     const svixAuthToken = new sst.Secret('SVIX_AUTH_TOKEN', '')
+    // The credential the usage exporter presents to Commerce's ingest route:
+    // half of a shared secret whose other half is a Secrets Manager container
+    // owned by boxlite-commerce's own stack, so both ends are set out of band
+    // from one value rather than generated here.
+    //
+    // It is a secret of this stack rather than a read of that container
+    // because the Api's *runtime* role could not read it if we tried. Its
+    // execution role carries the boxlite-<stage>-runtime-boundary, which
+    // admits only secret:boxlite-<stage>-* — deliberately, so one stage's
+    // tasks cannot reach another's secrets. ECS says so plainly when asked:
+    // it refuses to place the task with "no permissions boundary allows the
+    // secretsmanager:GetSecretValue action". (The deploy role is not the
+    // constraint — its boxlite-sst-deploy policy grants secretsmanager on
+    // every resource, and it carries no boundary at all.)
+    //
+    // Empty means the exporter stays off; see USAGE_EXPORT_ENABLED below.
+    const usageExportToken = new sst.Secret('USAGE_EXPORT_TOKEN', '')
 
     // ─── 2. PLATFORM ─────────────────────────────────────────────────────────
     // Network model + rationale (subnets / NAT / egress-only public IP, AWS citations): ./NETWORKING.md
@@ -685,7 +702,28 @@ export default $config({
         // the page itself (apps/dashboard/src/pages/Billing.tsx) and every
         // billing query hook, including the shell's wallet prefetch — stays
         // gated off and shows its placeholder instead.
-        ...(process.env.BILLING_API_URL && { BILLING_API_URL: process.env.BILLING_API_URL }),
+        ...(process.env.BILLING_API_URL && {
+          BILLING_API_URL: process.env.BILLING_API_URL,
+
+          // Where finalized usage periods are shipped, from the outbox in
+          // apps/api/src/usage/services/usage-export-publisher.service.ts.
+          // The same signal and the same service as BILLING_API_URL, but
+          // deliberately not the same value: the publisher appends
+          // /internal/usage-events, which Commerce serves off its bare origin
+          // because that route authenticates a service rather than a user and
+          // so sits outside its /api/billing prefix. Sending BILLING_API_URL's
+          // value here would 404 every batch — which is why this derives the
+          // origin from it rather than taking a second setting that could be
+          // pointed somewhere else.
+          USAGE_EXPORT_URL: envOr('USAGE_EXPORT_URL', new URL(process.env.BILLING_API_URL).origin),
+          USAGE_EXPORT_TOKEN: usageExportToken.value,
+          // Derived from the credential rather than set outright, because
+          // configuration.ts refuses to boot when export is on without a
+          // token: a stage pointed at a billing service but never given the
+          // shared secret would crash-loop on deploy instead of simply not
+          // exporting yet. Setting the secret is what turns delivery on.
+          USAGE_EXPORT_ENABLED: usageExportToken.value.apply((token) => (token.trim() ? 'true' : 'false')),
+        }),
       },
     })
 


### PR DESCRIPTION
The exporter shipped in #1169 and has never sent a batch: nothing passes USAGE_EXPORT_* to the Api, so usageExport.enabled is false and both the outbox write and the delivery cron return on their first line. Dev has been running it inert, which is why Commerce billed only usage seeded by hand.

Wired on the same signal as BILLING_API_URL — a stage exports usage exactly when a Commerce service exists to receive it — but deliberately not the same value. The publisher appends /internal/usage-events, which Commerce serves off its bare origin because that route is service-to-service and carries its own guard rather than the caller's token; BILLING_API_URL's /api/billing value there would 404 every batch.

The switch is derived from the credential rather than set outright: configuration.ts refuses to boot when export is on without a token, so a stage that runs Commerce but has never been given the shared secret would crash-loop on deploy instead of simply not exporting yet. The token is a secret of this stack rather than a read of Commerce's container because the Api's runtime role could not read that container: its execution role carries boxlite-<stage>-runtime-boundary, which admits only secret:boxlite-<stage>-*, and ECS refuses to place the task with "no permissions boundary allows the secretsmanager:GetSecretValue action".

## Summary
<!-- 1-2 sentences: what this changes and why. -->

## Call graph
<!-- Required. The end-to-end path this PR touches, before and after; one line
     per hop, only the hops that change. Worked example and the bug-fix markers:
     CONTRIBUTING.md#commit--pr-messages. -->

Before
<!-- replace with the hops: fn_name (Type · path/file.rs:LOC) — role -->

After
<!-- replace with the same hops, post-change -->

Fixes #<!-- issue number — bug fixes only; delete this line otherwise -->

## Changes
- <!-- notable change — what changed, not a restatement of the diff -->

## How to verify
- <!-- a command or step a reviewer can run -->

## Risks / rollout
- <!-- only if any; delete this section otherwise -->

<!-- Describe the change, not the process: no pasted logs, no AI/conversation
     narrative, no secrets. Keep it tight and delete sections that don't apply. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional usage-event export configuration for Commerce billing integration.
  * Usage exports can be enabled with a secure token and service URL.
  * The export URL defaults to the Commerce service, while exports remain disabled without a valid token.
  * Enabled exports securely pass usage data to the configured billing service.

* **Documentation**
  * Updated infrastructure configuration guidance to include the usage-export secret and setup requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->