### PR TITLE
feat(cli,rest): expose privileged mode via --privileged and self-hosted REST

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -208,8 +208,9 @@ processes. Both lists default to empty, preserving BoxLite's Docker-compatible
 - Use `drop=["ALL"]` with explicit additions to construct a minimal set.
 - Malformed names are rejected at the API boundary. A well-formed name that the
   bundled guest runtime does not support is rejected during container initialization.
-- A remote client and the host both check support before creating a box; a
-  custom policy is rejected rather than ignored when either side is too old.
+- The API and SDK validate the capability name shape, while the guest checks
+  support against its own kernel; a custom policy is rejected rather than
+  ignored when the guest cannot apply it.
 - The resolved set is applied to OCI bounding, effective, and permitted sets.
   Inheritable and ambient capabilities stay unset; they are not implied by `add`.
 

--- a/openapi/box.openapi.yaml
+++ b/openapi/box.openapi.yaml
@@ -1358,6 +1358,10 @@ components:
               type: boolean
               description: Whether Docker-style Linux capability add/drop policy is supported
               example: true
+            privileged_enabled:
+              type: boolean
+              description: Whether Docker-style privileged mode requests are supported. Privileged mode grants all Linux capabilities and opens the required guest sysctl path.
+              example: true
             max_cpus:
               type: integer
               description: Maximum allowed vCPUs per box
@@ -1793,6 +1797,10 @@ components:
       properties:
         capabilities:
           $ref: "#/components/schemas/CreateContainerCapabilities"
+        privileged:
+          type: boolean
+          default: false
+          description: Request Docker-style privileged mode for DinD. When true, the server grants all Linux capabilities and enables the complete guest-level privileged shape. It cannot be combined with cap_add or cap_drop; the only capability policy accepted alongside it is the canonical add=["ALL"] with an empty drop list that privileged mode itself expands to.
 
     CreateContainerCapabilities:
       type: object

--- a/openapi/reference-server/server.py
+++ b/openapi/reference-server/server.py
@@ -152,6 +152,24 @@ class CreateBoxAdvancedOptions(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     capabilities: ContainerCapabilities = Field(default_factory=ContainerCapabilities)
+    privileged: bool = False
+
+    @model_validator(mode="after")
+    def normalize_privileged(self) -> "CreateBoxAdvancedOptions":
+        if not self.privileged:
+            return self
+
+        # Privileged mode is a separate shape from capability overrides. Only
+        # the canonical policy it expands to is accepted alongside it; anything
+        # else is a conflict the caller must resolve, not something to rewrite
+        # behind their back.
+        canonical = self.capabilities.drop == [] and self.capabilities.add == ["ALL"]
+        if (self.capabilities.add or self.capabilities.drop) and not canonical:
+            raise ValueError("privileged mode cannot be combined with cap_add or cap_drop")
+
+        self.capabilities.add = ["ALL"]
+        self.capabilities.drop = []
+        return self
 
 
 class CreateBoxRequest(BaseModel):
@@ -405,13 +423,16 @@ def build_box_options(req: CreateBoxRequest) -> boxlite.BoxOptions:
     if req.user is not None:
         kwargs["user"] = req.user
     if req.advanced is not None and (
-        req.advanced.capabilities.add or req.advanced.capabilities.drop
+        req.advanced.capabilities.add
+        or req.advanced.capabilities.drop
+        or req.advanced.privileged
     ):
         kwargs["advanced"] = boxlite.AdvancedBoxOptions(
             capabilities=boxlite.ContainerCapabilities(
                 add=req.advanced.capabilities.add,
                 drop=req.advanced.capabilities.drop,
-            )
+            ),
+            privileged=req.advanced.privileged,
         )
     if req.secrets:
         kwargs["secrets"] = [
@@ -599,6 +620,7 @@ async def get_config():
         "overrides": {},
         "capabilities": {
             "linux_capabilities_enabled": True,
+            "privileged_enabled": True,
             "max_cpus": 32,
             "max_memory_mib": 16384,
             "max_disk_size_gb": 100,

--- a/openapi/reference-server/server.py
+++ b/openapi/reference-server/server.py
@@ -148,6 +148,14 @@ class ContainerCapabilities(BaseModel):
         return capabilities
 
 
+def _canonical_capability_name(capability: str) -> str:
+    """Mirrors the Rust core's `canonical_capability_name`: uppercase, then
+    strip an optional `CAP_` prefix — even if that leaves an empty string,
+    never fall back to treating the prefix as absent."""
+    normalized = capability.upper()
+    return normalized[4:] if normalized.startswith("CAP_") else normalized
+
+
 class CreateBoxAdvancedOptions(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -162,8 +170,15 @@ class CreateBoxAdvancedOptions(BaseModel):
         # Privileged mode is a separate shape from capability overrides. Only
         # the canonical policy it expands to is accepted alongside it; anything
         # else is a conflict the caller must resolve, not something to rewrite
-        # behind their back.
-        canonical = self.capabilities.drop == [] and self.capabilities.add == ["ALL"]
+        # behind their back. Names are case-insensitive and the CAP_ prefix is
+        # optional (see ContainerCapabilities.validate_capabilities), so the
+        # comparison here has to canonicalize too — the Rust runtime does,
+        # via the same rule, before it checks this shape.
+        canonical = (
+            self.capabilities.drop == []
+            and len(self.capabilities.add) == 1
+            and _canonical_capability_name(self.capabilities.add[0]) == "ALL"
+        )
         if (self.capabilities.add or self.capabilities.drop) and not canonical:
             raise ValueError("privileged mode cannot be combined with cap_add or cap_drop")
 

--- a/openapi/reference-server/tests/test_handle_cache.py
+++ b/openapi/reference-server/tests/test_handle_cache.py
@@ -169,16 +169,7 @@ class HandleCacheTests(unittest.IsolatedAsyncioTestCase):
         paths = {route.path for route in SERVER.app.routes}
         self.assertNotIn("/v1/{prefix}/boxes/{box_id}/ports", paths)
 
-    def test_build_box_options_forwards_capability_policy(self) -> None:
-        request = SERVER.CreateBoxRequest(
-            advanced=SERVER.CreateBoxAdvancedOptions(
-                capabilities=SERVER.ContainerCapabilities(
-                    add=["SYS_ADMIN"],
-                    drop=["CAP_NET_RAW"],
-                )
-            ),
-        )
-
+    def _build_with_mocked_boxlite(self, request):
         capabilities = object()
         advanced = object()
         with (
@@ -200,16 +191,77 @@ class HandleCacheTests(unittest.IsolatedAsyncioTestCase):
         ):
             SERVER.build_box_options(request)
 
+        return capabilities, advanced, capabilities_constructor, advanced_constructor, constructor
+
+    def test_build_box_options_forwards_capability_policy(self) -> None:
+        request = SERVER.CreateBoxRequest(
+            advanced=SERVER.CreateBoxAdvancedOptions(
+                capabilities=SERVER.ContainerCapabilities(
+                    add=["SYS_ADMIN"],
+                    drop=["CAP_NET_RAW"],
+                ),
+            ),
+        )
+
+        (
+            capabilities,
+            advanced,
+            capabilities_constructor,
+            advanced_constructor,
+            constructor,
+        ) = self._build_with_mocked_boxlite(request)
+
         capabilities_constructor.assert_called_once_with(
             add=["SYS_ADMIN"],
             drop=["CAP_NET_RAW"],
         )
-        advanced_constructor.assert_called_once_with(capabilities=capabilities)
+        advanced_constructor.assert_called_once_with(
+            capabilities=capabilities,
+            privileged=False,
+        )
         constructor.assert_called_once_with(
             image="alpine:latest",
             advanced=advanced,
             detach=False,
         )
+
+    def test_build_box_options_expands_privileged_to_the_canonical_policy(self) -> None:
+        request = SERVER.CreateBoxRequest(
+            advanced=SERVER.CreateBoxAdvancedOptions(privileged=True),
+        )
+
+        (
+            capabilities,
+            _advanced,
+            capabilities_constructor,
+            advanced_constructor,
+            _constructor,
+        ) = self._build_with_mocked_boxlite(request)
+
+        capabilities_constructor.assert_called_once_with(add=["ALL"], drop=[])
+        advanced_constructor.assert_called_once_with(
+            capabilities=capabilities,
+            privileged=True,
+        )
+
+    def test_privileged_rejects_conflicting_capability_overrides(self) -> None:
+        # Every other boundary rejects this rather than rewriting it; the
+        # reference server is what client implementations are checked against,
+        # so it has to agree.
+        with self.assertRaises(ValidationError):
+            SERVER.CreateBoxAdvancedOptions(
+                capabilities=SERVER.ContainerCapabilities(drop=["ALL"]),
+                privileged=True,
+            )
+
+    def test_privileged_accepts_the_canonical_policy_it_expands_to(self) -> None:
+        advanced = SERVER.CreateBoxAdvancedOptions(
+            capabilities=SERVER.ContainerCapabilities(add=["ALL"]),
+            privileged=True,
+        )
+
+        self.assertEqual(advanced.capabilities.add, ["ALL"])
+        self.assertEqual(advanced.capabilities.drop, [])
 
     def test_create_box_rejects_malformed_capability_policy(self) -> None:
         for capability in ("NET-ADMIN", "123", "ß"):

--- a/openapi/reference-server/tests/test_handle_cache.py
+++ b/openapi/reference-server/tests/test_handle_cache.py
@@ -263,6 +263,20 @@ class HandleCacheTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(advanced.capabilities.add, ["ALL"])
         self.assertEqual(advanced.capabilities.drop, [])
 
+    def test_privileged_accepts_case_insensitive_and_cap_prefixed_all(self) -> None:
+        # Capability names are documented as case-insensitive with an optional
+        # CAP_ prefix (ContainerCapabilities.validate_capabilities); the
+        # canonical-shape check for privileged mode has to agree, the same
+        # way the Rust core's canonical_capability_name does.
+        for spelling in ("all", "Cap_All", "CAP_ALL"):
+            advanced = SERVER.CreateBoxAdvancedOptions(
+                capabilities=SERVER.ContainerCapabilities(add=[spelling]),
+                privileged=True,
+            )
+
+            self.assertEqual(advanced.capabilities.add, ["ALL"], msg=spelling)
+            self.assertEqual(advanced.capabilities.drop, [], msg=spelling)
+
     def test_create_box_rejects_malformed_capability_policy(self) -> None:
         for capability in ("NET-ADMIN", "123", "ß"):
             with self.assertRaises(ValueError):

--- a/src/boxlite/src/rest/client.rs
+++ b/src/boxlite/src/rest/client.rs
@@ -501,6 +501,16 @@ impl ApiClient {
         )
     }
 
+    pub async fn require_privileged_enabled(&self) -> BoxliteResult<()> {
+        let config = self.fetch_config().await?;
+        let capabilities = config.capabilities.ok_or_else(|| {
+            BoxliteError::Unsupported(
+                "Remote server did not advertise privileged support".to_string(),
+            )
+        })?;
+        ensure_capability("privileged mode", capabilities.privileged_enabled)
+    }
+
     pub async fn require_clone_enabled(&self) -> BoxliteResult<()> {
         let config = self.get_config().await?;
         let capabilities = config.capabilities.ok_or_else(|| {

--- a/src/boxlite/src/rest/runtime.rs
+++ b/src/boxlite/src/rest/runtime.rs
@@ -111,6 +111,7 @@ fn reject_remote_experimental_options(options: &BoxOptions) -> BoxliteResult<()>
 #[async_trait::async_trait]
 impl RuntimeBackend for RestRuntime {
     async fn create(&self, options: BoxOptions, name: Option<String>) -> BoxliteResult<LiteBox> {
+        options.sanitize()?;
         validate_remote_box_options(&options)?;
         reject_remote_experimental_options(&options)?;
 
@@ -130,6 +131,9 @@ impl RuntimeBackend for RestRuntime {
         if !options.advanced.capabilities.is_empty() {
             self.client.require_linux_capabilities_enabled().await?;
         }
+        if options.advanced.privileged {
+            self.client.require_privileged_enabled().await?;
+        }
 
         let req = CreateBoxRequest::from_options(&options, name);
         let resp: BoxResponse = self.client.post("/boxes", &req).await?;
@@ -143,6 +147,7 @@ impl RuntimeBackend for RestRuntime {
         options: BoxOptions,
         name: Option<String>,
     ) -> BoxliteResult<(LiteBox, bool)> {
+        options.sanitize()?;
         validate_remote_box_options(&options)?;
         reject_remote_experimental_options(&options)?;
 

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -78,6 +78,7 @@ pub(crate) struct ServerConfig {
 #[derive(Debug, Deserialize, Clone, Default)]
 pub(crate) struct ServerCapabilities {
     pub linux_capabilities_enabled: Option<bool>,
+    pub privileged_enabled: Option<bool>,
     pub snapshots_enabled: Option<bool>,
     pub clone_enabled: Option<bool>,
     pub export_enabled: Option<bool>,
@@ -179,6 +180,9 @@ impl CreateBoxRequest {
         // `BoxOptions.advanced.security` because those run under the
         // caller's own trust boundary.
 
+        let mut advanced = options.advanced.clone();
+        advanced.normalize_privileged();
+
         Self {
             name,
             image,
@@ -196,9 +200,10 @@ impl CreateBoxRequest {
             volumes,
             detach: Some(options.detach),
             tty: options.tty.then_some(true),
-            advanced: (!options.advanced.capabilities.is_empty()).then(|| {
+            advanced: (!advanced.capabilities.is_empty() || advanced.privileged).then_some({
                 CreateBoxAdvancedOptions {
-                    capabilities: options.advanced.capabilities.clone(),
+                    capabilities: advanced.capabilities,
+                    privileged: advanced.privileged,
                 }
             }),
             // The deprecated remove-on-stop flag was never applied by the cloud
@@ -214,6 +219,8 @@ impl CreateBoxRequest {
 #[derive(Debug, Serialize)]
 pub(crate) struct CreateBoxAdvancedOptions {
     pub capabilities: ContainerCapabilities,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub privileged: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -775,6 +782,32 @@ mod tests {
     }
 
     #[test]
+    fn test_create_box_request_carries_privileged() {
+        let opts = BoxOptions {
+            advanced: crate::AdvancedBoxOptions {
+                privileged: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let req = CreateBoxRequest::from_options(&opts, None);
+        let json = serde_json::to_value(&req).expect("serialize create request");
+        assert_eq!(
+            json["advanced"]["privileged"],
+            serde_json::Value::Bool(true)
+        );
+        assert_eq!(
+            json["advanced"]["capabilities"]["add"],
+            serde_json::json!(["ALL"])
+        );
+        assert_eq!(
+            json["advanced"]["capabilities"]["drop"],
+            serde_json::json!([])
+        );
+    }
+
+    #[test]
     #[allow(deprecated)]
     fn deprecated_auto_remove_does_not_change_rest_lifecycle_defaults() {
         for auto_remove in [false, true] {
@@ -1033,6 +1066,7 @@ mod tests {
             "capabilities": {
                 "snapshots_enabled": true,
                 "linux_capabilities_enabled": true,
+                "privileged_enabled": true,
                 "clone_enabled": false,
                 "export_enabled": true
             }
@@ -1040,6 +1074,7 @@ mod tests {
         let resp: ServerConfig = serde_json::from_str(json).unwrap();
         let caps = resp.capabilities.unwrap();
         assert_eq!(caps.linux_capabilities_enabled, Some(true));
+        assert_eq!(caps.privileged_enabled, Some(true));
         assert_eq!(caps.snapshots_enabled, Some(true));
         assert_eq!(caps.clone_enabled, Some(false));
         assert_eq!(caps.export_enabled, Some(true));

--- a/src/cli/src/cli.rs
+++ b/src/cli/src/cli.rs
@@ -472,6 +472,12 @@ impl ProcessFlags {
 
 #[derive(Args, Debug, Clone, Default)]
 pub struct CapabilityFlags {
+    /// Request Docker-style privileged mode for the container (available on
+    /// `create` and `run`). This enables the complete guest-level privileged
+    /// shape required by DinD; it is not equivalent to `--cap-add ALL`.
+    #[arg(long)]
+    pub privileged: bool,
+
     /// Add a Linux capability to the container (repeatable; `ALL` is supported)
     #[arg(long = "cap-add", value_name = "CAPABILITY")]
     pub cap_add: Vec<String>,
@@ -482,9 +488,15 @@ pub struct CapabilityFlags {
 }
 
 impl CapabilityFlags {
-    pub fn apply_to(&self, opts: &mut BoxOptions) {
+    pub fn apply_to(&self, opts: &mut BoxOptions) -> anyhow::Result<()> {
+        if self.privileged && (!self.cap_add.is_empty() || !self.cap_drop.is_empty()) {
+            anyhow::bail!("--privileged cannot be combined with --cap-add or --cap-drop");
+        }
+
+        opts.advanced.privileged = self.privileged;
         opts.advanced.capabilities.add.clone_from(&self.cap_add);
         opts.advanced.capabilities.drop.clone_from(&self.cap_drop);
+        Ok(())
     }
 }
 

--- a/src/cli/src/commands/create.rs
+++ b/src/cli/src/commands/create.rs
@@ -73,7 +73,7 @@ impl CreateArgs {
             .require_enabled(global.experimental_features())?;
         let mut options = BoxOptions::default();
         self.resource.apply_to(&mut options);
-        self.capability.apply_to(&mut options);
+        self.capability.apply_to(&mut options)?;
         self.boot.apply_to(&mut options);
         self.management.apply_to(&mut options)?;
         self.publish.apply_to(&mut options)?;
@@ -188,5 +188,20 @@ mod tests {
             .expect("options should build");
         assert_eq!(opts.advanced.capabilities.add, vec!["SYS_ADMIN"]);
         assert_eq!(opts.advanced.capabilities.drop, vec!["CAP_NET_RAW"]);
+    }
+
+    #[test]
+    fn create_privileged_flag_reaches_box_options() {
+        let cli = Cli::try_parse_from(["boxlite", "create", "--privileged", "alpine"])
+            .expect("--privileged should parse");
+        let Commands::Create(args) = cli.command else {
+            panic!("expected create command");
+        };
+
+        let opts = args
+            .to_box_options(&cli.global)
+            .expect("privileged options should build");
+
+        assert!(opts.advanced.privileged);
     }
 }

--- a/src/cli/src/commands/run.rs
+++ b/src/cli/src/commands/run.rs
@@ -130,7 +130,7 @@ impl BoxRunner {
     ) -> anyhow::Result<LiteBox> {
         let mut options = BoxOptions::default();
         self.args.resource.apply_to(&mut options);
-        self.args.capability.apply_to(&mut options);
+        self.args.capability.apply_to(&mut options)?;
         self.args.boot.apply_to(&mut options);
         self.args.management.apply_to(&mut options)?;
         self.args.publish.apply_to(&mut options)?;
@@ -220,6 +220,45 @@ mod tests {
 
         assert_eq!(args.capability.cap_add, vec!["SYS_ADMIN", "NET_ADMIN"]);
         assert_eq!(args.capability.cap_drop, vec!["CAP_NET_RAW"]);
+    }
+
+    #[test]
+    fn run_privileged_flag_reaches_capability_options() {
+        let cli = Cli::try_parse_from(["boxlite", "run", "--privileged", "alpine"])
+            .expect("--privileged should parse");
+        let Commands::Run(args) = cli.command else {
+            panic!("expected run command");
+        };
+
+        let mut opts = BoxOptions::default();
+        args.capability
+            .apply_to(&mut opts)
+            .expect("privileged options should apply");
+
+        assert!(opts.advanced.privileged);
+    }
+
+    #[test]
+    fn run_rejects_privileged_with_capability_overrides() {
+        let cli = Cli::try_parse_from([
+            "boxlite",
+            "run",
+            "--privileged",
+            "--cap-drop",
+            "ALL",
+            "alpine",
+        ])
+        .expect("flags should parse before semantic validation");
+        let Commands::Run(args) = cli.command else {
+            panic!("expected run command");
+        };
+
+        let mut opts = BoxOptions::default();
+        let error = args
+            .capability
+            .apply_to(&mut opts)
+            .expect_err("privileged and cap-drop must be rejected together");
+        assert!(error.to_string().contains("cannot be combined"));
     }
 
     #[test]

--- a/src/cli/src/commands/serve/handlers/config.rs
+++ b/src/cli/src/commands/serve/handlers/config.rs
@@ -8,6 +8,7 @@ pub(in crate::commands::serve) async fn get_config() -> Json<ServerConfig> {
     Json(ServerConfig {
         capabilities: ServerCapabilities {
             linux_capabilities_enabled: true,
+            privileged_enabled: true,
             snapshots_enabled: true,
             clone_enabled: true,
             export_enabled: true,

--- a/src/cli/src/commands/serve/mod.rs
+++ b/src/cli/src/commands/serve/mod.rs
@@ -754,7 +754,7 @@ fn build_box_options(req: &CreateBoxRequest) -> Result<BoxOptions, boxlite::Boxl
     // server with a different default; clients cannot relax it.
 
     let auto_delete = req.auto_delete.unwrap_or(0);
-    Ok(BoxOptions {
+    let options = BoxOptions {
         rootfs,
         cpus: req.cpus,
         memory_mib: req.memory_mib,
@@ -771,6 +771,7 @@ fn build_box_options(req: &CreateBoxRequest) -> Result<BoxOptions, boxlite::Boxl
                 add: req.advanced.capabilities.add.clone(),
                 drop: req.advanced.capabilities.drop.clone(),
             },
+            privileged: req.advanced.privileged,
             ..Default::default()
         },
         auto_stop: req.auto_stop,
@@ -780,7 +781,9 @@ fn build_box_options(req: &CreateBoxRequest) -> Result<BoxOptions, boxlite::Boxl
         // boxes, but do not synthesize an invalid detached remove-on-stop box.
         detach: req.detach.unwrap_or(auto_delete == 0),
         ..Default::default()
-    })
+    };
+    options.sanitize()?;
+    Ok(options)
 }
 
 fn build_box_command(req: &ExecRequest) -> Result<BoxCommand, boxlite::BoxliteError> {
@@ -1344,6 +1347,18 @@ mod tests {
         let opts = build_box_options(&req).expect("build capability options");
         assert_eq!(opts.advanced.capabilities.add, vec!["SYS_ADMIN"]);
         assert_eq!(opts.advanced.capabilities.drop, vec!["CAP_NET_RAW"]);
+    }
+
+    #[test]
+    fn build_box_options_carries_privileged_from_the_wire() {
+        let req: super::types::CreateBoxRequest =
+            serde_json::from_str(r#"{"image":"alpine:latest","advanced":{"privileged":true}}"#)
+                .expect("privileged request must deserialize");
+
+        let opts = build_box_options(&req).expect("build privileged options");
+        assert!(opts.advanced.privileged);
+        assert_eq!(opts.advanced.capabilities.add, ["ALL"]);
+        assert!(opts.advanced.capabilities.drop.is_empty());
     }
 
     #[test]

--- a/src/cli/src/commands/serve/types.rs
+++ b/src/cli/src/commands/serve/types.rs
@@ -66,6 +66,7 @@ pub(super) struct CreateBoxRequest {
 #[serde(default, deny_unknown_fields)]
 pub(super) struct CreateBoxAdvancedOptions {
     pub capabilities: ContainerCapabilitiesRequest,
+    pub privileged: bool,
 }
 
 #[derive(Clone, Default, Deserialize)]
@@ -178,6 +179,7 @@ pub(super) struct ServerConfig {
 #[derive(Serialize)]
 pub(super) struct ServerCapabilities {
     pub linux_capabilities_enabled: bool,
+    pub privileged_enabled: bool,
     pub snapshots_enabled: bool,
     pub clone_enabled: bool,
     pub export_enabled: bool,


### PR DESCRIPTION
Adds the CLI `--privileged` flag and self-hosted REST/OpenAPI exposure for the `AdvancedBoxOptions.privileged` mechanism `#646` adds — split out of `#646` the same way `#1156` split out the control-plane/runner/SDK surfaces, so `#646` stays to the guest/core mechanism itself.

Depends on `#646`: needs `AdvancedBoxOptions.privileged`/`set_privileged` to exist, so the diff below overlaps with `#646`'s own content until `#646` merges — this branch is built on top of `feat/dind-privileged-plumbing`, not a clean fork of `main`. Merge `#646` first; this PR's diff will then automatically shrink to just this PR's own 13 files.

For the isolated diff right now (13 files, +239/-247): https://github.com/G4614/boxlite/compare/feat/dind-privileged-plumbing...feat/dind-cli-rest-privileged

Test plan:
- [x] `make clippy` — clean, including cross-compiled guest crate
- [x] `make test:unit:rust` — 1006 + 49 passed
- [x] `make fmt:check:rust` — clean
- [ ] CI (will run on push; blocked on #646 merging first)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added privileged container support through the CLI, API, SDK, and server configuration.
  * Added a `--privileged` option for creating and running containers.
  * Privileged containers receive all Linux capabilities with adjusted security restrictions.
  * Server capability information now reports privileged-mode availability.
  * Security settings, including read-only paths and system mounts, are applied consistently.

* **Bug Fixes**
  * Added validation for incompatible privileged and capability options.
  * Unsupported privileged requests and untrusted privileged imports are clearly rejected.
  * Capability and security settings are consistently applied during container startup.
  * Capability validation documentation now clarifies syntax and kernel-support checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->