### PR TITLE
fix(rest): return immediately on volume create, drop synchronous wait

### DIFF
--- a/apps/api/src/box/services/volume.service.spec.ts
+++ b/apps/api/src/box/services/volume.service.spec.ts
@@ -1,4 +1,4 @@
-import { NotFoundException, RequestTimeoutException } from '@nestjs/common'
+import { NotFoundException } from '@nestjs/common'
 import { VolumeState } from '../enums/volume-state.enum'
 import { VolumeService } from './volume.service'
 
@@ -37,38 +37,5 @@ describe('VolumeService delete', () => {
     const { service } = createService({ id: 'volume-1', state: VolumeState.DELETED })
 
     await expect(service.delete('volume-1')).rejects.toThrow("Volume must be in 'ready' or 'error' state")
-  })
-})
-
-describe('VolumeService waitForReady', () => {
-  function createService(...volumes: Array<Record<string, unknown> | null>) {
-    const volumeRepository = {
-      findOne: jest.fn().mockImplementation(() => Promise.resolve(volumes.shift() ?? null)),
-    }
-    const service = new VolumeService(volumeRepository as never, {} as never, {} as never, {} as never, {} as never)
-    return { service, volumeRepository }
-  }
-
-  it('returns the volume once it is ready', async () => {
-    const ready = { id: 'volume-1', state: VolumeState.READY }
-    const { service } = createService(ready)
-
-    await expect(service.waitForReady('volume-1', 1)).resolves.toBe(ready)
-  })
-
-  it('reports the backend error', async () => {
-    const { service } = createService({
-      id: 'volume-1',
-      state: VolumeState.ERROR,
-      errorReason: 'bucket creation failed',
-    })
-
-    await expect(service.waitForReady('volume-1', 1)).rejects.toThrow('Volume creation failed')
-  })
-
-  it('times out while the volume is still being created', async () => {
-    const { service } = createService({ id: 'volume-1', state: VolumeState.PENDING_CREATE })
-
-    await expect(service.waitForReady('volume-1', 0)).rejects.toBeInstanceOf(RequestTimeoutException)
   })
 })

--- a/apps/api/src/box/services/volume.service.ts
+++ b/apps/api/src/box/services/volume.service.ts
@@ -4,14 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import {
-  ConflictException,
-  Injectable,
-  Logger,
-  NotFoundException,
-  RequestTimeoutException,
-  ServiceUnavailableException,
-} from '@nestjs/common'
+import { ConflictException, Injectable, Logger, NotFoundException, ServiceUnavailableException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Repository, Not, In } from 'typeorm'
 import { Volume } from '../entities/volume.entity'
@@ -28,7 +21,6 @@ import { TypedConfigService } from '../../config/typed-config.service'
 import { RedisLockProvider } from '../common/redis-lock.provider'
 import { BoxRepository } from '../repositories/box.repository'
 import { BoxDesiredState } from '../enums/box-desired-state.enum'
-import { setTimeout as sleep } from 'timers/promises'
 
 @Injectable()
 export class VolumeService {
@@ -77,29 +69,6 @@ export class VolumeService {
     const savedVolume = await this.volumeRepository.save(volume)
     this.logger.debug(`Created volume ${savedVolume.id} for organization ${organization.id}`)
     return savedVolume
-  }
-
-  async waitForReady(volumeId: string, timeoutSeconds: number): Promise<Volume> {
-    const deadline = Date.now() + timeoutSeconds * 1000
-
-    while (true) {
-      const volume = await this.volumeRepository.findOne({ where: { id: volumeId } })
-      if (!volume) {
-        throw new NotFoundException(`Volume with ID ${volumeId} not found`)
-      }
-      if (volume.state === VolumeState.READY) {
-        return volume
-      }
-      if (volume.state === VolumeState.ERROR) {
-        throw new BadRequestError('Volume creation failed')
-      }
-
-      const remaining = deadline - Date.now()
-      if (remaining <= 0) {
-        throw new RequestTimeoutException(`Timed out waiting for volume ${volumeId} to become ready`)
-      }
-      await sleep(Math.min(500, remaining))
-    }
   }
 
   async delete(volumeId: string, force = false): Promise<void> {

--- a/apps/api/src/boxlite-rest/boxlite-volume.controller.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-volume.controller.spec.ts
@@ -20,7 +20,6 @@ describe('BoxliteVolumeController', () => {
   function createController() {
     const volumeService = {
       create: jest.fn().mockResolvedValue(volume),
-      waitForReady: jest.fn().mockResolvedValue(volume),
       findAll: jest.fn().mockResolvedValue([volume]),
       findOne: jest.fn().mockResolvedValue(volume),
       delete: jest.fn().mockResolvedValue(undefined),
@@ -50,7 +49,6 @@ describe('BoxliteVolumeController', () => {
       error_reason: undefined,
     })
     expect(volumeService.create).toHaveBeenCalledWith(organization, {})
-    expect(volumeService.waitForReady).toHaveBeenCalledWith(volume.id, 30)
   })
 
   it('lists volumes for the authenticated organization', async () => {

--- a/apps/api/src/boxlite-rest/boxlite-volume.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-volume.controller.ts
@@ -30,10 +30,15 @@ export class BoxliteVolumeController {
   constructor(private readonly volumeService: VolumeService) {}
 
   @Post()
+  @HttpCode(202)
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_VOLUMES])
   async create(@AuthContext() authContext: OrganizationAuthContext): Promise<RestVolumeResponse> {
+    // Returns as soon as the volume row exists (state=pending_create) — provisioning
+    // the backing object storage happens asynchronously. Callers learn readiness via
+    // GET or the volume.state.updated webhook (apps/api/src/webhook), same as the
+    // pre-existing classic VolumeController.
     const volume = await this.volumeService.create(authContext.organization, {})
-    return this.toResponse(await this.volumeService.waitForReady(volume.id, 30))
+    return this.toResponse(volume)
   }
 
   @Get()

--- a/openapi/box.openapi.yaml
+++ b/openapi/box.openapi.yaml
@@ -192,19 +192,22 @@ paths:
     post:
       operationId: createVolume
       summary: Create a managed persistent volume
-      description: Creates a volume and waits until its backing object storage is ready.
+      description: |
+        Accepts the volume for creation and returns immediately (state
+        `pending_create`); provisioning the backing object storage happens
+        asynchronously. Poll `GET /volumes/{volume_id}` or subscribe to the
+        `volume.state.updated` webhook to learn when it reaches `ready`
+        (or `error`).
       tags: [Volumes]
       responses:
-        "201":
-          description: Volume created and ready for use
+        "202":
+          description: Volume accepted for creation
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Volume"
         "400":
           $ref: "#/components/responses/BadRequestError"
-        "408":
-          $ref: "#/components/responses/RequestTimeoutError"
         "503":
           $ref: "#/components/responses/ServiceUnavailableError"
 
@@ -1294,13 +1297,6 @@ components:
               type: ImageError
               code: image_pull_failed
               request_id: req_01HZK4TNRPQSXYZ8WM6NCVT9R5
-
-    RequestTimeoutError:
-      description: The operation did not reach its target state before the timeout
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorResponse"
 
     ServiceUnavailableError:
       description: A required backend service is not configured or available

--- a/sdks/node/src/volumes.rs
+++ b/sdks/node/src/volumes.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use boxlite::runtime::VolumeHandle;
-use boxlite::runtime::types::VolumeInfo;
+use boxlite::runtime::types::{VolumeInfo, VolumeState};
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
@@ -16,6 +16,13 @@ pub struct JsVolumeInfo {
     pub created_at: String,
     #[napi(js_name = "sizeBytes")]
     pub size_bytes: Option<i64>,
+    /// Lifecycle state: one of "creating", "ready", "pending_create",
+    /// "pending_delete", "deleting", "deleted", "error". Creation is
+    /// asynchronous — poll `get()` until this is "ready" before mounting.
+    pub state: String,
+    /// Failure detail when `state` is "error".
+    #[napi(js_name = "errorReason")]
+    pub error_reason: Option<String>,
 }
 
 impl From<&VolumeInfo> for JsVolumeInfo {
@@ -28,6 +35,8 @@ impl From<&VolumeInfo> for JsVolumeInfo {
             size_bytes: info
                 .size_bytes
                 .map(|size| i64::try_from(size).unwrap_or(i64::MAX)),
+            state: volume_state_to_string(info.state),
+            error_reason: info.error_reason.clone(),
         }
     }
 }
@@ -36,6 +45,19 @@ impl From<VolumeInfo> for JsVolumeInfo {
     fn from(info: VolumeInfo) -> Self {
         Self::from(&info)
     }
+}
+
+fn volume_state_to_string(state: VolumeState) -> String {
+    match state {
+        VolumeState::Creating => "creating",
+        VolumeState::Ready => "ready",
+        VolumeState::PendingCreate => "pending_create",
+        VolumeState::PendingDelete => "pending_delete",
+        VolumeState::Deleting => "deleting",
+        VolumeState::Deleted => "deleted",
+        VolumeState::Error => "error",
+    }
+    .to_string()
 }
 
 /// Runtime-scoped handle for named-volume operations.
@@ -78,5 +100,27 @@ impl JsVolumeHandle {
             .remove(&id, force.unwrap_or(false))
             .await
             .map_err(map_err)
+    }
+
+    /// Poll `get(id)` until the volume reaches "ready", rejecting on "error"
+    /// or once `timeoutSecs` elapses (default 30).
+    ///
+    /// `create()` returns as soon as the volume is accepted (state
+    /// "pending_create") — provisioning happens asynchronously server-side.
+    /// This is a client-side convenience for callers that want to block
+    /// until the volume is actually usable.
+    #[napi]
+    pub async fn wait_until_ready(
+        &self,
+        id: String,
+        timeout_secs: Option<u32>,
+    ) -> Result<JsVolumeInfo> {
+        let handle = Arc::clone(&self.handle);
+        let timeout = std::time::Duration::from_secs(timeout_secs.unwrap_or(30) as u64);
+        let info = handle
+            .wait_until_ready(&id, timeout)
+            .await
+            .map_err(map_err)?;
+        Ok(JsVolumeInfo::from(&info))
     }
 }

--- a/sdks/python/src/volumes.rs
+++ b/sdks/python/src/volumes.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use boxlite::runtime::VolumeHandle;
-use boxlite::runtime::types::VolumeInfo;
+use boxlite::runtime::types::{VolumeInfo, VolumeState};
 use pyo3::prelude::*;
 
 use crate::util::map_err;
@@ -19,14 +19,22 @@ pub(crate) struct PyVolumeInfo {
     /// Volume size in bytes when the backend can report it.
     #[pyo3(get)]
     pub(crate) size_bytes: Option<u64>,
+    /// Lifecycle state: one of "creating", "ready", "pending_create",
+    /// "pending_delete", "deleting", "deleted", "error". Creation is
+    /// asynchronous — poll `get()` until this is "ready" before mounting.
+    #[pyo3(get)]
+    pub(crate) state: String,
+    /// Failure detail when `state` is "error".
+    #[pyo3(get)]
+    pub(crate) error_reason: Option<String>,
 }
 
 #[pymethods]
 impl PyVolumeInfo {
     fn __repr__(&self) -> String {
         format!(
-            "VolumeInfo(id={:?}, created_at={:?})",
-            self.id, self.created_at
+            "VolumeInfo(id={:?}, state={:?}, created_at={:?})",
+            self.id, self.state, self.created_at
         )
     }
 }
@@ -37,8 +45,23 @@ impl From<VolumeInfo> for PyVolumeInfo {
             id: info.id,
             created_at: info.created_at.to_rfc3339(),
             size_bytes: info.size_bytes,
+            state: volume_state_to_string(info.state),
+            error_reason: info.error_reason,
         }
     }
+}
+
+fn volume_state_to_string(state: VolumeState) -> String {
+    match state {
+        VolumeState::Creating => "creating",
+        VolumeState::Ready => "ready",
+        VolumeState::PendingCreate => "pending_create",
+        VolumeState::PendingDelete => "pending_delete",
+        VolumeState::Deleting => "deleting",
+        VolumeState::Deleted => "deleted",
+        VolumeState::Error => "error",
+    }
+    .to_string()
 }
 
 /// Runtime-scoped handle for named-volume operations.
@@ -97,6 +120,30 @@ impl PyVolumeHandle {
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             handle.remove(&id, force).await.map_err(map_err)?;
             Ok(())
+        })
+    }
+
+    /// Poll `get(id)` until the volume reaches "ready", raising on "error" or
+    /// once `timeout_secs` elapses.
+    ///
+    /// `create()` returns as soon as the volume is accepted (state
+    /// "pending_create") — provisioning happens asynchronously server-side.
+    /// This is a client-side convenience for callers that want to block
+    /// until the volume is actually usable.
+    #[pyo3(signature = (id, timeout_secs=30))]
+    fn wait_until_ready<'py>(
+        &self,
+        py: Python<'py>,
+        id: String,
+        timeout_secs: u64,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let handle = Arc::clone(&self.handle);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let info = handle
+                .wait_until_ready(&id, std::time::Duration::from_secs(timeout_secs))
+                .await
+                .map_err(map_err)?;
+            Ok(PyVolumeInfo::from(info))
         })
     }
 

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -391,8 +391,11 @@ pub(crate) struct CreateVolumeRequest {}
 pub(crate) struct VolumeResponse {
     pub id: String,
     pub created_at: String,
+    pub state: crate::volumes::VolumeState,
     #[serde(default)]
     pub size_bytes: Option<u64>,
+    #[serde(default)]
+    pub error_reason: Option<String>,
 }
 
 impl VolumeResponse {
@@ -405,6 +408,8 @@ impl VolumeResponse {
             id: self.id.clone(),
             created_at,
             size_bytes: self.size_bytes,
+            state: self.state,
+            error_reason: self.error_reason.clone(),
         }
     }
 }

--- a/src/boxlite/src/runtime/types.rs
+++ b/src/boxlite/src/runtime/types.rs
@@ -14,7 +14,7 @@ use crate::runtime::options::{NetworkConfig, NetworkMode, PortProtocol};
 /// Re-exported here so the CLI can reach volume metadata the same way it
 /// reaches [`ImageInfo`] (`boxlite::runtime::types::VolumeInfo`). The type
 /// itself lives with the store in [`crate::volumes`].
-pub use crate::volumes::VolumeInfo;
+pub use crate::volumes::{VolumeInfo, VolumeState};
 
 // ============================================================================
 // RESOURCE LIMIT TYPES (C-NEWTYPE: Semantic newtypes for distinct concepts)

--- a/src/boxlite/src/runtime/volumes.rs
+++ b/src/boxlite/src/runtime/volumes.rs
@@ -8,20 +8,27 @@
 //! The trait is `#[async_trait]` like the other capability backends
 //! ([`ImageBackend`](crate::runtime::images::ImageBackend),
 //! [`AuthBackend`](crate::runtime::auth::AuthBackend)) so REST backends can
-//! perform network calls. The concrete backend is not implemented yet — every
-//! operation currently returns `Unsupported`.
+//! perform network calls. The REST backend implements it against the managed
+//! `/v1/volumes` API; the local backend (`LocalRuntime`) does not have a
+//! volume store wired up yet and returns `Unsupported`.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 
-use crate::BoxliteResult;
-use crate::volumes::VolumeInfo;
+use crate::volumes::{VolumeInfo, VolumeState};
+use crate::{BoxliteError, BoxliteResult};
+
+/// Poll interval for [`VolumeHandle::wait_until_ready`]. The backing bucket
+/// is provisioned by a 5s reconciler tick server-side, so anything much
+/// shorter than that just adds request volume without reducing latency.
+const WAIT_UNTIL_READY_POLL_INTERVAL: Duration = Duration::from_millis(500);
 
 /// Internal trait for named-volume management.
 ///
-/// Implemented by both `LocalRuntime` and the REST runtime. Both return
-/// `Unsupported` until a managed volume backend is wired up.
+/// Implemented by both `LocalRuntime` (currently `Unsupported` — no local
+/// volume store yet) and the REST runtime (backed by `/v1/volumes`).
 #[async_trait]
 pub(crate) trait VolumeBackend: Send + Sync {
     /// Create a volume, returning its server-assigned metadata (including id).
@@ -69,5 +76,43 @@ impl VolumeHandle {
     /// Remove a volume by id. With `force`, a missing volume is a no-op.
     pub async fn remove(&self, id: &str, force: bool) -> BoxliteResult<()> {
         self.backend.remove_volume(id, force).await
+    }
+
+    /// Poll `get(id)` client-side until the volume reaches `Ready`, `Error`,
+    /// or `timeout` elapses.
+    ///
+    /// `create()` returns as soon as the volume is accepted (state
+    /// `PendingCreate`) — provisioning the backing object storage happens
+    /// asynchronously on the server. This is a convenience for callers that
+    /// want the old "create and block until usable" behavior without the
+    /// server itself holding the connection open (which risked client/gateway
+    /// timeouts for what both `boxlite`'s runner and API treat as inherently
+    /// async). Mirrors `ComputerBox`/`SkillBox`'s `waitUntilReady` in the
+    /// Node SDK (`sdks/node/lib/computerbox.ts`, `skillbox.ts`).
+    pub async fn wait_until_ready(&self, id: &str, timeout: Duration) -> BoxliteResult<VolumeInfo> {
+        let deadline = std::time::Instant::now() + timeout;
+
+        loop {
+            let info = self.get(id).await?;
+            match info.state {
+                VolumeState::Ready => return Ok(info),
+                VolumeState::Error => {
+                    return Err(BoxliteError::InvalidState(format!(
+                        "volume {id} failed to become ready: {}",
+                        info.error_reason.as_deref().unwrap_or("unknown error")
+                    )));
+                }
+                _ => {}
+            }
+
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            if remaining.is_zero() {
+                return Err(BoxliteError::InvalidState(format!(
+                    "timed out waiting for volume {id} to become ready (still {:?})",
+                    info.state
+                )));
+            }
+            tokio::time::sleep(WAIT_UNTIL_READY_POLL_INTERVAL.min(remaining)).await;
+        }
     }
 }

--- a/src/boxlite/src/volumes/mod.rs
+++ b/src/boxlite/src/volumes/mod.rs
@@ -3,7 +3,8 @@
 //! Provides:
 //! - `GuestVolumeManager` for virtiofs shares and block devices
 //! - `ContainerVolumeManager` for container bind mounts
-//! - `VolumeInfo` metadata for named volumes (backend not yet implemented)
+//! - `VolumeInfo`/`VolumeState` metadata for named volumes (REST-backed; no
+//!   local backend yet)
 
 mod container_volume;
 mod guest_volume;
@@ -15,4 +16,4 @@ pub use container_volume::{ContainerMount, ContainerVolumeManager};
 pub use guest_volume::GuestVolumeManager;
 pub use share::{VolumeShare, classify_volume_share};
 pub use staging::stage_single_file;
-pub use store::VolumeInfo;
+pub use store::{VolumeInfo, VolumeState};

--- a/src/boxlite/src/volumes/store.rs
+++ b/src/boxlite/src/volumes/store.rs
@@ -2,13 +2,26 @@
 //!
 //! [`VolumeInfo`] is the storage-agnostic view of a volume returned by the
 //! [`VolumeBackend`](crate::runtime::volumes::VolumeBackend) trait and rendered
-//! by the CLI. Volumes are addressed by a server-assigned id (like boxes). The
-//! concrete backend that would populate it is not yet implemented — see
-//! `impl VolumeBackend for LocalRuntime`, which currently returns `Unsupported`
-//! until a managed volume backend is wired up.
+//! by the CLI. Volumes are addressed by a server-assigned id (like boxes).
+//! Populated by the REST backend (`/v1/volumes`); `impl VolumeBackend for
+//! LocalRuntime` still returns `Unsupported` — there's no local volume store.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+
+/// Lifecycle state of a managed volume, mirroring the API's `VolumeState`
+/// enum (`apps/api/src/box/enums/volume-state.enum.ts`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VolumeState {
+    Creating,
+    Ready,
+    PendingCreate,
+    PendingDelete,
+    Deleting,
+    Deleted,
+    Error,
+}
 
 /// Public metadata about a volume.
 ///
@@ -24,4 +37,12 @@ pub struct VolumeInfo {
 
     /// Size of the payload in bytes, if it could be computed.
     pub size_bytes: Option<u64>,
+
+    /// Current lifecycle state. Creation is asynchronous — a freshly created
+    /// volume starts at `PendingCreate`/`Creating` and only becomes usable
+    /// once it reaches `Ready`; see [`crate::runtime::volumes::VolumeHandle::wait_until_ready`].
+    pub state: VolumeState,
+
+    /// Failure detail when `state` is `Error`.
+    pub error_reason: Option<String>,
 }

--- a/src/cli/src/commands/volume/create.rs
+++ b/src/cli/src/commands/volume/create.rs
@@ -1,16 +1,37 @@
+use std::time::Duration;
+
 use crate::cli::GlobalFlags;
 use clap::Args;
 
 /// Create a volume.
 ///
-/// Takes no arguments — the server assigns the id, which is printed on success
-/// (mirroring `boxlite create`).
+/// Takes no arguments besides `--wait` — the server assigns the id, which is
+/// printed on success (mirroring `boxlite create`).
 #[derive(Args, Debug)]
-pub struct CreateArgs {}
+pub struct CreateArgs {
+    /// Poll client-side until the volume is ready (or errors/times out)
+    /// before returning, instead of returning as soon as it's accepted.
+    /// The server never blocks on this itself — see
+    /// `VolumeHandle::wait_until_ready`.
+    #[arg(long)]
+    pub wait: bool,
 
-pub async fn run(_args: CreateArgs, global: &GlobalFlags) -> anyhow::Result<()> {
+    /// Timeout in seconds for `--wait`.
+    #[arg(long, default_value_t = 30, requires = "wait")]
+    pub wait_timeout: u64,
+}
+
+pub async fn run(args: CreateArgs, global: &GlobalFlags) -> anyhow::Result<()> {
     let rt = global.create_runtime()?;
-    let info = rt.volumes()?.create().await?;
+    let volumes = rt.volumes()?;
+    let info = volumes.create().await?;
+
+    if args.wait {
+        volumes
+            .wait_until_ready(&info.id, Duration::from_secs(args.wait_timeout))
+            .await?;
+    }
+
     // Like `boxlite create`, print the new id on success.
     println!("{}", info.id);
     Ok(())

--- a/src/cli/src/commands/volume/ls.rs
+++ b/src/cli/src/commands/volume/ls.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use crate::cli::GlobalFlags;
 use crate::formatter::{self, OutputFormat};
-use boxlite::runtime::types::VolumeInfo;
+use boxlite::runtime::types::{VolumeInfo, VolumeState};
 use clap::Args;
 use serde::Serialize;
 use tabled::Tabled;
@@ -26,6 +26,9 @@ pub struct VolumePresenter {
     #[tabled(rename = "ID")]
     #[serde(rename = "Id")]
     pub id: String,
+    #[tabled(rename = "STATE")]
+    #[serde(rename = "State")]
+    pub state: String,
     #[tabled(rename = "CREATED")]
     #[serde(rename = "CreatedAt")]
     pub created: String,
@@ -38,10 +41,26 @@ impl From<&VolumeInfo> for VolumePresenter {
     fn from(info: &VolumeInfo) -> Self {
         Self {
             id: info.id.clone(),
+            state: format_state(info.state),
             created: formatter::format_time(&info.created_at),
             size: format_size(info.size_bytes),
         }
     }
+}
+
+/// Render a [`VolumeState`] the way the table/JSON output expects: lowercase,
+/// underscore-separated, matching the API's own `snake_case` wire values.
+fn format_state(state: VolumeState) -> String {
+    match state {
+        VolumeState::Creating => "creating",
+        VolumeState::Ready => "ready",
+        VolumeState::PendingCreate => "pending_create",
+        VolumeState::PendingDelete => "pending_delete",
+        VolumeState::Deleting => "deleting",
+        VolumeState::Deleted => "deleted",
+        VolumeState::Error => "error",
+    }
+    .to_string()
 }
 
 /// Render an optional byte count as a short human string ("-" when unknown).
@@ -109,5 +128,16 @@ mod tests {
         assert_eq!(format_size(Some(1024)), "1.0KiB");
         assert_eq!(format_size(Some(1024 * 1024)), "1.0MiB");
         assert_eq!(format_size(Some(3 * 1024 * 1024 * 1024)), "3.0GiB");
+    }
+
+    #[test]
+    fn format_state_matches_api_wire_values() {
+        assert_eq!(format_state(VolumeState::Creating), "creating");
+        assert_eq!(format_state(VolumeState::Ready), "ready");
+        assert_eq!(format_state(VolumeState::PendingCreate), "pending_create");
+        assert_eq!(format_state(VolumeState::PendingDelete), "pending_delete");
+        assert_eq!(format_state(VolumeState::Deleting), "deleting");
+        assert_eq!(format_state(VolumeState::Deleted), "deleted");
+        assert_eq!(format_state(VolumeState::Error), "error");
     }
 }


### PR DESCRIPTION
Follow-up to #1191 (merged). `create` blocked up to 30s polling for the volume to become ready via `VolumeService.waitForReady`, risking client/gateway timeouts around that same window for what is an inherently async operation — bucket provisioning runs on a 5s reconciler tick (`VolumeManager.processPendingVolumes`), fully decoupled from the request.

**API**: `create` now returns 202 with `state=pending_create` as soon as the row exists, matching what the pre-existing classic `VolumeController` (`apps/api/src/box/controllers/volume.controller.ts`) already did — it never waited either. Removes `VolumeService.waitForReady`, now unused.

**Client-side wait**: the Rust core's `VolumeInfo`/`VolumeResponse` never carried `state` at all, so there was no way for any caller to observe readiness short of re-deserializing raw JSON. Adds a `VolumeState` enum (mirroring the API's) plus `state`/`error_reason` fields, and `VolumeHandle::wait_until_ready` — a client-side poll loop mirroring `ComputerBox`/`SkillBox`'s `waitUntilReady` in the Node SDK — that blocks until ready/error/timeout without the server holding a connection open. Wired into the CLI: `boxlite volume create --wait [--wait-timeout secs]` restores the old synchronous-feeling UX for callers who want it; `volume ls`/`get` now show a STATE column.

Callers who don't use `--wait` learn readiness via `GET /volumes/{id}` (always authoritative, no external dependency) or the existing `volume.state.updated` webhook if their org has one configured (best-effort, opt-in — not a delivery guarantee on its own).

Test plan:
- `yarn nx run api:build` / `yarn nx run api:test -- --testPathPatterns=volume` — 4 suites, 23 tests, all pass
- `cargo check -p boxlite --features rest` / `cargo build -p boxlite-cli` — clean
- `cargo test -p boxlite-cli volume::` — 2 new/updated unit tests pass
- `cargo fmt --all -- --check` — clean
- Manual E2E against a local isolated API+Postgres+MinIO stack: `boxlite volume create` returns in ~0.3s with `state=pending_create`; `boxlite volume create --wait` blocks ~2s and returns once `state=ready`; `boxlite volume ls` shows the new STATE column throughout