### PR TITLE
feat(rest): accept managed volume mounts on REST box creation

### DIFF
--- a/apps/api/src/boxlite-rest/dto/create-box.dto.spec.ts
+++ b/apps/api/src/boxlite-rest/dto/create-box.dto.spec.ts
@@ -140,14 +140,24 @@ describe('CreateBoxDto managed volumes', () => {
     expect(errors).toHaveLength(0)
   })
 
-  it('rejects volume mounts without a source', async () => {
+  it('rejects volume mounts with neither source nor host_path', async () => {
     const errors = await validate(
       plainToInstance(CreateBoxDto, {
         volumes: [{ guest_path: '/data', read_only: false }],
       }),
     )
 
-    expect(JSON.stringify(errors)).toContain('isString')
+    expect(JSON.stringify(errors)).toContain('hasVolumeSource')
+  })
+
+  it('accepts the deprecated host_path in place of source', async () => {
+    const errors = await validate(
+      plainToInstance(CreateBoxDto, {
+        volumes: [{ host_path: 'volume://volume-123', guest_path: '/data' }],
+      }),
+    )
+
+    expect(errors).toHaveLength(0)
   })
 
   it('rejects read-only cloud volume mounts until the backend supports them', async () => {

--- a/apps/api/src/boxlite-rest/dto/create-box.dto.spec.ts
+++ b/apps/api/src/boxlite-rest/dto/create-box.dto.spec.ts
@@ -122,3 +122,51 @@ describe('CreateBoxDto network validation', () => {
     expect(JSON.stringify(errors)).toContain('isIn')
   })
 })
+
+describe('CreateBoxDto managed volumes', () => {
+  function getReadOnlyConstraints(errors: Awaited<ReturnType<typeof validate>>) {
+    return errors
+      .find((error) => error.property === 'volumes')
+      ?.children?.[0]?.children?.find((error) => error.property === 'read_only')?.constraints
+  }
+
+  it('accepts read-write managed volume mounts', async () => {
+    const errors = await validate(
+      plainToInstance(CreateBoxDto, {
+        volumes: [{ source: 'volume://volume-123', guest_path: '/data', read_only: false }],
+      }),
+    )
+
+    expect(errors).toHaveLength(0)
+  })
+
+  it('rejects volume mounts without a source', async () => {
+    const errors = await validate(
+      plainToInstance(CreateBoxDto, {
+        volumes: [{ guest_path: '/data', read_only: false }],
+      }),
+    )
+
+    expect(JSON.stringify(errors)).toContain('isString')
+  })
+
+  it('rejects read-only cloud volume mounts until the backend supports them', async () => {
+    const errors = await validate(
+      plainToInstance(CreateBoxDto, {
+        volumes: [{ source: 'volume://volume-123', guest_path: '/data', read_only: true }],
+      }),
+    )
+
+    expect(getReadOnlyConstraints(errors)).toHaveProperty('isIn')
+  })
+
+  it('rejects null read_only values', async () => {
+    const errors = await validate(
+      plainToInstance(CreateBoxDto, {
+        volumes: [{ source: 'volume://volume-123', guest_path: '/data', read_only: null }],
+      }),
+    )
+
+    expect(getReadOnlyConstraints(errors)).toHaveProperty('isIn')
+  })
+})

--- a/apps/api/src/boxlite-rest/dto/create-box.dto.spec.ts
+++ b/apps/api/src/boxlite-rest/dto/create-box.dto.spec.ts
@@ -160,6 +160,38 @@ describe('CreateBoxDto managed volumes', () => {
     expect(errors).toHaveLength(0)
   })
 
+  it('rejects an empty source', async () => {
+    const errors = await validate(
+      plainToInstance(CreateBoxDto, {
+        volumes: [{ source: '', guest_path: '/data' }],
+      }),
+    )
+
+    expect(JSON.stringify(errors)).toContain('isNotEmpty')
+  })
+
+  it('rejects an empty host_path', async () => {
+    const errors = await validate(
+      plainToInstance(CreateBoxDto, {
+        volumes: [{ host_path: '', guest_path: '/data' }],
+      }),
+    )
+
+    expect(JSON.stringify(errors)).toContain('isNotEmpty')
+  })
+
+  it('rejects an empty source even with a valid host_path fallback available', async () => {
+    // An empty string is a malformed `source`, not an absent one - it must
+    // not be silently swapped for host_path in the mapper.
+    const errors = await validate(
+      plainToInstance(CreateBoxDto, {
+        volumes: [{ source: '', host_path: 'volume://volume-123', guest_path: '/data' }],
+      }),
+    )
+
+    expect(JSON.stringify(errors)).toContain('isNotEmpty')
+  })
+
   it('rejects read-only cloud volume mounts until the backend supports them', async () => {
     const errors = await validate(
       plainToInstance(CreateBoxDto, {

--- a/apps/api/src/boxlite-rest/dto/create-box.dto.ts
+++ b/apps/api/src/boxlite-rest/dto/create-box.dto.ts
@@ -7,6 +7,7 @@
 import { Type } from 'class-transformer'
 import {
   ArrayMaxSize,
+  IsNotEmpty,
   IsOptional,
   IsString,
   IsNumber,
@@ -63,8 +64,12 @@ export class NetworkSpecDto {
 }
 
 export class VolumeSpecDto {
+  // IsNotEmpty (not just IsOptional + IsString) so an explicit `source: ''`
+  // is a validation error on its own rather than being treated as "absent"
+  // and silently falling through to host_path in the mapper.
   @IsOptional()
   @IsString()
+  @IsNotEmpty()
   source?: string
 
   /**
@@ -74,6 +79,7 @@ export class VolumeSpecDto {
    */
   @IsOptional()
   @IsString()
+  @IsNotEmpty()
   host_path?: string
 
   @IsString()

--- a/apps/api/src/boxlite-rest/dto/create-box.dto.ts
+++ b/apps/api/src/boxlite-rest/dto/create-box.dto.ts
@@ -18,6 +18,7 @@ import {
   Validate,
   ValidateIf,
   ValidateNested,
+  ValidationArguments,
   ValidatorConstraint,
   ValidatorConstraintInterface,
 } from 'class-validator'
@@ -34,6 +35,21 @@ class IsNetworkAllowEntryConstraint implements ValidatorConstraintInterface {
   }
 }
 
+// Attached to `guest_path` (always validated) rather than `source`, since
+// `@IsOptional()` on `source` would skip a validator stacked on that same
+// property whenever `source` is absent - exactly the case this needs to see.
+@ValidatorConstraint({ name: 'hasVolumeSource', async: false })
+class HasVolumeSourceConstraint implements ValidatorConstraintInterface {
+  validate(_value: unknown, args: ValidationArguments): boolean {
+    const volume = args.object as VolumeSpecDto
+    return typeof volume.source === 'string' || typeof volume.host_path === 'string'
+  }
+
+  defaultMessage(): string {
+    return 'volume requires source (or the deprecated host_path)'
+  }
+}
+
 export class NetworkSpecDto {
   @IsIn(['enabled', 'disabled'])
   mode: 'enabled' | 'disabled'
@@ -47,10 +63,21 @@ export class NetworkSpecDto {
 }
 
 export class VolumeSpecDto {
+  @IsOptional()
   @IsString()
-  source: string
+  source?: string
+
+  /**
+   * @deprecated Use `source` with the `volume://<volume_id>` scheme instead.
+   * Accepted for backward compatibility with existing /v1 clients built
+   * against the pre-managed-volumes `VolumeSpec` schema; will be removed.
+   */
+  @IsOptional()
+  @IsString()
+  host_path?: string
 
   @IsString()
+  @Validate(HasVolumeSourceConstraint)
   guest_path: string
 
   @ValidateIf((_, value) => value !== undefined)

--- a/apps/api/src/boxlite-rest/dto/create-box.dto.ts
+++ b/apps/api/src/boxlite-rest/dto/create-box.dto.ts
@@ -16,6 +16,7 @@ import {
   Min,
   IsIn,
   Validate,
+  ValidateIf,
   ValidateNested,
   ValidatorConstraint,
   ValidatorConstraintInterface,
@@ -43,6 +44,18 @@ export class NetworkSpecDto {
   @IsString({ each: true })
   @Validate(IsNetworkAllowEntryConstraint, { each: true })
   allow_net?: string[]
+}
+
+export class VolumeSpecDto {
+  @IsString()
+  source: string
+
+  @IsString()
+  guest_path: string
+
+  @ValidateIf((_, value) => value !== undefined)
+  @IsIn([false])
+  read_only?: false
 }
 
 export class CreateBoxDto {
@@ -114,4 +127,10 @@ export class CreateBoxDto {
   @ValidateNested()
   @Type(() => NetworkSpecDto)
   network?: NetworkSpecDto
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => VolumeSpecDto)
+  volumes?: VolumeSpecDto[]
 }

--- a/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.spec.ts
+++ b/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.spec.ts
@@ -35,6 +35,17 @@ describe('BoxLite lifecycle policy mapper', () => {
     expect(mapped.volumes).toEqual([{ volumeId: 'volume-123', mountPath: '/data' }])
   })
 
+  it('does not fall back to host_path when source is an empty string', () => {
+    // DTO validation (IsNotEmpty) is the primary guard against this reaching
+    // the mapper at all; this locks in that the mapper itself also fails
+    // closed rather than treating '' as absent via `??`.
+    expect(() =>
+      createBoxToCreateBox({
+        volumes: [{ source: '', host_path: 'volume://volume-123', guest_path: '/data', read_only: false }],
+      }),
+    ).toThrow('volume source must use the volume:// scheme')
+  })
+
   it('prefers source over host_path when both are present', () => {
     const mapped = createBoxToCreateBox({
       volumes: [

--- a/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.spec.ts
+++ b/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.spec.ts
@@ -19,6 +19,30 @@ describe('BoxLite lifecycle policy mapper', () => {
     expect(mapped.autoResume).toBe(false)
   })
 
+  it('maps REST volume specs to managed volume mounts', () => {
+    const mapped = createBoxToCreateBox({
+      volumes: [{ source: 'volume://volume-123', guest_path: '/data', read_only: false }],
+    })
+
+    expect(mapped.volumes).toEqual([{ volumeId: 'volume-123', mountPath: '/data' }])
+  })
+
+  it('rejects non-volume scheme sources on the remote managed-volume mapper', () => {
+    expect(() =>
+      createBoxToCreateBox({
+        volumes: [{ source: 'host:///tmp/data', guest_path: '/data', read_only: false }],
+      }),
+    ).toThrow('volume source must use the volume:// scheme')
+  })
+
+  it('rejects source values without a supported scheme', () => {
+    expect(() =>
+      createBoxToCreateBox({
+        volumes: [{ source: 'volume-123', guest_path: '/data', read_only: false }],
+      }),
+    ).toThrow('volume source must use the volume:// scheme')
+  })
+
   it('returns the effective second-based policy', () => {
     const response = boxToBoxResponse({
       id: 'box-1',

--- a/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.spec.ts
+++ b/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.spec.ts
@@ -27,6 +27,24 @@ describe('BoxLite lifecycle policy mapper', () => {
     expect(mapped.volumes).toEqual([{ volumeId: 'volume-123', mountPath: '/data' }])
   })
 
+  it('maps the deprecated host_path field to managed volume mounts', () => {
+    const mapped = createBoxToCreateBox({
+      volumes: [{ host_path: 'volume://volume-123', guest_path: '/data', read_only: false }],
+    })
+
+    expect(mapped.volumes).toEqual([{ volumeId: 'volume-123', mountPath: '/data' }])
+  })
+
+  it('prefers source over host_path when both are present', () => {
+    const mapped = createBoxToCreateBox({
+      volumes: [
+        { source: 'volume://source-wins', host_path: 'volume://ignored', guest_path: '/data', read_only: false },
+      ],
+    })
+
+    expect(mapped.volumes).toEqual([{ volumeId: 'source-wins', mountPath: '/data' }])
+  })
+
   it('rejects non-volume scheme sources on the remote managed-volume mapper', () => {
     expect(() =>
       createBoxToCreateBox({

--- a/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.ts
+++ b/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.ts
@@ -59,8 +59,12 @@ export function createBoxToCreateBox(dto: RestCreateBoxDto, target?: string): Cr
 }
 
 function resolveVolumeId(volume: NonNullable<RestCreateBoxDto['volumes']>[number]): string {
-  if (volume.source.startsWith('volume://')) {
-    const volumeId = volume.source.slice('volume://'.length)
+  // `host_path` is the deprecated pre-managed-volumes field name; DTO
+  // validation (HasVolumeSourceConstraint) already guarantees one of the two
+  // is present.
+  const source = volume.source ?? volume.host_path
+  if (source?.startsWith('volume://')) {
+    const volumeId = source.slice('volume://'.length)
     if (volumeId) {
       return volumeId
     }

--- a/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.ts
+++ b/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
+import { BadRequestException } from '@nestjs/common'
 import { BoxDto } from '../../box/dto/box.dto'
 import { BoxState } from '../../box/enums/box-state.enum'
 import {
@@ -45,12 +46,26 @@ export function createBoxToCreateBox(dto: RestCreateBoxDto, target?: string): Cr
   createDto.autoStop = dto.auto_stop
   createDto.autoDelete = dto.auto_delete
   createDto.autoResume = dto.auto_resume
+  createDto.volumes = dto.volumes?.map((volume) => ({
+    volumeId: resolveVolumeId(volume),
+    mountPath: volume.guest_path,
+  }))
   if (dto.network) {
     const allowNet = dto.network.allow_net?.map((entry) => entry.trim()).filter(Boolean)
     createDto.networkBlockAll = dto.network.mode === 'disabled'
     createDto.networkAllowList = dto.network.mode === 'enabled' && allowNet?.length ? allowNet.join(',') : undefined
   }
   return createDto
+}
+
+function resolveVolumeId(volume: NonNullable<RestCreateBoxDto['volumes']>[number]): string {
+  if (volume.source.startsWith('volume://')) {
+    const volumeId = volume.source.slice('volume://'.length)
+    if (volumeId) {
+      return volumeId
+    }
+  }
+  throw new BadRequestException('volume source must use the volume:// scheme')
 }
 
 function mapState(state: string | BoxState | undefined): string {

--- a/openapi/box.openapi.yaml
+++ b/openapi/box.openapi.yaml
@@ -1719,12 +1719,15 @@ components:
 
     VolumeSpec:
       type: object
-      description: Host-to-guest filesystem mount
-      required: [host_path, guest_path]
+      description: Filesystem mount attached to a box
+      required: [source, guest_path]
       properties:
-        host_path:
+        source:
           type: string
-          description: Path on the host filesystem
+          description: |
+            Scheme-qualified mount source. Use `volume://<volume_id>` for managed
+            volumes.
+          example: volume://vol_01K2EXAMPLE
         guest_path:
           type: string
           description: Mount point inside the container

--- a/openapi/box.openapi.yaml
+++ b/openapi/box.openapi.yaml
@@ -1719,14 +1719,25 @@ components:
 
     VolumeSpec:
       type: object
-      description: Filesystem mount attached to a box
-      required: [source, guest_path]
+      description: |
+        Filesystem mount attached to a box. One of `source` or the deprecated
+        `host_path` is required.
+      required: [guest_path]
       properties:
         source:
           type: string
           description: |
             Scheme-qualified mount source. Use `volume://<volume_id>` for managed
             volumes.
+          example: volume://vol_01K2EXAMPLE
+        host_path:
+          type: string
+          deprecated: true
+          description: |
+            Deprecated alias for `source`, kept for backward compatibility with
+            existing /v1 clients built against the pre-managed-volumes schema.
+            Use `source` with the `volume://<volume_id>` scheme instead; this
+            field will be removed in a future API version.
           example: volume://vol_01K2EXAMPLE
         guest_path:
           type: string

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -117,6 +117,8 @@ pub(crate) struct CreateBoxRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub secrets: Option<Vec<CreateBoxSecret>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub volumes: Option<Vec<CreateBoxVolumeSpec>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub detach: Option<bool>,
     /// A terminal for the main command (`run -t`). Only sent when asked for:
     /// the server rejects unknown fields, so an older one would 400 on it —
@@ -157,6 +159,17 @@ impl CreateBoxRequest {
         } else {
             Some(options.secrets.iter().map(CreateBoxSecret::from).collect())
         };
+        let volumes = if options.volumes.is_empty() {
+            None
+        } else {
+            Some(
+                options
+                    .volumes
+                    .iter()
+                    .map(CreateBoxVolumeSpec::from)
+                    .collect(),
+            )
+        };
 
         // SecurityOptions is intentionally NOT carried on the wire.
         // Sandbox security is the operator's policy and is set
@@ -180,6 +193,7 @@ impl CreateBoxRequest {
             cmd: options.cmd.clone(),
             user: options.user.clone(),
             secrets,
+            volumes,
             detach: Some(options.detach),
             tty: options.tty.then_some(true),
             advanced: (!options.advanced.capabilities.is_empty()).then(|| {
@@ -200,6 +214,31 @@ impl CreateBoxRequest {
 #[derive(Debug, Serialize)]
 pub(crate) struct CreateBoxAdvancedOptions {
     pub capabilities: ContainerCapabilities,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct CreateBoxVolumeSpec {
+    pub source: String,
+    pub guest_path: String,
+    pub read_only: bool,
+}
+
+impl From<&crate::runtime::options::VolumeSpec> for CreateBoxVolumeSpec {
+    fn from(volume: &crate::runtime::options::VolumeSpec) -> Self {
+        Self {
+            source: managed_volume_source(&volume.host_path),
+            guest_path: volume.guest_path.clone(),
+            read_only: volume.read_only,
+        }
+    }
+}
+
+fn managed_volume_source(source: &str) -> String {
+    if source.starts_with("volume://") {
+        source.to_string()
+    } else {
+        format!("volume://{source}")
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -602,6 +641,7 @@ mod tests {
                 hosts: vec!["api.openai.com".into()],
                 placeholder: "<BOXLITE_SECRET:openai>".into(),
             }]),
+            volumes: None,
             detach: None,
             advanced: None,
             auto_stop: Some(900),
@@ -623,7 +663,7 @@ mod tests {
 
     #[test]
     fn test_create_box_request_from_options() {
-        use crate::runtime::options::{BoxOptions, NetworkSpec, RootfsSpec, Secret};
+        use crate::runtime::options::{BoxOptions, NetworkSpec, RootfsSpec, Secret, VolumeSpec};
 
         let opts = BoxOptions {
             rootfs: RootfsSpec::Image("alpine:latest".into()),
@@ -637,6 +677,11 @@ mod tests {
                 value: "sk-test".into(),
                 hosts: vec!["api.openai.com".into()],
                 placeholder: "<BOXLITE_SECRET:openai>".into(),
+            }],
+            volumes: vec![VolumeSpec {
+                host_path: "volume-123".into(),
+                guest_path: "/data".into(),
+                read_only: false,
             }],
             auto_stop: Some(1800),
             auto_delete: Some(604800),
@@ -657,6 +702,19 @@ mod tests {
             Some(vec!["api.openai.com".into()])
         );
         assert_eq!(req.secrets.as_ref().map(Vec::len), Some(1));
+        let volume = &req.volumes.as_ref().unwrap()[0];
+        assert_eq!(volume.source, "volume://volume-123");
+        assert_eq!(volume.guest_path, "/data");
+        assert!(!volume.read_only);
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(
+            json["volumes"],
+            serde_json::json!([{
+                "source": "volume://volume-123",
+                "guest_path": "/data",
+                "read_only": false
+            }])
+        );
         assert_eq!(req.auto_stop, Some(1800));
         assert_eq!(req.auto_delete, Some(604800));
         assert_eq!(
@@ -692,6 +750,24 @@ mod tests {
         let defaults = CreateBoxRequest::from_options(&BoxOptions::default(), None);
         let defaults_json = serde_json::to_value(defaults).expect("serialize defaults");
         assert!(defaults_json.get("advanced").is_none());
+    }
+
+    #[test]
+    fn test_create_box_request_preserves_scheme_volume_source() {
+        use crate::runtime::options::{BoxOptions, VolumeSpec};
+
+        let opts = BoxOptions {
+            volumes: vec![VolumeSpec {
+                host_path: "volume://volume-123".into(),
+                guest_path: "/data".into(),
+                read_only: false,
+            }],
+            ..Default::default()
+        };
+
+        let req = CreateBoxRequest::from_options(&opts, None);
+        let volume = &req.volumes.as_ref().unwrap()[0];
+        assert_eq!(volume.source, "volume://volume-123");
     }
 
     #[test]


### PR DESCRIPTION
Split out of #1056 for independent review — box-mount wiring only, no volume CRUD endpoints (those are in #1191).

Lets the REST box-create endpoint accept volume mounts via `source: volume://<volume_id>`, replacing the plain `host_path` field in `VolumeSpec`. `box-to-box.mapper` translates the scheme-qualified source into the same managed-volume mount structure the pre-existing box-creation path (`BoxService.create` / `VolumeService.validateVolumes`, unchanged by this PR) already validates and forwards to the runner. Does not depend on #1191 — both build on the same pre-existing volume-mount plumbing on main.

Test plan:
- `yarn nx run api:test -- --testPathPatterns=create-box.dto` — 23 tests, all pass
- `yarn nx run api:test -- --testPathPatterns=box-to-box.mapper` — 6 tests, all pass
- `BOXLITE_DEPS_STUB=1 cargo test -p boxlite --lib --features rest test_create_box_request_from_options` — 2 tests, all pass
- `yarn nx run api:build` — clean build
- openapi/box.openapi.yaml hand-split from #1056's diff to include only the VolumeSpec.source rename (verified byte-for-byte equal to #1056's diff minus the Volumes CRUD paths/schemas, which belong to #1191)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring managed volumes when creating boxes.
  - Volume sources now use the `volume://` format while preserving mount paths and read-only settings.
  - Retained `host_path` as a deprecated compatibility option.

- **Bug Fixes**
  - Invalid, empty, or unsupported volume sources are now rejected with a clear request error.
  - Added validation requiring a volume source and guest path.
  - Read-only volume mounts are rejected when unsupported.

- **Documentation**
  - Updated the API schema to reflect managed volume sources and deprecated `host_path` usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->