### PR TITLE
feat(api): mark boxes on draining runners for migration

### DIFF
--- a/apps/api/src/box/box.module.ts
+++ b/apps/api/src/box/box.module.ts
@@ -45,15 +45,17 @@ import { RegionBoxAccessGuard } from './guards/region-box-access.guard'
 import { ProxyGuard } from './guards/proxy.guard'
 import { EventEmitter2 } from '@nestjs/event-emitter'
 import { BoxLastActivity } from './entities/box-last-activity.entity'
+import { BoxMigration } from './entities/box-migration.entity'
 import { BoxActivityService } from './services/box-activity.service'
 import { BoxStateWaiterService } from './services/box-state-waiter.service'
+import { BoxMigrationService } from './services/box-migration.service'
 
 @Module({
   imports: [
     UserModule,
     OrganizationModule,
     RegionModule,
-    TypeOrmModule.forFeature([Box, Runner, WarmPool, Volume, Region, Job, BoxLastActivity]),
+    TypeOrmModule.forFeature([Box, Runner, WarmPool, Volume, Region, Job, BoxLastActivity, BoxMigration]),
   ],
   controllers: [BoxController, RunnerController, PreviewController, VolumeController, JobController],
   providers: [
@@ -75,6 +77,7 @@ import { BoxStateWaiterService } from './services/box-state-waiter.service'
     JobStateHandlerService,
     BoxActivityService,
     BoxStateWaiterService,
+    BoxMigrationService,
     BoxAccessGuard,
     RunnerAccessGuard,
     RegionRunnerAccessGuard,

--- a/apps/api/src/box/entities/box-migration.entity.ts
+++ b/apps/api/src/box/entities/box-migration.entity.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Column, Entity, Index, JoinColumn, OneToOne, PrimaryColumn } from 'typeorm'
+import { BoxMigrationState } from '../enums/box-migration-state.enum'
+import { Box } from './box.entity'
+
+/**
+ * A box migration between runners, one row per box being moved.
+ *
+ * The row is the migration: it appears when the marker claims a parked box and
+ * is deleted once the box is no longer migrating, so "not migrating" has a
+ * single representation and the table stays the size of the work in flight
+ * rather than the size of the fleet. Deleting the box takes the row with it.
+ */
+@Entity('box_migration')
+@Index('box_migration_state_idx', ['state'])
+export class BoxMigration {
+  @PrimaryColumn({ name: 'boxId' })
+  boxId: string
+
+  //  Which migration job this box is waiting on, never what the migration has
+  //  produced — that is what `arcPath` and `runnerId` record.
+  @Column({
+    type: 'enum',
+    enum: BoxMigrationState,
+  })
+  state: BoxMigrationState
+
+  //  Object key of the archive the migration put on the object store. Empty
+  //  means there is no archive to reclaim. Written whether or not the migration
+  //  stayed valid, because the object exists either way and the rollback path
+  //  needs the key to delete it.
+  @Column({ type: 'character varying', default: '' })
+  arcPath = ''
+
+  //  The second runner a migration involves: before the commit point the runner
+  //  the box was imported onto, after it the runner still holding the original
+  //  box to discard. Null means no such box exists.
+  @Column({
+    type: 'uuid',
+    nullable: true,
+  })
+  runnerId?: string
+
+  //  A copy of `box.updatedAt`, taken by every migration step while it holds the
+  //  box row, so `box_migration.updatedAt = box.updatedAt` reads as "nothing
+  //  outside the migration has touched this box". A write from anywhere else
+  //  moves `box.updatedAt` past this copy and breaks the equality, the signal
+  //  to roll back. Deliberately the same column type as `box.updatedAt`: a
+  //  narrower precision here would round the copy and fail the comparison it
+  //  exists for.
+  @Column({ type: 'timestamp with time zone' })
+  updatedAt: Date
+
+  @OneToOne(() => Box, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'boxId' })
+  box?: Box
+}

--- a/apps/api/src/box/enums/box-migration-state.enum.ts
+++ b/apps/api/src/box/enums/box-migration-state.enum.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+/**
+ * Where a box is in a migration from one runner to another.
+ *
+ * A box that is not migrating has no `box_migration` row at all, so there is no
+ * state for it; every value here names a job the migration is waiting on, and is
+ * left behind by that job's receiver:
+ *
+ *     (no row) ─▶ PENDING_EXPORT ─▶ PENDING_IMPORT ─▶ PENDING_DISCARD_EXPORTED ─▶ COMPLETED
+ *                       └──────────────┴──▶ PENDING_ROLLBACK ─▶ (row deleted)
+ *
+ * The state records what the migration is waiting for, never what it has
+ * produced: `box_migration.arcPath` says an archive is on the object store and
+ * `box_migration.runnerId` says a box exists on another runner. Nor does the
+ * state mark a job as in flight — a box sits in PENDING_IMPORT both before its
+ * IMPORT_BOX job is submitted and while it runs, and the per-box Redis lock is
+ * what tells those two apart.
+ */
+export enum BoxMigrationState {
+  PENDING_EXPORT = 'pending_export',
+  PENDING_IMPORT = 'pending_import',
+  PENDING_DISCARD_EXPORTED = 'pending_discard_exported',
+  PENDING_ROLLBACK = 'pending_rollback',
+  COMPLETED = 'completed',
+}

--- a/apps/api/src/box/repositories/box.repository.migrate-marker.integration.spec.ts
+++ b/apps/api/src/box/repositories/box.repository.migrate-marker.integration.spec.ts
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { randomUUID } from 'node:crypto'
+import { DataSource, Repository } from 'typeorm'
+import { CustomNamingStrategy } from '../../common/utils/naming-strategy.util'
+import { Box } from '../entities/box.entity'
+import { BoxLastActivity } from '../entities/box-last-activity.entity'
+import { BoxMigration } from '../entities/box-migration.entity'
+import { BoxDesiredState } from '../enums/box-desired-state.enum'
+import { BoxMigrationState } from '../enums/box-migration-state.enum'
+import { BoxState } from '../enums/box-state.enum'
+import { BoxRepository } from './box.repository'
+
+const describeIfDatabase = process.env.DB_HOST ? describe : describe.skip
+const schemaName = `box_migrate_marker_${process.pid}_${randomUUID().replaceAll('-', '')}`
+const drainingRunnerId = '00000000-0000-4000-8000-00000000000a'
+const healthyRunnerId = '00000000-0000-4000-8000-00000000000b'
+const organizationId = '00000000-0000-4000-8000-0000000000ff'
+
+function parkedBox(
+  name: string,
+  overrides: Partial<Pick<Box, 'runnerId' | 'state' | 'desiredState' | 'pending'>> = {},
+): Box {
+  const box = new Box('us', name)
+  box.organizationId = organizationId
+  box.osUser = 'boxlite'
+  box.runnerId = drainingRunnerId
+  box.state = BoxState.STOPPED
+  box.desiredState = BoxDesiredState.STOPPED
+  box.pending = false
+  Object.assign(box, overrides)
+  return box
+}
+
+describeIfDatabase('BoxRepository.markParkedBoxesForExport (integration, real Postgres)', () => {
+  let dataSource: DataSource
+  let boxes: Repository<Box>
+  let migrations: Repository<BoxMigration>
+  let repository: BoxRepository
+  let ownsSchema = false
+
+  beforeAll(async () => {
+    dataSource = await new DataSource({
+      type: 'postgres',
+      host: process.env.DB_HOST,
+      port: Number(process.env.DB_PORT || 5432),
+      username: process.env.DB_USERNAME,
+      password: process.env.DB_PASSWORD,
+      database: process.env.DB_DATABASE,
+      schema: schemaName,
+      entities: [Box, BoxLastActivity, BoxMigration],
+      namingStrategy: new CustomNamingStrategy(),
+      entitySkipConstructor: true,
+      synchronize: false,
+      // TypeORM creates the enum types inside `schema` but copies partial-index
+      // predicates into CREATE INDEX verbatim, so box_active_only_idx's
+      // `::box_state_enum` cast arrives unqualified and would resolve against
+      // the default search_path instead of this run's schema. Putting the schema
+      // on the search_path is what lets synchronize() build that index here.
+      extra: { options: `-c search_path=${schemaName},public` },
+    }).initialize()
+
+    await dataSource.query(`CREATE SCHEMA "${schemaName}"`)
+    ownsSchema = true
+    await dataSource.synchronize()
+    boxes = dataSource.getRepository(Box)
+    migrations = dataSource.getRepository(BoxMigration)
+    repository = new BoxRepository(
+      dataSource,
+      { emit: jest.fn() } as any,
+      {
+        invalidate: jest.fn(),
+        invalidateOrgId: jest.fn(),
+      } as any,
+    )
+  })
+
+  afterAll(async () => {
+    if (!dataSource?.isInitialized) {
+      return
+    }
+
+    try {
+      if (ownsSchema) {
+        await dataSource.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`)
+      }
+    } finally {
+      await dataSource.destroy()
+    }
+  })
+
+  beforeEach(async () => {
+    await dataSource.query(`DELETE FROM "${schemaName}"."box_migration"`)
+    await dataSource.query(`DELETE FROM "${schemaName}"."box_last_activity"`)
+    await dataSource.query(`DELETE FROM "${schemaName}"."box"`)
+  })
+
+  it('opens the migration on a copy of the box stamp, leaving the box alone', async () => {
+    const box = parkedBox('parked')
+    await boxes.insert(box)
+    const untouched = await boxes.findOneByOrFail({ id: box.id })
+
+    expect(await repository.markParkedBoxesForExport([drainingRunnerId])).toBe(1)
+
+    const migration = await migrations.findOneByOrFail({ boxId: box.id })
+    expect(migration.state).toBe(BoxMigrationState.PENDING_EXPORT)
+    // The equality every later validity check reads — and the box row it is
+    // measured against is the one that was already there. A claim that wrote the
+    // box would be indistinguishable from the interference it is watching for.
+    expect((await boxes.findOneByOrFail({ id: box.id })).updatedAt).toEqual(untouched.updatedAt)
+    expect(migration.updatedAt).toEqual(untouched.updatedAt)
+  })
+
+  it('breaks the timestamp equality on the next write from outside the migration', async () => {
+    const box = parkedBox('started-underneath')
+    await boxes.insert(box)
+    await repository.markParkedBoxesForExport([drainingRunnerId])
+
+    // What a user starting the box does to the row, minus the entity-level
+    // guards: it moves updatedAt and nothing else.
+    await repository.update(box.id, { updateData: { desiredState: BoxDesiredState.STARTED } }, true)
+
+    const interfered = await boxes.findOneByOrFail({ id: box.id })
+    const migration = await migrations.findOneByOrFail({ boxId: box.id })
+    expect(migration.state).toBe(BoxMigrationState.PENDING_EXPORT)
+    expect(migration.updatedAt).not.toEqual(interfered.updatedAt)
+    // Both stamps come from the server — TypeORM's update builder writes
+    // updatedAt as CURRENT_TIMESTAMP too — so the later write is strictly newer
+    // and this ordering carries no dependence on the test machine's clock.
+    expect(migration.updatedAt.getTime()).toBeLessThan(interfered.updatedAt.getTime())
+  })
+
+  it('claims a box a previous drain already migrated', async () => {
+    const box = parkedBox('re-drained')
+    await boxes.insert(box)
+    const finished = await boxes.findOneByOrFail({ id: box.id })
+    await migrations.insert({ boxId: box.id, state: BoxMigrationState.COMPLETED, updatedAt: finished.updatedAt })
+    // Someone stopped the box again between the two drains, so the stamp the
+    // finished migration copied is now behind the box's.
+    await repository.update(box.id, { updateData: { desiredState: BoxDesiredState.STOPPED } }, true)
+
+    expect(await repository.markParkedBoxesForExport([drainingRunnerId])).toBe(1)
+
+    const reclaimed = await migrations.findOneByOrFail({ boxId: box.id })
+    expect(reclaimed.state).toBe(BoxMigrationState.PENDING_EXPORT)
+    // The finished migration's stamp has to be replaced, not kept: the second
+    // migration is validated against the box row as it stands now, and keeping
+    // the old copy would open a migration that reads as already disturbed.
+    expect(reclaimed.updatedAt).toEqual((await boxes.findOneByOrFail({ id: box.id })).updatedAt)
+    expect(reclaimed.updatedAt.getTime()).toBeGreaterThan(finished.updatedAt.getTime())
+  })
+
+  it('passes over a box another transaction is holding', async () => {
+    const box = parkedBox('locked-elsewhere')
+    await boxes.insert(box)
+
+    const holder = dataSource.createQueryRunner()
+    await holder.connect()
+    await holder.startTransaction()
+    try {
+      await holder.query(`SELECT "id" FROM "${schemaName}"."box" WHERE "id" = $1 FOR UPDATE`, [box.id])
+
+      // Waiting for that transaction would park the whole tick — and the Redis
+      // lock it runs under — behind it, so the box is left for the next tick.
+      expect(await repository.markParkedBoxesForExport([drainingRunnerId])).toBe(0)
+      expect(await migrations.count()).toBe(0)
+    } finally {
+      await holder.rollbackTransaction()
+      await holder.release()
+    }
+
+    expect(await repository.markParkedBoxesForExport([drainingRunnerId])).toBe(1)
+  })
+
+  it('leaves alone every box the migration must not move', async () => {
+    const alreadyExporting = parkedBox('already-exporting')
+    const rollingBack = parkedBox('rolling-back')
+    await boxes.insert([
+      parkedBox('on-healthy-runner', { runnerId: healthyRunnerId }),
+      parkedBox('still-running', { state: BoxState.STARTED, desiredState: BoxDesiredState.STARTED }),
+      parkedBox('wants-to-start', { desiredState: BoxDesiredState.STARTED, pending: true }),
+      parkedBox('mid-transition', { pending: true }),
+      alreadyExporting,
+      rollingBack,
+    ])
+
+    const inFlight = [
+      { box: alreadyExporting, state: BoxMigrationState.PENDING_EXPORT },
+      { box: rollingBack, state: BoxMigrationState.PENDING_ROLLBACK },
+    ]
+    for (const { box, state } of inFlight) {
+      const stored = await boxes.findOneByOrFail({ id: box.id })
+      await migrations.insert({ boxId: box.id, state, updatedAt: stored.updatedAt })
+    }
+    const before = await boxes.find({ order: { name: 'ASC' } })
+
+    expect(await repository.markParkedBoxesForExport([drainingRunnerId])).toBe(0)
+
+    // No migration opened on the four that are not parked on a draining
+    // runner, and the two already migrating kept the state and the stamp their
+    // own migration is being validated against.
+    expect(await migrations.count()).toBe(inFlight.length)
+    for (const { box, state } of inFlight) {
+      const migration = await migrations.findOneByOrFail({ boxId: box.id })
+      expect(migration.state).toBe(state)
+      expect(migration.updatedAt).toEqual((await boxes.findOneByOrFail({ id: box.id })).updatedAt)
+    }
+    // A box left out of the claim must not have its updatedAt moved either: a
+    // bumped stamp on a box a migration already owns reads as interference.
+    expect((await boxes.find({ order: { name: 'ASC' } })).map((box) => box.updatedAt)).toEqual(
+      before.map((box) => box.updatedAt),
+    )
+  })
+
+  it('marks nothing when no runner is draining', async () => {
+    await boxes.insert(parkedBox('parked'))
+
+    expect(await repository.markParkedBoxesForExport([])).toBe(0)
+    expect(await migrations.count()).toBe(0)
+  })
+
+  it('drops the migration with the box it belongs to', async () => {
+    const box = parkedBox('deleted-mid-migration')
+    await boxes.insert(box)
+    await repository.markParkedBoxesForExport([drainingRunnerId])
+
+    await boxes.delete({ id: box.id })
+
+    // Nothing outside this table has to remember to clean it up.
+    expect(await migrations.count()).toBe(0)
+  })
+})

--- a/apps/api/src/box/repositories/box.repository.migrate-marker.spec.ts
+++ b/apps/api/src/box/repositories/box.repository.migrate-marker.spec.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { DataSource, EntityManager } from 'typeorm'
+import { BoxRepository } from './box.repository'
+
+// What the marker makes of the two steps it drives, with no database behind it.
+// The companion *.integration.spec.ts proves what Postgres does with the
+// statements the query builders produce; this covers what is decided in
+// TypeScript — that the claim runs in one transaction, that a tick with nothing
+// to claim opens no migration, and which of the two steps the count comes from.
+describe('BoxRepository.markParkedBoxesForExport', () => {
+  let repository: BoxRepository
+  let transaction: jest.Mock
+  let parkedBoxes: Array<{ id: string; updatedAt: Date }>
+  let insertedRows: Array<{ boxId: string }>
+  let insertBuilders: number
+
+  // Every builder call chains except the ones that end a step, so a step is
+  // recorded by what it returns: the locked boxes, or the rows the insert's
+  // conflict guard let through.
+  function queryBuilderStub(onInsert: () => void): Record<string, unknown> {
+    const steps: Record<string, unknown> = {
+      getRawMany: () => Promise.resolve(parkedBoxes),
+      execute: () => Promise.resolve({ raw: insertedRows }),
+      getQuery: () => '(SELECT 1)',
+      insert: () => {
+        onInsert()
+        return builder
+      },
+    }
+    const builder: Record<string, unknown> = new Proxy(steps, {
+      // Anything the builder is asked for that does not end a step chains, so a
+      // call the repository adds keeps working without touching this stub.
+      get: (target, property) => (typeof property === 'string' ? (target[property] ?? (() => builder)) : undefined),
+    })
+    return builder
+  }
+
+  beforeEach(() => {
+    parkedBoxes = []
+    insertedRows = []
+    insertBuilders = 0
+
+    const entityManager = {
+      createQueryBuilder: () => queryBuilderStub(() => insertBuilders++),
+      // The insert's conflict guard names the table it upserts into, which the
+      // manager carries the entity metadata for. What that name produces is the
+      // integration spec's to check; here it only has to be answerable.
+      connection: { getMetadata: () => ({ tableName: 'box_migration' }) },
+    } as unknown as EntityManager
+
+    transaction = jest.fn((runInTransaction: (manager: EntityManager) => Promise<number>) =>
+      runInTransaction(entityManager),
+    )
+
+    const dataSource = {
+      getRepository: () => ({ manager: { transaction } }),
+    } as unknown as DataSource
+
+    repository = new BoxRepository(
+      dataSource,
+      { emit: jest.fn() } as any,
+      {
+        invalidate: jest.fn(),
+        invalidateOrgId: jest.fn(),
+      } as any,
+    )
+  })
+
+  it('claims and opens the migrations inside one transaction', async () => {
+    parkedBoxes = [{ id: 'box-a', updatedAt: new Date() }]
+    insertedRows = [{ boxId: 'box-a' }]
+
+    expect(await repository.markParkedBoxesForExport(['runner-a'])).toBe(1)
+
+    // The select's row locks are what keep the copied stamp true until the insert
+    // lands, and those last only as long as the transaction holding them.
+    expect(transaction).toHaveBeenCalledTimes(1)
+    expect(insertBuilders).toBe(1)
+  })
+
+  it('counts the boxes the insert claimed, not the ones it locked', async () => {
+    // A box the select locked can still lose its claim: a migration opened
+    // between the two steps is invisible to the select and fails the insert's
+    // conflict guard, so the box is left for the next tick.
+    parkedBoxes = [
+      { id: 'box-a', updatedAt: new Date() },
+      { id: 'box-b', updatedAt: new Date() },
+    ]
+    insertedRows = [{ boxId: 'box-a' }]
+
+    expect(await repository.markParkedBoxesForExport(['runner-a'])).toBe(1)
+  })
+
+  it('opens no migration when no box is claimable', async () => {
+    expect(await repository.markParkedBoxesForExport(['runner-a'])).toBe(0)
+
+    // An insert built from no boxes would be a statement with an empty VALUES
+    // list, which TypeORM answers with a result that has no rows to count.
+    expect(insertBuilders).toBe(0)
+  })
+
+  it('sends nothing when no runner is draining', async () => {
+    expect(await repository.markParkedBoxesForExport([])).toBe(0)
+
+    // An empty id list would make the runner predicate match every box in the
+    // fleet, so nothing must be sent at all.
+    expect(transaction).not.toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/box/repositories/box.repository.ts
+++ b/apps/api/src/box/repositories/box.repository.ts
@@ -7,8 +7,10 @@
 import { DataSource, EntityManager, FindOptionsWhere } from 'typeorm'
 import { Box } from '../entities/box.entity'
 import { BoxLastActivity } from '../entities/box-last-activity.entity'
+import { BoxMigration } from '../entities/box-migration.entity'
 import { BoxState } from '../enums/box-state.enum'
 import { BoxDesiredState } from '../enums/box-desired-state.enum'
+import { BoxMigrationState } from '../enums/box-migration-state.enum'
 import { Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { BoxConflictError } from '../errors/box-conflict.error'
 import { InjectDataSource } from '@nestjs/typeorm'
@@ -34,6 +36,9 @@ const PROXY_START_LOCK_TIMEOUT_MS = 2000
 // SQLSTATE for `lock_not_available` — raised when a statement waits longer than
 // lock_timeout to acquire a lock.
 const PG_LOCK_TIMEOUT_CODE = '55P03'
+
+// A box the migration marker may claim, with the stamp its claim copies.
+type ParkedBox = { id: string; updatedAt: Date }
 
 @Injectable()
 export class BoxRepository extends BaseRepository<Box> {
@@ -247,6 +252,117 @@ export class BoxRepository extends BaseRepository<Box> {
       }
       throw err
     }
+  }
+
+  /**
+   * Opens a migration on every parked box currently owned by one of `runnerIds`,
+   * as a `box_migration` row the later steps drive forward.
+   *
+   * A box is parked when it is stopped and wants to stay stopped, which is the
+   * only shape a migration can move. Boxes already part-way through one are left
+   * alone; the row a COMPLETED migration left behind is taken over, so a runner
+   * that drains a second time re-migrates what it took back.
+   *
+   * The lock the select takes has to still be held when the insert copies the
+   * stamp it read, so both steps share one transaction.
+   *
+   * @returns How many boxes were marked.
+   */
+  async markParkedBoxesForExport(runnerIds: string[]): Promise<number> {
+    if (runnerIds.length === 0) {
+      return 0
+    }
+
+    return this.manager.transaction(async (entityManager) => {
+      const parked = await this.lockParkedBoxes(entityManager, runnerIds)
+      if (parked.length === 0) {
+        return 0
+      }
+
+      return this.openMigrations(entityManager, parked)
+    })
+  }
+
+  /**
+   * Locks the parked boxes owned by `runnerIds` and reads the stamp to copy.
+   *
+   * The box is locked rather than written: the lock is what stops a write landing
+   * between the read of `updatedAt` and the insert that copies it, and leaving the
+   * row untouched keeps a claim from looking like a change to everything else that
+   * watches `box.updatedAt`. The lock lives until the caller's transaction ends.
+   *
+   * SKIP LOCKED passes over the boxes another transaction is holding right now.
+   * Those are the boxes about to break the equality anyway, and blocking on one
+   * would hold the tick — and the Redis lock it runs under — open behind someone
+   * else's transaction.
+   */
+  private async lockParkedBoxes(entityManager: EntityManager, runnerIds: string[]): Promise<ParkedBox[]> {
+    // A box is claimable when no migration owns it — either no row at all, or the
+    // row a finished migration left behind — so COMPLETED reads as "not
+    // claimable" here and as "claimable" in the conflict guard on the insert.
+    const migrationInFlight = entityManager
+      .createQueryBuilder()
+      .subQuery()
+      .select('1')
+      .from(BoxMigration, 'migration')
+      .where('migration.boxId = box.id')
+      .andWhere('migration.state <> :claimable')
+
+    return entityManager
+      .createQueryBuilder(Box, 'box')
+      .select('box.id', 'id')
+      .addSelect('box.updatedAt', 'updatedAt')
+      .where('box.runnerId IN (:...runnerIds)', { runnerIds })
+      .andWhere('box.state = :state', { state: BoxState.STOPPED })
+      .andWhere('box.desiredState = :desiredState', { desiredState: BoxDesiredState.STOPPED })
+      .andWhere('box.pending = false')
+      .andWhere(`NOT EXISTS ${migrationInFlight.getQuery()}`)
+      .setParameter('claimable', BoxMigrationState.COMPLETED)
+      .setLock('pessimistic_write')
+      .setOnLocked('skip_locked')
+      .getRawMany<ParkedBox>()
+  }
+
+  /**
+   * Opens a migration on each locked box, on a copy of the stamp read under the
+   * lock.
+   *
+   * The conflict guard is what a migration opened since the select survives: the
+   * select's view of this table is a statement older than the lock, so a row
+   * inserted in between is only visible here, and DO UPDATE takes over the
+   * COMPLETED row a finished migration left while leaving a live one alone.
+   *
+   * @returns How many boxes got a migration — the rows the guard let through.
+   */
+  private async openMigrations(entityManager: EntityManager, parked: ParkedBox[]): Promise<number> {
+    // ON CONFLICT names the row already there by the table's own name, and the
+    // guard is written against that name by hand: an object-form condition is
+    // built against the builder's alias for the target instead, which is the
+    // entity's table path — under a non-default schema that is quoted whole,
+    // as "schema.box_migration", a table no clause of the statement has.
+    const conflictTarget = entityManager.connection.getMetadata(BoxMigration).tableName
+
+    const claimed = await entityManager
+      .createQueryBuilder()
+      .insert()
+      .into(BoxMigration)
+      .values(
+        parked.map(({ id, updatedAt }) => ({
+          boxId: id,
+          state: BoxMigrationState.PENDING_EXPORT,
+          updatedAt,
+        })),
+      )
+      .orUpdate(['state', 'updatedAt'], ['boxId'], {
+        overwriteCondition: {
+          where: `"${conflictTarget}"."state" = :claimable`,
+          parameters: { claimable: BoxMigrationState.COMPLETED },
+        },
+      })
+      .returning('"boxId"')
+      .execute()
+
+    return (claimed.raw as Array<{ boxId: string }>).length
   }
 
   /**

--- a/apps/api/src/box/services/box-activity.service.integration.spec.ts
+++ b/apps/api/src/box/services/box-activity.service.integration.spec.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { randomUUID } from 'node:crypto'
+import { DataSource, Repository } from 'typeorm'
+import { CustomNamingStrategy } from '../../common/utils/naming-strategy.util'
+import { Box } from '../entities/box.entity'
+import { BoxLastActivity } from '../entities/box-last-activity.entity'
+import { BoxMigration } from '../entities/box-migration.entity'
+import { BoxActivityService } from './box-activity.service'
+
+const describeIfDatabase = process.env.DB_HOST ? describe : describe.skip
+const schemaName = `box_activity_flush_${process.pid}_${randomUUID().replaceAll('-', '')}`
+const organizationId = '00000000-0000-4000-8000-0000000000ff'
+
+function box(name: string): Box {
+  const created = new Box('us', name)
+  created.organizationId = organizationId
+  created.osUser = 'boxlite'
+  return created
+}
+
+// The flush swallows what the upsert throws — a statement Postgres rejects
+// leaves no trace beyond a log line — so every case here is asserted on the
+// rows the flush left behind rather than on the call.
+describeIfDatabase('BoxActivityService.flushActivityToDb (integration, real Postgres)', () => {
+  let dataSource: DataSource
+  let boxes: Repository<Box>
+  let activity: Repository<BoxLastActivity>
+  let service: BoxActivityService
+  let buffered: Array<{ boxId: string; lastActivityAt: Date }>
+  let ownsSchema = false
+
+  beforeAll(async () => {
+    dataSource = await new DataSource({
+      type: 'postgres',
+      host: process.env.DB_HOST,
+      port: Number(process.env.DB_PORT || 5432),
+      username: process.env.DB_USERNAME,
+      password: process.env.DB_PASSWORD,
+      database: process.env.DB_DATABASE,
+      schema: schemaName,
+      entities: [Box, BoxLastActivity, BoxMigration],
+      namingStrategy: new CustomNamingStrategy(),
+      entitySkipConstructor: true,
+      synchronize: false,
+      // Partial-index predicates reach CREATE INDEX with their enum casts
+      // unqualified, so this run's schema has to be on the search_path for
+      // synchronize() to build them here.
+      extra: { options: `-c search_path=${schemaName},public` },
+    }).initialize()
+
+    await dataSource.query(`CREATE SCHEMA "${schemaName}"`)
+    ownsSchema = true
+    await dataSource.synchronize()
+    boxes = dataSource.getRepository(Box)
+    activity = dataSource.getRepository(BoxLastActivity)
+
+    service = new BoxActivityService(
+      {
+        // What the buffer holds, in the flat member/score shape WITHSCORES returns.
+        zrangebyscore: () =>
+          Promise.resolve(buffered.flatMap(({ boxId, lastActivityAt }) => [boxId, String(lastActivityAt.getTime())])),
+        zremrangebyscore: () => Promise.resolve(0),
+      } as any,
+      dataSource,
+      { lock: () => Promise.resolve(true), unlock: () => Promise.resolve() } as any,
+      { getOrThrow: () => 100 } as any,
+    )
+  })
+
+  afterAll(async () => {
+    if (!dataSource?.isInitialized) {
+      return
+    }
+
+    try {
+      if (ownsSchema) {
+        await dataSource.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`)
+      }
+    } finally {
+      await dataSource.destroy()
+    }
+  })
+
+  beforeEach(async () => {
+    buffered = []
+    await dataSource.query(`DELETE FROM "${schemaName}"."box_last_activity"`)
+    await dataSource.query(`DELETE FROM "${schemaName}"."box"`)
+  })
+
+  it('writes the buffered timestamp for a box with no activity row', async () => {
+    const target = box('first-activity')
+    await boxes.insert(target)
+    const lastActivityAt = new Date('2026-01-01T00:00:00.000Z')
+    buffered = [{ boxId: target.id, lastActivityAt }]
+
+    await service.flushActivityToDb()
+
+    expect((await activity.findOneByOrFail({ boxId: target.id })).lastActivityAt).toEqual(lastActivityAt)
+  })
+
+  it('keeps the later of the buffered and stored timestamps', async () => {
+    const advanced = box('advanced')
+    const stale = box('stale')
+    await boxes.insert([advanced, stale])
+    const stored = new Date('2026-01-01T00:00:00.000Z')
+    await activity.insert([
+      { boxId: advanced.id, lastActivityAt: stored },
+      { boxId: stale.id, lastActivityAt: stored },
+    ])
+    const newer = new Date('2026-01-02T00:00:00.000Z')
+    const older = new Date('2025-12-31T00:00:00.000Z')
+    buffered = [
+      { boxId: advanced.id, lastActivityAt: newer },
+      { boxId: stale.id, lastActivityAt: older },
+    ]
+
+    await service.flushActivityToDb()
+
+    // The guard on the upsert is the whole point of the conditional: a buffered
+    // value the database has already moved past must not travel backwards, or
+    // an idle box would look freshly used to the auto-stop lifecycle.
+    expect((await activity.findOneByOrFail({ boxId: advanced.id })).lastActivityAt).toEqual(newer)
+    expect((await activity.findOneByOrFail({ boxId: stale.id })).lastActivityAt).toEqual(stored)
+  })
+
+  it('fills a row that has no timestamp yet', async () => {
+    const target = box('never-active')
+    await boxes.insert(target)
+    await activity.insert({ boxId: target.id })
+    const lastActivityAt = new Date('2026-01-01T00:00:00.000Z')
+    buffered = [{ boxId: target.id, lastActivityAt }]
+
+    await service.flushActivityToDb()
+
+    // Null is not "later than everything" to Postgres — the comparison alone
+    // would answer NULL and drop the write, so the guard names this case.
+    expect((await activity.findOneByOrFail({ boxId: target.id })).lastActivityAt).toEqual(lastActivityAt)
+  })
+
+  it('flushes the boxes that still exist when one in the batch is gone', async () => {
+    const live = box('still-here')
+    await boxes.insert(live)
+    const lastActivityAt = new Date('2026-01-01T00:00:00.000Z')
+    // The buffer outlives the box it was written for, so the batch carries a
+    // foreign key no box row satisfies.
+    buffered = [
+      { boxId: 'box-deleted-mid-flush', lastActivityAt },
+      { boxId: live.id, lastActivityAt },
+    ]
+
+    await service.flushActivityToDb()
+
+    expect((await activity.findOneByOrFail({ boxId: live.id })).lastActivityAt).toEqual(lastActivityAt)
+    expect(await activity.count()).toBe(1)
+  })
+})

--- a/apps/api/src/box/services/box-activity.service.ts
+++ b/apps/api/src/box/services/box-activity.service.ts
@@ -7,7 +7,7 @@ import { Injectable, Logger } from '@nestjs/common'
 import { InjectRedis } from '@nestjs-modules/ioredis'
 import Redis from 'ioredis'
 import { InjectDataSource } from '@nestjs/typeorm'
-import { DataSource, IsNull, Raw } from 'typeorm'
+import { DataSource } from 'typeorm'
 import { Cron, CronExpression } from '@nestjs/schedule'
 import { RedisLockProvider } from '../common/redis-lock.provider'
 import { BoxLastActivity } from '../entities/box-last-activity.entity'
@@ -127,6 +127,14 @@ export class BoxActivityService {
    * Uses a conditional upsert that only updates when the incoming timestamp is newer, preventing updates to stale buffered values.
    */
   private buildUpsertQuery(values: BoxActivityUpdate | BoxActivityUpdate[]) {
+    // ON CONFLICT names the row already there by the table's own name, and the
+    // guard is written against that name by hand: an object-form condition is
+    // built against the builder's alias for the target instead, which is the
+    // entity's table path — under a non-default schema that is quoted whole,
+    // as "schema.box_last_activity", a table no clause of the statement has.
+    const conflictTarget = this.dataSource.getMetadata(BoxLastActivity).tableName
+    const storedAt = `"${conflictTarget}"."lastActivityAt"`
+
     return this.dataSource
       .createQueryBuilder()
       .insert()
@@ -134,10 +142,7 @@ export class BoxActivityService {
       .values(values)
       .orUpdate(['lastActivityAt'], ['boxId'], {
         overwriteCondition: {
-          where: [
-            { lastActivityAt: IsNull() },
-            { lastActivityAt: Raw((alias) => `${alias} < EXCLUDED."lastActivityAt"`) },
-          ],
+          where: `(${storedAt} IS NULL OR ${storedAt} < EXCLUDED."lastActivityAt")`,
         },
       })
   }

--- a/apps/api/src/box/services/box-migration.service.spec.ts
+++ b/apps/api/src/box/services/box-migration.service.spec.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Not } from 'typeorm'
+import { RunnerState } from '../enums/runner-state.enum'
+import { BoxMigrationService } from './box-migration.service'
+
+type Harness = {
+  service: BoxMigrationService
+  runnerFind: jest.Mock
+  markParkedBoxesForExport: jest.Mock
+  lock: jest.Mock
+  unlock: jest.Mock
+  logger: { log: jest.Mock; error: jest.Mock }
+}
+
+function createService(
+  params: { drainingRunnerIds?: string[]; acquiresLock?: boolean; marked?: number } = {},
+): Harness {
+  const { drainingRunnerIds = [], acquiresLock = true, marked = 0 } = params
+
+  const service = Object.create(BoxMigrationService.prototype) as BoxMigrationService
+  const runnerFind = jest.fn().mockResolvedValue(drainingRunnerIds.map((id) => ({ id })))
+  const markParkedBoxesForExport = jest.fn().mockResolvedValue(marked)
+  const lock = jest.fn().mockResolvedValue(acquiresLock)
+  const unlock = jest.fn().mockResolvedValue(undefined)
+  const logger = { log: jest.fn(), error: jest.fn() }
+
+  ;(service as any).logger = logger
+  ;(service as any).runnerRepository = { find: runnerFind }
+  ;(service as any).boxRepository = { markParkedBoxesForExport }
+  ;(service as any).redisLockProvider = { lock, unlock }
+
+  return { service, runnerFind, markParkedBoxesForExport, lock, unlock, logger }
+}
+
+function runMarker(service: BoxMigrationService): Promise<void> {
+  return (service as any).markBoxesOnDrainingRunners()
+}
+
+describe('BoxMigrationService marker loop', () => {
+  it('marks the parked boxes of every draining runner', async () => {
+    const { service, markParkedBoxesForExport, logger } = createService({
+      drainingRunnerIds: ['runner-a', 'runner-b'],
+      marked: 3,
+    })
+
+    await runMarker(service)
+
+    expect(markParkedBoxesForExport).toHaveBeenCalledWith(['runner-a', 'runner-b'])
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
+  it('skips runners that have already been decommissioned', async () => {
+    const { service, runnerFind } = createService({ drainingRunnerIds: ['runner-a'] })
+
+    await runMarker(service)
+
+    // A decommissioned runner cannot export anything, so marking its boxes
+    // would open migrations that can only ever roll back.
+    expect(runnerFind).toHaveBeenCalledWith({
+      where: { draining: true, state: Not(RunnerState.DECOMMISSIONED) },
+      select: ['id'],
+    })
+  })
+
+  it('does not touch the box table when no runner is draining', async () => {
+    const { service, markParkedBoxesForExport, unlock } = createService({ drainingRunnerIds: [] })
+
+    await runMarker(service)
+
+    expect(markParkedBoxesForExport).not.toHaveBeenCalled()
+    expect(unlock).toHaveBeenCalledTimes(1)
+  })
+
+  it('yields to the worker that already holds the tick', async () => {
+    const { service, runnerFind, markParkedBoxesForExport, unlock } = createService({
+      drainingRunnerIds: ['runner-a'],
+      acquiresLock: false,
+    })
+
+    await runMarker(service)
+
+    expect(runnerFind).not.toHaveBeenCalled()
+    expect(markParkedBoxesForExport).not.toHaveBeenCalled()
+    // Releasing here would hand the tick to a second worker mid-flight.
+    expect(unlock).not.toHaveBeenCalled()
+  })
+
+  it('releases the tick lock when marking fails', async () => {
+    const { service, markParkedBoxesForExport, unlock, logger } = createService({ drainingRunnerIds: ['runner-a'] })
+    markParkedBoxesForExport.mockRejectedValue(new Error('deadlock detected'))
+
+    await expect(runMarker(service)).resolves.toBeUndefined()
+
+    // A held lock would park the loop until the TTL expires, long after the
+    // failure that caused it has passed.
+    expect(unlock).toHaveBeenCalledTimes(1)
+    expect(logger.error).toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/box/services/box-migration.service.ts
+++ b/apps/api/src/box/services/box-migration.service.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Injectable, Logger } from '@nestjs/common'
+import { Cron, CronExpression } from '@nestjs/schedule'
+import { InjectRepository } from '@nestjs/typeorm'
+import { Not, Repository } from 'typeorm'
+
+import { Runner } from '../entities/runner.entity'
+import { RunnerState } from '../enums/runner-state.enum'
+import { BoxRepository } from '../repositories/box.repository'
+import { RedisLockProvider } from '../common/redis-lock.provider'
+import { LogExecution } from '../../common/decorators/log-execution.decorator'
+import { WithInstrumentation } from '../../common/decorators/otel.decorator'
+
+// One name for the loop: the cron entry, the execution log line, and the Redis
+// key that keeps two workers off the same tick.
+const MARKER_LOOP = 'migration-marker'
+
+// One tick's worth of headroom: long enough that a slow tick keeps its lock to
+// the end, short enough that a worker lost mid-tick does not park the loop for
+// more than the tick after it.
+const MARKER_LOOP_LOCK_TTL_SECONDS = 120
+
+/**
+ * Drives boxes off draining runners.
+ *
+ * This is the entry point of a migration and the only one that decides a box
+ * should move; every later step reacts to the state this leaves behind. The
+ * marking is a single conditional UPDATE rather than a read-then-write, so
+ * concurrent starts and stops either land before it and disqualify the box, or
+ * land after it and break the timestamp equality a later validity check reads.
+ */
+@Injectable()
+export class BoxMigrationService {
+  private readonly logger = new Logger(BoxMigrationService.name)
+
+  constructor(
+    @InjectRepository(Runner)
+    private readonly runnerRepository: Repository<Runner>,
+    private readonly boxRepository: BoxRepository,
+    private readonly redisLockProvider: RedisLockProvider,
+  ) {}
+
+  @Cron(CronExpression.EVERY_MINUTE, { name: MARKER_LOOP })
+  @LogExecution(MARKER_LOOP)
+  @WithInstrumentation()
+  private async markBoxesOnDrainingRunners(): Promise<void> {
+    // Two workers marking at once would be harmless — the UPDATE is idempotent
+    // and the second matches nothing — but it costs a full scan per worker.
+    if (!(await this.redisLockProvider.lock(MARKER_LOOP, MARKER_LOOP_LOCK_TTL_SECONDS))) {
+      return
+    }
+
+    try {
+      const runnerIds = await this.findDrainingRunnerIds()
+      if (runnerIds.length === 0) {
+        return
+      }
+
+      const marked = await this.boxRepository.markParkedBoxesForExport(runnerIds)
+      if (marked > 0) {
+        this.logger.log(`Marked ${marked} parked boxes on ${runnerIds.length} draining runners for migration`)
+      }
+    } catch (error) {
+      // Nothing here is half-done: the marking is one statement, so it either
+      // committed or it did not, and the next tick re-selects whatever is left.
+      this.logger.error('Error marking boxes on draining runners for migration', error)
+    } finally {
+      await this.redisLockProvider.unlock(MARKER_LOOP)
+    }
+  }
+
+  /**
+   * Runners being emptied, excluding the ones already gone — a decommissioned
+   * runner cannot export the box it no longer serves.
+   */
+  private async findDrainingRunnerIds(): Promise<string[]> {
+    const runners = await this.runnerRepository.find({
+      where: {
+        draining: true,
+        state: Not(RunnerState.DECOMMISSIONED),
+      },
+      select: ['id'],
+    })
+
+    return runners.map((runner) => runner.id)
+  }
+}

--- a/apps/api/src/migrations/pre-deploy/1786200000000-add-box-migration-table-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1786200000000-add-box-migration-table-migration.ts
@@ -1,0 +1,32 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddBoxMigrationTable1786200000000 implements MigrationInterface {
+  name = 'AddBoxMigrationTable1786200000000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."box_migration_state_enum" AS ENUM('pending_export', 'pending_import', 'pending_discard_exported', 'pending_rollback', 'completed')`,
+    )
+    // One row per migration in flight, keyed by the box it moves. There is no
+    // "not migrating" state: that is the absence of a row, which is also what
+    // the cascade leaves behind when the box goes away.
+    //
+    // `arcPath` is empty, not null, when there is no archive to reclaim — the
+    // rollback path tests it for emptiness, and one sentinel keeps that a plain
+    // comparison instead of a null-or-empty pair. `updatedAt` is NOT NULL
+    // because the marker copies `box.updatedAt` into it in the statement that
+    // creates the row.
+    await queryRunner.query(
+      `CREATE TABLE "box_migration" ("boxId" character varying NOT NULL, "state" "public"."box_migration_state_enum" NOT NULL, "arcPath" character varying NOT NULL DEFAULT '', "runnerId" uuid, "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL, CONSTRAINT "box_migration_boxId_pk" PRIMARY KEY ("boxId"), CONSTRAINT "box_migration_boxId_fk" FOREIGN KEY ("boxId") REFERENCES "box"("id") ON DELETE CASCADE ON UPDATE NO ACTION)`,
+    )
+    // The migration loops scan by state, and every row in this table is a
+    // migration in flight, so the index covers the whole table.
+    await queryRunner.query(`CREATE INDEX "box_migration_state_idx" ON "box_migration" ("state")`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "public"."box_migration_state_idx"`)
+    await queryRunner.query(`DROP TABLE "box_migration"`)
+    await queryRunner.query(`DROP TYPE "public"."box_migration_state_enum"`)
+  }
+}


### PR DESCRIPTION
## Summary

A box migration moves a stopped box between runners through an archive in the object store. The runner already performs one step per job (#1189); this adds the box-table half of the state machine and the loop that opens it.

## Call graph

Before

```text
handleCheckDecommissionRunners   (RunnerService · apps/api/src/box/services/runner.service.ts:643)      — waits for a draining runner to empty
  └─ count                       (BoxRepository · apps/api/src/box/repositories/box.repository.ts)      — counts boxes still owned by it
                                                                                                          nothing moves a parked box, so the count never drops
  …
exportBox                        (Executor · apps/runner/pkg/runner/v2/executor/migrate.go:40)          — never reached: no migration job is ever submitted
```

After

```text
markBoxesOnDrainingRunners       (BoxMigrationService · apps/api/src/box/services/box-migration.service.ts:50)  — cron, once a minute, behind a Redis lock
  ├─ findDrainingRunnerIds       (BoxMigrationService · apps/api/src/box/services/box-migration.service.ts:80)  — draining and not decommissioned
  └─ markParkedBoxesForExport    (BoxRepository · apps/api/src/box/repositories/box.repository.ts:263)          — one conditional UPDATE over the parked boxes
       └─ migrateState = PENDING_EXPORT, migrateUpdatedAt = updatedAt = CURRENT_TIMESTAMP
                                 (Box · apps/api/src/box/entities/box.entity.ts:180)                            — the state a later step reacts to
  …
exportBox                        (Executor · apps/runner/pkg/runner/v2/executor/migrate.go:40)                  — unchanged; still waits on a job a later PR submits
```

## Changes

- `Box` carries four migrate columns. `migrateState` names the job the migration is waiting on, never what it has produced — that is what `migrateArcPath` (an archive on the object store) and `migrateRunnerId` (a box on a second runner) record, so a rollback can reclaim either one whether or not the migration stayed valid. `migrateRunnerId` is its own column rather than a reuse of `prevRunnerId`, which the archived-box start path already clears for its own purpose.
- `BoxMigrationService` claims, every minute, the boxes parked on a draining runner — stopped, wanting to stay stopped, and not already migrating — in one conditional `UPDATE`. Concurrent starts and stops either land before it and disqualify the box, or land after it and break the timestamp equality a later validity check reads.
- `migrateUpdatedAt` and `updatedAt` are written from the same statement's `CURRENT_TIMESTAMP`, so the two start out equal and any later write from outside the migration moves `updatedAt` alone. That broken equality is how every later step tells that a box was touched underneath it.
- `COMPLETED` is claimable again, so a runner that drains a second time re-migrates what it took back.
- The schema change is additive and pre-deploy: the enum defaults to `none` and the timestamp stays null until a migration writes it.

## How to verify

```bash
cd apps
npx nx test api --testPathPatterns=box-migration.service.spec.ts --testPathPatterns=box.repository.migrate-marker.spec.ts
```

The marker's SQL is covered against a real Postgres by `box.repository.migrate-marker.integration.spec.ts`, which runs whenever `DB_HOST` is set and skips otherwise.

## Risks / rollout

- No behavior changes until a runner is flagged `draining`; on a fleet with none, the loop finds no runners and returns.
- This PR only opens the migration — nothing submits `EXPORT_BOX` yet, so a marked box sits in `pending_export` until the step that submits it lands. Rollback is dropping the migration and the service registration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated tracking of parked boxes that need export during runner draining.
  * Added migration states for export, import, discard, rollback, and completion.
  * Added scheduled processing with safe locking and recovery when processing fails.
  * Added database support for preserving box timestamps and migration progress.

* **Bug Fixes**
  * Improved activity updates so newer timestamps reliably take precedence while preserving existing activity data.

* **Tests**
  * Added unit and integration coverage for claiming, locking, retries, exclusions, cleanup, and activity recording behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->