### PR TITLE
fix(rest): buffer split UTF-8 codepoints across PTY frames

### DIFF
--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -648,6 +648,36 @@ async fn attach_ws(
     .await;
 }
 
+/// Decode as much of `payload` as forms valid UTF-8, prepending any bytes
+/// carried over from a previous call. A codepoint split across two frames
+/// stays buffered in `pending` until the rest arrives, instead of the
+/// incomplete tail being replaced with U+FFFD.
+fn decode_utf8_streaming(pending: &mut Vec<u8>, payload: &[u8]) -> String {
+    pending.extend_from_slice(payload);
+    match std::str::from_utf8(pending) {
+        Ok(s) => {
+            let text = s.to_string();
+            pending.clear();
+            text
+        }
+        Err(e) => {
+            let valid_up_to = e.valid_up_to();
+            let text = std::str::from_utf8(&pending[..valid_up_to])
+                .expect("bytes before valid_up_to are always valid UTF-8")
+                .to_string();
+            if e.error_len().is_none() {
+                // Incomplete sequence at the end of the buffer -- keep it
+                // for the next frame.
+                pending.drain(..valid_up_to);
+            } else {
+                // Genuinely invalid bytes; buffering them won't help.
+                pending.clear();
+            }
+            text
+        }
+    }
+}
+
 /// Pump stdin/stdout/stderr/control over a WebSocket attach. On transient
 /// disconnects (watchdog timeout, close frame, stream error) the pump probes
 /// the server's view of the execution; if the exec is still running it
@@ -687,6 +717,10 @@ async fn attach_ws_pump(
     // Sticky across reconnects: once the server has ever sent a frame the
     // exec is real, so a later reconnect uses the steady-state watchdog.
     let mut first_frame_seen = false;
+    // Trailing bytes of a UTF-8 codepoint split across two frames, held
+    // here until the rest arrives. Independent per channel.
+    let mut stdout_pending: Vec<u8> = Vec::new();
+    let mut stderr_pending: Vec<u8> = Vec::new();
 
     let mut current_stream = Some(initial_stream);
 
@@ -796,15 +830,20 @@ async fn attach_ws_pump(
                     match frame {
                         Message::Binary(bytes) => {
                             if let Some((channel, payload)) = bytes.split_first() {
-                                let text = String::from_utf8_lossy(payload).into_owned();
                                 match *channel {
                                     0x01 => {
-                                        tracing::trace!(len = text.len(), "WS attach: stdout frame");
-                                        let _ = stdout_tx.send(text);
+                                        let text = decode_utf8_streaming(&mut stdout_pending, payload);
+                                        if !text.is_empty() {
+                                            tracing::trace!(len = text.len(), "WS attach: stdout frame");
+                                            let _ = stdout_tx.send(text);
+                                        }
                                     }
                                     0x02 => {
-                                        tracing::trace!(len = text.len(), "WS attach: stderr frame");
-                                        let _ = stderr_tx.send(text);
+                                        let text = decode_utf8_streaming(&mut stderr_pending, payload);
+                                        if !text.is_empty() {
+                                            tracing::trace!(len = text.len(), "WS attach: stderr frame");
+                                            let _ = stderr_tx.send(text);
+                                        }
                                     }
                                     other => {
                                         tracing::warn!(channel = other, "WS attach: unknown channel prefix");
@@ -1581,6 +1620,61 @@ mod tests {
             s.received_stdin
         );
         drop(s);
+        server.abort();
+    }
+
+    // ─── ws_stdout_utf8_split_across_frames ───────────────────────────────
+    //
+    // A multi-byte UTF-8 codepoint (€, bytes E2 82 AC) is split across two
+    // stdout binary frames. The client must reassemble it instead of
+    // replacing the incomplete tail with U+FFFD per frame.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ws_stdout_utf8_split_across_frames() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let state: SharedState = Arc::new(Mutex::new(ServerState::default()));
+        let state_clone = state.clone();
+        let server = tokio::spawn(async move {
+            run_server(listener, state_clone, None, |mut ws, _state| async move {
+                ws.send(Message::Binary(vec![0x01, 0xE2, 0x82]))
+                    .await
+                    .unwrap();
+                ws.send(Message::Binary(vec![0x01, 0xAC])).await.unwrap();
+                ws.send(Message::Text(r#"{"type":"exit","exit_code":0}"#.into()))
+                    .await
+                    .unwrap();
+                let _ = ws.close(None).await;
+            })
+            .await;
+        });
+
+        let client = client_for(port);
+        let (stdout_tx, mut stdout_rx) = mpsc::unbounded_channel::<String>();
+        let (stderr_tx, _stderr_rx) = mpsc::unbounded_channel::<String>();
+        let (_stdin_tx, stdin_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+        let (result_tx, mut result_rx) = mpsc::unbounded_channel::<ExecResult>();
+
+        let attach = tokio::spawn(async move {
+            attach_ws(
+                &client, "box1", "exec1", stdin_rx, stdout_tx, stderr_tx, result_tx,
+            )
+            .await;
+        });
+
+        tokio::time::timeout(Duration::from_secs(3), result_rx.recv())
+            .await
+            .expect("result channel timed out")
+            .expect("result channel closed without value");
+
+        let mut received = String::new();
+        while let Ok(Some(chunk)) =
+            tokio::time::timeout(Duration::from_millis(200), stdout_rx.recv()).await
+        {
+            received.push_str(&chunk);
+        }
+        assert_eq!(received, "€");
+
+        attach.await.unwrap();
         server.abort();
     }
 

--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -652,25 +652,45 @@ async fn attach_ws(
 /// over in `pending` instead of replacing it with U+FFFD.
 fn decode_utf8_streaming(pending: &mut Vec<u8>, payload: &[u8]) -> String {
     pending.extend_from_slice(payload);
-    match std::str::from_utf8(pending) {
-        Ok(s) => {
-            let text = s.to_string();
-            pending.clear();
-            text
-        }
-        Err(e) => {
-            let valid_up_to = e.valid_up_to();
-            let text = std::str::from_utf8(&pending[..valid_up_to])
-                .expect("bytes before valid_up_to are always valid UTF-8")
-                .to_string();
-            if e.error_len().is_none() {
-                pending.drain(..valid_up_to);
-            } else {
+    let mut text = String::new();
+    loop {
+        match std::str::from_utf8(pending) {
+            Ok(s) => {
+                text.push_str(s);
                 pending.clear();
+                break;
             }
-            text
+            Err(e) => {
+                let valid_up_to = e.valid_up_to();
+                text.push_str(
+                    std::str::from_utf8(&pending[..valid_up_to])
+                        .expect("bytes before valid_up_to are always valid UTF-8"),
+                );
+                match e.error_len() {
+                    Some(invalid_len) => {
+                        text.push('\u{FFFD}');
+                        pending.drain(..valid_up_to + invalid_len);
+                    }
+                    None => {
+                        pending.drain(..valid_up_to);
+                        break;
+                    }
+                }
+            }
         }
     }
+    text
+}
+
+/// Lossily flushes and clears whatever partial sequence is still buffered.
+/// Called on terminal returns, where there is no next payload to complete it.
+fn flush_pending(pending: &mut Vec<u8>) -> Option<String> {
+    if pending.is_empty() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(pending).into_owned();
+    pending.clear();
+    Some(text)
 }
 
 /// Pump stdin/stdout/stderr/control over a WebSocket attach. On transient
@@ -848,6 +868,12 @@ async fn attach_ws_pump(
                         Message::Text(text) => match parse_control_frame(&text) {
                             ControlFrame::Exit { exit_code } => {
                                 tracing::debug!(exit_code, "WS attach: exit control frame");
+                                if let Some(text) = flush_pending(&mut stdout_pending) {
+                                    let _ = stdout_tx.send(text);
+                                }
+                                if let Some(text) = flush_pending(&mut stderr_pending) {
+                                    let _ = stderr_tx.send(text);
+                                }
                                 let _ = result_tx.send(ExecResult {
                                     exit_code,
                                     error_message: None,
@@ -883,6 +909,12 @@ async fn attach_ws_pump(
                     cause = %disconnect_cause,
                     "WS attach: disconnected without an exit frame — taking exit code from status probe (any unstreamed stdout/stderr is lost)"
                 );
+                if let Some(text) = flush_pending(&mut stdout_pending) {
+                    let _ = stdout_tx.send(text);
+                }
+                if let Some(text) = flush_pending(&mut stderr_pending) {
+                    let _ = stderr_tx.send(text);
+                }
                 let _ = result_tx.send(result);
                 return;
             }
@@ -1792,6 +1824,217 @@ mod tests {
                 server.abort();
             }
         }
+    }
+
+    // ─── ws_stderr_utf8_split_across_frames ────────────────────────────────
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ws_stderr_utf8_split_across_frames() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let state: SharedState = Arc::new(Mutex::new(ServerState::default()));
+        let state_clone = state.clone();
+        let server = tokio::spawn(async move {
+            run_server(listener, state_clone, None, |mut ws, _state| async move {
+                ws.send(Message::Binary(vec![0x02, 0xE2, 0x82]))
+                    .await
+                    .unwrap();
+                ws.send(Message::Binary(vec![0x02, 0xAC])).await.unwrap();
+                ws.send(Message::Text(r#"{"type":"exit","exit_code":0}"#.into()))
+                    .await
+                    .unwrap();
+                let _ = ws.close(None).await;
+            })
+            .await;
+        });
+
+        let client = client_for(port);
+        let (stdout_tx, _stdout_rx) = mpsc::unbounded_channel::<String>();
+        let (stderr_tx, mut stderr_rx) = mpsc::unbounded_channel::<String>();
+        let (_stdin_tx, stdin_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+        let (result_tx, mut result_rx) = mpsc::unbounded_channel::<ExecResult>();
+
+        let attach = tokio::spawn(async move {
+            attach_ws(
+                &client, "box1", "exec1", stdin_rx, stdout_tx, stderr_tx, result_tx,
+            )
+            .await;
+        });
+
+        tokio::time::timeout(Duration::from_secs(3), result_rx.recv())
+            .await
+            .expect("result channel timed out")
+            .expect("result channel closed without value");
+
+        let mut received = String::new();
+        while let Ok(Some(chunk)) =
+            tokio::time::timeout(Duration::from_millis(200), stderr_rx.recv()).await
+        {
+            received.push_str(&chunk);
+        }
+        assert_eq!(received, "€");
+
+        attach.await.unwrap();
+        server.abort();
+    }
+
+    // ─── ws_stdout_stderr_pending_buffers_stay_isolated ────────────────────
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ws_stdout_stderr_pending_buffers_stay_isolated() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let state: SharedState = Arc::new(Mutex::new(ServerState::default()));
+        let state_clone = state.clone();
+        let server = tokio::spawn(async move {
+            run_server(listener, state_clone, None, |mut ws, _state| async move {
+                ws.send(Message::Binary(vec![0x01, 0xE2, 0x82]))
+                    .await
+                    .unwrap();
+                ws.send(Message::Binary(vec![0x02, 0xE2, 0x94]))
+                    .await
+                    .unwrap();
+                ws.send(Message::Binary(vec![0x01, 0xAC])).await.unwrap();
+                ws.send(Message::Binary(vec![0x02, 0x80])).await.unwrap();
+                ws.send(Message::Text(r#"{"type":"exit","exit_code":0}"#.into()))
+                    .await
+                    .unwrap();
+                let _ = ws.close(None).await;
+            })
+            .await;
+        });
+
+        let client = client_for(port);
+        let (stdout_tx, mut stdout_rx) = mpsc::unbounded_channel::<String>();
+        let (stderr_tx, mut stderr_rx) = mpsc::unbounded_channel::<String>();
+        let (_stdin_tx, stdin_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+        let (result_tx, mut result_rx) = mpsc::unbounded_channel::<ExecResult>();
+
+        let attach = tokio::spawn(async move {
+            attach_ws(
+                &client, "box1", "exec1", stdin_rx, stdout_tx, stderr_tx, result_tx,
+            )
+            .await;
+        });
+
+        tokio::time::timeout(Duration::from_secs(3), result_rx.recv())
+            .await
+            .expect("result channel timed out")
+            .expect("result channel closed without value");
+
+        let mut stdout_received = String::new();
+        while let Ok(Some(chunk)) =
+            tokio::time::timeout(Duration::from_millis(200), stdout_rx.recv()).await
+        {
+            stdout_received.push_str(&chunk);
+        }
+        let mut stderr_received = String::new();
+        while let Ok(Some(chunk)) =
+            tokio::time::timeout(Duration::from_millis(200), stderr_rx.recv()).await
+        {
+            stderr_received.push_str(&chunk);
+        }
+        assert_eq!(stdout_received, "€");
+        assert_eq!(stderr_received, "─");
+
+        attach.await.unwrap();
+        server.abort();
+    }
+
+    // ─── ws_stdout_pending_flushed_on_exit ─────────────────────────────────
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ws_stdout_pending_flushed_on_exit() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let state: SharedState = Arc::new(Mutex::new(ServerState::default()));
+        let state_clone = state.clone();
+        let server = tokio::spawn(async move {
+            run_server(listener, state_clone, None, |mut ws, _state| async move {
+                ws.send(Message::Binary(vec![0x01, 0xE2, 0x82]))
+                    .await
+                    .unwrap();
+                ws.send(Message::Text(r#"{"type":"exit","exit_code":0}"#.into()))
+                    .await
+                    .unwrap();
+                let _ = ws.close(None).await;
+            })
+            .await;
+        });
+
+        let client = client_for(port);
+        let (stdout_tx, mut stdout_rx) = mpsc::unbounded_channel::<String>();
+        let (stderr_tx, _stderr_rx) = mpsc::unbounded_channel::<String>();
+        let (_stdin_tx, stdin_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+        let (result_tx, mut result_rx) = mpsc::unbounded_channel::<ExecResult>();
+
+        let attach = tokio::spawn(async move {
+            attach_ws(
+                &client, "box1", "exec1", stdin_rx, stdout_tx, stderr_tx, result_tx,
+            )
+            .await;
+        });
+
+        tokio::time::timeout(Duration::from_secs(3), result_rx.recv())
+            .await
+            .expect("result channel timed out")
+            .expect("result channel closed without value");
+
+        let out = tokio::time::timeout(Duration::from_secs(1), stdout_rx.recv())
+            .await
+            .expect("stdout timed out")
+            .expect("stdout channel closed");
+        assert_eq!(out, "\u{FFFD}");
+
+        attach.await.unwrap();
+        server.abort();
+    }
+
+    // ─── ws_stdout_valid_bytes_survive_malformed_sequence ──────────────────
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ws_stdout_valid_bytes_survive_malformed_sequence() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let state: SharedState = Arc::new(Mutex::new(ServerState::default()));
+        let state_clone = state.clone();
+        let server = tokio::spawn(async move {
+            run_server(listener, state_clone, None, |mut ws, _state| async move {
+                let mut frame = vec![0x01];
+                frame.extend_from_slice(b"ab");
+                frame.push(0xFF);
+                frame.extend_from_slice(b"cd");
+                ws.send(Message::Binary(frame)).await.unwrap();
+                ws.send(Message::Text(r#"{"type":"exit","exit_code":0}"#.into()))
+                    .await
+                    .unwrap();
+                let _ = ws.close(None).await;
+            })
+            .await;
+        });
+
+        let client = client_for(port);
+        let (stdout_tx, mut stdout_rx) = mpsc::unbounded_channel::<String>();
+        let (stderr_tx, _stderr_rx) = mpsc::unbounded_channel::<String>();
+        let (_stdin_tx, stdin_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+        let (result_tx, mut result_rx) = mpsc::unbounded_channel::<ExecResult>();
+
+        let attach = tokio::spawn(async move {
+            attach_ws(
+                &client, "box1", "exec1", stdin_rx, stdout_tx, stderr_tx, result_tx,
+            )
+            .await;
+        });
+
+        tokio::time::timeout(Duration::from_secs(3), result_rx.recv())
+            .await
+            .expect("result channel timed out")
+            .expect("result channel closed without value");
+
+        let out = tokio::time::timeout(Duration::from_secs(1), stdout_rx.recv())
+            .await
+            .expect("stdout timed out")
+            .expect("stdout channel closed");
+        assert_eq!(out, "ab\u{FFFD}cd");
+
+        attach.await.unwrap();
+        server.abort();
     }
 
     // ─── ws_close_without_exit_falls_back_to_status ──────────────────────

--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -648,10 +648,8 @@ async fn attach_ws(
     .await;
 }
 
-/// Decode as much of `payload` as forms valid UTF-8, prepending any bytes
-/// carried over from a previous call. A codepoint split across two frames
-/// stays buffered in `pending` until the rest arrives, instead of the
-/// incomplete tail being replaced with U+FFFD.
+/// Decodes `payload` as UTF-8, carrying an incomplete trailing codepoint
+/// over in `pending` instead of replacing it with U+FFFD.
 fn decode_utf8_streaming(pending: &mut Vec<u8>, payload: &[u8]) -> String {
     pending.extend_from_slice(payload);
     match std::str::from_utf8(pending) {
@@ -666,11 +664,8 @@ fn decode_utf8_streaming(pending: &mut Vec<u8>, payload: &[u8]) -> String {
                 .expect("bytes before valid_up_to are always valid UTF-8")
                 .to_string();
             if e.error_len().is_none() {
-                // Incomplete sequence at the end of the buffer -- keep it
-                // for the next frame.
                 pending.drain(..valid_up_to);
             } else {
-                // Genuinely invalid bytes; buffering them won't help.
                 pending.clear();
             }
             text
@@ -717,8 +712,7 @@ async fn attach_ws_pump(
     // Sticky across reconnects: once the server has ever sent a frame the
     // exec is real, so a later reconnect uses the steady-state watchdog.
     let mut first_frame_seen = false;
-    // Trailing bytes of a UTF-8 codepoint split across two frames, held
-    // here until the rest arrives. Independent per channel.
+    // Per-channel carry buffers for decode_utf8_streaming.
     let mut stdout_pending: Vec<u8> = Vec::new();
     let mut stderr_pending: Vec<u8> = Vec::new();
 
@@ -1624,10 +1618,6 @@ mod tests {
     }
 
     // ─── ws_stdout_utf8_split_across_frames ───────────────────────────────
-    //
-    // A multi-byte UTF-8 codepoint (€, bytes E2 82 AC) is split across two
-    // stdout binary frames. The client must reassemble it instead of
-    // replacing the incomplete tail with U+FFFD per frame.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn ws_stdout_utf8_split_across_frames() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -1679,10 +1669,6 @@ mod tests {
     }
 
     // ─── ws_stdout_utf8_split_across_frames_4byte ──────────────────────────
-    //
-    // A 4-byte UTF-8 codepoint (😀, bytes F0 9F 98 80) is split across two
-    // stdout binary frames at every possible boundary (after 1, 2, or 3
-    // bytes). The client must reassemble it in every case.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn ws_stdout_utf8_split_across_frames_4byte() {
         let emoji: [u8; 4] = [0xF0, 0x9F, 0x98, 0x80]; // 😀
@@ -1741,6 +1727,70 @@ mod tests {
 
             attach.await.unwrap();
             server.abort();
+        }
+    }
+
+    // ─── ws_stdout_utf8_split_across_frames_tui_chars ──────────────────────
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ws_stdout_utf8_split_across_frames_tui_chars() {
+        let cases: [(&str, [u8; 3]); 2] = [("─", [0xE2, 0x94, 0x80]), ("⠋", [0xE2, 0xA0, 0x8B])];
+
+        for (expected, bytes) in cases {
+            for split_at in 1..3 {
+                let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+                let port = listener.local_addr().unwrap().port();
+                let state: SharedState = Arc::new(Mutex::new(ServerState::default()));
+                let state_clone = state.clone();
+                let (first, second) = bytes.split_at(split_at);
+                let mut first_frame = vec![0x01];
+                first_frame.extend_from_slice(first);
+                let mut second_frame = vec![0x01];
+                second_frame.extend_from_slice(second);
+
+                let server = tokio::spawn(async move {
+                    run_server(listener, state_clone, None, |mut ws, _state| async move {
+                        ws.send(Message::Binary(first_frame)).await.unwrap();
+                        ws.send(Message::Binary(second_frame)).await.unwrap();
+                        ws.send(Message::Text(r#"{"type":"exit","exit_code":0}"#.into()))
+                            .await
+                            .unwrap();
+                        let _ = ws.close(None).await;
+                    })
+                    .await;
+                });
+
+                let client = client_for(port);
+                let (stdout_tx, mut stdout_rx) = mpsc::unbounded_channel::<String>();
+                let (stderr_tx, _stderr_rx) = mpsc::unbounded_channel::<String>();
+                let (_stdin_tx, stdin_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+                let (result_tx, mut result_rx) = mpsc::unbounded_channel::<ExecResult>();
+
+                let attach = tokio::spawn(async move {
+                    attach_ws(
+                        &client, "box1", "exec1", stdin_rx, stdout_tx, stderr_tx, result_tx,
+                    )
+                    .await;
+                });
+
+                tokio::time::timeout(Duration::from_secs(3), result_rx.recv())
+                    .await
+                    .expect("result channel timed out")
+                    .expect("result channel closed without value");
+
+                let mut received = String::new();
+                while let Ok(Some(chunk)) =
+                    tokio::time::timeout(Duration::from_millis(200), stdout_rx.recv()).await
+                {
+                    received.push_str(&chunk);
+                }
+                assert_eq!(
+                    received, expected,
+                    "{expected:?} split at byte {split_at} failed to reassemble"
+                );
+
+                attach.await.unwrap();
+                server.abort();
+            }
         }
     }
 

--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -1678,6 +1678,72 @@ mod tests {
         server.abort();
     }
 
+    // ─── ws_stdout_utf8_split_across_frames_4byte ──────────────────────────
+    //
+    // A 4-byte UTF-8 codepoint (😀, bytes F0 9F 98 80) is split across two
+    // stdout binary frames at every possible boundary (after 1, 2, or 3
+    // bytes). The client must reassemble it in every case.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ws_stdout_utf8_split_across_frames_4byte() {
+        let emoji: [u8; 4] = [0xF0, 0x9F, 0x98, 0x80]; // 😀
+
+        for split_at in 1..4 {
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let port = listener.local_addr().unwrap().port();
+            let state: SharedState = Arc::new(Mutex::new(ServerState::default()));
+            let state_clone = state.clone();
+            let (first, second) = emoji.split_at(split_at);
+            let mut first_frame = vec![0x01];
+            first_frame.extend_from_slice(first);
+            let mut second_frame = vec![0x01];
+            second_frame.extend_from_slice(second);
+
+            let server = tokio::spawn(async move {
+                run_server(listener, state_clone, None, |mut ws, _state| async move {
+                    ws.send(Message::Binary(first_frame)).await.unwrap();
+                    ws.send(Message::Binary(second_frame)).await.unwrap();
+                    ws.send(Message::Text(r#"{"type":"exit","exit_code":0}"#.into()))
+                        .await
+                        .unwrap();
+                    let _ = ws.close(None).await;
+                })
+                .await;
+            });
+
+            let client = client_for(port);
+            let (stdout_tx, mut stdout_rx) = mpsc::unbounded_channel::<String>();
+            let (stderr_tx, _stderr_rx) = mpsc::unbounded_channel::<String>();
+            let (_stdin_tx, stdin_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+            let (result_tx, mut result_rx) = mpsc::unbounded_channel::<ExecResult>();
+
+            let attach = tokio::spawn(async move {
+                attach_ws(
+                    &client, "box1", "exec1", stdin_rx, stdout_tx, stderr_tx, result_tx,
+                )
+                .await;
+            });
+
+            tokio::time::timeout(Duration::from_secs(3), result_rx.recv())
+                .await
+                .expect("result channel timed out")
+                .expect("result channel closed without value");
+
+            let mut received = String::new();
+            while let Ok(Some(chunk)) =
+                tokio::time::timeout(Duration::from_millis(200), stdout_rx.recv()).await
+            {
+                received.push_str(&chunk);
+            }
+            assert_eq!(
+                received, "😀",
+                "split at byte {split_at} failed to reassemble"
+            );
+
+            attach.await.unwrap();
+            server.abort();
+        }
+    }
+
     // ─── ws_close_without_exit_falls_back_to_status ──────────────────────
     //
     // Server sends one stdout frame, then closes WITHOUT an exit frame.


### PR DESCRIPTION
## Summary
A multi-byte UTF-8 character split across two WS stdout/stderr frames was decoded per-frame, turning the incomplete half into U+FFFD. Buffer the incomplete tail per channel, flush it on terminal return, and preserve valid bytes after a genuinely malformed sequence.

## Call graph

Before
```
attach_ws_pump          (rest client · src/boxlite/src/rest/litebox.rs:706)
  └─ 0x01/0x02 branch   ← BUG: from_utf8_lossy(payload) decodes each frame in isolation
       └─ stdout_tx/stderr_tx.send(text) — sends U+FFFD when a codepoint straddles two frames
```

After
```
attach_ws_pump                  (rest client · src/boxlite/src/rest/litebox.rs:706)
  ├─ 0x01/0x02 branch
  │    └─ decode_utf8_streaming(&mut stdout_pending/stderr_pending, payload)  (litebox.rs:653)
  │         └─ stdout_tx/stderr_tx.send(text) — only sent once a full codepoint is buffered; malformed bytes are skipped without dropping valid bytes after them
  └─ ControlFrame::Exit / ProbeResult::Terminal terminal returns  (litebox.rs:869, 907)
       └─ flush_pending(&mut stdout_pending/stderr_pending)  (litebox.rs:687)
            └─ stdout_tx/stderr_tx.send(text) — flushes a still-incomplete trailing sequence instead of dropping it silently
```

Fixes #1155

## Changes
- Added `decode_utf8_streaming`, buffering an incomplete trailing UTF-8 sequence instead of lossily replacing it; on genuinely malformed bytes, only the bad sequence becomes U+FFFD and decoding continues on the rest of the buffer.
- Added `flush_pending`, called on both terminal-return paths so a partial sequence still in the buffer when the exec ends isn't silently lost.
- Two independent carry buffers (`stdout_pending`, `stderr_pending`) persist across reconnects and never mix bytes between channels.
- Tests: 3-byte (€) and 4-byte (😀, all split points) on stdout and stderr, box-drawing (─) and braille spinner (⠋), channel isolation, flush-on-exit, and valid-bytes-survive-malformed-sequence.

## How to verify
```
cargo test -p boxlite --no-default-features --features rest,test-support --lib rest::litebox::tests::ws_std
```
