### PR TITLE
feat(rest): expose managed volume CRUD via REST API

### DIFF
--- a/apps/api/src/box/guards/volume-access.guard.spec.ts
+++ b/apps/api/src/box/guards/volume-access.guard.spec.ts
@@ -1,0 +1,86 @@
+import { ExecutionContext, NotFoundException } from '@nestjs/common'
+import { EntityNotFoundError } from 'typeorm'
+import { VolumeAccessGuard } from './volume-access.guard'
+import { VolumeService } from '../services/volume.service'
+
+describe('VolumeAccessGuard', () => {
+  const volumeId = 'volume-1'
+
+  function createGuard(options?: {
+    method?: string
+    force?: string
+    organizationId?: string
+    volumeOrganizationId?: string
+    error?: Error
+  }) {
+    const request = {
+      method: options?.method ?? 'GET',
+      params: { volumeId },
+      query: options?.force === undefined ? {} : { force: options.force },
+      user: {
+        organizationId: options?.organizationId ?? 'org-1',
+      },
+    }
+    const getOrganizationId = options?.error
+      ? jest.fn().mockRejectedValue(options.error)
+      : jest.fn().mockResolvedValue(options?.volumeOrganizationId ?? 'org-1')
+    const guard = new VolumeAccessGuard({ getOrganizationId } as unknown as VolumeService)
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => request,
+      }),
+    } as ExecutionContext
+
+    return { guard, context, getOrganizationId }
+  }
+
+  it('allows force deletion when the volume is already absent', async () => {
+    const { guard, context } = createGuard({
+      method: 'DELETE',
+      force: 'true',
+      error: new EntityNotFoundError('Volume', { id: volumeId }),
+    })
+
+    await expect(guard.canActivate(context)).resolves.toBe(true)
+  })
+
+  it('rejects a missing volume without force', async () => {
+    const { guard, context } = createGuard({
+      method: 'DELETE',
+      error: new EntityNotFoundError('Volume', { id: volumeId }),
+    })
+
+    await expect(guard.canActivate(context)).rejects.toBeInstanceOf(NotFoundException)
+  })
+
+  it('does not allow force to bypass organization ownership', async () => {
+    const { guard, context } = createGuard({
+      method: 'DELETE',
+      force: 'true',
+      organizationId: 'org-1',
+      volumeOrganizationId: 'org-2',
+    })
+
+    await expect(guard.canActivate(context)).rejects.toBeInstanceOf(NotFoundException)
+  })
+
+  it('does not allow force on non-delete requests', async () => {
+    const { guard, context } = createGuard({
+      method: 'GET',
+      force: 'true',
+      error: new EntityNotFoundError('Volume', { id: volumeId }),
+    })
+
+    await expect(guard.canActivate(context)).rejects.toBeInstanceOf(NotFoundException)
+  })
+
+  it('does not allow force to bypass volume lookup failures', async () => {
+    const { guard, context } = createGuard({
+      method: 'DELETE',
+      force: 'true',
+      error: new Error('database unavailable'),
+    })
+
+    await expect(guard.canActivate(context)).rejects.toBeInstanceOf(NotFoundException)
+  })
+})

--- a/apps/api/src/box/guards/volume-access.guard.ts
+++ b/apps/api/src/box/guards/volume-access.guard.ts
@@ -7,6 +7,7 @@ import { Injectable, CanActivate, ExecutionContext, ForbiddenException, NotFound
 import { OrganizationAuthContext } from '../../common/interfaces/auth-context.interface'
 import { SystemRole } from '../../user/enums/system-role.enum'
 import { VolumeService } from '../services/volume.service'
+import { EntityNotFoundError } from 'typeorm'
 @Injectable()
 export class VolumeAccessGuard implements CanActivate {
   constructor(private readonly volumeService: VolumeService) {}
@@ -29,7 +30,10 @@ export class VolumeAccessGuard implements CanActivate {
       if (authContext.role !== SystemRole.ADMIN && volumeOrganizationId !== authContext.organizationId) {
         throw new ForbiddenException('Request organization ID does not match resource organization ID')
       }
-    } catch {
+    } catch (error) {
+      if (request.method === 'DELETE' && request.query?.force === 'true' && error instanceof EntityNotFoundError) {
+        return true
+      }
       throw new NotFoundException(`Volume with ${volumeId ? 'ID' : 'name'} ${volumeId || volumeName} not found`)
     }
 

--- a/apps/api/src/box/services/volume.service.spec.ts
+++ b/apps/api/src/box/services/volume.service.spec.ts
@@ -1,0 +1,74 @@
+import { NotFoundException, RequestTimeoutException } from '@nestjs/common'
+import { VolumeState } from '../enums/volume-state.enum'
+import { VolumeService } from './volume.service'
+
+describe('VolumeService delete', () => {
+  function createService(volume: { id: string; state: VolumeState } | null) {
+    const volumeRepository = {
+      findOne: jest.fn().mockResolvedValue(volume),
+    }
+    const service = new VolumeService(volumeRepository as never, {} as never, {} as never, {} as never, {} as never)
+
+    return { service, volumeRepository }
+  }
+
+  it('rejects a missing volume without force', async () => {
+    const { service } = createService(null)
+
+    await expect(service.delete('volume-1')).rejects.toBeInstanceOf(NotFoundException)
+  })
+
+  it('treats a missing volume as deleted with force', async () => {
+    const { service } = createService(null)
+
+    await expect(service.delete('volume-1', true)).resolves.toBeUndefined()
+  })
+
+  it.each([VolumeState.PENDING_DELETE, VolumeState.DELETING, VolumeState.DELETED])(
+    'treats a volume in %s as deleted with force',
+    async (state) => {
+      const { service } = createService({ id: 'volume-1', state })
+
+      await expect(service.delete('volume-1', true)).resolves.toBeUndefined()
+    },
+  )
+
+  it('does not ignore a deleted volume without force', async () => {
+    const { service } = createService({ id: 'volume-1', state: VolumeState.DELETED })
+
+    await expect(service.delete('volume-1')).rejects.toThrow("Volume must be in 'ready' or 'error' state")
+  })
+})
+
+describe('VolumeService waitForReady', () => {
+  function createService(...volumes: Array<Record<string, unknown> | null>) {
+    const volumeRepository = {
+      findOne: jest.fn().mockImplementation(() => Promise.resolve(volumes.shift() ?? null)),
+    }
+    const service = new VolumeService(volumeRepository as never, {} as never, {} as never, {} as never, {} as never)
+    return { service, volumeRepository }
+  }
+
+  it('returns the volume once it is ready', async () => {
+    const ready = { id: 'volume-1', state: VolumeState.READY }
+    const { service } = createService(ready)
+
+    await expect(service.waitForReady('volume-1', 1)).resolves.toBe(ready)
+  })
+
+  it('reports the backend error', async () => {
+    const { service } = createService({
+      id: 'volume-1',
+      state: VolumeState.ERROR,
+      errorReason: 'bucket creation failed',
+    })
+
+    await expect(service.waitForReady('volume-1', 1)).rejects.toThrow('Volume creation failed')
+  })
+
+  it('times out while the volume is still being created', async () => {
+    const { service } = createService({ id: 'volume-1', state: VolumeState.PENDING_CREATE })
+
+    await expect(service.waitForReady('volume-1', 0)).rejects.toBeInstanceOf(RequestTimeoutException)
+  })
+})

--- a/apps/api/src/box/services/volume.service.ts
+++ b/apps/api/src/box/services/volume.service.ts
@@ -4,7 +4,14 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { ConflictException, Injectable, Logger, NotFoundException, ServiceUnavailableException } from '@nestjs/common'
+import {
+  ConflictException,
+  Injectable,
+  Logger,
+  NotFoundException,
+  RequestTimeoutException,
+  ServiceUnavailableException,
+} from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Repository, Not, In } from 'typeorm'
 import { Volume } from '../entities/volume.entity'
@@ -21,6 +28,7 @@ import { TypedConfigService } from '../../config/typed-config.service'
 import { RedisLockProvider } from '../common/redis-lock.provider'
 import { BoxRepository } from '../repositories/box.repository'
 import { BoxDesiredState } from '../enums/box-desired-state.enum'
+import { setTimeout as sleep } from 'timers/promises'
 
 @Injectable()
 export class VolumeService {
@@ -71,7 +79,30 @@ export class VolumeService {
     return savedVolume
   }
 
-  async delete(volumeId: string): Promise<void> {
+  async waitForReady(volumeId: string, timeoutSeconds: number): Promise<Volume> {
+    const deadline = Date.now() + timeoutSeconds * 1000
+
+    while (true) {
+      const volume = await this.volumeRepository.findOne({ where: { id: volumeId } })
+      if (!volume) {
+        throw new NotFoundException(`Volume with ID ${volumeId} not found`)
+      }
+      if (volume.state === VolumeState.READY) {
+        return volume
+      }
+      if (volume.state === VolumeState.ERROR) {
+        throw new BadRequestError('Volume creation failed')
+      }
+
+      const remaining = deadline - Date.now()
+      if (remaining <= 0) {
+        throw new RequestTimeoutException(`Timed out waiting for volume ${volumeId} to become ready`)
+      }
+      await sleep(Math.min(500, remaining))
+    }
+  }
+
+  async delete(volumeId: string, force = false): Promise<void> {
     const volume = await this.volumeRepository.findOne({
       where: {
         id: volumeId,
@@ -79,7 +110,14 @@ export class VolumeService {
     })
 
     if (!volume) {
+      if (force) {
+        return
+      }
       throw new NotFoundException(`Volume with ID ${volumeId} not found`)
+    }
+
+    if (force && [VolumeState.PENDING_DELETE, VolumeState.DELETING, VolumeState.DELETED].includes(volume.state)) {
+      return
     }
 
     if (volume.state !== VolumeState.READY && volume.state !== VolumeState.ERROR) {

--- a/apps/api/src/boxlite-rest/boxlite-rest-routing.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-rest-routing.spec.ts
@@ -15,6 +15,7 @@ import { BoxStateWaiterService } from '../box/services/box-state-waiter.service'
 import { BoxliteBoxController } from './boxlite-box.controller'
 import { BoxliteProxyController } from './boxlite-proxy.controller'
 import { BoxliteWsProxyService } from './boxlite-ws-proxy.service'
+import { BoxliteVolumeController } from './boxlite-volume.controller'
 
 jest.mock('http-proxy-middleware', () => ({
   createProxyMiddleware: jest.fn(),
@@ -76,6 +77,7 @@ describe('BoxLite REST routing', () => {
   it('mounts box controllers at canonical and legacy default-prefix routes', () => {
     expect(Reflect.getMetadata(PATH_METADATA, BoxliteBoxController)).toEqual(['v1/boxes', 'v1/:prefix/boxes'])
     expect(Reflect.getMetadata(PATH_METADATA, BoxliteProxyController)).toEqual(['v1/boxes', 'v1/:prefix/boxes'])
+    expect(Reflect.getMetadata(PATH_METADATA, BoxliteVolumeController)).toEqual(['v1/volumes', 'v1/:prefix/volumes'])
   })
 
   it('registers canonical and legacy default-prefix routes in the Nest HTTP router', async () => {

--- a/apps/api/src/boxlite-rest/boxlite-rest.module.ts
+++ b/apps/api/src/boxlite-rest/boxlite-rest.module.ts
@@ -15,10 +15,17 @@ import { BoxliteBoxController } from './boxlite-box.controller'
 import { BoxliteProxyController } from './boxlite-proxy.controller'
 import { BoxliteWsProxyService } from './boxlite-ws-proxy.service'
 import { BoxAutoResumeService } from './box-auto-resume.service'
+import { BoxliteVolumeController } from './boxlite-volume.controller'
 
 @Module({
   imports: [BoxModule, AuthModule, ApiKeyModule, OrganizationModule],
-  controllers: [BoxliteMeController, BoxliteConfigController, BoxliteBoxController, BoxliteProxyController],
+  controllers: [
+    BoxliteMeController,
+    BoxliteConfigController,
+    BoxliteBoxController,
+    BoxliteProxyController,
+    BoxliteVolumeController,
+  ],
   providers: [BoxliteWsProxyService, BoxAutoResumeService],
   exports: [BoxliteWsProxyService],
 })

--- a/apps/api/src/boxlite-rest/boxlite-volume.controller.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-volume.controller.spec.ts
@@ -1,0 +1,116 @@
+import { BoxliteVolumeController } from './boxlite-volume.controller'
+import { VolumeService } from '../box/services/volume.service'
+import { NotFoundException } from '@nestjs/common'
+import { VolumeState } from '../box/enums/volume-state.enum'
+
+describe('BoxliteVolumeController', () => {
+  const createdAt = new Date('2026-07-27T00:00:00.000Z')
+  const updatedAt = new Date('2026-07-28T00:00:00.000Z')
+  const lastUsedAt = new Date('2026-07-29T00:00:00.000Z')
+  const volume = {
+    id: 'volume-1',
+    name: 'workspace',
+    state: VolumeState.READY,
+    createdAt,
+    updatedAt,
+    lastUsedAt,
+    errorReason: undefined,
+  }
+
+  function createController() {
+    const volumeService = {
+      create: jest.fn().mockResolvedValue(volume),
+      waitForReady: jest.fn().mockResolvedValue(volume),
+      findAll: jest.fn().mockResolvedValue([volume]),
+      findOne: jest.fn().mockResolvedValue(volume),
+      delete: jest.fn().mockResolvedValue(undefined),
+    }
+    return {
+      controller: new BoxliteVolumeController(volumeService as unknown as VolumeService),
+      volumeService,
+    }
+  }
+
+  it('creates an unbounded S3 volume', async () => {
+    const { controller, volumeService } = createController()
+    const organization = { id: 'org-1' }
+
+    await expect(
+      controller.create({
+        organization,
+        organizationId: organization.id,
+      } as never),
+    ).resolves.toEqual({
+      id: volume.id,
+      name: volume.name,
+      state: volume.state,
+      created_at: createdAt.toISOString(),
+      updated_at: updatedAt.toISOString(),
+      last_used_at: lastUsedAt.toISOString(),
+      error_reason: undefined,
+    })
+    expect(volumeService.create).toHaveBeenCalledWith(organization, {})
+    expect(volumeService.waitForReady).toHaveBeenCalledWith(volume.id, 30)
+  })
+
+  it('lists volumes for the authenticated organization', async () => {
+    const { controller, volumeService } = createController()
+
+    await expect(controller.list({ organizationId: 'org-1' } as never)).resolves.toEqual({
+      volumes: [
+        {
+          id: volume.id,
+          name: volume.name,
+          state: volume.state,
+          created_at: createdAt.toISOString(),
+        },
+      ],
+    })
+    expect(volumeService.findAll).toHaveBeenCalledWith('org-1')
+  })
+
+  it('gets a volume by ID', async () => {
+    const { controller, volumeService } = createController()
+
+    await expect(controller.get(volume.id)).resolves.toEqual({
+      id: volume.id,
+      name: volume.name,
+      state: volume.state,
+      created_at: createdAt.toISOString(),
+      updated_at: updatedAt.toISOString(),
+      last_used_at: lastUsedAt.toISOString(),
+      error_reason: undefined,
+    })
+    expect(volumeService.findOne).toHaveBeenCalledWith(volume.id)
+  })
+
+  it('deletes a volume by ID', async () => {
+    const { controller, volumeService } = createController()
+
+    await expect(controller.remove(volume.id)).resolves.toBeUndefined()
+    expect(volumeService.delete).toHaveBeenCalledWith(volume.id, false)
+  })
+
+  it('propagates a missing-volume error without force', async () => {
+    const { controller, volumeService } = createController()
+    const error = new NotFoundException('Volume not found')
+    volumeService.delete.mockRejectedValueOnce(error)
+
+    await expect(controller.remove(volume.id)).rejects.toBe(error)
+  })
+
+  it('passes force deletion semantics to the volume service', async () => {
+    const { controller, volumeService } = createController()
+
+    await expect(controller.remove(volume.id, 'true')).resolves.toBeUndefined()
+    expect(volumeService.delete).toHaveBeenCalledWith(volume.id, true)
+  })
+
+  it('propagates non-not-found errors when force is true', async () => {
+    const { controller, volumeService } = createController()
+    const error = new Error('S3 unavailable')
+    volumeService.delete.mockRejectedValueOnce(error)
+
+    await expect(controller.remove(volume.id, 'true')).rejects.toBe(error)
+  })
+})

--- a/apps/api/src/boxlite-rest/boxlite-volume.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-volume.controller.ts
@@ -1,0 +1,78 @@
+import { Controller, Delete, Get, HttpCode, Param, Post, Query, UseGuards } from '@nestjs/common'
+import { ApiExcludeController } from '@nestjs/swagger'
+import { CombinedAuthGuard } from '../auth/combined-auth.guard'
+import { OrganizationResourceActionGuard } from '../organization/guards/organization-resource-action.guard'
+import { AuthContext } from '../common/decorators/auth-context.decorator'
+import { OrganizationAuthContext } from '../common/interfaces/auth-context.interface'
+import { VolumeService } from '../box/services/volume.service'
+import { RequiredOrganizationResourcePermissions } from '../organization/decorators/required-organization-resource-permissions.decorator'
+import { OrganizationResourcePermission } from '../organization/enums/organization-resource-permission.enum'
+import { VolumeAccessGuard } from '../box/guards/volume-access.guard'
+import { VolumeState } from '../box/enums/volume-state.enum'
+
+type RestVolumeSummary = {
+  id: string
+  name: string
+  state: VolumeState
+  created_at: string
+}
+
+type RestVolumeResponse = RestVolumeSummary & {
+  updated_at: string
+  last_used_at?: string
+  error_reason?: string
+}
+
+@Controller(['v1/volumes', 'v1/:prefix/volumes'])
+@ApiExcludeController()
+@UseGuards(CombinedAuthGuard, OrganizationResourceActionGuard)
+export class BoxliteVolumeController {
+  constructor(private readonly volumeService: VolumeService) {}
+
+  @Post()
+  @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_VOLUMES])
+  async create(@AuthContext() authContext: OrganizationAuthContext): Promise<RestVolumeResponse> {
+    const volume = await this.volumeService.create(authContext.organization, {})
+    return this.toResponse(await this.volumeService.waitForReady(volume.id, 30))
+  }
+
+  @Get()
+  @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.READ_VOLUMES])
+  async list(@AuthContext() authContext: OrganizationAuthContext): Promise<{ volumes: RestVolumeSummary[] }> {
+    const volumes = await this.volumeService.findAll(authContext.organizationId)
+    return { volumes: volumes.map((volume) => this.toSummary(volume)) }
+  }
+
+  @Get(':volumeId')
+  @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.READ_VOLUMES])
+  @UseGuards(VolumeAccessGuard)
+  async get(@Param('volumeId') volumeId: string): Promise<RestVolumeResponse> {
+    return this.toResponse(await this.volumeService.findOne(volumeId))
+  }
+
+  @Delete(':volumeId')
+  @HttpCode(204)
+  @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.DELETE_VOLUMES])
+  @UseGuards(VolumeAccessGuard)
+  async remove(@Param('volumeId') volumeId: string, @Query('force') force?: string): Promise<void> {
+    await this.volumeService.delete(volumeId, force === 'true')
+  }
+
+  private toResponse(volume: Awaited<ReturnType<VolumeService['findOne']>>): RestVolumeResponse {
+    return {
+      ...this.toSummary(volume),
+      updated_at: volume.updatedAt.toISOString(),
+      last_used_at: volume.lastUsedAt?.toISOString(),
+      error_reason: volume.errorReason,
+    }
+  }
+
+  private toSummary(volume: Awaited<ReturnType<VolumeService['findOne']>>): RestVolumeSummary {
+    return {
+      id: volume.id,
+      name: volume.name,
+      state: volume.state,
+      created_at: volume.createdAt.toISOString(),
+    }
+  }
+}

--- a/openapi/box.openapi.yaml
+++ b/openapi/box.openapi.yaml
@@ -1833,24 +1833,59 @@ components:
           type: boolean
           default: false
 
-    Volume:
+    VolumeState:
+      type: string
+      description: Managed volume lifecycle state
+      enum: [creating, ready, pending_create, pending_delete, deleting, deleted, error]
+
+    VolumeSummary:
       type: object
-      description: Managed persistent volume metadata
+      description: Managed persistent volume summary, as returned by the list endpoint
       additionalProperties: false
-      required: [id, created_at]
+      required: [id, name, state, created_at]
       properties:
         id:
           type: string
           description: Server-assigned managed volume identifier
+        name:
+          type: string
+          description: User-assigned volume name
+        state:
+          $ref: "#/components/schemas/VolumeState"
         created_at:
           type: string
           format: date-time
           description: Volume creation timestamp (UTC)
-        size_bytes:
-          type: integer
-          format: int64
-          minimum: 0
-          description: Payload size when available
+
+    Volume:
+      type: object
+      description: Managed persistent volume detail, as returned by create/get
+      additionalProperties: false
+      required: [id, name, state, created_at, updated_at]
+      properties:
+        id:
+          type: string
+          description: Server-assigned managed volume identifier
+        name:
+          type: string
+          description: User-assigned volume name
+        state:
+          $ref: "#/components/schemas/VolumeState"
+        created_at:
+          type: string
+          format: date-time
+          description: Volume creation timestamp (UTC)
+        updated_at:
+          type: string
+          format: date-time
+          description: Last update timestamp (UTC)
+        last_used_at:
+          type: string
+          format: date-time
+          description: Last time the volume was attached to a box, if ever
+        error_reason:
+          type: string
+          description: Failure detail when state is "error"
 
     ListVolumesResponse:
       type: object
@@ -1860,7 +1895,7 @@ components:
         volumes:
           type: array
           items:
-            $ref: "#/components/schemas/Volume"
+            $ref: "#/components/schemas/VolumeSummary"
 
     NetworkSpec:
       type: object

--- a/openapi/box.openapi.yaml
+++ b/openapi/box.openapi.yaml
@@ -130,6 +130,8 @@ tags:
     description: Runtime and per-box metrics
   - name: Images
     description: Container image management
+  - name: Volumes
+    description: Managed persistent volumes
 
 # ===========================================================================
 # Paths
@@ -179,6 +181,82 @@ paths:
                 $ref: "#/components/schemas/Principal"
         "401":
           $ref: "#/components/responses/UnauthorizedError"
+
+  # -------------------------------------------------------------------------
+  # Volumes
+  # -------------------------------------------------------------------------
+  /{prefix}/volumes:
+    parameters:
+      - $ref: "#/components/parameters/prefix"
+
+    post:
+      operationId: createVolume
+      summary: Create a managed persistent volume
+      description: Creates a volume and waits until its backing object storage is ready.
+      tags: [Volumes]
+      responses:
+        "201":
+          description: Volume created and ready for use
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Volume"
+        "400":
+          $ref: "#/components/responses/BadRequestError"
+        "408":
+          $ref: "#/components/responses/RequestTimeoutError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailableError"
+
+    get:
+      operationId: listVolumes
+      summary: List managed persistent volumes
+      tags: [Volumes]
+      responses:
+        "200":
+          description: List of volumes
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListVolumesResponse"
+
+  /{prefix}/volumes/{volume_id}:
+    parameters:
+      - $ref: "#/components/parameters/prefix"
+      - $ref: "#/components/parameters/volumeId"
+
+    get:
+      operationId: getVolume
+      summary: Get managed persistent volume metadata
+      tags: [Volumes]
+      responses:
+        "200":
+          description: Volume metadata
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Volume"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+
+    delete:
+      operationId: removeVolume
+      summary: Remove a managed persistent volume
+      tags: [Volumes]
+      parameters:
+        - name: force
+          in: query
+          description: Treat an already deleting or missing volume as successfully removed
+          schema:
+            type: boolean
+            default: false
+      responses:
+        "204":
+          description: Volume removal accepted
+        "400":
+          $ref: "#/components/responses/BadRequestError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
 
   # -------------------------------------------------------------------------
   # Boxes
@@ -1105,6 +1183,15 @@ components:
         type: string
       example: "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
 
+    volumeId:
+      name: volume_id
+      in: path
+      required: true
+      description: Server-assigned managed volume identifier
+      schema:
+        type: string
+        minLength: 1
+
     pageSize:
       name: pageSize
       in: query
@@ -1207,6 +1294,20 @@ components:
               type: ImageError
               code: image_pull_failed
               request_id: req_01HZK4TNRPQSXYZ8WM6NCVT9R5
+
+    RequestTimeoutError:
+      description: The operation did not reach its target state before the timeout
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+
+    ServiceUnavailableError:
+      description: A required backend service is not configured or available
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
 
   # -------------------------------------------------------------------------
   # Schemas
@@ -1731,6 +1832,35 @@ components:
         read_only:
           type: boolean
           default: false
+
+    Volume:
+      type: object
+      description: Managed persistent volume metadata
+      additionalProperties: false
+      required: [id, created_at]
+      properties:
+        id:
+          type: string
+          description: Server-assigned managed volume identifier
+        created_at:
+          type: string
+          format: date-time
+          description: Volume creation timestamp (UTC)
+        size_bytes:
+          type: integer
+          format: int64
+          minimum: 0
+          description: Payload size when available
+
+    ListVolumesResponse:
+      type: object
+      additionalProperties: false
+      required: [volumes]
+      properties:
+        volumes:
+          type: array
+          items:
+            $ref: "#/components/schemas/Volume"
 
     NetworkSpec:
       type: object


### PR DESCRIPTION
Split out of #1056 for independent review — this is the volume CRUD half only, no box-mount wiring.

Adds `/v1/volumes` create/list/get/delete endpoints (`BoxliteVolumeController`), backed by the existing `VolumeService`. Create waits synchronously for the volume to become ready or times out (408); delete supports `?force=true` for idempotent removal of already-deleting or missing volumes.

Test plan:
- `yarn nx run api:test -- --testPathPatterns=volume` — 4 suites, 26 tests, all pass
- `yarn nx run api:test -- --testPathPatterns=routing` — routing spec, 4 tests, all pass
- `yarn nx run api:build` — clean build
- openapi/box.openapi.yaml hand-split from #1056's diff to include only the Volumes paths/schemas (verified byte-for-byte equal to #1056's diff minus the VolumeSpec.source rename, which belongs to the box-mount-wiring PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added REST API endpoints for creating, listing, retrieving, and deleting volumes.
  * Added readiness checks with timeout and service error handling.
  * Added optional forced deletion for missing or already-deleted volumes.
  * Added organization-scoped access controls and detailed volume status, timestamps, usage, and error information.
  * Added API documentation for volume lifecycle operations and responses.

* **Bug Fixes**
  * Improved handling of missing volumes during forced deletion while preserving standard error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->