### PR TITLE
feat(cli): let -v mount managed volumes by name or id

### DIFF
--- a/docs/reference/cli/README.md
+++ b/docs/reference/cli/README.md
@@ -673,7 +673,7 @@ Used by `run` and `create` (defined at `src/cli/src/cli.rs:407-578`).
 
 | Flag | Short | Description |
 |------|-------|-------------|
-| `--volume VOLUME` | `-v` | Mount a volume; repeatable (see [Volume Mount Syntax](#volume-mount-syntax)) |
+| `--volume VOLUME` | `-v` | Mount a volume, local or managed; repeatable (see [Volume Mount Syntax](#volume-mount-syntax)) |
 
 ### `ManagementFlags`
 
@@ -691,10 +691,12 @@ Used by `run` and `create` (defined at `src/cli/src/cli.rs:584-604`).
 
 ## Volume Mount Syntax
 
-`-v`/`--volume` accepts the grammar implemented at `src/cli/src/cli.rs:442-519`:
+`-v`/`--volume` accepts the grammar implemented at `src/cli/src/cli.rs:836-916`
+(managed-volume form: `src/cli/src/cli.rs:799-825`):
 
 ```
-VOLUME := HOST_PATH ':' BOX_PATH [':' OPTIONS]          # bind mount
+VOLUME := 'volume://' VOLUME_NAME_OR_ID ':' BOX_PATH     # managed volume
+        | HOST_PATH ':' BOX_PATH [':' OPTIONS]           # bind mount
         | BOX_PATH [':' OPTIONS]                         # anonymous volume
 ```
 
@@ -705,8 +707,14 @@ VOLUME := HOST_PATH ':' BOX_PATH [':' OPTIONS]          # bind mount
 | `HOST_PATH:BOX_PATH` | `/host/data:/data` | Bind mount (host directory must exist) |
 | `HOST_PATH:BOX_PATH:OPTIONS` | `/host/data:/data:ro` | Bind mount with options |
 | `C:\HOST\PATH:/BOX_PATH[:OPTIONS]` | `C:\data:/app/data:ro` | Windows drive paths are handled — the drive-letter colon is not treated as a separator |
+| `volume://VOLUME_NAME_OR_ID:BOX_PATH` | `volume://myvolume:/data` | Managed volume, resolved server-side by name or id (REST runtime only, see `has_managed_volumes` at `src/cli/src/cli.rs:992-999`); box path must be absolute and read-write |
 
 **Options:** `ro` (read-only) or `rw` (read-write, default). Other options are ignored. Relative host paths are canonicalized at parse time; missing host paths fail with `volume host path ...`.
+
+The `volume://` prefix is required and unambiguous: without it, `-v` behaves
+exactly as it did before managed volumes existed — a bare token like
+`myvolume:/data` is always a local path (and fails if it doesn't exist), never
+guessed at as a volume name.
 
 The anonymous-volume base directory is resolved as: `--home`, else `$BOXLITE_HOME`, else `~/.boxlite`, else the system temp dir.
 

--- a/docs/reference/cli/README.md
+++ b/docs/reference/cli/README.md
@@ -691,13 +691,13 @@ Used by `run` and `create` (defined at `src/cli/src/cli.rs:584-604`).
 
 ## Volume Mount Syntax
 
-`-v`/`--volume` accepts the grammar implemented at `src/cli/src/cli.rs:836-916`
-(managed-volume form: `src/cli/src/cli.rs:799-825`):
+`-v`/`--volume` accepts the grammar implemented at `src/cli/src/cli.rs:838-918`
+(managed-volume form: `src/cli/src/cli.rs:799-827`):
 
 ```
-VOLUME := 'volume://' VOLUME_NAME_OR_ID ':' BOX_PATH     # managed volume
-        | HOST_PATH ':' BOX_PATH [':' OPTIONS]           # bind mount
-        | BOX_PATH [':' OPTIONS]                         # anonymous volume
+VOLUME := 'volume://' VOLUME_NAME_OR_ID ':' BOX_PATH [':' 'rw']  # managed volume
+        | HOST_PATH ':' BOX_PATH [':' OPTIONS]                   # bind mount
+        | BOX_PATH [':' OPTIONS]                                 # anonymous volume
 ```
 
 | Form | Example | Behavior |
@@ -707,9 +707,9 @@ VOLUME := 'volume://' VOLUME_NAME_OR_ID ':' BOX_PATH     # managed volume
 | `HOST_PATH:BOX_PATH` | `/host/data:/data` | Bind mount (host directory must exist) |
 | `HOST_PATH:BOX_PATH:OPTIONS` | `/host/data:/data:ro` | Bind mount with options |
 | `C:\HOST\PATH:/BOX_PATH[:OPTIONS]` | `C:\data:/app/data:ro` | Windows drive paths are handled — the drive-letter colon is not treated as a separator |
-| `volume://VOLUME_NAME_OR_ID:BOX_PATH` | `volume://myvolume:/data` | Managed volume, resolved server-side by name or id (REST runtime only, see `has_managed_volumes` at `src/cli/src/cli.rs:992-999`); box path must be absolute and read-write |
+| `volume://VOLUME_NAME_OR_ID:BOX_PATH[:rw]` | `volume://myvolume:/data` | Managed volume, resolved server-side by name or id (REST runtime only, see `has_managed_volumes` at `src/cli/src/cli.rs:994-1001`); box path must be absolute. `:ro` is rejected — managed volumes are read-write only for now; the accepted third component is only the redundant explicit `:rw`. |
 
-**Options:** `ro` (read-only) or `rw` (read-write, default). Other options are ignored. Relative host paths are canonicalized at parse time; missing host paths fail with `volume host path ...`.
+**Options:** `ro` (read-only) or `rw` (read-write, default) for local bind mounts and anonymous volumes — managed volumes reject `:ro` outright (see above). Other options are ignored. Relative host paths are canonicalized when the mount is applied (`VolumeFlags::apply_to`, `src/cli/src/cli.rs:939-988`), not during parsing; missing host paths fail with `volume host path ...`.
 
 The `volume://` prefix is required and unambiguous: without it, `-v` behaves
 exactly as it did before managed volumes existed — a bare token like

--- a/docs/reference/cli/README.md
+++ b/docs/reference/cli/README.md
@@ -691,30 +691,37 @@ Used by `run` and `create` (defined at `src/cli/src/cli.rs:584-604`).
 
 ## Volume Mount Syntax
 
-`-v`/`--volume` accepts the grammar implemented at `src/cli/src/cli.rs:838-918`
-(managed-volume form: `src/cli/src/cli.rs:799-827`):
+`-v`/`--volume` accepts the grammar implemented at `src/cli/src/cli.rs:852-935`
+(managed-volume branch: `src/cli/src/cli.rs:817-839`):
 
 ```text
-VOLUME := 'volume://' VOLUME_NAME_OR_ID ':' BOX_PATH [':' 'rw']  # managed volume
-        | HOST_PATH ':' BOX_PATH [':' OPTIONS]                   # bind mount
-        | BOX_PATH [':' OPTIONS]                                 # anonymous volume
+VOLUME := HOST_PATH ':' BOX_PATH [':' OPTIONS]  # bind mount, or managed volume
+        | BOX_PATH [':' OPTIONS]                # anonymous volume
 ```
+
+`HOST_PATH` is a managed-volume name/id unless it's an absolute path — the
+same rule Docker's `-v` uses to tell `docker run -v myvol:/data` (named
+volume) apart from `docker run -v /data:/data` (bind mount): not absolute
+means volume, no exceptions.
 
 | Form | Example | Behavior |
 |------|---------|----------|
 | `BOX_PATH` | `/data` | Anonymous volume stored under `{home}/volumes/anonymous/<ulid>` |
 | `BOX_PATH:ro` / `BOX_PATH:rw` | `/data:ro` | Anonymous volume with explicit mode |
-| `HOST_PATH:BOX_PATH` | `/host/data:/data` | Bind mount (host directory must exist) |
-| `HOST_PATH:BOX_PATH:OPTIONS` | `/host/data:/data:ro` | Bind mount with options |
+| `HOST_PATH:BOX_PATH` (absolute `HOST_PATH`) | `/host/data:/data` | Bind mount (host directory must exist) |
+| `HOST_PATH:BOX_PATH:OPTIONS` (absolute `HOST_PATH`) | `/host/data:/data:ro` | Bind mount with options |
 | `C:\HOST\PATH:/BOX_PATH[:OPTIONS]` | `C:\data:/app/data:ro` | Windows drive paths are handled — the drive-letter colon is not treated as a separator |
-| `volume://VOLUME_NAME_OR_ID:BOX_PATH[:rw]` | `volume://myvolume:/data` | Managed volume, resolved server-side by name or id (REST runtime only, see `has_managed_volumes` at `src/cli/src/cli.rs:994-1001`); box path must be absolute. `:ro` is rejected — managed volumes are read-write only for now; the accepted third component is only the redundant explicit `:rw`. |
+| `VOLUME_NAME_OR_ID:BOX_PATH[:rw]` (non-absolute `HOST_PATH`) | `myvolume:/data` | Managed volume, resolved server-side by name or id (REST runtime only, see `has_managed_volumes` at `src/cli/src/cli.rs:1011-1018`); box path must be absolute. `:ro` is rejected — managed volumes are read-write only for now; the accepted third component is only the redundant explicit `:rw`. |
 
-**Options:** `ro` (read-only) or `rw` (read-write, default) for local bind mounts and anonymous volumes — managed volumes reject `:ro` outright (see above). Other options are ignored. Relative host paths are canonicalized when the mount is applied (`VolumeFlags::apply_to`, `src/cli/src/cli.rs:939-988`), not during parsing; missing host paths fail with `volume host path ...`.
+**Options:** `ro` (read-only) or `rw` (read-write, default) for local bind mounts and anonymous volumes — managed volumes reject `:ro` outright (see above). Other options are ignored. Bind-mount host paths are canonicalized when the mount is applied (`VolumeFlags::apply_to`, `src/cli/src/cli.rs:956-1005`), not during parsing; missing host paths fail with `volume host path ...`.
 
-The `volume://` prefix is required and unambiguous: without it, `-v` behaves
-exactly as it did before managed volumes existed — a bare token like
-`myvolume:/data` is always a local path (and fails if it doesn't exist), never
-guessed at as a volume name.
+There is no scheme to type — classification is purely `is_absolute_host_path`
+(`src/cli/src/cli.rs:787-789`) on `HOST_PATH`. This carries the same trade-off
+Docker itself accepts: a relative path like `./data` is not absolute, so
+`-v ./data:/data` is read as a managed-volume reference named `./data`, not a
+local bind mount (see `docker/cli#1203`, `moby/moby#16132` for the real-world
+impact on Docker). Use an absolute path (or `$(pwd)/data`) to bind-mount a
+relative directory.
 
 The anonymous-volume base directory is resolved as: `--home`, else `$BOXLITE_HOME`, else `~/.boxlite`, else the system temp dir.
 

--- a/docs/reference/cli/README.md
+++ b/docs/reference/cli/README.md
@@ -694,7 +694,7 @@ Used by `run` and `create` (defined at `src/cli/src/cli.rs:584-604`).
 `-v`/`--volume` accepts the grammar implemented at `src/cli/src/cli.rs:838-918`
 (managed-volume form: `src/cli/src/cli.rs:799-827`):
 
-```
+```text
 VOLUME := 'volume://' VOLUME_NAME_OR_ID ':' BOX_PATH [':' 'rw']  # managed volume
         | HOST_PATH ':' BOX_PATH [':' OPTIONS]                   # bind mount
         | BOX_PATH [':' OPTIONS]                                 # anonymous volume

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -317,7 +317,7 @@ silently restarting it, because restarting would run the command a second time.
 | `--env KEY=VALUE` | `-e` | Set environment variables (repeatable) |
 | `--workdir PATH` | `-w` | Working directory in the box |
 | `--publish PORT` | `-p` | Publish a TCP box port locally (`80` = automatic host port, `8080:80` = fixed) |
-| `--volume VOLUME` | `-v` | Mount a volume (e.g. `hostPath:boxPath`, `boxPath` for anonymous) |
+| `--volume VOLUME` | `-v` | Mount a volume (e.g. `hostPath:boxPath`, `boxPath` for anonymous, `volume://volumeNameOrId:boxPath` for a managed volume) |
 | `--cpus N` | | CPU limit |
 | `--memory MiB` | | Memory limit (MiB) |
 | `--cap-add CAPABILITY` | | Add a Linux capability (repeatable; accepts `CAP_` prefix or `ALL`) |
@@ -362,7 +362,7 @@ default, and `exec` still starts it on demand.
 | `--env KEY=VALUE` | `-e` | Environment variables |
 | `--workdir PATH` | `-w` | Working directory |
 | `--publish PORT` | `-p` | Publish a TCP box port locally (`80` = automatic host port, `8080:80` = fixed) |
-| `--volume VOLUME` | `-v` | Mount a volume (e.g. `hostPath:boxPath`, or box path for anonymous) |
+| `--volume VOLUME` | `-v` | Mount a volume (e.g. `hostPath:boxPath`, box path for anonymous, or `volume://volumeNameOrId:boxPath` for a managed volume) |
 | `--cpus N` | | CPU limit |
 | `--memory MiB` | | Memory limit (MiB) |
 | `--cap-add CAPABILITY` | | Add a Linux capability (repeatable; accepts `CAP_` prefix or `ALL`) |

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -317,7 +317,7 @@ silently restarting it, because restarting would run the command a second time.
 | `--env KEY=VALUE` | `-e` | Set environment variables (repeatable) |
 | `--workdir PATH` | `-w` | Working directory in the box |
 | `--publish PORT` | `-p` | Publish a TCP box port locally (`80` = automatic host port, `8080:80` = fixed) |
-| `--volume VOLUME` | `-v` | Mount a volume (e.g. `hostPath:boxPath`, `boxPath` for anonymous, `volume://volumeNameOrId:boxPath` for a managed volume) |
+| `--volume VOLUME` | `-v` | Mount a volume (e.g. `hostPath:boxPath`, `boxPath` for anonymous, or `volumeNameOrId:boxPath` for a managed volume if hostPath is not an absolute path) |
 | `--cpus N` | | CPU limit |
 | `--memory MiB` | | Memory limit (MiB) |
 | `--cap-add CAPABILITY` | | Add a Linux capability (repeatable; accepts `CAP_` prefix or `ALL`) |
@@ -362,7 +362,7 @@ default, and `exec` still starts it on demand.
 | `--env KEY=VALUE` | `-e` | Environment variables |
 | `--workdir PATH` | `-w` | Working directory |
 | `--publish PORT` | `-p` | Publish a TCP box port locally (`80` = automatic host port, `8080:80` = fixed) |
-| `--volume VOLUME` | `-v` | Mount a volume (e.g. `hostPath:boxPath`, box path for anonymous, or `volume://volumeNameOrId:boxPath` for a managed volume) |
+| `--volume VOLUME` | `-v` | Mount a volume (e.g. `hostPath:boxPath`, box path for anonymous, or `volumeNameOrId:boxPath` for a managed volume if hostPath is not an absolute path) |
 | `--cpus N` | | CPU limit |
 | `--memory MiB` | | Memory limit (MiB) |
 | `--cap-add CAPABILITY` | | Add a Linux capability (repeatable; accepts `CAP_` prefix or `ALL`) |

--- a/src/cli/src/cli.rs
+++ b/src/cli/src/cli.rs
@@ -758,18 +758,35 @@ struct ParsedVolumeSpec {
 pub struct VolumeFlags {
     /// Mount a volume. `hostPath:boxPath[:options]` for a local bind mount
     /// (e.g. `/data:/app/data`, `/data:/app/data:ro`); `boxPath` (or
-    /// `boxPath:ro`) for an anonymous local volume;
-    /// `volume://<idOrName>:boxPath` for a managed volume, resolved
-    /// server-side and only meaningful against a REST runtime.
+    /// `boxPath:ro`) for an anonymous local volume; `idOrName:boxPath` for a
+    /// managed volume, resolved server-side and only meaningful against a
+    /// REST runtime. The two are told apart the same way Docker's `-v`
+    /// does: `hostPath` is a managed-volume name unless it's an absolute
+    /// path (see `is_absolute_host_path`) — so a relative path (`./data`)
+    /// is read as a volume name, not a local path, matching Docker's own
+    /// behavior for `-v myvol:/data` vs `-v ./data:/data`.
     #[arg(short = 'v', long = "volume", value_name = "VOLUME")]
     pub volume: Vec<String>,
 }
 
-/// Prefix that marks a `-v` host side as a managed-volume reference rather
-/// than a local path. Explicit and unambiguous by construction — unlike
-/// guessing from what a bare token "looks like", a real path can never
-/// collide with this prefix, so there is nothing to disambiguate.
-const MANAGED_VOLUME_SCHEME: &str = "volume://";
+/// Internal wire marker for a managed-volume reference. Prepended to
+/// `ParsedVolumeSpec.host_path` once `parse_volume_spec` classifies a `-v`
+/// token as a volume name rather than a host path — never something a
+/// caller types themselves (see `is_absolute_host_path`).
+const MANAGED_VOLUME_WIRE_PREFIX: &str = "volume://";
+
+/// True if `s` looks like an absolute filesystem path — Unix (`/...`) or
+/// Windows drive-qualified (`C:\...`, `C:/...`). Anything else (a bare
+/// name, or a relative path like `./data`) is classified as a
+/// managed-volume reference instead. Mirrors Docker's own `-v myvol:/data`
+/// rule — `path.IsAbs(source)` in `moby/moby`
+/// `daemon/volume/mounts/linux_parser.go ParseMountRaw`: not absolute means
+/// volume, no exceptions — including the same accepted trade-off that a
+/// relative path like `./data` is read as a volume name rather than
+/// erroring (real-world impact: `docker/cli#1203`, `moby/moby#16132`).
+fn is_absolute_host_path(s: &str) -> bool {
+    std::path::Path::new(s).is_absolute() || is_windows_absolute_path(s)
+}
 
 /// True if the segment is a single ASCII letter (Windows drive, e.g. "C" in "C:\path").
 fn is_windows_drive(segment: &str) -> bool {
@@ -792,47 +809,42 @@ fn parse_volume_read_only(opts: &str) -> bool {
     opts.split(',').any(|o| o.trim().eq_ignore_ascii_case("ro"))
 }
 
-/// Parse the `volume://<idOrName>:boxPath` form. Split out of
-/// `parse_volume_spec` because embedding a `://` scheme breaks that
-/// function's colon-count-based grammar (`volume://x:/y`.split(':')` is
-/// three parts, not the two a bind mount would produce) — checking the
-/// scheme prefix first and handling it separately avoids that entirely
-/// rather than working around it inside the general parser.
-fn parse_managed_volume_spec(s: &str) -> anyhow::Result<ParsedVolumeSpec> {
-    let rest = s
-        .strip_prefix(MANAGED_VOLUME_SCHEME)
-        .expect("caller already matched the volume:// prefix");
-    let parts: Vec<&str> = rest.split(':').collect();
-    let (id, guest_path, read_only) = match parts.as_slice() {
-        [id, guest_path] => (*id, *guest_path, false),
-        [id, guest_path, opts] => (*id, *guest_path, parse_volume_read_only(opts)),
-        _ => anyhow::bail!(
-            "managed volume spec {s:?} must be {MANAGED_VOLUME_SCHEME}<id-or-name>:<box-path>[:ro|:rw]"
-        ),
-    };
+/// Validate and build a managed-volume `ParsedVolumeSpec` for the given
+/// volume id/name and box path — the else-branch of the classification
+/// `is_absolute_host_path` drives in `parse_volume_spec`. Mirrors the
+/// constraints a scheme-qualified reference used to carry: id non-empty,
+/// box path absolute, read-write only.
+fn managed_volume_spec(
+    id: &str,
+    guest_path: &str,
+    read_only: bool,
+    original: &str,
+) -> anyhow::Result<ParsedVolumeSpec> {
     if id.is_empty() {
-        anyhow::bail!("managed volume id or name must be non-empty (got {s:?})");
+        anyhow::bail!("managed volume id or name must be non-empty (got {original:?})");
     }
     if guest_path.is_empty() || !guest_path.starts_with('/') {
-        anyhow::bail!(
-            "managed volume box path must be absolute (e.g. {MANAGED_VOLUME_SCHEME}{id}:/data)"
-        );
+        anyhow::bail!("managed volume box path must be absolute (e.g. {id}:/data)");
     }
     if read_only {
-        anyhow::bail!("managed volume mounts are read-write only for now (remove :ro from {s:?})");
+        anyhow::bail!(
+            "managed volume mounts are read-write only for now (remove :ro from {original:?})"
+        );
     }
     Ok(ParsedVolumeSpec {
-        host_path: Some(format!("{MANAGED_VOLUME_SCHEME}{id}")),
+        host_path: Some(format!("{MANAGED_VOLUME_WIRE_PREFIX}{id}")),
         guest_path: guest_path.to_string(),
         read_only: false,
     })
 }
 
 /// Parse a single volume spec.
-/// - Managed volume: `volume://<idOrName>:boxPath` (e.g. `volume://myvolume:/data`),
-///   resolved server-side; only meaningful against a REST runtime.
-/// - Anonymous     : `boxPath` or `boxPath:ro` (e.g. `/data`, `/data:ro`).
-/// - Bind mount    : `hostPath:boxPath[:options]` (e.g. `/data:/app/data`, `/data:/app/data:ro`).
+/// - Anonymous  : `boxPath` or `boxPath:ro` (e.g. `/data`, `/data:ro`).
+/// - Bind mount : `hostPath:boxPath[:options]` (e.g. `/data:/app/data`, `/data:/app/data:ro`) —
+///   `hostPath` must be an absolute path (see `is_absolute_host_path`).
+/// - Managed volume: `idOrName:boxPath[:rw]` (e.g. `myvolume:/data`), resolved server-side and
+///   only meaningful against a REST runtime — anything in `hostPath` position that isn't an
+///   absolute path is read as a volume name, the same rule Docker's `-v` uses.
 ///
 /// Options: `ro` (read-only), `rw` (read-write, default). Other options are ignored.
 ///   Windows: host path may be a drive path like `C:\data`; the colon after the drive letter is not
@@ -841,9 +853,6 @@ fn parse_volume_spec(s: &str) -> anyhow::Result<ParsedVolumeSpec> {
     let s = s.trim();
     if s.is_empty() {
         anyhow::bail!("empty volume spec");
-    }
-    if s.starts_with(MANAGED_VOLUME_SCHEME) {
-        return parse_managed_volume_spec(s);
     }
     let parts: Vec<&str> = s.split(':').map(str::trim).collect();
 
@@ -863,7 +872,8 @@ fn parse_volume_spec(s: &str) -> anyhow::Result<ParsedVolumeSpec> {
             (None, guest, false)
         }
         2 => {
-            // Either anonymous with options (guest:ro) or bind (host:guest)
+            // Either anonymous with options (guest:ro), bind (host:guest), or
+            // managed volume (name:guest) — decided by is_absolute_host_path.
             let second = parts[1];
             if second.eq_ignore_ascii_case("ro") || second.eq_ignore_ascii_case("rw") {
                 let guest = parts[0].to_string();
@@ -871,17 +881,22 @@ fn parse_volume_spec(s: &str) -> anyhow::Result<ParsedVolumeSpec> {
                     anyhow::bail!("volume box path must be non-empty");
                 }
                 (None, guest, second.eq_ignore_ascii_case("ro"))
-            } else {
+            } else if is_absolute_host_path(parts[0]) {
                 (Some(parts[0].to_string()), parts[1].to_string(), false)
+            } else {
+                return managed_volume_spec(parts[0], parts[1], false, s);
             }
         }
         3 => {
             if is_windows_drive(parts[0]) {
                 let host = format!("{}:{}", parts[0], parts[1]);
                 (Some(host), parts[2].to_string(), false)
-            } else {
+            } else if is_absolute_host_path(parts[0]) {
                 let ro = parse_volume_read_only(parts[2]);
                 (Some(parts[0].to_string()), parts[1].to_string(), ro)
+            } else {
+                let ro = parse_volume_read_only(parts[2]);
+                return managed_volume_spec(parts[0], parts[1], ro, s);
             }
         }
         4.. => {
@@ -958,7 +973,7 @@ impl VolumeFlags {
                 // string is never touched on this host. Already fully
                 // validated (absolute guest path, no :ro) by
                 // parse_managed_volume_spec.
-                Some(host) if host.starts_with(MANAGED_VOLUME_SCHEME) => host,
+                Some(host) if host.starts_with(MANAGED_VOLUME_WIRE_PREFIX) => host,
                 Some(host) => {
                     let mut path = host;
                     if std::path::Path::new(&path).is_relative() && !is_windows_absolute_path(&path)
@@ -997,7 +1012,7 @@ impl VolumeFlags {
         self.volume.iter().any(|s| {
             parse_volume_spec(s).is_ok_and(|spec| {
                 spec.host_path
-                    .is_some_and(|host| host.starts_with(MANAGED_VOLUME_SCHEME))
+                    .is_some_and(|host| host.starts_with(MANAGED_VOLUME_WIRE_PREFIX))
             })
         })
     }
@@ -1769,25 +1784,18 @@ mod tests {
     // --- Managed volumes via -v (explicit volume:// scheme) ---
 
     #[test]
-    fn test_parse_volume_spec_scheme_is_managed() {
-        let spec = super::parse_volume_spec("volume://myvolume:/data").unwrap();
+    fn test_parse_volume_spec_bare_name_is_managed() {
+        // No scheme: a bare, non-absolute hostPath token is read as a
+        // managed-volume name — the same rule Docker's `-v myvol:/data`
+        // uses (`path.IsAbs(source)`).
+        let spec = super::parse_volume_spec("myvolume:/data").unwrap();
         assert_eq!(spec.host_path.as_deref(), Some("volume://myvolume"));
         assert_eq!(spec.guest_path, "/data");
         assert!(!spec.read_only);
     }
 
     #[test]
-    fn test_parse_volume_spec_bare_tokens_are_never_managed() {
-        // Without the scheme, everything parses exactly as it did before
-        // managed volumes existed — a bare token is a literal local path,
-        // canonicalized against this host, not guessed at as a volume name.
-        assert_eq!(
-            super::parse_volume_spec("myvolume:/data")
-                .unwrap()
-                .host_path
-                .as_deref(),
-            Some("myvolume")
-        );
+    fn test_parse_volume_spec_absolute_path_is_never_managed() {
         assert_eq!(
             super::parse_volume_spec("/host:/guest")
                 .unwrap()
@@ -1795,19 +1803,32 @@ mod tests {
                 .as_deref(),
             Some("/host")
         );
-        assert_eq!(
-            super::parse_volume_spec(r"subdir\cache:/guest")
-                .unwrap()
-                .host_path
-                .as_deref(),
-            Some(r"subdir\cache")
-        );
+    }
+
+    #[test]
+    fn test_is_absolute_host_path() {
+        assert!(super::is_absolute_host_path("/data"));
+        assert!(super::is_absolute_host_path(r"C:\data"));
+        assert!(super::is_absolute_host_path("D:/data"));
+        assert!(!super::is_absolute_host_path("myvolume"));
+        assert!(!super::is_absolute_host_path("./data"));
+        assert!(!super::is_absolute_host_path("data/sub"));
+    }
+
+    #[test]
+    fn test_parse_volume_spec_relative_path_is_managed_like_docker() {
+        // Matches Docker's own accepted trade-off: a relative host path
+        // (not absolute) is read as a volume name rather than erroring or
+        // being resolved against the local filesystem. Real-world impact
+        // on Docker itself: docker/cli#1203, moby/moby#16132.
+        let spec = super::parse_volume_spec("./data:/guest").unwrap();
+        assert_eq!(spec.host_path.as_deref(), Some("volume://./data"));
     }
 
     #[test]
     fn test_volume_flags_apply_to_managed_volume() {
         let flags = VolumeFlags {
-            volume: vec!["volume://myvolume:/data".to_string()],
+            volume: vec!["myvolume:/data".to_string()],
         };
         let mut opts = BoxOptions::default();
         flags.apply_to(&mut opts, None).unwrap();
@@ -1823,7 +1844,7 @@ mod tests {
     #[test]
     fn test_volume_flags_apply_to_managed_volume_rejects_empty_id() {
         let flags = VolumeFlags {
-            volume: vec!["volume://:/data".to_string()],
+            volume: vec![":/data".to_string()],
         };
         let mut opts = BoxOptions::default();
         let err = flags
@@ -1839,7 +1860,7 @@ mod tests {
     #[test]
     fn test_volume_flags_apply_to_managed_volume_rejects_relative_box_path() {
         let flags = VolumeFlags {
-            volume: vec!["volume://myvolume:data".to_string()],
+            volume: vec!["myvolume:data".to_string()],
         };
         let mut opts = BoxOptions::default();
         let err = flags
@@ -1855,7 +1876,7 @@ mod tests {
     #[test]
     fn test_volume_flags_apply_to_managed_volume_rejects_read_only() {
         let flags = VolumeFlags {
-            volume: vec!["volume://myvolume:/data:ro".to_string()],
+            volume: vec!["myvolume:/data:ro".to_string()],
         };
         let mut opts = BoxOptions::default();
         let err = flags
@@ -1871,7 +1892,7 @@ mod tests {
     #[test]
     fn test_volume_flags_has_managed_volumes_via_dash_v() {
         let managed = VolumeFlags {
-            volume: vec!["volume://myvolume:/data".to_string()],
+            volume: vec!["myvolume:/data".to_string()],
         };
         assert!(managed.has_managed_volumes());
 
@@ -1879,25 +1900,17 @@ mod tests {
             volume: vec!["/host:/data".to_string()],
         };
         assert!(!local.has_managed_volumes());
-
-        // A bare token — no scheme — is a local path, not a managed volume,
-        // even though that's exactly the string a volume's name might be.
-        let bare_token = VolumeFlags {
-            volume: vec!["myvolume:/data".to_string()],
-        };
-        assert!(!bare_token.has_managed_volumes());
     }
 
     #[test]
     fn test_run_parses_managed_volume_via_dash_v() {
-        let cli =
-            Cli::try_parse_from(["boxlite", "run", "-v", "volume://myvolume:/data", "alpine"])
-                .expect("run -v volume://myvolume:/data should parse");
+        let cli = Cli::try_parse_from(["boxlite", "run", "-v", "myvolume:/data", "alpine"])
+            .expect("run -v myvolume:/data should parse");
         let Commands::Run(args) = cli.command else {
             panic!("expected run command");
         };
 
-        assert_eq!(args.volume.volume, vec!["volume://myvolume:/data"]);
+        assert_eq!(args.volume.volume, vec!["myvolume:/data"]);
     }
 
     // ─── auth subcommand parse tests ───────────────────────────────────────

--- a/src/cli/src/cli.rs
+++ b/src/cli/src/cli.rs
@@ -316,6 +316,14 @@ impl GlobalFlags {
         }
     }
 
+    pub fn resolves_rest_runtime(&self) -> bool {
+        let stored = crate::credentials::load_named(&self.resolved_profile())
+            .ok()
+            .flatten();
+        let env_api_key = std::env::var("BOXLITE_API_KEY").ok();
+        self.resolve_rest_options(stored, env_api_key).is_some()
+    }
+
     /// Build REST connection options from the selected credential profile and
     /// the ambient `BOXLITE_API_KEY`. Returns `None` when no URL is configured
     /// (the caller then falls back to the local runtime). Pure — takes the
@@ -748,10 +756,20 @@ struct ParsedVolumeSpec {
 
 #[derive(Args, Debug, Clone)]
 pub struct VolumeFlags {
-    /// Mount a volume (format: hostPath:boxPath[:options], or boxPath for anonymous volume, e.g. /data:/app/data, /data:ro)
+    /// Mount a volume. `hostPath:boxPath[:options]` for a local bind mount
+    /// (e.g. `/data:/app/data`, `/data:/app/data:ro`); `boxPath` (or
+    /// `boxPath:ro`) for an anonymous local volume;
+    /// `volume://<idOrName>:boxPath` for a managed volume, resolved
+    /// server-side and only meaningful against a REST runtime.
     #[arg(short = 'v', long = "volume", value_name = "VOLUME")]
     pub volume: Vec<String>,
 }
+
+/// Prefix that marks a `-v` host side as a managed-volume reference rather
+/// than a local path. Explicit and unambiguous by construction — unlike
+/// guessing from what a bare token "looks like", a real path can never
+/// collide with this prefix, so there is nothing to disambiguate.
+const MANAGED_VOLUME_SCHEME: &str = "volume://";
 
 /// True if the segment is a single ASCII letter (Windows drive, e.g. "C" in "C:\path").
 fn is_windows_drive(segment: &str) -> bool {
@@ -774,9 +792,47 @@ fn parse_volume_read_only(opts: &str) -> bool {
     opts.split(',').any(|o| o.trim().eq_ignore_ascii_case("ro"))
 }
 
+/// Parse the `volume://<idOrName>:boxPath` form. Split out of
+/// `parse_volume_spec` because embedding a `://` scheme breaks that
+/// function's colon-count-based grammar (`volume://x:/y`.split(':')` is
+/// three parts, not the two a bind mount would produce) — checking the
+/// scheme prefix first and handling it separately avoids that entirely
+/// rather than working around it inside the general parser.
+fn parse_managed_volume_spec(s: &str) -> anyhow::Result<ParsedVolumeSpec> {
+    let rest = s
+        .strip_prefix(MANAGED_VOLUME_SCHEME)
+        .expect("caller already matched the volume:// prefix");
+    let parts: Vec<&str> = rest.split(':').collect();
+    let (id, guest_path, read_only) = match parts.as_slice() {
+        [id, guest_path] => (*id, *guest_path, false),
+        [id, guest_path, opts] => (*id, *guest_path, parse_volume_read_only(opts)),
+        _ => anyhow::bail!(
+            "managed volume spec {s:?} must be {MANAGED_VOLUME_SCHEME}<id-or-name>:<box-path>[:ro|:rw]"
+        ),
+    };
+    if id.is_empty() {
+        anyhow::bail!("managed volume id or name must be non-empty (got {s:?})");
+    }
+    if guest_path.is_empty() || !guest_path.starts_with('/') {
+        anyhow::bail!(
+            "managed volume box path must be absolute (e.g. {MANAGED_VOLUME_SCHEME}{id}:/data)"
+        );
+    }
+    if read_only {
+        anyhow::bail!("managed volume mounts are read-write only for now (remove :ro from {s:?})");
+    }
+    Ok(ParsedVolumeSpec {
+        host_path: Some(format!("{MANAGED_VOLUME_SCHEME}{id}")),
+        guest_path: guest_path.to_string(),
+        read_only: false,
+    })
+}
+
 /// Parse a single volume spec.
-/// - Anonymous : `boxPath` or `boxPath:ro` (e.g. `/data`, `/data:ro`).
-/// - Bind mount: `hostPath:boxPath[:options]` (e.g. `/data:/app/data`, `/data:/app/data:ro`).
+/// - Managed volume: `volume://<idOrName>:boxPath` (e.g. `volume://myvolume:/data`),
+///   resolved server-side; only meaningful against a REST runtime.
+/// - Anonymous     : `boxPath` or `boxPath:ro` (e.g. `/data`, `/data:ro`).
+/// - Bind mount    : `hostPath:boxPath[:options]` (e.g. `/data:/app/data`, `/data:/app/data:ro`).
 ///
 /// Options: `ro` (read-only), `rw` (read-write, default). Other options are ignored.
 ///   Windows: host path may be a drive path like `C:\data`; the colon after the drive letter is not
@@ -785,6 +841,9 @@ fn parse_volume_spec(s: &str) -> anyhow::Result<ParsedVolumeSpec> {
     let s = s.trim();
     if s.is_empty() {
         anyhow::bail!("empty volume spec");
+    }
+    if s.starts_with(MANAGED_VOLUME_SCHEME) {
+        return parse_managed_volume_spec(s);
     }
     let parts: Vec<&str> = s.split(':').map(str::trim).collect();
 
@@ -887,12 +946,19 @@ impl VolumeFlags {
         let base = anonymous_volume_base(home);
         for s in self.volume.iter() {
             let spec = parse_volume_spec(s)?;
-            let host_path = match spec.host_path {
-                // TODO(#942): when the host side of a `-v <src>:<guest>` spec is a
-                // bare name (not a path) that matches a named volume, resolve it
-                // to the volume's mountpoint here (via the volume backend) and
-                // bind that payload dir instead of treating the name as a literal
-                // host path.
+            let ParsedVolumeSpec {
+                host_path,
+                guest_path,
+                read_only,
+            } = spec;
+            let host_path = match host_path {
+                // Managed volume reference: resolved server-side (REST
+                // create/attach already accept id-or-name, scoped to the
+                // caller's org), so — unlike a bind-mount path — this
+                // string is never touched on this host. Already fully
+                // validated (absolute guest path, no :ro) by
+                // parse_managed_volume_spec.
+                Some(host) if host.starts_with(MANAGED_VOLUME_SCHEME) => host,
                 Some(host) => {
                     let mut path = host;
                     if std::path::Path::new(&path).is_relative() && !is_windows_absolute_path(&path)
@@ -916,11 +982,24 @@ impl VolumeFlags {
             };
             opts.volumes.push(VolumeSpec {
                 host_path,
-                guest_path: spec.guest_path,
-                read_only: spec.read_only,
+                guest_path,
+                read_only,
             });
         }
         Ok(())
+    }
+
+    /// True if any `-v` entry is a managed-volume reference (`volume://...`)
+    /// rather than a local bind mount — these require a REST runtime.
+    /// Unparseable entries are treated as non-managed here; `apply_to`
+    /// surfaces the real parse error when it runs moments later.
+    pub fn has_managed_volumes(&self) -> bool {
+        self.volume.iter().any(|s| {
+            parse_volume_spec(s).is_ok_and(|spec| {
+                spec.host_path
+                    .is_some_and(|host| host.starts_with(MANAGED_VOLUME_SCHEME))
+            })
+        })
     }
 }
 
@@ -1685,6 +1764,140 @@ mod tests {
         assert_eq!(opts.volumes[1].guest_path, "/cache");
         assert!(opts.volumes[1].read_only);
         assert!(opts.volumes[1].host_path.contains("anonymous"));
+    }
+
+    // --- Managed volumes via -v (explicit volume:// scheme) ---
+
+    #[test]
+    fn test_parse_volume_spec_scheme_is_managed() {
+        let spec = super::parse_volume_spec("volume://myvolume:/data").unwrap();
+        assert_eq!(spec.host_path.as_deref(), Some("volume://myvolume"));
+        assert_eq!(spec.guest_path, "/data");
+        assert!(!spec.read_only);
+    }
+
+    #[test]
+    fn test_parse_volume_spec_bare_tokens_are_never_managed() {
+        // Without the scheme, everything parses exactly as it did before
+        // managed volumes existed — a bare token is a literal local path,
+        // canonicalized against this host, not guessed at as a volume name.
+        assert_eq!(
+            super::parse_volume_spec("myvolume:/data")
+                .unwrap()
+                .host_path
+                .as_deref(),
+            Some("myvolume")
+        );
+        assert_eq!(
+            super::parse_volume_spec("/host:/guest")
+                .unwrap()
+                .host_path
+                .as_deref(),
+            Some("/host")
+        );
+        assert_eq!(
+            super::parse_volume_spec(r"subdir\cache:/guest")
+                .unwrap()
+                .host_path
+                .as_deref(),
+            Some(r"subdir\cache")
+        );
+    }
+
+    #[test]
+    fn test_volume_flags_apply_to_managed_volume() {
+        let flags = VolumeFlags {
+            volume: vec!["volume://myvolume:/data".to_string()],
+        };
+        let mut opts = BoxOptions::default();
+        flags.apply_to(&mut opts, None).unwrap();
+
+        assert_eq!(opts.volumes.len(), 1);
+        // Passed through verbatim: never canonicalized against this host's
+        // filesystem, unlike a bind-mount path.
+        assert_eq!(opts.volumes[0].host_path, "volume://myvolume");
+        assert_eq!(opts.volumes[0].guest_path, "/data");
+        assert!(!opts.volumes[0].read_only);
+    }
+
+    #[test]
+    fn test_volume_flags_apply_to_managed_volume_rejects_empty_id() {
+        let flags = VolumeFlags {
+            volume: vec!["volume://:/data".to_string()],
+        };
+        let mut opts = BoxOptions::default();
+        let err = flags
+            .apply_to(&mut opts, None)
+            .expect_err("managed volume id must be rejected when empty");
+
+        assert!(
+            err.to_string().contains("must be non-empty"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_volume_flags_apply_to_managed_volume_rejects_relative_box_path() {
+        let flags = VolumeFlags {
+            volume: vec!["volume://myvolume:data".to_string()],
+        };
+        let mut opts = BoxOptions::default();
+        let err = flags
+            .apply_to(&mut opts, None)
+            .expect_err("managed volume box path must be absolute");
+
+        assert!(
+            err.to_string().contains("box path must be absolute"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_volume_flags_apply_to_managed_volume_rejects_read_only() {
+        let flags = VolumeFlags {
+            volume: vec!["volume://myvolume:/data:ro".to_string()],
+        };
+        let mut opts = BoxOptions::default();
+        let err = flags
+            .apply_to(&mut opts, None)
+            .expect_err("managed volume mounts are read-write only for now");
+
+        assert!(
+            err.to_string().contains("read-write only"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_volume_flags_has_managed_volumes_via_dash_v() {
+        let managed = VolumeFlags {
+            volume: vec!["volume://myvolume:/data".to_string()],
+        };
+        assert!(managed.has_managed_volumes());
+
+        let local = VolumeFlags {
+            volume: vec!["/host:/data".to_string()],
+        };
+        assert!(!local.has_managed_volumes());
+
+        // A bare token — no scheme — is a local path, not a managed volume,
+        // even though that's exactly the string a volume's name might be.
+        let bare_token = VolumeFlags {
+            volume: vec!["myvolume:/data".to_string()],
+        };
+        assert!(!bare_token.has_managed_volumes());
+    }
+
+    #[test]
+    fn test_run_parses_managed_volume_via_dash_v() {
+        let cli =
+            Cli::try_parse_from(["boxlite", "run", "-v", "volume://myvolume:/data", "alpine"])
+                .expect("run -v volume://myvolume:/data should parse");
+        let Commands::Run(args) = cli.command else {
+            panic!("expected run command");
+        };
+
+        assert_eq!(args.volume.volume, vec!["volume://myvolume:/data"]);
     }
 
     // ─── auth subcommand parse tests ───────────────────────────────────────

--- a/src/cli/src/commands/create.rs
+++ b/src/cli/src/commands/create.rs
@@ -78,6 +78,9 @@ impl CreateArgs {
         self.management.apply_to(&mut options)?;
         self.publish.apply_to(&mut options)?;
         self.volume.apply_to(&mut options, global.home.as_deref())?;
+        if self.volume.has_managed_volumes() && !global.resolves_rest_runtime() {
+            anyhow::bail!("managed volume mounts require a REST runtime");
+        }
         self.network.apply_to(&mut options)?;
 
         // A `create`d box is a background box: `create` then `start`/`exec` runs

--- a/src/cli/src/commands/run.rs
+++ b/src/cli/src/commands/run.rs
@@ -55,6 +55,9 @@ pub async fn execute(args: RunArgs, global: &GlobalFlags) -> anyhow::Result<i32>
     args.boot.require_enabled(global.experimental_features())?;
     args.management
         .require_enabled(global.experimental_features())?;
+    if args.volume.has_managed_volumes() && !global.resolves_rest_runtime() {
+        anyhow::bail!("managed volume mounts require a REST runtime");
+    }
     let (rootfs, command_args) = args.rootfs_and_command()?;
     let command_args = command_args.to_vec();
     let mut runner = BoxRunner::new(args, global)?;


### PR DESCRIPTION
Lets `-v`/`--volume` accept a `volume://<idOrName>:boxPath` form for managed volumes — reintroducing (via `-v` instead of a separate flag) the capability `--mount` provided before #1216 removed it.

Classification is an explicit scheme prefix, not a heuristic: without `volume://`, `-v` behaves byte-for-byte as it did before managed volumes existed — a bare token is always a local path. No guessing from what a token "looks like," so no edge cases to chase (an earlier draft of this PR used a `looks_like_host_path` heuristic that mis-classified Windows drive-relative paths; this version has nothing to mis-classify).

Rebased onto main after #1216 merged (`--mount` is gone there); this PR restores the REST-runtime guard `--mount` used to provide (`GlobalFlags::resolves_rest_runtime`, `has_managed_volumes`) now that `-v` carries that capability again.

**Call graph**

Before (#1216, current main):
```
-v <host>:<box> → parse_volume_spec → always a local bind mount or anonymous volume
(no managed-volume path at all — --mount removed with no replacement)
```

After:
```
-v volume://<id-or-name>:<box> → parse_managed_volume_spec (cli.rs:806) → managed volume
-v <anything else>:<box>       → parse_volume_spec (cli.rs:845, unchanged) → local bind mount / anonymous
```

**Test plan:** `cargo test -p boxlite-cli --bin boxlite` — 187/187 pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for attaching managed volumes by name or ID using the `volume://VOLUME_NAME_OR_ID:BOX_PATH` syntax.
  - Preserved support for local bind mounts and anonymous volumes.

- **Bug Fixes**
  - Improved volume parsing to distinguish managed volumes from local paths.
  - Added validation requiring absolute, read-write box paths for managed volumes.
  - Prevented managed-volume attachments with unsupported runtimes.

- **Documentation**
  - Updated CLI documentation with managed-volume syntax and usage details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->