### PR TITLE
docs(infra): stop documenting the removed ops-console workload

### DIFF
--- a/apps/infra/scripts/resource-name.mjs
+++ b/apps/infra/scripts/resource-name.mjs
@@ -6,10 +6,10 @@
  *
  *   <namespace>-<workload>-<stage>-<name>[-<attribute>...]
  *
- * The workload slot exists because the account holds more than one: the application stack, the
- * ops console (boxlite-ops-console*), and the e2e fleet (boxlite-e2e-*). Without it nothing
- * distinguishes a workload token from a stage — `boxlite-e2e-runner` reads equally as stage=e2e
- * or workload=e2e — and a reader cannot parse a name back into its parts.
+ * The workload slot exists because the account holds more than one: the application stack and the
+ * e2e fleet (boxlite-e2e-*). Without it nothing distinguishes a workload token from a stage —
+ * `boxlite-e2e-runner` reads equally as stage=e2e or workload=e2e — and a reader cannot parse a
+ * name back into its parts.
  *
  * Most files that touch one of these two names go through awsResourceName; the exceptions are
  * the ones that cannot call JavaScript: ci/github-deploy-role.yaml declares both,
@@ -38,7 +38,7 @@
  * they already exist and are referenced elsewhere, not because anything makes them unrenamable.
  */
 
-// The application stack, as distinct from the ops-console and e2e workloads in the same account.
+// The application stack, as distinct from the e2e workload in the same account.
 const WORKLOAD = 'app'
 
 export function awsResourceName({ app, stage, name, attributes = [] }) {


### PR DESCRIPTION
The ops-console workload and every AWS resource behind it were deleted, so the naming comment described an account that no longer exists.

The workload slot itself still earns its place: the e2e fleet (boxlite-e2e-*) remains, and without the slot boxlite-e2e-runner reads equally as stage=e2e or workload=e2e.

Claude-Session: https://claude.ai/code/session_01XvjqvYt1SsEjT3znhM2JZQ

## Summary
<!-- 1-2 sentences: what this changes and why. -->

## Call graph
<!-- Required. The end-to-end path this PR touches, before and after; one line
     per hop, only the hops that change. Worked example and the bug-fix markers:
     CONTRIBUTING.md#commit--pr-messages. -->

Before
<!-- replace with the hops: fn_name (Type · path/file.rs:LOC) — role -->

After
<!-- replace with the same hops, post-change -->

Fixes #<!-- issue number — bug fixes only; delete this line otherwise -->

## Changes
- <!-- notable change — what changed, not a restatement of the diff -->

## How to verify
- <!-- a command or step a reviewer can run -->

## Risks / rollout
- <!-- only if any; delete this section otherwise -->

<!-- Describe the change, not the process: no pasted logs, no AI/conversation
     narrative, no secrets. Keep it tight and delete sections that don't apply. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified resource-naming guidance by removing the ops-console workload.
  * Documented that the application stack is separate from the end-to-end testing workload.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->