### PR TITLE
feat[runner]:  Runner Decommission 

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -9,6 +9,9 @@ DB_DATABASE=application_ctx
 REDIS_HOST=redis
 REDIS_PORT=6379
 
+DRAINING_BOX_CONCURRENCY=10
+DRAINING_RUNNER_CONCURRENCY=2
+
 OIDC_CLIENT_ID=boxlite
 OIDC_ISSUER_BASE_URL=http://localhost:5556/dex
 OIDC_AUDIENCE=boxlite
@@ -137,4 +140,3 @@ HEALTH_CHECK_API_KEY=supersecretkey
 # shared example value here would let anyone who copies this file unmodified
 # authenticate as it. Every deployment must set its own.
 BILLING_API_KEY=
-

--- a/apps/api/src/box/entities/box.entity.spec.ts
+++ b/apps/api/src/box/entities/box.entity.spec.ts
@@ -5,6 +5,8 @@
  */
 
 import { BOX_ID_LENGTH, BOX_ID_REGEX } from '../utils/box-id.util'
+import { BoxDesiredState } from '../enums/box-desired-state.enum'
+import { BoxState } from '../enums/box-state.enum'
 import { Box } from './box.entity'
 
 describe('Box entity public identity', () => {
@@ -15,5 +17,18 @@ describe('Box entity public identity', () => {
     expect(box.id).toMatch(BOX_ID_REGEX)
     expect((box as any).boxId).toBeUndefined()
     expect(box.name).toBe('data-loader')
+  })
+})
+
+describe('Box entity destroy invariant', () => {
+  it('keeps an errored box pending while a destroy intent is being reconciled', () => {
+    const box = new Box('us', 'errored-box')
+    box.state = BoxState.ERROR
+    box.desiredState = BoxDesiredState.DESTROYED
+    box.pending = true
+
+    box.enforceInvariants()
+
+    expect(box.pending).toBe(true)
   })
 })

--- a/apps/api/src/box/entities/box.entity.ts
+++ b/apps/api/src/box/entities/box.entity.ts
@@ -266,7 +266,7 @@ export class Box {
     if (this.pending && String(this.state) === String(this.desiredState)) {
       changes.pending = false
     }
-    if (this.state === BoxState.ERROR) {
+    if (this.state === BoxState.ERROR && this.desiredState !== BoxDesiredState.DESTROYED) {
       changes.pending = false
     }
 

--- a/apps/api/src/box/managers/box.manager.draining.spec.ts
+++ b/apps/api/src/box/managers/box.manager.draining.spec.ts
@@ -148,4 +148,18 @@ describe('BoxManager runner draining', () => {
 
     expect(destroyAction.run).toHaveBeenCalled()
   })
+
+  it('retries scheduled destruction for an errored box with an existing destroy intent', async () => {
+    const { manager, boxRepository } = createManager()
+    const box = createBox('retry-destroy', BoxState.ERROR)
+    box.desiredState = BoxDesiredState.DESTROYED
+    box.pending = true
+    boxRepository.find.mockResolvedValue([box])
+    const sync = jest.spyOn(manager, 'syncInstanceState').mockResolvedValue(undefined)
+
+    await manager.drainingRunnerBoxesCheck()
+
+    expect(sync).toHaveBeenCalledWith(box.id, false)
+    expect(boxRepository.updateWhere).not.toHaveBeenCalled()
+  })
 })

--- a/apps/api/src/box/managers/box.manager.draining.spec.ts
+++ b/apps/api/src/box/managers/box.manager.draining.spec.ts
@@ -39,7 +39,12 @@ describe('BoxManager runner draining', () => {
       get: jest.fn().mockResolvedValue(cursor),
       set: jest.fn().mockResolvedValue('OK'),
     }
-    const configService = { get: jest.fn().mockReturnValue(force) }
+    const configService = {
+      get: jest.fn((key: string) => {
+        if (key === 'draining.force') return force
+        return key === 'draining.runnerConcurrency' ? 2 : 10
+      }),
+    }
     const destroyAction = { run: jest.fn().mockResolvedValue(DONT_SYNC_AGAIN) }
     const manager = new BoxManager(
       boxRepository as any,
@@ -179,5 +184,24 @@ describe('BoxManager runner draining', () => {
 
     expect(boxRepository.find).toHaveBeenCalledTimes(2)
     expect(boxRepository.updateWhere).toHaveBeenCalledWith(stopped.id, expect.any(Object))
+  })
+
+  it('limits concurrent box draining operations', async () => {
+    const { manager, boxRepository } = createManager()
+    boxRepository.find
+      .mockResolvedValueOnce(Array.from({ length: 20 }, (_, index) => createBox(`box-${index}`, BoxState.STOPPED)))
+      .mockResolvedValueOnce([])
+    let active = 0
+    let maxActive = 0
+    jest.spyOn(manager as any, 'drainBox').mockImplementation(async () => {
+      active += 1
+      maxActive = Math.max(maxActive, active)
+      await new Promise((resolve) => setImmediate(resolve))
+      active -= 1
+    })
+
+    await manager.drainingRunnerBoxesCheck()
+
+    expect(maxActive).toBe(10)
   })
 })

--- a/apps/api/src/box/managers/box.manager.draining.spec.ts
+++ b/apps/api/src/box/managers/box.manager.draining.spec.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BoxDesiredState } from '../enums/box-desired-state.enum'
+import { BoxState } from '../enums/box-state.enum'
+import { Box } from '../entities/box.entity'
+import { DONT_SYNC_AGAIN } from './box-actions/box.action'
+import { BoxManager } from './box.manager'
+
+describe('BoxManager runner draining', () => {
+  const createBox = (id: string, state: BoxState): Box => {
+    const box = new Box('us', id)
+    box.id = id
+    box.runnerId = 'runner-1'
+    box.state = state
+    box.desiredState = state as unknown as BoxDesiredState
+    box.pending = false
+    return box
+  }
+
+  const createManager = (force = false, cursor = '0') => {
+    const boxRepository = {
+      find: jest.fn(),
+      findOneOrFail: jest.fn(),
+      updateWhere: jest.fn().mockResolvedValue(undefined),
+    }
+    const runnerService = {
+      findDrainingPaginated: jest.fn().mockResolvedValue([{ id: 'runner-1' }]),
+      getRunnerApiVersion: jest.fn().mockResolvedValue('2'),
+    }
+    const redisLockProvider = {
+      lock: jest.fn().mockResolvedValue(true),
+      unlock: jest.fn().mockResolvedValue(undefined),
+    }
+    const redis = {
+      get: jest.fn().mockResolvedValue(cursor),
+      set: jest.fn().mockResolvedValue('OK'),
+    }
+    const configService = { get: jest.fn().mockReturnValue(force) }
+    const destroyAction = { run: jest.fn().mockResolvedValue(DONT_SYNC_AGAIN) }
+    const manager = new BoxManager(
+      boxRepository as any,
+      runnerService as any,
+      {} as any,
+      redisLockProvider as any,
+      {} as any,
+      {} as any,
+      destroyAction as any,
+      redis as any,
+      configService as any,
+    )
+
+    return { manager, boxRepository, runnerService, redisLockProvider, redis, destroyAction }
+  }
+
+  it('destroys stopped and errored boxes but leaves started boxes untouched by default', async () => {
+    const { manager, boxRepository } = createManager()
+    const stopped = createBox('stopped', BoxState.STOPPED)
+    const errored = createBox('errored', BoxState.ERROR)
+    boxRepository.find.mockResolvedValue([stopped, errored])
+    jest.spyOn(manager, 'syncInstanceState').mockResolvedValue(undefined)
+
+    await manager.drainingRunnerBoxesCheck()
+
+    expect(boxRepository.find).toHaveBeenCalledTimes(1)
+    expect(boxRepository.updateWhere).toHaveBeenCalledTimes(2)
+    expect(boxRepository.updateWhere).toHaveBeenCalledWith(
+      'stopped',
+      expect.objectContaining({ updateData: expect.objectContaining({ desiredState: BoxDesiredState.DESTROYED }) }),
+    )
+  })
+
+  it('requests a stop for started boxes when force draining is enabled', async () => {
+    const { manager, boxRepository } = createManager(true)
+    const started = createBox('started', BoxState.STARTED)
+    boxRepository.find.mockResolvedValue([started])
+    jest.spyOn(manager, 'syncInstanceState').mockResolvedValue(undefined)
+
+    await manager.drainingRunnerBoxesCheck()
+
+    expect(boxRepository.updateWhere).toHaveBeenCalledWith(
+      'started',
+      expect.objectContaining({
+        updateData: expect.objectContaining({ desiredState: BoxDesiredState.STOPPED, pending: true }),
+      }),
+    )
+    expect(manager.syncInstanceState).toHaveBeenCalledWith('started', true)
+  })
+
+  it('does no work when another worker owns the draining lock', async () => {
+    const { manager, boxRepository, runnerService, redisLockProvider } = createManager()
+    redisLockProvider.lock.mockResolvedValueOnce(false)
+
+    await manager.drainingRunnerBoxesCheck()
+
+    expect(runnerService.findDrainingPaginated).not.toHaveBeenCalled()
+    expect(boxRepository.find).not.toHaveBeenCalled()
+  })
+
+  it('rotates the draining runner cursor so stuck first-page runners cannot starve later runners', async () => {
+    const { manager, boxRepository, runnerService, redis } = createManager(false, '10')
+    boxRepository.find.mockResolvedValue([])
+
+    await manager.drainingRunnerBoxesCheck()
+
+    expect(runnerService.findDrainingPaginated).toHaveBeenCalledWith(10, 10)
+    expect(redis.set).toHaveBeenCalledWith('draining-runner-boxes-skip', 11)
+  })
+
+  it('resets the draining runner cursor after reaching an empty page', async () => {
+    const { manager, runnerService, redis } = createManager(false, '20')
+    runnerService.findDrainingPaginated.mockResolvedValue([])
+
+    await manager.drainingRunnerBoxesCheck()
+
+    expect(runnerService.findDrainingPaginated).toHaveBeenCalledWith(20, 10)
+    expect(redis.set).toHaveBeenCalledWith('draining-runner-boxes-skip', 0)
+  })
+
+  it('reconciles an errored box whose desired state is destroyed', async () => {
+    const { manager, boxRepository, destroyAction } = createManager()
+    const box = createBox('errored', BoxState.ERROR)
+    box.desiredState = BoxDesiredState.DESTROYED
+    box.pending = true
+    boxRepository.findOneOrFail.mockResolvedValue(box)
+
+    await manager.syncInstanceState(box.id)
+
+    expect(destroyAction.run).toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/box/managers/box.manager.draining.spec.ts
+++ b/apps/api/src/box/managers/box.manager.draining.spec.ts
@@ -90,6 +90,23 @@ describe('BoxManager runner draining', () => {
     expect(manager.syncInstanceState).toHaveBeenCalledWith('started', true)
   })
 
+  it('uses the safe destroy path for recoverable errors until stopped recovery is supported', async () => {
+    const { manager, boxRepository } = createManager()
+    const errored = createBox('recoverable', BoxState.ERROR)
+    errored.recoverable = true
+    boxRepository.find.mockResolvedValue([errored])
+    jest.spyOn(manager, 'syncInstanceState').mockResolvedValue(undefined)
+
+    await manager.drainingRunnerBoxesCheck()
+
+    expect(boxRepository.updateWhere).toHaveBeenCalledWith(
+      errored.id,
+      expect.objectContaining({
+        updateData: expect.objectContaining({ desiredState: BoxDesiredState.DESTROYED }),
+      }),
+    )
+  })
+
   it('does no work when another worker owns the draining lock', async () => {
     const { manager, boxRepository, runnerService, redisLockProvider } = createManager()
     redisLockProvider.lock.mockResolvedValueOnce(false)

--- a/apps/api/src/box/managers/box.manager.draining.spec.ts
+++ b/apps/api/src/box/managers/box.manager.draining.spec.ts
@@ -60,12 +60,12 @@ describe('BoxManager runner draining', () => {
     const { manager, boxRepository } = createManager()
     const stopped = createBox('stopped', BoxState.STOPPED)
     const errored = createBox('errored', BoxState.ERROR)
-    boxRepository.find.mockResolvedValue([stopped, errored])
+    boxRepository.find.mockResolvedValueOnce([stopped, errored]).mockResolvedValueOnce([])
     jest.spyOn(manager, 'syncInstanceState').mockResolvedValue(undefined)
 
     await manager.drainingRunnerBoxesCheck()
 
-    expect(boxRepository.find).toHaveBeenCalledTimes(1)
+    expect(boxRepository.find).toHaveBeenCalledTimes(2)
     expect(boxRepository.updateWhere).toHaveBeenCalledTimes(2)
     expect(boxRepository.updateWhere).toHaveBeenCalledWith(
       'stopped',
@@ -76,7 +76,7 @@ describe('BoxManager runner draining', () => {
   it('requests a stop for started boxes when force draining is enabled', async () => {
     const { manager, boxRepository } = createManager(true)
     const started = createBox('started', BoxState.STARTED)
-    boxRepository.find.mockResolvedValue([started])
+    boxRepository.find.mockResolvedValueOnce([started]).mockResolvedValueOnce([])
     jest.spyOn(manager, 'syncInstanceState').mockResolvedValue(undefined)
 
     await manager.drainingRunnerBoxesCheck()
@@ -94,7 +94,7 @@ describe('BoxManager runner draining', () => {
     const { manager, boxRepository } = createManager()
     const errored = createBox('recoverable', BoxState.ERROR)
     errored.recoverable = true
-    boxRepository.find.mockResolvedValue([errored])
+    boxRepository.find.mockResolvedValueOnce([errored]).mockResolvedValueOnce([])
     jest.spyOn(manager, 'syncInstanceState').mockResolvedValue(undefined)
 
     await manager.drainingRunnerBoxesCheck()
@@ -154,12 +154,30 @@ describe('BoxManager runner draining', () => {
     const box = createBox('retry-destroy', BoxState.ERROR)
     box.desiredState = BoxDesiredState.DESTROYED
     box.pending = true
-    boxRepository.find.mockResolvedValue([box])
+    boxRepository.find.mockResolvedValueOnce([]).mockResolvedValueOnce([box])
     const sync = jest.spyOn(manager, 'syncInstanceState').mockResolvedValue(undefined)
 
     await manager.drainingRunnerBoxesCheck()
 
     expect(sync).toHaveBeenCalledWith(box.id, false)
     expect(boxRepository.updateWhere).not.toHaveBeenCalled()
+  })
+
+  it('keeps fresh drain candidates separate from a full destroy-retry batch', async () => {
+    const { manager, boxRepository } = createManager()
+    const stopped = createBox('fresh-stopped', BoxState.STOPPED)
+    const retries = Array.from({ length: 100 }, (_, index) => {
+      const box = createBox(`retry-${index}`, BoxState.ERROR)
+      box.desiredState = BoxDesiredState.DESTROYED
+      box.pending = true
+      return box
+    })
+    boxRepository.find.mockResolvedValueOnce([stopped]).mockResolvedValueOnce(retries)
+    jest.spyOn(manager, 'syncInstanceState').mockResolvedValue(undefined)
+
+    await manager.drainingRunnerBoxesCheck()
+
+    expect(boxRepository.find).toHaveBeenCalledTimes(2)
+    expect(boxRepository.updateWhere).toHaveBeenCalledWith(stopped.id, expect.any(Object))
   })
 })

--- a/apps/api/src/box/managers/box.manager.ts
+++ b/apps/api/src/box/managers/box.manager.ts
@@ -252,43 +252,58 @@ export class BoxManager implements TrackableJobExecutions, OnApplicationShutdown
 
       await this.redis.set(cursorKey, skip + drainingRunners.length)
       const force = this.configService.get('draining.force')
+      const runnerConcurrency = this.configService.get('draining.runnerConcurrency')
+      const boxConcurrency = this.configService.get('draining.boxConcurrency')
 
-      await Promise.allSettled(
-        drainingRunners.map(async (runner) => {
-          try {
-            const states = force
-              ? [BoxState.STARTED, BoxState.STOPPED, BoxState.ERROR]
-              : [BoxState.STOPPED, BoxState.ERROR]
-            const [boxes, destroyRetries] = await Promise.all([
-              this.boxRepository.find({
-                where: {
-                  runnerId: runner.id,
-                  state: In(states),
-                  desiredState: Not(BoxDesiredState.DESTROYED),
-                  pending: false,
-                },
-                take: 100,
-              }),
-              this.boxRepository.find({
-                where: {
-                  runnerId: runner.id,
-                  state: BoxState.ERROR,
-                  desiredState: BoxDesiredState.DESTROYED,
-                  pending: true,
-                },
-                take: 100,
-              }),
-            ])
+      await this.forEachConcurrent(drainingRunners, runnerConcurrency, async (runner) => {
+        try {
+          const states = force
+            ? [BoxState.STARTED, BoxState.STOPPED, BoxState.ERROR]
+            : [BoxState.STOPPED, BoxState.ERROR]
+          const [boxes, destroyRetries] = await Promise.all([
+            this.boxRepository.find({
+              where: {
+                runnerId: runner.id,
+                state: In(states),
+                desiredState: Not(BoxDesiredState.DESTROYED),
+                pending: false,
+              },
+              take: 100,
+            }),
+            this.boxRepository.find({
+              where: {
+                runnerId: runner.id,
+                state: BoxState.ERROR,
+                desiredState: BoxDesiredState.DESTROYED,
+                pending: true,
+              },
+              take: 100,
+            }),
+          ])
 
-            await Promise.allSettled([...boxes, ...destroyRetries].map((box) => this.drainBox(box, force)))
-          } catch (error) {
-            this.logger.error(`Error draining boxes from runner ${runner.id}:`, error)
-          }
-        }),
-      )
+          await this.forEachConcurrent([...boxes, ...destroyRetries], boxConcurrency, (box) =>
+            this.drainBox(box, force),
+          )
+        } catch (error) {
+          this.logger.error(`Error draining boxes from runner ${runner.id}:`, error)
+        }
+      })
     } finally {
       await this.redisLockProvider.unlock(lockKey)
     }
+  }
+
+  private async forEachConcurrent<T>(items: T[], concurrency: number, process: (item: T) => Promise<void>) {
+    const queue = [...items]
+    const worker = async () => {
+      while (queue.length > 0) {
+        const item = queue.shift()
+        if (item !== undefined) {
+          await process(item).catch((error) => this.logger.error('Error processing draining item:', error))
+        }
+      }
+    }
+    await Promise.allSettled(Array.from({ length: Math.min(Math.max(concurrency, 1), items.length) }, worker))
   }
 
   private async drainBox(box: Box, force: boolean): Promise<void> {

--- a/apps/api/src/box/managers/box.manager.ts
+++ b/apps/api/src/box/managers/box.manager.ts
@@ -259,25 +259,28 @@ export class BoxManager implements TrackableJobExecutions, OnApplicationShutdown
             const states = force
               ? [BoxState.STARTED, BoxState.STOPPED, BoxState.ERROR]
               : [BoxState.STOPPED, BoxState.ERROR]
-            const boxes = await this.boxRepository.find({
-              where: [
-                {
+            const [boxes, destroyRetries] = await Promise.all([
+              this.boxRepository.find({
+                where: {
                   runnerId: runner.id,
                   state: In(states),
                   desiredState: Not(BoxDesiredState.DESTROYED),
                   pending: false,
                 },
-                {
+                take: 100,
+              }),
+              this.boxRepository.find({
+                where: {
                   runnerId: runner.id,
                   state: BoxState.ERROR,
                   desiredState: BoxDesiredState.DESTROYED,
                   pending: true,
                 },
-              ],
-              take: 100,
-            })
+                take: 100,
+              }),
+            ])
 
-            await Promise.allSettled(boxes.map((box) => this.drainBox(box, force)))
+            await Promise.allSettled([...boxes, ...destroyRetries].map((box) => this.drainBox(box, force)))
           } catch (error) {
             this.logger.error(`Error draining boxes from runner ${runner.id}:`, error)
           }

--- a/apps/api/src/box/managers/box.manager.ts
+++ b/apps/api/src/box/managers/box.manager.ts
@@ -6,7 +6,10 @@
 
 import { Injectable, Logger, OnApplicationShutdown } from '@nestjs/common'
 import { Cron, CronExpression } from '@nestjs/schedule'
+import { InjectRedis } from '@nestjs-modules/ioredis'
 import { randomUUID } from 'crypto'
+import { Redis } from 'ioredis'
+import { In, Not } from 'typeorm'
 
 import { BoxConflictError } from '../errors/box-conflict.error'
 import { JobConflictError } from '../errors/job-conflict.error'
@@ -41,6 +44,7 @@ import { getStateChangeLockKey } from '../utils/lock-key.util'
 import { OnAsyncEvent } from '../../common/decorators/on-async-event.decorator'
 import { sanitizeBoxError } from '../utils/sanitize-error.util'
 import { Box } from '../entities/box.entity'
+import { TypedConfigService } from '../../config/typed-config.service'
 
 @Injectable()
 export class BoxManager implements TrackableJobExecutions, OnApplicationShutdown {
@@ -56,6 +60,8 @@ export class BoxManager implements TrackableJobExecutions, OnApplicationShutdown
     private readonly boxStartAction: BoxStartAction,
     private readonly boxStopAction: BoxStopAction,
     private readonly boxDestroyAction: BoxDestroyAction,
+    @InjectRedis() private readonly redis: Redis,
+    private readonly configService: TypedConfigService,
   ) {}
 
   async onApplicationShutdown() {
@@ -224,6 +230,102 @@ export class BoxManager implements TrackableJobExecutions, OnApplicationShutdown
     }
   }
 
+  @Cron(CronExpression.EVERY_10_SECONDS, { name: 'draining-runner-boxes-check' })
+  @TrackJobExecution()
+  @LogExecution('draining-runner-boxes-check')
+  @WithInstrumentation()
+  async drainingRunnerBoxesCheck(): Promise<void> {
+    const lockKey = 'draining-runner-boxes-check'
+    if (!(await this.redisLockProvider.lock(lockKey, 10 * 60))) {
+      return
+    }
+
+    try {
+      const cursorKey = 'draining-runner-boxes-skip'
+      const skip = Number((await this.redis.get(cursorKey)) || 0)
+      const drainingRunners = await this.runnerService.findDrainingPaginated(skip, 10)
+
+      if (drainingRunners.length === 0) {
+        await this.redis.set(cursorKey, 0)
+        return
+      }
+
+      await this.redis.set(cursorKey, skip + drainingRunners.length)
+      const force = this.configService.get('draining.force')
+
+      await Promise.allSettled(
+        drainingRunners.map(async (runner) => {
+          try {
+            const states = force
+              ? [BoxState.STARTED, BoxState.STOPPED, BoxState.ERROR]
+              : [BoxState.STOPPED, BoxState.ERROR]
+            const boxes = await this.boxRepository.find({
+              where: {
+                runnerId: runner.id,
+                state: In(states),
+                desiredState: Not(BoxDesiredState.DESTROYED),
+                pending: false,
+              },
+              take: 100,
+            })
+
+            await Promise.allSettled(boxes.map((box) => this.drainBox(box, force)))
+          } catch (error) {
+            this.logger.error(`Error draining boxes from runner ${runner.id}:`, error)
+          }
+        }),
+      )
+    } finally {
+      await this.redisLockProvider.unlock(lockKey)
+    }
+  }
+
+  private async drainBox(box: Box, force: boolean): Promise<void> {
+    const lockKey = getStateChangeLockKey(box.id)
+    if (!(await this.redisLockProvider.lock(lockKey, 30))) {
+      return
+    }
+
+    let forceStop = false
+    let shouldSync = false
+    try {
+      if (box.state === BoxState.STARTED && force) {
+        await this.boxRepository.updateWhere(box.id, {
+          updateData: { desiredState: BoxDesiredState.STOPPED, pending: true },
+          whereCondition: {
+            state: BoxState.STARTED,
+            desiredState: BoxDesiredState.STARTED,
+            pending: false,
+          },
+        })
+        forceStop = true
+        shouldSync = true
+      } else if ([BoxState.STOPPED, BoxState.ERROR].includes(box.state)) {
+        await this.boxRepository.updateWhere(box.id, {
+          updateData: Box.getSoftDeleteUpdate(box),
+          whereCondition: {
+            state: box.state,
+            desiredState: box.desiredState,
+            pending: false,
+          },
+        })
+        shouldSync = true
+      }
+    } catch (error) {
+      this.logger.error(`Error preparing box ${box.id} for runner drain:`, error)
+    } finally {
+      await this.redisLockProvider.unlock(lockKey)
+    }
+
+    if (shouldSync) {
+      try {
+        await this.syncInstanceState(box.id, forceStop)
+      } catch (error) {
+        this.logger.error(`Error syncing box ${box.id} during runner drain:`, error)
+      }
+    }
+  }
+
   @Cron(CronExpression.EVERY_10_SECONDS, { name: 'sync-states' })
   @TrackJobExecution()
   @WithInstrumentation()
@@ -331,7 +433,10 @@ export class BoxManager implements TrackableJobExecutions, OnApplicationShutdown
       })
 
       while (new Date().getTime() - startedAt.getTime() <= 10000) {
-        if ([BoxState.DESTROYED, BoxState.RESIZING].includes(box.state) || box.state === BoxState.ERROR) {
+        if (
+          [BoxState.DESTROYED, BoxState.RESIZING].includes(box.state) ||
+          (box.state === BoxState.ERROR && box.desiredState !== BoxDesiredState.DESTROYED)
+        ) {
           // Break sync loop if box reaches a terminal state.
           break
         }

--- a/apps/api/src/box/managers/box.manager.ts
+++ b/apps/api/src/box/managers/box.manager.ts
@@ -260,12 +260,20 @@ export class BoxManager implements TrackableJobExecutions, OnApplicationShutdown
               ? [BoxState.STARTED, BoxState.STOPPED, BoxState.ERROR]
               : [BoxState.STOPPED, BoxState.ERROR]
             const boxes = await this.boxRepository.find({
-              where: {
-                runnerId: runner.id,
-                state: In(states),
-                desiredState: Not(BoxDesiredState.DESTROYED),
-                pending: false,
-              },
+              where: [
+                {
+                  runnerId: runner.id,
+                  state: In(states),
+                  desiredState: Not(BoxDesiredState.DESTROYED),
+                  pending: false,
+                },
+                {
+                  runnerId: runner.id,
+                  state: BoxState.ERROR,
+                  desiredState: BoxDesiredState.DESTROYED,
+                  pending: true,
+                },
+              ],
               take: 100,
             })
 
@@ -299,6 +307,12 @@ export class BoxManager implements TrackableJobExecutions, OnApplicationShutdown
           },
         })
         forceStop = true
+        shouldSync = true
+      } else if (
+        box.state === BoxState.ERROR &&
+        box.desiredState === BoxDesiredState.DESTROYED &&
+        box.pending
+      ) {
         shouldSync = true
       } else if ([BoxState.STOPPED, BoxState.ERROR].includes(box.state)) {
         await this.boxRepository.updateWhere(box.id, {

--- a/apps/api/src/box/services/box.service.spec.ts
+++ b/apps/api/src/box/services/box.service.spec.ts
@@ -7,6 +7,7 @@ import { BadRequestException, ForbiddenException } from '@nestjs/common'
 import { BoxService } from './box.service'
 import { BoxState } from '../enums/box-state.enum'
 import { BoxDesiredState } from '../enums/box-desired-state.enum'
+import { RunnerState } from '../enums/runner-state.enum'
 import { BoxEvents } from '../constants/box-events.constants'
 
 // ensureStartedForProxy touches boxRepository + eventEmitter +
@@ -293,6 +294,17 @@ describe('BoxService network tunnel URLs', () => {
 describe('BoxService public defaults', () => {
   function makeCreateService() {
     const boxRepository = { insert: jest.fn(async (box: any) => box) } as any
+    const runner = { id: 'runner-1', draining: false, state: RunnerState.READY }
+    const runnerService = {
+      getRandomAvailableRunner: jest.fn().mockResolvedValue(runner),
+      findOneOrFail: jest.fn().mockResolvedValue(runner),
+    }
+    const redisLockProvider = {
+      acquireLease: jest.fn().mockResolvedValue({
+        signal: new AbortController().signal,
+        release: jest.fn().mockResolvedValue(undefined),
+      }),
+    }
     const service = Object.create(BoxService.prototype) as BoxService
     Object.assign(service as any, {
       getValidatedOrDefaultRegion: jest.fn().mockResolvedValue({ id: 'region-1' }),
@@ -303,12 +315,13 @@ describe('BoxService public defaults', () => {
         rollbackPendingUsage: jest.fn().mockResolvedValue(undefined),
       },
       redis: { exists: jest.fn().mockResolvedValue(1) },
-      runnerService: { getRandomAvailableRunner: jest.fn().mockResolvedValue({ id: 'runner-1' }) },
+      runnerService,
+      redisLockProvider,
       boxRepository,
       eventEmitter: { emitAsync: jest.fn().mockResolvedValue(undefined) },
       toBoxDto: jest.fn((box) => box),
     })
-    return { service, boxRepository }
+    return { service, boxRepository, runnerService, redisLockProvider }
   }
 
   it.each([
@@ -320,6 +333,19 @@ describe('BoxService public defaults', () => {
     await service.create({ name: 'fresh-box', public: requestedPublic } as any, { id: 'org-1' } as any)
 
     expect(boxRepository.insert).toHaveBeenCalledWith(expect.objectContaining({ public: expectedPublic }))
+  })
+
+  it('rechecks runner eligibility under the assignment fence before inserting', async () => {
+    const { service, boxRepository, runnerService, redisLockProvider } = makeCreateService()
+    runnerService.findOneOrFail
+      .mockResolvedValueOnce({ id: 'runner-1', draining: true, state: RunnerState.READY })
+      .mockResolvedValueOnce({ id: 'runner-1', draining: false, state: RunnerState.READY })
+
+    await service.create({ name: 'fenced-box' } as any, { id: 'org-1' } as any)
+
+    expect(redisLockProvider.acquireLease).toHaveBeenCalledWith('runner:runner-1:box-assignment', 30)
+    expect(runnerService.findOneOrFail).toHaveBeenCalledTimes(2)
+    expect(boxRepository.insert).toHaveBeenCalledTimes(1)
   })
 
   it.each([

--- a/apps/api/src/box/services/box.service.spec.ts
+++ b/apps/api/src/box/services/box.service.spec.ts
@@ -297,7 +297,7 @@ describe('BoxService public defaults', () => {
     const runner = { id: 'runner-1', draining: false, state: RunnerState.READY }
     const runnerService = {
       getRandomAvailableRunner: jest.fn().mockResolvedValue(runner),
-      findOneOrFail: jest.fn().mockResolvedValue(runner),
+      findOneUncachedOrFail: jest.fn().mockResolvedValue(runner),
     }
     const redisLockProvider = {
       acquireLease: jest.fn().mockResolvedValue({
@@ -337,15 +337,32 @@ describe('BoxService public defaults', () => {
 
   it('rechecks runner eligibility under the assignment fence before inserting', async () => {
     const { service, boxRepository, runnerService, redisLockProvider } = makeCreateService()
-    runnerService.findOneOrFail
+    runnerService.findOneUncachedOrFail
       .mockResolvedValueOnce({ id: 'runner-1', draining: true, state: RunnerState.READY })
       .mockResolvedValueOnce({ id: 'runner-1', draining: false, state: RunnerState.READY })
 
     await service.create({ name: 'fenced-box' } as any, { id: 'org-1' } as any)
 
     expect(redisLockProvider.acquireLease).toHaveBeenCalledWith('runner:runner-1:box-assignment', 30)
-    expect(runnerService.findOneOrFail).toHaveBeenCalledTimes(2)
+    expect(runnerService.findOneUncachedOrFail).toHaveBeenCalledTimes(2)
     expect(boxRepository.insert).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns a committed box when the assignment lease aborts immediately after insert', async () => {
+    const { service, boxRepository, redisLockProvider } = makeCreateService()
+    const controller = new AbortController()
+    redisLockProvider.acquireLease.mockResolvedValue({
+      signal: controller.signal,
+      release: jest.fn().mockResolvedValue(undefined),
+    })
+    boxRepository.insert.mockImplementation(async (box: any) => {
+      controller.abort(new Error('lease lost after commit'))
+      return box
+    })
+
+    await expect(service.create({ name: 'committed-box' } as any, { id: 'org-1' } as any)).resolves.toEqual(
+      expect.objectContaining({ name: 'committed-box' }),
+    )
   })
 
   it.each([

--- a/apps/api/src/box/services/box.service.ts
+++ b/apps/api/src/box/services/box.service.ts
@@ -139,21 +139,30 @@ export class BoxService {
         continue
       }
 
-      const inserted = await withRedisLockLease(lease, async (signal) => {
-        const currentRunner = await this.runnerService.findOneOrFail(runner.id)
-        if (currentRunner.draining || currentRunner.state !== RunnerState.READY) {
-          excludedRunnerIds.push(runner.id)
-          return null
-        }
+      let committed: Box | null = null
+      try {
+        const inserted = await withRedisLockLease(lease, async (signal) => {
+          const currentRunner = await this.runnerService.findOneUncachedOrFail(runner.id)
+          if (currentRunner.draining || currentRunner.state !== RunnerState.READY) {
+            excludedRunnerIds.push(runner.id)
+            return null
+          }
 
-        signal.throwIfAborted()
-        box.runnerId = currentRunner.id
-        const result = await persist()
-        signal.throwIfAborted()
-        return result
-      })
-      if (inserted) {
-        return inserted
+          signal.throwIfAborted()
+          box.runnerId = currentRunner.id
+          committed = await persist()
+          return committed
+        })
+        if (inserted) {
+          return inserted
+        }
+      } catch (error) {
+        // Once insert committed, returning the entity keeps quota realization
+        // and CREATED event handling consistent even if the lease is lost while releasing.
+        if (committed) {
+          return committed
+        }
+        throw error
       }
     }
 

--- a/apps/api/src/box/services/box.service.ts
+++ b/apps/api/src/box/services/box.service.ts
@@ -12,8 +12,9 @@ import { persistWithGeneratedBoxName } from '../utils/box-name-generator'
 import { CreateBoxDto } from '../dto/create-box.dto'
 import { BoxState } from '../enums/box-state.enum'
 import { BoxClass } from '../enums/box-class.enum'
+import { RunnerState } from '../enums/runner-state.enum'
 import { BoxDesiredState } from '../enums/box-desired-state.enum'
-import { RunnerService } from './runner.service'
+import { GetRunnerParams, RunnerService } from './runner.service'
 import { BoxError } from '../../exceptions/box-error.exception'
 import { BadRequestError } from '../../exceptions/bad-request.exception'
 import { Cron, CronExpression } from '@nestjs/schedule'
@@ -50,11 +51,12 @@ import {
 } from '../dto/list-boxes-query.dto'
 import { createRangeFilter } from '../../common/utils/range-filter'
 import { LogExecution } from '../../common/decorators/log-execution.decorator'
-import { RedisLockProvider } from '../common/redis-lock.provider'
+import { RedisLockProvider, withRedisLockLease } from '../common/redis-lock.provider'
 import { customAlphabet as customNanoid, nanoid, urlAlphabet } from 'nanoid'
 import { WithInstrumentation } from '../../common/decorators/otel.decorator'
 import { validateMountPaths, validateSubpaths } from '../utils/volume-mount-path-validation.util'
 import { BoxRepository } from '../repositories/box.repository'
+import { getRunnerAssignmentLockKey } from '../utils/lock-key.util'
 import { Job } from '../entities/job.entity'
 import { JobService } from './job.service'
 import { JobStatus, JobType, ResourceType } from '../dto/job.dto'
@@ -122,6 +124,42 @@ export class BoxService {
     return `box:${id}:state-change`
   }
 
+  private async persistWithRunnerAssignmentFence(
+    box: Box,
+    runnerParams: GetRunnerParams,
+    persist: () => Promise<Box>,
+  ): Promise<Box> {
+    const excludedRunnerIds = [...(runnerParams.excludedRunnerIds ?? [])]
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const runner = await this.runnerService.getRandomAvailableRunner({ ...runnerParams, excludedRunnerIds })
+      const lockKey = getRunnerAssignmentLockKey(runner.id)
+      const lease = await this.redisLockProvider.acquireLease(lockKey, 30)
+      if (!lease) {
+        excludedRunnerIds.push(runner.id)
+        continue
+      }
+
+      const inserted = await withRedisLockLease(lease, async (signal) => {
+        const currentRunner = await this.runnerService.findOneOrFail(runner.id)
+        if (currentRunner.draining || currentRunner.state !== RunnerState.READY) {
+          excludedRunnerIds.push(runner.id)
+          return null
+        }
+
+        signal.throwIfAborted()
+        box.runnerId = currentRunner.id
+        const result = await persist()
+        signal.throwIfAborted()
+        return result
+      })
+      if (inserted) {
+        return inserted
+      }
+    }
+
+    throw new BadRequestError('No runner remained available while assigning the box')
+  }
+
   private assertBoxNotErrored(box: Box): void {
     if (box.state === BoxState.ERROR) {
       throw new BoxError('Box is in an errored state')
@@ -144,17 +182,13 @@ export class BoxService {
     box.mem = warmPoolItem.mem
     box.disk = warmPoolItem.disk
 
-    // TODO(image-rewrite): box image resolution removed with the image subsystem; rebuild here.
-    const runner = await this.runnerService.getRandomAvailableRunner({
-      regions: [box.region],
-      boxClass: box.class,
-    })
-
-    box.runnerId = runner.id
     box.pending = true
 
-    await this.boxRepository.insert(box)
-    return box
+    return this.persistWithRunnerAssignmentFence(
+      box,
+      { regions: [box.region], boxClass: box.class },
+      () => this.boxRepository.insert(box),
+    )
   }
 
   async create(createBoxDto: CreateBoxDto, organization: Organization): Promise<BoxDto> {
@@ -219,11 +253,6 @@ export class BoxService {
         }
       }
 
-      const runner = await this.runnerService.getRandomAvailableRunner({
-        regions: [region.id],
-        boxClass,
-      })
-
       const box = new Box(region.id, createBoxDto.name)
 
       box.organizationId = organization.id
@@ -264,18 +293,22 @@ export class BoxService {
         box.volumes = this.resolveVolumes(createBoxDto.volumes)
       }
 
-      box.runnerId = runner.id
       box.pending = true
 
       // No caller-provided name -> assign a fun default (e.g. "cozy-otter"),
       // falling back to "cozy-otter-{boxId}" if it collides with the per-org
       // @Unique(['organizationId', 'name']) constraint.
-      const insertedBox = createBoxDto.name
-        ? await this.boxRepository.insert(box)
-        : await persistWithGeneratedBoxName(box.id, (name) => {
-            box.name = name
-            return this.boxRepository.insert(box)
-          })
+      const insertedBox = await this.persistWithRunnerAssignmentFence(
+        box,
+        { regions: [region.id], boxClass },
+        () =>
+          createBoxDto.name
+            ? this.boxRepository.insert(box)
+            : persistWithGeneratedBoxName(box.id, (name) => {
+                box.name = name
+                return this.boxRepository.insert(box)
+              }),
+      )
 
       this.eventEmitter
         .emitAsync(BoxEvents.CREATED, new BoxCreatedEvent(insertedBox))

--- a/apps/api/src/box/services/runner.service.decommission.spec.ts
+++ b/apps/api/src/box/services/runner.service.decommission.spec.ts
@@ -44,7 +44,7 @@ describe('RunnerService decommission verification', () => {
       redisLockProvider as any,
       configService as any,
       {} as any,
-      {} as any,
+      { emit: jest.fn() } as any,
       dataSource as any,
       redis as any,
     )
@@ -102,7 +102,7 @@ describe('RunnerService decommission verification', () => {
 
   it('does not decommission when draining is cleared before final verification', async () => {
     const { service, runnerRepository, boxRepository } = createService(0, '2')
-    runnerRepository.findOneOrFail.mockResolvedValue({ id: 'runner-1', draining: false, state: RunnerState.READY })
+    runnerRepository.findOne.mockResolvedValue({ id: 'runner-1', draining: false, state: RunnerState.READY })
 
     await (service as any).handleCheckDecommissionRunners()
 
@@ -120,5 +120,27 @@ describe('RunnerService decommission verification', () => {
       30,
       expect.any(AbortSignal),
     )
+  })
+
+  it('keeps a runner decommissioned when an in-flight health write completes later', async () => {
+    const { service, runnerRepository } = createService(0)
+    runnerRepository.findOne.mockResolvedValue({ id: 'runner-1', state: RunnerState.READY })
+
+    await service.updateRunnerHealth('runner-1')
+
+    expect(runnerRepository.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'runner-1',
+        state: expect.any(Object),
+      }),
+      expect.objectContaining({ state: RunnerState.READY }),
+    )
+  })
+
+  it('translates a missing uncached runner into NotFoundException', async () => {
+    const { service, runnerRepository } = createService(0)
+    runnerRepository.findOne.mockResolvedValue(null)
+
+    await expect(service.findOneUncachedOrFail('missing')).rejects.toMatchObject({ status: 404 })
   })
 })

--- a/apps/api/src/box/services/runner.service.decommission.spec.ts
+++ b/apps/api/src/box/services/runner.service.decommission.spec.ts
@@ -21,6 +21,10 @@ describe('RunnerService decommission verification', () => {
     const redisLockProvider = {
       lock: jest.fn().mockResolvedValue(true),
       unlock: jest.fn().mockResolvedValue(undefined),
+      acquireLease: jest.fn().mockResolvedValue({
+        signal: new AbortController().signal,
+        release: jest.fn().mockResolvedValue(undefined),
+      }),
     }
     const configService = { getOrThrow: jest.fn().mockReturnValue(1) }
     const redis = {
@@ -79,5 +83,16 @@ describe('RunnerService decommission verification', () => {
     await service.updateDrainingStatus('runner-1', false)
 
     expect(redis.del).toHaveBeenCalledWith('runner:draining-check:runner-1')
+  })
+
+  it('does not publish decommission when an assignment appears after taking the assignment fence', async () => {
+    const { service, runnerRepository, boxRepository, redis, redisLockProvider } = createService(0, '2')
+    boxRepository.count.mockResolvedValueOnce(0).mockResolvedValueOnce(1)
+
+    await (service as any).handleCheckDecommissionRunners()
+
+    expect(runnerRepository.update).not.toHaveBeenCalled()
+    expect(redis.set).toHaveBeenCalledWith('runner:draining-check:runner-1', '0', 'EX', 600)
+    expect(redisLockProvider.acquireLease).toHaveBeenCalledWith('runner:runner-1:box-assignment', 30)
   })
 })

--- a/apps/api/src/box/services/runner.service.decommission.spec.ts
+++ b/apps/api/src/box/services/runner.service.decommission.spec.ts
@@ -25,6 +25,10 @@ describe('RunnerService decommission verification', () => {
         signal: new AbortController().signal,
         release: jest.fn().mockResolvedValue(undefined),
       }),
+      waitForLease: jest.fn().mockResolvedValue({
+        signal: new AbortController().signal,
+        release: jest.fn().mockResolvedValue(undefined),
+      }),
     }
     const configService = { getOrThrow: jest.fn().mockReturnValue(1) }
     const redis = {
@@ -94,5 +98,27 @@ describe('RunnerService decommission verification', () => {
     expect(runnerRepository.update).not.toHaveBeenCalled()
     expect(redis.set).toHaveBeenCalledWith('runner:draining-check:runner-1', '0', 'EX', 600)
     expect(redisLockProvider.acquireLease).toHaveBeenCalledWith('runner:runner-1:box-assignment', 30)
+  })
+
+  it('does not decommission when draining is cleared before final verification', async () => {
+    const { service, runnerRepository, boxRepository } = createService(0, '2')
+    runnerRepository.findOneOrFail.mockResolvedValue({ id: 'runner-1', draining: false, state: RunnerState.READY })
+
+    await (service as any).handleCheckDecommissionRunners()
+
+    expect(boxRepository.count).toHaveBeenCalledTimes(1)
+    expect(runnerRepository.update).not.toHaveBeenCalled()
+  })
+
+  it('updates draining while holding the runner assignment lease', async () => {
+    const { service, redisLockProvider } = createService(0)
+
+    await service.updateDrainingStatus('runner-1', false)
+
+    expect(redisLockProvider.waitForLease).toHaveBeenCalledWith(
+      'runner:runner-1:box-assignment',
+      30,
+      expect.any(AbortSignal),
+    )
   })
 })

--- a/apps/api/src/box/services/runner.service.decommission.spec.ts
+++ b/apps/api/src/box/services/runner.service.decommission.spec.ts
@@ -37,6 +37,7 @@ describe('RunnerService decommission verification', () => {
       del: jest.fn().mockResolvedValue(1),
     }
     const dataSource = { queryResultCache: undefined }
+    const eventEmitter = { emit: jest.fn() }
     const service = new RunnerService(
       runnerRepository as any,
       {} as any,
@@ -44,12 +45,12 @@ describe('RunnerService decommission verification', () => {
       redisLockProvider as any,
       configService as any,
       {} as any,
-      { emit: jest.fn() } as any,
+      eventEmitter as any,
       dataSource as any,
       redis as any,
     )
 
-    return { service, runnerRepository, boxRepository, redisLockProvider, redis }
+    return { service, runnerRepository, boxRepository, redisLockProvider, redis, eventEmitter }
   }
 
   it('resets verification while any box is still assigned to the draining runner', async () => {
@@ -135,6 +136,15 @@ describe('RunnerService decommission verification', () => {
       }),
       expect.objectContaining({ state: RunnerState.READY }),
     )
+  })
+
+  it('does not emit a stale state event when the guarded health update loses the race', async () => {
+    const { service, runnerRepository, eventEmitter } = createService(0)
+    runnerRepository.update.mockResolvedValue({ affected: 0 })
+
+    await service.updateRunnerHealth('runner-1')
+
+    expect(eventEmitter.emit).not.toHaveBeenCalled()
   })
 
   it('translates a missing uncached runner into NotFoundException', async () => {

--- a/apps/api/src/box/services/runner.service.decommission.spec.ts
+++ b/apps/api/src/box/services/runner.service.decommission.spec.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { RunnerState } from '../enums/runner-state.enum'
+import { RunnerService } from './runner.service'
+
+describe('RunnerService decommission verification', () => {
+  const createService = (boxCount: number, checkCount: string | null = null) => {
+    const runner = { id: 'runner-1', draining: true, state: RunnerState.READY }
+    const runnerRepository = {
+      find: jest.fn().mockResolvedValue([runner]),
+      findOne: jest.fn().mockResolvedValue(runner),
+      findOneOrFail: jest.fn().mockResolvedValue(runner),
+      save: jest.fn().mockResolvedValue(runner),
+      update: jest.fn().mockResolvedValue({ affected: 1 }),
+    }
+    const boxRepository = { count: jest.fn().mockResolvedValue(boxCount) }
+    const redisLockProvider = {
+      lock: jest.fn().mockResolvedValue(true),
+      unlock: jest.fn().mockResolvedValue(undefined),
+    }
+    const configService = { getOrThrow: jest.fn().mockReturnValue(1) }
+    const redis = {
+      get: jest.fn().mockResolvedValue(checkCount),
+      set: jest.fn().mockResolvedValue('OK'),
+      del: jest.fn().mockResolvedValue(1),
+    }
+    const dataSource = { queryResultCache: undefined }
+    const service = new RunnerService(
+      runnerRepository as any,
+      {} as any,
+      boxRepository as any,
+      redisLockProvider as any,
+      configService as any,
+      {} as any,
+      {} as any,
+      dataSource as any,
+      redis as any,
+    )
+
+    return { service, runnerRepository, boxRepository, redisLockProvider, redis }
+  }
+
+  it('resets verification while any box is still assigned to the draining runner', async () => {
+    const { service, runnerRepository, boxRepository, redis } = createService(1, '2')
+
+    await (service as any).handleCheckDecommissionRunners()
+
+    expect(boxRepository.count).toHaveBeenCalledWith({ where: { runnerId: 'runner-1' } })
+    expect(redis.set).toHaveBeenCalledWith('runner:draining-check:runner-1', '0', 'EX', 600)
+    expect(runnerRepository.update).not.toHaveBeenCalled()
+  })
+
+  it('decommissions only after three checks with no remaining runner assignments', async () => {
+    const { service, runnerRepository, redis } = createService(0, '2')
+
+    await (service as any).handleCheckDecommissionRunners()
+
+    expect(runnerRepository.update).toHaveBeenCalledWith('runner-1', { state: RunnerState.DECOMMISSIONED })
+    expect(redis.del).toHaveBeenCalledWith('runner:draining-check:runner-1')
+  })
+
+  it('does not inspect runners when another worker owns the verification lock', async () => {
+    const { service, runnerRepository, redisLockProvider } = createService(0)
+    redisLockProvider.lock.mockResolvedValue(false)
+
+    await (service as any).handleCheckDecommissionRunners()
+
+    expect(runnerRepository.find).not.toHaveBeenCalled()
+    expect(redisLockProvider.unlock).not.toHaveBeenCalled()
+  })
+
+  it('clears prior verification progress whenever draining status changes', async () => {
+    const { service, redis } = createService(0, '2')
+
+    await service.updateDrainingStatus('runner-1', false)
+
+    expect(redis.del).toHaveBeenCalledWith('runner:draining-check:runner-1')
+  })
+})

--- a/apps/api/src/box/services/runner.service.ts
+++ b/apps/api/src/box/services/runner.service.ts
@@ -40,7 +40,6 @@ import { generateApiKeyValue } from '../../common/utils/api-key'
 import { RunnerFullDto } from '../dto/runner-full.dto'
 import { InjectRedis } from '@nestjs-modules/ioredis'
 import Redis from 'ioredis'
-import { BoxDesiredState } from '../enums/box-desired-state.enum'
 import { runnerLookupCacheKeyById, RUNNER_LOOKUP_CACHE_TTL_MS } from '../utils/runner-lookup-cache.util'
 import { BoxRepository } from '../repositories/box.repository'
 import { RunnerServiceInfo } from '../common/runner-service-info'
@@ -660,22 +659,21 @@ export class RunnerService {
       await Promise.allSettled(
         drainingRunners.map(async (runner) => {
           try {
-            // Check if runner has any boxes with desiredState != DESTROYED
-            const nonDestroyedBoxCount = await this.boxRepository.count({
+            // A box releases runnerId only after runtime destruction is confirmed.
+            // Treat every remaining assignment as a blocker, including boxes whose
+            // desired state is already DESTROYED but are still being reconciled.
+            const assignedBoxCount = await this.boxRepository.count({
               where: {
                 runnerId: runner.id,
-                desiredState: Not(BoxDesiredState.DESTROYED),
               },
             })
 
             const redisKey = `runner:draining-check:${runner.id}`
 
-            if (nonDestroyedBoxCount > 0) {
-              // Reset counter if there are non-destroyed boxes
+            if (assignedBoxCount > 0) {
+              // Reset counter while any box still references this runner.
               await this.redis.set(redisKey, '0', 'EX', 600) // 10 minute TTL
-              this.logger.debug(
-                `Runner ${runner.id} has ${nonDestroyedBoxCount} boxes with desiredState != DESTROYED, reset counter`,
-              )
+              this.logger.debug(`Runner ${runner.id} still has ${assignedBoxCount} assigned boxes, reset counter`)
             } else {
               // Increment counter
               const currentCount = await this.redis.get(redisKey)
@@ -690,9 +688,7 @@ export class RunnerService {
                 this.logger.log(`Runner ${runner.id} has been decommissioned after 3 successful draining checks`)
               } else {
                 await this.redis.set(redisKey, count.toString(), 'EX', 600) // 10 minute TTL
-                this.logger.debug(
-                  `Runner ${runner.id} draining check passed (${count}/3), all boxes have desiredState = DESTROYED`,
-                )
+                this.logger.debug(`Runner ${runner.id} draining check passed (${count}/3), no boxes remain assigned`)
               }
             }
           } catch (e) {
@@ -714,6 +710,7 @@ export class RunnerService {
 
   async updateDrainingStatus(id: string, draining: boolean): Promise<Runner> {
     const runner = await this.findOneOrFail(id)
+    await this.redis.del(`runner:draining-check:${id}`)
     runner.draining = draining
     await this.runnerRepository.save(runner)
     return runner

--- a/apps/api/src/box/services/runner.service.ts
+++ b/apps/api/src/box/services/runner.service.ts
@@ -225,7 +225,11 @@ export class RunnerService {
   }
 
   async findOneUncachedOrFail(id: string): Promise<Runner> {
-    return this.runnerRepository.findOneOrFail({ where: { id } })
+    const runner = await this.runnerRepository.findOne({ where: { id } })
+    if (!runner) {
+      throw new NotFoundException(`Runner with ID ${id} not found`)
+    }
+    return runner
   }
 
   async findOneFullOrFail(id: string): Promise<RunnerFullDto> {
@@ -451,7 +455,7 @@ export class RunnerService {
       })
     }
 
-    await this.updateRunner(runnerId, updateData)
+    await this.updateRunnerUnlessDecommissioned(runnerId, updateData)
     this.logger.debug(`Updated health for runner ${runnerId}`)
 
     this.eventEmitter.emit(
@@ -473,7 +477,7 @@ export class RunnerService {
       return
     }
 
-    await this.updateRunner(runnerId, {
+    await this.updateRunnerUnlessDecommissioned(runnerId, {
       state: newState,
       lastChecked: new Date(),
     })
@@ -790,6 +794,15 @@ export class RunnerService {
     data: Partial<Omit<Runner, 'id' | 'createdAt' | 'updatedAt'>>,
   ): Promise<UpdateResult> {
     const result = await this.runnerRepository.update(id, data)
+    this.invalidateRunnerCache(id)
+    return result
+  }
+
+  private async updateRunnerUnlessDecommissioned(
+    id: string,
+    data: Partial<Omit<Runner, 'id' | 'createdAt' | 'updatedAt'>>,
+  ): Promise<UpdateResult> {
+    const result = await this.runnerRepository.update({ id, state: Not(RunnerState.DECOMMISSIONED) }, data)
     this.invalidateRunnerCache(id)
     return result
   }

--- a/apps/api/src/box/services/runner.service.ts
+++ b/apps/api/src/box/services/runner.service.ts
@@ -224,6 +224,10 @@ export class RunnerService {
     return runner
   }
 
+  async findOneUncachedOrFail(id: string): Promise<Runner> {
+    return this.runnerRepository.findOneOrFail({ where: { id } })
+  }
+
   async findOneFullOrFail(id: string): Promise<RunnerFullDto> {
     const runner = await this.findOneOrFail(id)
     const region = await this.regionService.findOne(runner.region)
@@ -688,6 +692,12 @@ export class RunnerService {
                 }
 
                 await withRedisLockLease(assignmentLease, async (signal) => {
+                  const currentRunner = await this.findOneUncachedOrFail(runner.id)
+                  if (!currentRunner.draining || currentRunner.state === RunnerState.DECOMMISSIONED) {
+                    await this.redis.del(redisKey)
+                    return
+                  }
+
                   const finalAssignedBoxCount = await this.boxRepository.count({
                     where: { runnerId: runner.id },
                   })
@@ -729,11 +739,21 @@ export class RunnerService {
   }
 
   async updateDrainingStatus(id: string, draining: boolean): Promise<Runner> {
-    const runner = await this.findOneOrFail(id)
-    await this.redis.del(`runner:draining-check:${id}`)
-    runner.draining = draining
-    await this.runnerRepository.save(runner)
-    return runner
+    const lease = await this.redisLockProvider.waitForLease(
+      getRunnerAssignmentLockKey(id),
+      30,
+      new AbortController().signal,
+    )
+    return withRedisLockLease(lease, async (signal) => {
+      const runner = await this.findOneUncachedOrFail(id)
+      if (runner.state === RunnerState.DECOMMISSIONED) {
+        throw new ConflictException('Cannot update draining status of a decommissioned runner')
+      }
+      signal.throwIfAborted()
+      await this.redis.del(`runner:draining-check:${id}`)
+      runner.draining = draining
+      return this.runnerRepository.save(runner)
+    })
   }
 
   async getRandomAvailableRunner(params: GetRunnerParams): Promise<Runner> {

--- a/apps/api/src/box/services/runner.service.ts
+++ b/apps/api/src/box/services/runner.service.ts
@@ -455,7 +455,9 @@ export class RunnerService {
       })
     }
 
-    await this.updateRunnerUnlessDecommissioned(runnerId, updateData)
+    if (!(await this.updateRunnerUnlessDecommissioned(runnerId, updateData))) {
+      return
+    }
     this.logger.debug(`Updated health for runner ${runnerId}`)
 
     this.eventEmitter.emit(
@@ -477,10 +479,14 @@ export class RunnerService {
       return
     }
 
-    await this.updateRunnerUnlessDecommissioned(runnerId, {
-      state: newState,
-      lastChecked: new Date(),
-    })
+    if (
+      !(await this.updateRunnerUnlessDecommissioned(runnerId, {
+        state: newState,
+        lastChecked: new Date(),
+      }))
+    ) {
+      return
+    }
 
     this.eventEmitter.emit(RunnerEvents.STATE_UPDATED, new RunnerStateUpdatedEvent(runner, runner.state, newState))
   }
@@ -801,10 +807,10 @@ export class RunnerService {
   private async updateRunnerUnlessDecommissioned(
     id: string,
     data: Partial<Omit<Runner, 'id' | 'createdAt' | 'updatedAt'>>,
-  ): Promise<UpdateResult> {
+  ): Promise<boolean> {
     const result = await this.runnerRepository.update({ id, state: Not(RunnerState.DECOMMISSIONED) }, data)
     this.invalidateRunnerCache(id)
-    return result
+    return (result.affected ?? 0) > 0
   }
 
   private invalidateRunnerCache(runnerId: string): void {

--- a/apps/api/src/box/services/runner.service.ts
+++ b/apps/api/src/box/services/runner.service.ts
@@ -25,7 +25,7 @@ import { BadRequestError } from '../../exceptions/bad-request.exception'
 import { EventEmitter2 } from '@nestjs/event-emitter'
 import { BoxState } from '../enums/box-state.enum'
 import { RunnerAdapterFactory, RunnerInfo } from '../runner-adapter/runnerAdapter'
-import { RedisLockProvider } from '../common/redis-lock.provider'
+import { RedisLockProvider, withRedisLockLease } from '../common/redis-lock.provider'
 import { TypedConfigService } from '../../config/typed-config.service'
 import { LogExecution } from '../../common/decorators/log-execution.decorator'
 import { WithInstrumentation } from '../../common/decorators/otel.decorator'
@@ -43,6 +43,7 @@ import Redis from 'ioredis'
 import { runnerLookupCacheKeyById, RUNNER_LOOKUP_CACHE_TTL_MS } from '../utils/runner-lookup-cache.util'
 import { BoxRepository } from '../repositories/box.repository'
 import { RunnerServiceInfo } from '../common/runner-service-info'
+import { getRunnerAssignmentLockKey } from '../utils/lock-key.util'
 
 @Injectable()
 export class RunnerService {
@@ -680,12 +681,31 @@ export class RunnerService {
               const count = currentCount ? parseInt(currentCount, 10) + 1 : 1
 
               if (count >= 3) {
-                // Decommission the runner
-                await this.updateRunner(runner.id, {
-                  state: RunnerState.DECOMMISSIONED,
+                const assignmentLockKey = getRunnerAssignmentLockKey(runner.id)
+                const assignmentLease = await this.redisLockProvider.acquireLease(assignmentLockKey, 30)
+                if (!assignmentLease) {
+                  return
+                }
+
+                await withRedisLockLease(assignmentLease, async (signal) => {
+                  const finalAssignedBoxCount = await this.boxRepository.count({
+                    where: { runnerId: runner.id },
+                  })
+                  if (finalAssignedBoxCount > 0) {
+                    await this.redis.set(redisKey, '0', 'EX', 600)
+                    this.logger.warn(
+                      `Runner ${runner.id} received ${finalAssignedBoxCount} box assignments during decommission verification`,
+                    )
+                    return
+                  }
+
+                  signal.throwIfAborted()
+                  await this.updateRunner(runner.id, {
+                    state: RunnerState.DECOMMISSIONED,
+                  })
+                  await this.redis.del(redisKey)
+                  this.logger.log(`Runner ${runner.id} has been decommissioned after 3 successful draining checks`)
                 })
-                await this.redis.del(redisKey)
-                this.logger.log(`Runner ${runner.id} has been decommissioned after 3 successful draining checks`)
               } else {
                 await this.redis.set(redisKey, count.toString(), 'EX', 600) // 10 minute TTL
                 this.logger.debug(`Runner ${runner.id} draining check passed (${count}/3), no boxes remain assigned`)

--- a/apps/api/src/box/utils/lock-key.util.ts
+++ b/apps/api/src/box/utils/lock-key.util.ts
@@ -7,3 +7,7 @@
 export function getStateChangeLockKey(id: string): string {
   return `box:${id}:state-change`
 }
+
+export function getRunnerAssignmentLockKey(id: string): string {
+  return `runner:${id}:box-assignment`
+}

--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -312,6 +312,10 @@ const configuration = {
     apiVersion: (process.env.DEFAULT_RUNNER_API_VERSION || '2') as '0' | '2',
     name: process.env.DEFAULT_RUNNER_NAME,
   },
+  draining: {
+    // Running boxes are left untouched unless operators explicitly opt in.
+    force: process.env.DRAINING_FORCE === 'true',
+  },
   runnerScore: {
     thresholds: {
       declarativeBuild: parseInt(process.env.RUNNER_DECLARATIVE_BUILD_SCORE_THRESHOLD || '10', 10),

--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -315,6 +315,8 @@ const configuration = {
   draining: {
     // Running boxes are left untouched unless operators explicitly opt in.
     force: process.env.DRAINING_FORCE === 'true',
+    runnerConcurrency: requiredCount(process.env.DRAINING_RUNNER_CONCURRENCY, 2, 'DRAINING_RUNNER_CONCURRENCY'),
+    boxConcurrency: requiredCount(process.env.DRAINING_BOX_CONCURRENCY, 10, 'DRAINING_BOX_CONCURRENCY'),
   },
   runnerScore: {
     thresholds: {

--- a/apps/libs/api-client-go/api/openapi.yaml
+++ b/apps/libs/api-client-go/api/openapi.yaml
@@ -6188,6 +6188,11 @@ components:
       - INSPECT_ARTIFACT_IN_REGISTRY
       - REMOVE_ARTIFACT
       - UPDATE_BOX_NETWORK_SETTINGS
+      - EXPORT_BOX
+      - IMPORT_BOX
+      - ROLLBACK_EXPORT_BOX
+      - ROLLBACK_IMPORT_BOX
+      - DISCARD_EXPORTED_BOX
       type: string
     Job:
       example:


### PR DESCRIPTION
## Summary
Ports and completes Daytona-style runner decommissioning for BoxLite: draining runners stop receiving assignments, their eligible boxes are reconciled toward destruction, and runners are decommissioned only after repeated verification that no boxes remain assigned. The flow is fenced against concurrent assignment and stale health/state writes, with bounded draining concurrency.

## Call graph
<!-- Required. The end-to-end path this PR touches, before and after; one line
     per hop, only the hops that change. Worked example and the bug-fix markers:
     CONTRIBUTING.md#commit--pr-messages. -->

Before
`RunnerService.handleCheckDecommissionRunners` (scheduled service · `apps/api/src/box/services/runner.service.ts`) — decommissions a draining runner after repeated checks of desired box state

`BoxService.create` (service · `apps/api/src/box/services/box.service.ts`) — selects a ready runner and persists the assignment without coordinating with decommission finalization

After
`BoxManager.drainingRunnerBoxesCheck` (scheduled manager · `apps/api/src/box/managers/box.manager.ts`) → `BoxManager.drainBox` → `BoxManager.syncInstanceState` — fairly scans draining runners, stops boxes when forced, destroys stopped/errored boxes, and retries failed destroy intents with bounded runner/box concurrency

`BoxService.create` / warm-pool creation → `BoxService.persistWithRunnerAssignmentFence` (service · `apps/api/src/box/services/box.service.ts`) → `RunnerService.findOneUncachedOrFail` — serializes runner eligibility validation and box assignment under an owner-safe renewable lease

`RunnerService.handleCheckDecommissionRunners` (scheduled service · `apps/api/src/box/services/runner.service.ts`) → assignment fence → uncached runner recheck → assigned-box count — publishes `DECOMMISSIONED` only after three empty checks and a final fenced verification

`RunnerController.updateDrainingStatus` → `RunnerService.updateDrainingStatus` (service · `apps/api/src/box/services/runner.service.ts`) → assignment fence — serializes draining-state changes with assignment and resets prior verification progress

`RunnerService.updateRunnerHealth` / `updateRunnerState` → `updateRunnerUnlessDecommissioned` — prevents stale health checks from restoring a decommissioned runner or emitting a transition that was not persisted



## Changes
- Drain stopped and errored boxes from draining runners; optionally stop running boxes first with `DRAINING_FORCE=true`.
- Retry errored boxes that already have a pending destroy intent, while keeping fresh drain candidates in a separate batch to prevent starvation.
- Rotate the draining-runner cursor and bound reconciliation with `DRAINING_RUNNER_CONCURRENCY` and `DRAINING_BOX_CONCURRENCY`.
- Require three consecutive empty checks and a final assignment-fenced, uncached verification before setting a runner to `DECOMMISSIONED`.
- Fence regular and warm-pool box assignment against draining/decommission transitions with renewable, ownership-safe Redis leases.
- Clear decommission verification progress whenever draining status changes and prevent updates to an already decommissioned runner.
- Keep errored destroy operations pending until runtime destruction completes, so `runnerId` remains the source of truth blocking premature decommission.
- Refresh the generated Go OpenAPI JobType enum for the current merge base.

## How to verify
- Mark an empty runner as draining. Confirm it becomes `DECOMMISSIONED` only after three consecutive checks with no assigned boxes.
- Stop a box and mark its runner as draining. Confirm the box is destroyed and its `runnerId` is cleared before the runner is decommissioned.
- With `DRAINING_FORCE=false`, confirm a running box remains running and blocks runner decommission.
- With `DRAINING_FORCE=true`, confirm a running box is stopped, destroyed, and then its runner is decommissioned.
- Temporarily make the runner API unavailable during destruction. Confirm the box retains its pending destroy intent, blocks decommission, and is retried after connectivity is restored.
- Disable and re-enable draining after one or two empty checks. Confirm the verification counter resets and three new checks are required.
- Create boxes while changing a runner to draining. Confirm no new box is assigned to the draining or decommissioned runner.

## Risks / rollout
- Draining is intentionally fail-safe: a box that cannot be destroyed retains its runner assignment and blocks decommission until the failure is resolved.
- Forced draining is opt-in. Keep `DRAINING_FORCE=false` unless operators explicitly want running boxes stopped during scale-in.
- Defaults limit reconciliation to 2 runners concurrently and 10 boxes per runner; tune the two concurrency settings according to Redis, database, and runner API capacity.

<!-- Describe the change, not the process: no pasted logs, no AI/conversation
     narrative, no secrets. Keep it tight and delete sections that don't apply. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved box creation by assigning boxes only to available, ready runners.
  - Added automatic draining workflows for stopped or errored boxes.
  - Added optional force-stopping for running boxes during runner draining.
  - Added configurable concurrency limits for draining operations.
  - Added export, import, rollback, and discard-exported-box job types.

- **Bug Fixes**
  - Errored boxes marked for destruction now continue through the destruction process.
  - Improved runner decommissioning safeguards and concurrent assignment handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->