### PR TITLE
fix(example): use bounded timeout when draining callbacks

### DIFF
--- a/examples/c/example_common.h
+++ b/examples/c/example_common.h
@@ -47,7 +47,7 @@ static int example_drain_until_done(CBoxliteRuntime *runtime, const int *done,
                                     const char *context) {
   while (!*done) {
     CBoxliteError error = {0};
-    if (boxlite_runtime_drain(runtime, -1, &error) < 0) {
+    if (boxlite_runtime_drain(runtime, 100, &error) < 0) {
       print_error(context, &error);
       boxlite_error_free(&error);
       return 0;


### PR DESCRIPTION
## Summary
use bounded timeout when draining callbacks in `example/c/execute.c`, avoiding the caller's while-loop never regains control;


## Call graph
<!-- Required. The end-to-end path this PR touches, before and after; one line
     per hop, only the hops that change. Worked example and the bug-fix markers:
     CONTRIBUTING.md#commit--pr-messages. -->
Before
  create_alpine_box_or_exit        (example · examples/c/example_common.h:70)
    └─ example_drain_until_done    (example · examples/c/example_common.h:46)
         └─ boxlite_runtime_drain  (runtime, -1) (FFI · sdks/c/src/runtime.rs:180)
               └─ drain()          ← BUG : queue is empty and cv.wait blocks forever

After
  create_alpine_box_or_exit        (example · examples/c/example_common.h:70)
    └─ example_drain_until_done    (example · examples/c/example_common.h:46)
         └─ boxlite_runtime_drain  (runtime, 100) (FFI · sdks/c/src/runtime.rs:180)
               └─ drain()          - cv.wait_timeout reaches the bounded timeout 
                                        and return; 


## Changes
- `examples/c/example_common.h`：Modified `-1` to bounded `100ms` called by `boxlite_runtime_drain` in `example_drain_until_done`

## How to verify
- compile and run `examples/c/execute.c` with `-1` timeout, it has no output follow by the version info and totally blocked
- compile and run `examples/c/execute.c` with `100ms` timeout, program will continue working and output normally

<!-- Describe the change, not the process: no pasted logs, no AI/conversation
     narrative, no secrets. Keep it tight and delete sections that don't apply. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the example runtime drain behavior to use a 100 ms timeout, preventing it from blocking indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->