### PR TITLE
refactor(guest): replace external chown with syscalls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ on:
       - 'src/shared/**'
       - 'src/cli/**'
       - 'src/guest/**'
+      - 'make/test.mk'
       - 'sdks/**'
       - 'apps/**'
       - '!apps/e2e/**' # Stack e2e runs in e2e-stack.yml / e2e-cloud.yml, not this unit matrix.
@@ -69,6 +70,7 @@ jobs:
               - 'src/boxlite/**'
               - 'src/shared/**'
               - 'src/guest/**'
+              - 'make/test.mk'
               - '**/Cargo.toml'
               - 'Cargo.lock'
             cli:
@@ -113,7 +115,7 @@ jobs:
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libseccomp-dev protobuf-compiler
+        run: sudo apt-get update && sudo apt-get install -y jq libseccomp-dev protobuf-compiler util-linux
 
       - name: Install system dependencies (macOS)
         if: runner.os == 'macOS'
@@ -132,6 +134,10 @@ jobs:
       - name: Run guest unit tests
         if: runner.os == 'Linux'
         run: make test:unit:guest
+
+      - name: Run guest ownership tests
+        if: runner.os == 'Linux'
+        run: make test:guest-perms
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/make/help.mk
+++ b/make/help.mk
@@ -39,6 +39,7 @@ help:
 	@echo "    make test:unit:sdk          - Run SDK unit suites (Python + Node + C + Go)"
 	@echo "    make test:integration:sdk   - Run SDK integration suites (Python + Node + C)"
 	@echo "    make test:unit:rust         - Run Rust unit tests (nextest when available)"
+	@echo "    make test:guest-perms       - Run guest ownership tests (privileged cases use sudo)"
 	@echo "    make test:warm-cache:rust   - Pre-warm Rust integration image cache"
 	@echo "    make test:integration:rust  - Run Rust integration tests (requires VM, FILTER=<pattern>)"
 	@echo "    make test:unit:ffi          - Run BoxLite FFI unit tests"

--- a/make/test.mk
+++ b/make/test.mk
@@ -1,4 +1,4 @@
-PHONY_TARGETS += test test\:unit\:guest _ensure-infra-deps test\:apps\:infra test\:apps\:infra-config
+PHONY_TARGETS += test test\:unit\:guest test\:guest-perms _ensure-infra-deps test\:apps\:infra test\:apps\:infra-config
 
 # Mirrors GitHub Actions strategy.fail-fast. Default false: aggregator
 # targets run every sub-suite even if an earlier one fails, then exit
@@ -222,6 +222,55 @@ test\:unit\:guest:
 		cargo nextest run --no-tests=fail -p boxlite-guest; \
 	else \
 		cargo test -p boxlite-guest --bins -- --test-threads=1 capabilit spec::tests; \
+	fi
+
+# Keep ordinary ownership tests unprivileged. Only explicitly ignored tests
+# whose names contain `privileged_` run as root, inside a private mount
+# namespace so bind mounts cannot escape into the host namespace.
+test\:guest-perms:
+	@if [ "$$(uname)" != "Linux" ]; then \
+		echo "⏭️  Guest ownership tests require Linux"; \
+		exit 0; \
+	fi; \
+	echo "🧪 Running guest ownership tests..."; \
+	cargo test -p boxlite-guest --bin boxlite-guest 'storage::perms::tests' -- \
+		--test-threads=1 --skip privileged_ || exit $$?; \
+	if ! command -v jq >/dev/null 2>&1; then \
+		echo "❌ jq is required to locate the prebuilt guest test executable"; \
+		exit 1; \
+	fi; \
+	if ! test_metadata=$$(mktemp "$${TMPDIR:-/tmp}/boxlite-guest-perms.XXXXXX"); then \
+		echo "❌ Could not create temporary Cargo metadata file"; \
+		exit 1; \
+	fi; \
+	trap 'rm -f -- "$$test_metadata"' EXIT; \
+	if ! cargo test -p boxlite-guest --bin boxlite-guest --no-run \
+		--message-format=json >"$$test_metadata"; then \
+		echo "❌ Failed to build the boxlite-guest test executable"; \
+		exit 1; \
+	fi; \
+	if ! test_binary=$$(jq --slurp --raw-output --exit-status \
+		'[.[] | select(.reason == "compiler-artifact" and .profile.test == true and .target.name == "boxlite-guest" and .executable != null) | .executable] | last' \
+		"$$test_metadata"); then \
+		echo "❌ Could not parse the prebuilt boxlite-guest test executable"; \
+		exit 1; \
+	fi; \
+	if [ -z "$$test_binary" ] || [ ! -x "$$test_binary" ]; then \
+		echo "❌ Could not locate the prebuilt boxlite-guest test executable"; \
+		exit 1; \
+	fi; \
+	echo "🔐 Running privileged guest ownership tests..."; \
+	if [ "$$(id -u)" -eq 0 ]; then \
+		unshare --mount --propagation private -- \
+			"$$test_binary" 'storage::perms::tests::privileged_' \
+			--ignored --test-threads=1; \
+	elif command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then \
+		sudo -n unshare --mount --propagation private -- \
+			"$$test_binary" 'storage::perms::tests::privileged_' \
+			--ignored --test-threads=1; \
+	else \
+		echo "❌ Privileged ownership tests require root or passwordless sudo"; \
+		exit 1; \
 	fi
 
 # Pre-warm Rust integration test image cache (internal helper, still callable).

--- a/src/guest/Cargo.toml
+++ b/src/guest/Cargo.toml
@@ -20,7 +20,7 @@ base64 = "0.22"
 bytes = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-nix = { version = "0.29", features = ["mount", "process", "fs", "sched", "socket", "poll", "user"] }
+nix = { version = "0.29", features = ["mount", "process", "fs", "dir", "sched", "socket", "poll", "user"] }
 async-trait = "0.1"
 uuid = { version = "1.10", features = ["v4"] }
 tonic = "0.12"

--- a/src/guest/src/storage/perms.rs
+++ b/src/guest/src/storage/perms.rs
@@ -1,10 +1,17 @@
 //! Filesystem ownership and permission utilities.
 
-use std::path::Path;
-use std::process::Command;
+use std::os::fd::AsRawFd;
+use std::os::unix::ffi::OsStrExt;
+use std::path::{Path, PathBuf};
 
-use boxlite_shared::errors::{BoxliteError, BoxliteResult};
+use boxlite_shared::errors::BoxliteResult;
+use nix::dir::{Dir, OwningIter};
+use nix::fcntl::{openat, AtFlags, OFlag};
 use nix::libc;
+use nix::sys::stat::{fstat, fstatat, Mode};
+use nix::unistd::{close, fchown, fchownat, Gid, Uid};
+
+const WARNING_SAMPLE_LIMIT: usize = 8;
 
 /// Fixes filesystem ownership to match current process uid:gid.
 pub struct OwnershipFixer;
@@ -13,11 +20,13 @@ impl OwnershipFixer {
     /// Fix ownership of all files/directories to current uid:gid if needed.
     ///
     /// Checks ownership first and skips if already correct.
-    /// Uses chown -R for efficiency.
     pub fn fix_if_needed(path: &Path) -> BoxliteResult<()> {
         let current_uid = unsafe { libc::getuid() };
         let current_gid = unsafe { libc::getgid() };
+        Self::fix_for_owner(path, current_uid, current_gid)
+    }
 
+    fn fix_for_owner(path: &Path, current_uid: u32, current_gid: u32) -> BoxliteResult<()> {
         // Check if ownership fix is needed by sampling root and subdirectories
         if Self::ownership_matches(path, current_uid, current_gid) {
             tracing::debug!(
@@ -29,41 +38,40 @@ impl OwnershipFixer {
             return Ok(());
         }
 
-        let owner = format!("{}:{}", current_uid, current_gid);
-
-        tracing::info!("Fixing ownership of {} to {}", path.display(), owner);
+        tracing::info!(
+            "Fixing ownership of {} to {}:{}",
+            path.display(),
+            current_uid,
+            current_gid
+        );
 
         let start = std::time::Instant::now();
-
-        // Use chown -R for efficiency (much faster than walking in Rust).
-        // Fence the reaper across spawn-and-wait (see reap_fence): output()
-        // self-waits and would otherwise race waitpid(-1) into ECHILD.
-        let output = {
-            let _fence = crate::reaper::reap_fence();
-            Command::new("chown")
-                .args(["-R", &owner])
-                .arg(path)
-                .output()
-        }
-        .map_err(|e| BoxliteError::Storage(format!("Failed to run chown: {}", e)))?;
-
+        let report = RecursiveChowner::new(current_uid, current_gid).chown_path(path);
         let duration = start.elapsed();
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
+        if report.has_warnings() {
             tracing::warn!(
-                "chown -R {} {} had errors (took {:?}): {}",
-                owner,
+                "Ownership repair of {} to {}:{} completed with warnings in {:?}: \
+                 visited={}, changed={}, failures={}, cycles={}, samples={:?}",
                 path.display(),
+                current_uid,
+                current_gid,
                 duration,
-                stderr
+                report.visited,
+                report.changed,
+                report.failures,
+                report.cycles,
+                report.warning_samples
             );
         } else {
             tracing::info!(
-                "Fixed ownership of {} to {} in {:?}",
+                "Fixed ownership of {} to {}:{} in {:?} (visited={}, changed={})",
                 path.display(),
-                owner,
-                duration
+                current_uid,
+                current_gid,
+                duration,
+                report.visited,
+                report.changed
             );
         }
 
@@ -97,3 +105,362 @@ impl OwnershipFixer {
         true
     }
 }
+
+struct RecursiveChowner {
+    uid: Uid,
+    gid: Gid,
+    report: ChownReport,
+    #[cfg(test)]
+    test_faults: TestFaults,
+}
+
+impl RecursiveChowner {
+    fn new(uid: u32, gid: u32) -> Self {
+        Self {
+            uid: Uid::from_raw(uid),
+            gid: Gid::from_raw(gid),
+            report: ChownReport::default(),
+            #[cfg(test)]
+            test_faults: TestFaults::default(),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_test_faults(mut self, test_faults: TestFaults) -> Self {
+        self.test_faults = test_faults;
+        self
+    }
+
+    fn chown_path(mut self, path: &Path) -> ChownReport {
+        // check if it is file, if it is just chown it and return
+        let stat = match fstatat(None, path, AtFlags::AT_SYMLINK_NOFOLLOW) {
+            Ok(stat) => stat,
+            Err(error) => {
+                self.report.record_failure("stat", path, error);
+                return self.report;
+            }
+        };
+        self.report.visited = 1;
+
+        if stat.st_mode & libc::S_IFMT != libc::S_IFDIR {
+            self.chown_operand(path);
+            return self.report;
+        }
+
+        // now it is directory, we need to traverse it
+        let flags = OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC;
+        let root = match Dir::open(path, flags, Mode::empty()) {
+            Ok(root) => root,
+            Err(error) => {
+                self.report.record_failure("open directory", path, error);
+                return self.report;
+            }
+        };
+        let root_stat = match fstat(root.as_raw_fd()) {
+            Ok(stat) => stat,
+            Err(error) => {
+                self.report.record_failure("stat directory", path, error);
+                return self.report;
+            }
+        };
+
+        // use stack to dfs traverse it. DirectoryFrame wrap an OwningIter, iterator for the directory
+        // hint: if dir too deep, may cost too much fd. fix it in future.
+        let mut stack = vec![DirectoryFrame::new(root, path.to_path_buf(), &root_stat)];
+        while !stack.is_empty() {
+            #[cfg(test)]
+            let inject_read_error = self
+                .test_faults
+                .should_fail_read(&stack.last().expect("non-empty directory stack").path);
+            #[cfg(test)]
+            let next_entry = if inject_read_error {
+                Some(Err(nix::errno::Errno::EIO))
+            } else {
+                stack
+                    .last_mut()
+                    .expect("non-empty directory stack")
+                    .entries
+                    .next()
+            };
+            #[cfg(not(test))]
+            let next_entry = stack
+                .last_mut()
+                .expect("non-empty directory stack")
+                .entries
+                .next();
+
+            let entry = match next_entry {
+                Some(Ok(entry)) => entry,
+                Some(Err(error)) => {
+                    let frame = stack.pop().expect("non-empty directory stack");
+                    self.report
+                        .record_failure("read directory", &frame.path, error);
+                    continue;
+                }
+                None => {
+                    let frame = stack.pop().expect("non-empty directory stack");
+                    self.chown_directory(frame);
+                    continue;
+                }
+            };
+
+            let name = entry.file_name();
+            if name.to_bytes() == b"." || name.to_bytes() == b".." {
+                continue;
+            }
+
+            let parent = stack.last().expect("entry has a parent frame");
+            let parent_fd = parent.entries.as_raw_fd();
+            let path = parent
+                .path
+                .join(std::ffi::OsStr::from_bytes(name.to_bytes()));
+            self.report.visited += 1;
+
+            let stat = match fstatat(Some(parent_fd), name, AtFlags::AT_SYMLINK_NOFOLLOW) {
+                Ok(stat) => stat,
+                Err(error) => {
+                    self.report.record_failure("stat", &path, error);
+                    continue;
+                }
+            };
+
+            if stat.st_mode & libc::S_IFMT != libc::S_IFDIR {
+                self.chown_entry(parent_fd, name, &path);
+                continue;
+            }
+
+            #[cfg(test)]
+            let inject_open_error = self
+                .test_faults
+                .should_fail_descent(&path, TestDescentFailure::Open);
+            #[cfg(test)]
+            let child_open = if inject_open_error {
+                Err(nix::errno::Errno::EMFILE)
+            } else {
+                openat(
+                    Some(parent_fd),
+                    name,
+                    OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
+                    Mode::empty(),
+                )
+            };
+            #[cfg(not(test))]
+            let child_open = openat(
+                Some(parent_fd),
+                name,
+                OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
+                Mode::empty(),
+            );
+            let child_fd = match child_open {
+                Ok(fd) => fd,
+                Err(error) => {
+                    self.report.record_failure("open directory", &path, error);
+                    continue;
+                }
+            };
+
+            #[cfg(test)]
+            let inject_stat_error = self
+                .test_faults
+                .should_fail_descent(&path, TestDescentFailure::Stat);
+            #[cfg(test)]
+            let child_stat_result = if inject_stat_error {
+                Err(nix::errno::Errno::EIO)
+            } else {
+                fstat(child_fd)
+            };
+            #[cfg(not(test))]
+            let child_stat_result = fstat(child_fd);
+            let child_stat = match child_stat_result {
+                Ok(stat) => stat,
+                Err(error) => {
+                    self.report.record_failure("stat directory", &path, error);
+                    let _ = close(child_fd);
+                    continue;
+                }
+            };
+
+            let child_identity = DirectoryIdentity::from(&child_stat);
+            if stack
+                .iter()
+                .any(|ancestor| ancestor.identity == child_identity)
+            {
+                let _ = close(child_fd);
+                self.report.record_cycle(&path);
+                continue;
+            }
+
+            #[cfg(test)]
+            let inject_stream_error = self
+                .test_faults
+                .should_fail_descent(&path, TestDescentFailure::Stream);
+            #[cfg(test)]
+            let child_stream = if inject_stream_error {
+                let _ = close(child_fd);
+                Err(nix::errno::Errno::EIO)
+            } else {
+                Dir::from_fd(child_fd)
+            };
+            #[cfg(not(test))]
+            let child_stream = Dir::from_fd(child_fd);
+            let child_dir = match child_stream {
+                Ok(dir) => dir,
+                Err(error) => {
+                    self.report
+                        .record_failure("open directory stream for", &path, error);
+                    continue;
+                }
+            };
+            stack.push(DirectoryFrame::new(child_dir, path, &child_stat));
+        }
+
+        self.report
+    }
+
+    fn chown_operand(&mut self, path: &Path) {
+        match fchownat(
+            None,
+            path,
+            Some(self.uid),
+            Some(self.gid),
+            AtFlags::AT_SYMLINK_NOFOLLOW,
+        ) {
+            Ok(()) => self.report.changed += 1,
+            Err(error) => self.report.record_failure("chown", path, error),
+        }
+    }
+
+    fn chown_entry(&mut self, parent_fd: i32, name: &std::ffi::CStr, path: &Path) {
+        match fchownat(
+            Some(parent_fd),
+            name,
+            Some(self.uid),
+            Some(self.gid),
+            AtFlags::AT_SYMLINK_NOFOLLOW,
+        ) {
+            Ok(()) => self.report.changed += 1,
+            Err(error) => self.report.record_failure("chown", path, error),
+        }
+    }
+
+    fn chown_directory(&mut self, frame: DirectoryFrame) {
+        match fchown(frame.entries.as_raw_fd(), Some(self.uid), Some(self.gid)) {
+            Ok(()) => self.report.changed += 1,
+            Err(error) => self
+                .report
+                .record_failure("chown directory", &frame.path, error),
+        }
+    }
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum TestDescentFailure {
+    Open,
+    Stat,
+    Stream,
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct TestFaults {
+    descent_failure: Option<(PathBuf, TestDescentFailure)>,
+    read_failure: Option<PathBuf>,
+}
+
+#[cfg(test)]
+impl TestFaults {
+    fn should_fail_descent(&mut self, path: &Path, stage: TestDescentFailure) -> bool {
+        let should_fail =
+            self.descent_failure
+                .as_ref()
+                .is_some_and(|(failure_path, failure_stage)| {
+                    failure_path == path && *failure_stage == stage
+                });
+        if should_fail {
+            self.descent_failure = None;
+        }
+        should_fail
+    }
+
+    fn should_fail_read(&mut self, path: &Path) -> bool {
+        if self.read_failure.as_deref() == Some(path) {
+            self.read_failure = None;
+            return true;
+        }
+        false
+    }
+}
+
+struct DirectoryFrame {
+    entries: OwningIter,
+    path: PathBuf,
+    identity: DirectoryIdentity,
+}
+
+impl DirectoryFrame {
+    fn new(directory: Dir, path: PathBuf, stat: &libc::stat) -> Self {
+        Self {
+            entries: directory.into_iter(),
+            path,
+            identity: DirectoryIdentity::from(stat),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+struct DirectoryIdentity {
+    device: libc::dev_t,
+    inode: libc::ino_t,
+}
+
+impl From<&libc::stat> for DirectoryIdentity {
+    fn from(stat: &libc::stat) -> Self {
+        Self {
+            device: stat.st_dev,
+            inode: stat.st_ino,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct ChownReport {
+    visited: usize,
+    changed: usize,
+    failures: usize,
+    cycles: usize,
+    warning_samples: Vec<String>,
+}
+
+impl ChownReport {
+    fn has_warnings(&self) -> bool {
+        self.failures != 0 || self.cycles != 0
+    }
+
+    fn record_failure(&mut self, operation: &str, path: &Path, error: nix::Error) {
+        self.failures += 1;
+        self.record_sample(format!(
+            "{} {}: {}",
+            operation,
+            path.to_string_lossy(),
+            error
+        ));
+    }
+
+    fn record_cycle(&mut self, path: &Path) {
+        self.cycles += 1;
+        self.record_sample(format!(
+            "skipped directory cycle at {}",
+            path.to_string_lossy()
+        ));
+    }
+
+    fn record_sample(&mut self, sample: String) {
+        if self.warning_samples.len() < WARNING_SAMPLE_LIMIT {
+            self.warning_samples.push(sample);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/guest/src/storage/perms/tests.rs
+++ b/src/guest/src/storage/perms/tests.rs
@@ -1,0 +1,532 @@
+use super::*;
+use nix::mount::{mount, umount2, MntFlags, MsFlags};
+use nix::unistd::{chown, mkfifo, Gid, Uid};
+use std::ffi::OsString;
+use std::fs::{self, File, Permissions};
+use std::io::{self, Write};
+use std::os::unix::ffi::OsStringExt;
+use std::os::unix::fs::{symlink, MetadataExt, PermissionsExt};
+use std::os::unix::net::UnixListener;
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone, Default)]
+struct CapturedLogs(Arc<Mutex<Vec<u8>>>);
+
+struct CapturedWriter(Arc<Mutex<Vec<u8>>>);
+
+impl CapturedLogs {
+    fn contents(&self) -> String {
+        String::from_utf8(self.0.lock().expect("lock captured logs").clone())
+            .expect("tracing output is UTF-8")
+    }
+}
+
+impl<'writer> tracing_subscriber::fmt::MakeWriter<'writer> for CapturedLogs {
+    type Writer = CapturedWriter;
+
+    fn make_writer(&'writer self) -> Self::Writer {
+        CapturedWriter(Arc::clone(&self.0))
+    }
+}
+
+impl Write for CapturedWriter {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        self.0.lock().expect("lock captured logs").write(buffer)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+struct PathGuard(Option<std::ffi::OsString>);
+
+impl PathGuard {
+    fn clear() -> Self {
+        let original = std::env::var_os("PATH");
+        std::env::set_var("PATH", "");
+        Self(original)
+    }
+}
+
+impl Drop for PathGuard {
+    fn drop(&mut self) {
+        if let Some(path) = self.0.take() {
+            std::env::set_var("PATH", path);
+        } else {
+            std::env::remove_var("PATH");
+        }
+    }
+}
+
+struct MountGuard(PathBuf);
+
+impl Drop for MountGuard {
+    fn drop(&mut self) {
+        umount2(&self.0, MntFlags::MNT_DETACH).expect("unmount test bind mount");
+    }
+}
+
+fn current_owner() -> (u32, u32) {
+    (unsafe { libc::getuid() }, unsafe { libc::getgid() })
+}
+
+fn chown_path_for_current_process(path: &Path) -> ChownReport {
+    let (uid, gid) = current_owner();
+    RecursiveChowner::new(uid, gid).chown_path(path)
+}
+
+fn chown_path_with_test_faults(path: &Path, test_faults: TestFaults) -> ChownReport {
+    let (uid, gid) = current_owner();
+    RecursiveChowner::new(uid, gid)
+        .with_test_faults(test_faults)
+        .chown_path(path)
+}
+
+fn descent_failure_report(stage: TestDescentFailure) -> ChownReport {
+    let temp = tempfile::tempdir().expect("create temporary directory");
+    let child = temp.path().join("child");
+    fs::create_dir(&child).expect("create child directory");
+    let test_faults = TestFaults {
+        descent_failure: Some((child, stage)),
+        read_failure: None,
+    };
+    chown_path_with_test_faults(temp.path(), test_faults)
+}
+
+fn set_mode(path: &Path, mode: u32) {
+    fs::set_permissions(path, Permissions::from_mode(mode)).expect("set fixture mode");
+}
+
+fn set_distinct_owner(path: &Path) {
+    let (uid, gid) = current_owner();
+    let different_uid = if uid == 0 { 1 } else { 0 };
+    let different_gid = if gid == 0 { 1 } else { 0 };
+    chown(
+        path,
+        Some(Uid::from_raw(different_uid)),
+        Some(Gid::from_raw(different_gid)),
+    )
+    .expect("privileged ownership test requires a mapped alternate uid/gid");
+}
+
+#[test]
+#[ignore = "requires root; mutates process PATH"]
+fn privileged_fix_does_not_depend_on_path() {
+    assert_eq!(unsafe { libc::geteuid() }, 0, "test requires root");
+    let temp = tempfile::tempdir().expect("create temporary directory");
+    set_distinct_owner(temp.path());
+
+    let _path = PathGuard::clear();
+    OwnershipFixer::fix_if_needed(temp.path())
+        .expect("ownership repair must not depend on a PATH chown binary");
+}
+
+#[test]
+fn walks_non_utf8_and_deep_directory_names_without_recursion() {
+    let temp = tempfile::tempdir().expect("create temporary directory");
+    let non_utf8 = OsString::from_vec(vec![b'n', b'a', b'm', b'e', 0xff]);
+    File::create(temp.path().join(non_utf8)).expect("create non-UTF-8 file");
+
+    let mut deepest = temp.path().to_path_buf();
+    for _ in 0..256 {
+        deepest.push("d");
+        fs::create_dir(&deepest).expect("create deep directory");
+    }
+    File::create(deepest.join("leaf")).expect("create deep leaf");
+
+    let report = chown_path_for_current_process(temp.path());
+
+    assert_eq!(report.failures, 0);
+    assert_eq!(report.cycles, 0);
+    assert_eq!(report.visited, 259);
+    assert_eq!(report.changed, report.visited);
+}
+
+#[test]
+fn directory_open_failure_does_not_chown_inode() {
+    let report = descent_failure_report(TestDescentFailure::Open);
+
+    assert_eq!(report.visited, 2);
+    assert_eq!(report.failures, 1);
+    assert_eq!(
+        report.changed, 1,
+        "only the fully traversed root is changed"
+    );
+}
+
+#[test]
+fn directory_stat_failure_does_not_chown_inode() {
+    let report = descent_failure_report(TestDescentFailure::Stat);
+
+    assert_eq!(report.visited, 2);
+    assert_eq!(report.failures, 1);
+    assert_eq!(
+        report.changed, 1,
+        "only the fully traversed root is changed"
+    );
+}
+
+#[test]
+fn directory_stream_failure_does_not_chown_inode() {
+    let report = descent_failure_report(TestDescentFailure::Stream);
+
+    assert_eq!(report.visited, 2);
+    assert_eq!(report.failures, 1);
+    assert_eq!(
+        report.changed, 1,
+        "only the fully traversed root is changed"
+    );
+}
+
+#[test]
+fn directory_read_error_is_terminal_and_does_not_chown_inode() {
+    let temp = tempfile::tempdir().expect("create temporary directory");
+    File::create(temp.path().join("unreachable")).expect("create sibling");
+    let report = chown_path_with_test_faults(
+        temp.path(),
+        TestFaults {
+            descent_failure: None,
+            read_failure: Some(temp.path().to_path_buf()),
+        },
+    );
+
+    assert_eq!(report.failures, 1);
+    assert_eq!(report.visited, 1);
+    assert_eq!(report.changed, 0);
+}
+
+#[test]
+fn does_not_follow_external_or_dangling_symlinks() {
+    let root = tempfile::tempdir().expect("create root directory");
+    let outside = tempfile::tempdir().expect("create outside directory");
+    let outside_file = outside.path().join("target");
+    File::create(&outside_file).expect("create outside file");
+    set_mode(&outside_file, 0o4755);
+
+    symlink(&outside_file, root.path().join("external")).expect("create outside symlink");
+    symlink("missing", root.path().join("dangling")).expect("create dangling symlink");
+
+    let report = chown_path_for_current_process(root.path());
+
+    assert_eq!(report.failures, 0);
+    assert_eq!(report.visited, 3);
+    assert_ne!(
+        fs::metadata(&outside_file)
+            .expect("stat outside file")
+            .mode()
+            & 0o4000,
+        0,
+        "following the symlink would clear the target's setuid bit"
+    );
+}
+
+#[test]
+fn handles_hardlinks_fifo_and_unix_socket() {
+    let target_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target");
+    let temp = tempfile::Builder::new()
+        .prefix("boxlite-perms-")
+        .tempdir_in(target_dir)
+        .expect("create temporary directory");
+    let original = temp.path().join("original");
+    let hardlink = temp.path().join("hardlink");
+    File::create(&original).expect("create hardlink source");
+    fs::hard_link(&original, &hardlink).expect("create hardlink");
+    mkfifo(&temp.path().join("fifo"), Mode::S_IRUSR | Mode::S_IWUSR).expect("create FIFO");
+    let socket = match UnixListener::bind(temp.path().join("socket")) {
+        Ok(socket) => Some(socket),
+        Err(error) if error.raw_os_error() == Some(libc::EPERM) => {
+            eprintln!("skipping Unix socket fixture: sandbox denies bind(2)");
+            None
+        }
+        Err(error) => panic!("create Unix socket: {error}"),
+    };
+
+    let report = chown_path_for_current_process(temp.path());
+
+    assert_eq!(report.failures, 0);
+    assert_eq!(report.visited, if socket.is_some() { 5 } else { 4 });
+    assert_eq!(fs::metadata(original).expect("stat hardlink").nlink(), 2);
+    drop(socket);
+}
+
+#[test]
+fn continues_after_entry_failures_and_bounds_warning_samples() {
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("skipping permission-denied fixture as root");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("create temporary directory");
+    let sibling = temp.path().join("sibling");
+    File::create(&sibling).expect("create successful sibling");
+    let blocked: Vec<_> = (0..10)
+        .map(|index| {
+            let path = temp.path().join(format!("blocked-{index}"));
+            fs::create_dir(&path).expect("create blocked directory");
+            set_mode(&path, 0);
+            path
+        })
+        .collect();
+
+    let report = chown_path_for_current_process(temp.path());
+
+    for path in &blocked {
+        set_mode(path, 0o700);
+    }
+    assert_eq!(report.failures, blocked.len());
+    assert_eq!(report.warning_samples.len(), WARNING_SAMPLE_LIMIT);
+    assert_eq!(report.changed, 2, "root and sibling are changed");
+    assert!(sibling.exists());
+}
+
+#[test]
+fn public_entry_preserves_nonfatal_setup_errors() {
+    let temp = tempfile::tempdir().expect("create temporary directory");
+
+    OwnershipFixer::fix_if_needed(&temp.path().join("missing"))
+        .expect("missing operands remain non-fatal");
+    OwnershipFixer::fix_if_needed(Path::new("")).expect("empty operands remain non-fatal");
+}
+
+#[test]
+fn public_entry_accepts_matching_root_and_intermediate_symlinks() {
+    let temp = tempfile::tempdir().expect("create temporary directory");
+    let target = temp.path().join("target");
+    let child = target.join("child");
+    fs::create_dir_all(&child).expect("create symlink target child");
+    let link = temp.path().join("link");
+    symlink(&target, &link).expect("create root symlink");
+
+    OwnershipFixer::fix_if_needed(&link)
+        .expect("legacy sampling follows a matching symlink operand");
+    OwnershipFixer::fix_if_needed(&link.join("child"))
+        .expect("legacy sampling follows a matching intermediate symlink");
+}
+
+#[test]
+fn supports_file_fifo_and_socket_operands() {
+    let temp = tempfile::tempdir().expect("create temporary directory");
+    let file = temp.path().join("file");
+    File::create(&file).expect("create file operand");
+    let fifo = temp.path().join("fifo");
+    mkfifo(&fifo, Mode::S_IRUSR | Mode::S_IWUSR).expect("create FIFO operand");
+    let socket_path = temp.path().join("socket");
+    let socket = match UnixListener::bind(&socket_path) {
+        Ok(socket) => Some(socket),
+        Err(error) if error.raw_os_error() == Some(libc::EPERM) => None,
+        Err(error) => panic!("create Unix socket: {error}"),
+    };
+
+    for path in [file, fifo] {
+        let report = chown_path_for_current_process(&path);
+        assert_eq!(report.visited, 1);
+        assert_eq!(report.changed, 1);
+        assert_eq!(report.failures, 0);
+    }
+    if socket.is_some() {
+        let report = chown_path_for_current_process(&socket_path);
+        assert_eq!(report.visited, 1);
+        assert_eq!(report.changed, 1);
+        assert_eq!(report.failures, 0);
+    }
+}
+
+#[test]
+#[ignore = "requires root"]
+fn privileged_preserves_sampling_skip_behavior() {
+    let temp = tempfile::tempdir().expect("create temporary directory");
+    let sampled = temp.path().join("sampled");
+    fs::create_dir(&sampled).expect("create sampled directory");
+    let nested = sampled.join("nested");
+    File::create(&nested).expect("create nested file");
+    set_distinct_owner(&nested);
+    let before = fs::symlink_metadata(&nested).expect("stat nested fixture");
+
+    OwnershipFixer::fix_if_needed(temp.path()).expect("sampling skip succeeds");
+
+    let after = fs::symlink_metadata(&nested).expect("stat nested file after skip");
+    assert_eq!((after.uid(), after.gid()), (before.uid(), before.gid()));
+}
+
+#[test]
+#[ignore = "requires root"]
+fn privileged_blanket_fix_changes_the_whole_tree() {
+    let temp = tempfile::tempdir().expect("create temporary directory");
+    let directory = temp.path().join("directory");
+    fs::create_dir(&directory).expect("create child directory");
+    let file = directory.join("file");
+    File::create(&file).expect("create child file");
+    set_distinct_owner(&directory);
+    set_distinct_owner(&file);
+
+    OwnershipFixer::fix_if_needed(temp.path()).expect("blanket ownership fix");
+
+    let expected = current_owner();
+    for path in [temp.path(), directory.as_path(), file.as_path()] {
+        let metadata = fs::symlink_metadata(path).expect("stat fixed path");
+        assert_eq!((metadata.uid(), metadata.gid()), expected);
+    }
+}
+
+#[test]
+#[ignore = "requires root"]
+fn privileged_continues_when_ownership_root_is_read_only() {
+    let root = tempfile::tempdir().expect("create root directory");
+    let source = tempfile::tempdir().expect("create read-only root source");
+    mount(
+        Option::<&str>::None,
+        source.path(),
+        Some("tmpfs"),
+        MsFlags::empty(),
+        Some("size=1m"),
+    )
+    .expect("mount private tmpfs fixture");
+    let source_guard = MountGuard(source.path().to_path_buf());
+    File::create(source.path().join("file")).expect("create root fixture file");
+
+    mount(
+        Some(source.path()),
+        root.path(),
+        Option::<&str>::None,
+        MsFlags::MS_BIND,
+        Option::<&str>::None,
+    )
+    .expect("bind root fixture");
+    let root_guard = MountGuard(root.path().to_path_buf());
+    let expected_owner = current_owner();
+    let before = fs::symlink_metadata(root.path()).expect("stat root before repair");
+    assert_eq!((before.uid(), before.gid()), expected_owner);
+    mount(
+        Option::<&Path>::None,
+        root.path(),
+        Option::<&str>::None,
+        MsFlags::MS_BIND | MsFlags::MS_REMOUNT | MsFlags::MS_RDONLY,
+        Option::<&str>::None,
+    )
+    .expect("remount root fixture read-only");
+    let (uid, gid) = current_owner();
+    let mismatched_gid = if gid == u32::MAX { gid - 1 } else { gid + 1 };
+
+    let report = chown_path_for_current_process(root.path());
+    assert_eq!(report.visited, 2);
+    assert_eq!(report.changed, 0);
+    assert_eq!(report.failures, 2);
+    assert!(report
+        .warning_samples
+        .iter()
+        .any(|sample| sample.contains("chown directory") && sample.contains("EROFS")));
+
+    let logs = CapturedLogs::default();
+    let subscriber = tracing_subscriber::fmt()
+        .without_time()
+        .with_ansi(false)
+        .with_max_level(tracing::Level::WARN)
+        .with_writer(logs.clone())
+        .finish();
+    tracing::subscriber::with_default(subscriber, || {
+        OwnershipFixer::fix_for_owner(root.path(), uid, mismatched_gid)
+    })
+    .expect("root chown failure remains non-fatal");
+
+    let after = fs::symlink_metadata(root.path()).expect("stat root after repair");
+    assert_eq!((after.uid(), after.gid()), (before.uid(), before.gid()));
+    let logs = logs.contents();
+    assert!(logs.contains("completed with warnings"), "logs: {logs}");
+    assert!(logs.contains("chown directory"), "logs: {logs}");
+    drop(root_guard);
+    drop(source_guard);
+}
+
+#[test]
+#[ignore = "requires root"]
+fn privileged_continues_past_read_only_mount() {
+    let root = tempfile::tempdir().expect("create root directory");
+    let source = tempfile::tempdir().expect("create read-only mount source");
+    mount(
+        Option::<&str>::None,
+        source.path(),
+        Some("tmpfs"),
+        MsFlags::empty(),
+        Some("size=1m"),
+    )
+    .expect("mount private tmpfs fixture");
+    let source_guard = MountGuard(source.path().to_path_buf());
+    File::create(source.path().join("read-only-file")).expect("create read-only file");
+    let mountpoint = root.path().join("read-only");
+    fs::create_dir(&mountpoint).expect("create read-only mountpoint");
+    mount(
+        Some(source.path()),
+        &mountpoint,
+        Option::<&str>::None,
+        MsFlags::MS_BIND,
+        Option::<&str>::None,
+    )
+    .expect("bind read-only fixture");
+    let mount_guard = MountGuard(mountpoint.clone());
+    mount(
+        Option::<&Path>::None,
+        &mountpoint,
+        Option::<&str>::None,
+        MsFlags::MS_BIND | MsFlags::MS_REMOUNT | MsFlags::MS_RDONLY,
+        Option::<&str>::None,
+    )
+    .expect("remount fixture read-only");
+    File::create(root.path().join("sibling")).expect("create writable sibling");
+
+    let report = chown_path_for_current_process(root.path());
+
+    assert_eq!(report.visited, 4);
+    assert_eq!(report.changed, 2, "root and writable sibling are changed");
+    assert_eq!(report.failures, 2, "read-only directory and file fail");
+    assert!(report
+        .warning_samples
+        .iter()
+        .all(|sample| sample.contains("EROFS")));
+    drop(mount_guard);
+    drop(source_guard);
+}
+
+#[test]
+#[ignore = "requires root"]
+fn privileged_crosses_mounts_and_stops_ancestor_cycles() {
+    let root = tempfile::tempdir().expect("create root directory");
+    let source = tempfile::tempdir().expect("create mount source");
+    File::create(source.path().join("mounted-file")).expect("create mounted file");
+    let mountpoint = root.path().join("mounted");
+    fs::create_dir(&mountpoint).expect("create mountpoint");
+    mount(
+        Some(source.path()),
+        &mountpoint,
+        Option::<&str>::None,
+        MsFlags::MS_BIND,
+        Option::<&str>::None,
+    )
+    .expect("bind child filesystem");
+    let mounted_guard = MountGuard(mountpoint.clone());
+
+    let crossed = chown_path_for_current_process(root.path());
+    assert_eq!(crossed.failures, 0);
+    assert_eq!(crossed.cycles, 0);
+    assert_eq!(crossed.visited, 3);
+    drop(mounted_guard);
+
+    let cyclepoint = root.path().join("cycle");
+    fs::create_dir(&cyclepoint).expect("create cycle mountpoint");
+    mount(
+        Some(root.path()),
+        &cyclepoint,
+        Option::<&str>::None,
+        MsFlags::MS_BIND,
+        Option::<&str>::None,
+    )
+    .expect("bind ancestor onto descendant");
+    let cycle_guard = MountGuard(cyclepoint);
+
+    let cycled = chown_path_for_current_process(root.path());
+    assert_eq!(cycled.failures, 0);
+    assert_eq!(cycled.cycles, 1);
+    assert_eq!(cycled.warning_samples.len(), 1);
+
+    drop(cycle_guard);
+}


### PR DESCRIPTION
## Summary

Replace the guest's PATH-resolved `chown -R` subprocess with an in-process, fd-relative syscall implementation while preserving the existing ownership sampling and best-effort repair behavior.

## Call graph

Before
  mount                     (BlockDeviceMount · src/guest/src/storage/block_device.rs:25) — mounts and initializes the guest filesystem
    └─ fix_if_needed        (OwnershipFixer · src/guest/src/storage/perms.rs:17) — samples ownership before repair
         ├─ ownership_matches (OwnershipFixer · src/guest/src/storage/perms.rs:74) — skips an already-matching tree
         └─ Command::new("chown") (std::process::Command · src/guest/src/storage/perms.rs:43) — runs PATH-resolved `chown -R`

After
  mount                     (BlockDeviceMount · src/guest/src/storage/block_device.rs:25) — mounts and initializes the guest filesystem
    └─ fix_if_needed        (OwnershipFixer · src/guest/src/storage/perms.rs:23) — preserves the existing ownership sample gate
         ├─ ownership_matches (OwnershipFixer · src/guest/src/storage/perms.rs:82) — keeps the original root-plus-five sampling policy
         └─ chown_path      (RecursiveChowner · src/guest/src/storage/perms.rs:134) — walks the tree iteratively with fd-relative syscalls
              ├─ chown_operand   (RecursiveChowner · src/guest/src/storage/perms.rs:316) — changes a non-directory root without following symlinks
              ├─ chown_entry     (RecursiveChowner · src/guest/src/storage/perms.rs:329) — changes descendant entries with `fchownat`
              └─ chown_directory (RecursiveChowner · src/guest/src/storage/perms.rs:342) — changes directories post-order with `fchown`

## Changes

- Remove the runtime `chown` binary, PATH lookup, and reaper-fence dependency from guest ownership repair.
- Add an iterative, fd-relative walker that handles non-UTF-8 names, symlinks, special files, cross-mount traversal, ancestor cycles, and bounded warning samples.
- Add focused ordinary and privileged ownership tests plus a Linux CI target.

## How to verify

- `make test:unit:guest`
- `make test:guest-perms`
- `make fmt:check:rust`
- `make clippy`
- `git diff --check`

## Risks / rollout

- Ownership repair now depends on Linux filesystem syscalls instead of GNU `chown`; privileged Linux tests cover recursive repair, read-only mounts, cross-mount traversal, and bind-mount cycles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved guest ownership repair across files, directories, symlinks, and special files.
  * Ownership repair now continues safely when individual entries cannot be accessed.
  * Added protection against directory cycles and unsafe symlink traversal.
  * Added detailed repair results and warning reporting.

* **Tests**
  * Expanded coverage for permissions, ownership, filesystem errors, links, mounts, and edge cases.
  * Added automated privileged ownership tests on Linux.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->