### PR TITLE
feat(api): submit box migration jobs from the control plane

### DIFF
--- a/apps/api/src/box/box.module.ts
+++ b/apps/api/src/box/box.module.ts
@@ -15,6 +15,7 @@ import { RunnerService } from './services/runner.service'
 import { Runner } from './entities/runner.entity'
 import { RunnerController } from './controllers/runner.controller'
 import { BoxManager } from './managers/box.manager'
+import { BoxMigrationManager } from './managers/box-migration.manager'
 import { RedisLockProvider } from './common/redis-lock.provider'
 import { OrganizationModule } from '../organization/organization.module'
 import { BoxWarmPoolService } from './services/box-warm-pool.service'
@@ -78,6 +79,7 @@ import { BoxMigrationService } from './services/box-migration.service'
     BoxActivityService,
     BoxStateWaiterService,
     BoxMigrationService,
+    BoxMigrationManager,
     BoxAccessGuard,
     RunnerAccessGuard,
     RegionRunnerAccessGuard,

--- a/apps/api/src/box/box.module.ts
+++ b/apps/api/src/box/box.module.ts
@@ -45,15 +45,17 @@ import { RegionBoxAccessGuard } from './guards/region-box-access.guard'
 import { ProxyGuard } from './guards/proxy.guard'
 import { EventEmitter2 } from '@nestjs/event-emitter'
 import { BoxLastActivity } from './entities/box-last-activity.entity'
+import { BoxMigration } from './entities/box-migration.entity'
 import { BoxActivityService } from './services/box-activity.service'
 import { BoxStateWaiterService } from './services/box-state-waiter.service'
+import { BoxMigrationService } from './services/box-migration.service'
 
 @Module({
   imports: [
     UserModule,
     OrganizationModule,
     RegionModule,
-    TypeOrmModule.forFeature([Box, Runner, WarmPool, Volume, Region, Job, BoxLastActivity]),
+    TypeOrmModule.forFeature([Box, Runner, WarmPool, Volume, Region, Job, BoxLastActivity, BoxMigration]),
   ],
   controllers: [BoxController, RunnerController, PreviewController, VolumeController, JobController],
   providers: [
@@ -75,6 +77,7 @@ import { BoxStateWaiterService } from './services/box-state-waiter.service'
     JobStateHandlerService,
     BoxActivityService,
     BoxStateWaiterService,
+    BoxMigrationService,
     BoxAccessGuard,
     RunnerAccessGuard,
     RegionRunnerAccessGuard,

--- a/apps/api/src/box/entities/box-migration.entity.ts
+++ b/apps/api/src/box/entities/box-migration.entity.ts
@@ -4,7 +4,9 @@
  */
 
 import { Column, Entity, Index, JoinColumn, OneToOne, PrimaryColumn } from 'typeorm'
+import { BoxDesiredState } from '../enums/box-desired-state.enum'
 import { BoxMigrationState } from '../enums/box-migration-state.enum'
+import { BoxState } from '../enums/box-state.enum'
 import { Box } from './box.entity'
 
 /**
@@ -58,4 +60,25 @@ export class BoxMigration {
   @OneToOne(() => Box, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'boxId' })
   box?: Box
+
+  /**
+   * ValidCheck — whether this migration is still the only writer of its box.
+   *
+   * The box has to still be parked, and `updatedAt` has to still be the copy
+   * the migration took: any write from outside the migration (a user starting
+   * the box, a reconciler) moves `box.updatedAt` past that copy, and the
+   * migration must roll back rather than move a box someone else is using.
+   *
+   * Callers must run this on a box row they hold, immediately before the
+   * irreversible action it guards.
+   */
+  isUndisturbedBy(box: Box): boolean {
+    if (box.state !== BoxState.STOPPED || box.desiredState !== BoxDesiredState.STOPPED) {
+      return false
+    }
+    if (!this.updatedAt || !box.updatedAt) {
+      return false
+    }
+    return this.updatedAt.getTime() === box.updatedAt.getTime()
+  }
 }

--- a/apps/api/src/box/entities/box-migration.entity.ts
+++ b/apps/api/src/box/entities/box-migration.entity.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Column, Entity, Index, JoinColumn, OneToOne, PrimaryColumn } from 'typeorm'
+import { BoxMigrationState } from '../enums/box-migration-state.enum'
+import { Box } from './box.entity'
+
+/**
+ * A box migration between runners, one row per box being moved.
+ *
+ * The row is the migration: it appears when the marker claims a parked box and
+ * is deleted once the box is no longer migrating, so "not migrating" has a
+ * single representation and the table stays the size of the work in flight
+ * rather than the size of the fleet. Deleting the box takes the row with it.
+ */
+@Entity('box_migration')
+@Index('box_migration_state_idx', ['state'])
+export class BoxMigration {
+  @PrimaryColumn({ name: 'boxId' })
+  boxId: string
+
+  //  Which migration job this box is waiting on, never what the migration has
+  //  produced — that is what `arcPath` and `runnerId` record.
+  @Column({
+    type: 'enum',
+    enum: BoxMigrationState,
+  })
+  state: BoxMigrationState
+
+  //  Object key of the archive the migration put on the object store. Empty
+  //  means there is no archive to reclaim. Written whether or not the migration
+  //  stayed valid, because the object exists either way and the rollback path
+  //  needs the key to delete it.
+  @Column({ type: 'character varying', default: '' })
+  arcPath = ''
+
+  //  The second runner a migration involves: before the commit point the runner
+  //  the box was imported onto, after it the runner still holding the original
+  //  box to discard. Null means no such box exists.
+  @Column({
+    type: 'uuid',
+    nullable: true,
+  })
+  runnerId?: string
+
+  //  A copy of `box.updatedAt`, taken by every migration step while it holds the
+  //  box row, so `box_migration.updatedAt = box.updatedAt` reads as "nothing
+  //  outside the migration has touched this box". A write from anywhere else
+  //  moves `box.updatedAt` past this copy and breaks the equality, the signal
+  //  to roll back. Deliberately the same column type as `box.updatedAt`: a
+  //  narrower precision here would round the copy and fail the comparison it
+  //  exists for.
+  @Column({ type: 'timestamp with time zone' })
+  updatedAt: Date
+
+  @OneToOne(() => Box, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'boxId' })
+  box?: Box
+}

--- a/apps/api/src/box/enums/box-migration-state.enum.ts
+++ b/apps/api/src/box/enums/box-migration-state.enum.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+/**
+ * Where a box is in a migration from one runner to another.
+ *
+ * A box that is not migrating has no `box_migration` row at all, so there is no
+ * state for it; every value here names a job the migration is waiting on, and is
+ * left behind by that job's receiver:
+ *
+ *     (no row) ─▶ PENDING_EXPORT ─▶ PENDING_IMPORT ─▶ PENDING_DISCARD_EXPORTED ─▶ COMPLETED
+ *                       └──────────────┴──▶ PENDING_ROLLBACK ─▶ (row deleted)
+ *
+ * The state records what the migration is waiting for, never what it has
+ * produced: `box_migration.arcPath` says an archive is on the object store and
+ * `box_migration.runnerId` says a box exists on another runner. Nor does the
+ * state mark a job as in flight — a box sits in PENDING_IMPORT both before its
+ * IMPORT_BOX job is submitted and while it runs, and the per-box Redis lock is
+ * what tells those two apart.
+ */
+export enum BoxMigrationState {
+  PENDING_EXPORT = 'pending_export',
+  PENDING_IMPORT = 'pending_import',
+  PENDING_DISCARD_EXPORTED = 'pending_discard_exported',
+  PENDING_ROLLBACK = 'pending_rollback',
+  COMPLETED = 'completed',
+}

--- a/apps/api/src/box/managers/box-migration.manager.spec.ts
+++ b/apps/api/src/box/managers/box-migration.manager.spec.ts
@@ -1,0 +1,326 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BoxMigrationManager } from './box-migration.manager'
+import { Box } from '../entities/box.entity'
+import { BoxMigration } from '../entities/box-migration.entity'
+import { BoxMigrationState } from '../enums/box-migration-state.enum'
+import { BoxState } from '../enums/box-state.enum'
+import { BoxDesiredState } from '../enums/box-desired-state.enum'
+import { JobType } from '../enums/job-type.enum'
+import { ResourceType } from '../enums/resource-type.enum'
+import { getMigrateJobLockKey } from '../utils/lock-key.util'
+
+const BOX_ID = 'box-1'
+const SOURCE_RUNNER = 'runner-a'
+const TARGET_RUNNER = 'runner-b'
+
+// The Marker copies the box's own updatedAt into the box_migration row, so the
+// two start out equal and ValidCheck holds.
+const STAMPED = new Date('2026-01-01T00:00:00.000Z')
+
+function makeBox(overrides: Partial<Box> = {}): Box {
+  const box = new Box('us-east')
+  box.id = BOX_ID
+  box.runnerId = SOURCE_RUNNER
+  box.state = BoxState.STOPPED
+  box.desiredState = BoxDesiredState.STOPPED
+  box.updatedAt = STAMPED
+  Object.assign(box, overrides)
+  return box
+}
+
+function makeMigration(state: BoxMigrationState, overrides: Partial<BoxMigration> = {}): BoxMigration {
+  const migration = new BoxMigration()
+  migration.boxId = BOX_ID
+  migration.state = state
+  migration.arcPath = ''
+  migration.updatedAt = STAMPED
+  migration.box = makeBox()
+  Object.assign(migration, overrides)
+  return migration
+}
+
+type RecordedWrite = { kind: 'update' | 'delete'; values?: any; params: any }
+
+/** Collects the SET/WHERE of the manager's conditional box_migration writes. */
+function makeWriteRecorder() {
+  const writes: RecordedWrite[] = []
+  const createQueryBuilder = () => {
+    const recorded: RecordedWrite = { kind: 'update', params: {} }
+    const builder: any = {
+      update: () => builder,
+      delete: () => {
+        recorded.kind = 'delete'
+        return builder
+      },
+      from: () => builder,
+      set: (values: any) => {
+        recorded.values = values
+        return builder
+      },
+      where: (_sql: string, params: any) => {
+        Object.assign(recorded.params, params)
+        return builder
+      },
+      andWhere: (_sql: string, params: any) => {
+        Object.assign(recorded.params, params)
+        return builder
+      },
+      execute: async () => {
+        writes.push(recorded)
+        return { affected: 1 }
+      },
+    }
+    return builder
+  }
+  return { writes, createQueryBuilder }
+}
+
+function makeHarness(
+  migrations: BoxMigration[],
+  locked?: { box?: Box; migration?: BoxMigration },
+  archivePrefix = 'box-migrations/',
+) {
+  const { writes, createQueryBuilder } = makeWriteRecorder()
+  const lockedBox = locked?.box ?? migrations[0]?.box
+  const lockedMigration = locked?.migration ?? migrations[0]
+  const entityManager = {
+    findOne: jest.fn().mockImplementation(async (entity: any) => (entity === Box ? lockedBox : lockedMigration)),
+    createQueryBuilder,
+  }
+  const find = jest.fn().mockResolvedValue(migrations)
+  const dataSource = {
+    getRepository: jest.fn().mockReturnValue({ find }),
+    transaction: jest.fn().mockImplementation((run: any) => run(entityManager)),
+    manager: entityManager,
+  } as any
+  const runnerService = {
+    getRandomAvailableRunner: jest.fn().mockResolvedValue({ id: TARGET_RUNNER }),
+  } as any
+  const jobService = {
+    createJob: jest.fn().mockResolvedValue(undefined),
+  } as any
+  const redisLockProvider = {
+    lock: jest.fn().mockResolvedValue(true),
+    unlock: jest.fn().mockResolvedValue(undefined),
+  } as any
+  const configService = {
+    getOrThrow: jest.fn().mockReturnValue(archivePrefix),
+  } as any
+
+  return {
+    manager: new BoxMigrationManager(dataSource, runnerService, jobService, redisLockProvider, configService),
+    entityManager,
+    find,
+    runnerService,
+    jobService,
+    redisLockProvider,
+    writes,
+  }
+}
+
+describe('BoxMigrationManager submitter loop', () => {
+  it('submits EXPORT_BOX to the box runner and holds the lock for the job in flight', async () => {
+    const migration = makeMigration(BoxMigrationState.PENDING_EXPORT)
+    const h = makeHarness([migration])
+
+    await h.manager.submitMigrationJobs()
+
+    expect(h.jobService.createJob).toHaveBeenCalledWith(
+      h.entityManager,
+      JobType.EXPORT_BOX,
+      SOURCE_RUNNER,
+      ResourceType.BOX,
+      BOX_ID,
+      { arcPath: 'box-migrations/box-1.boxlite' },
+    )
+    expect(h.redisLockProvider.unlock).not.toHaveBeenCalledWith(getMigrateJobLockKey(BOX_ID, JobType.EXPORT_BOX))
+    expect(h.writes).toHaveLength(0)
+  })
+
+  // The archive key is the one thing both runners and the object store have to
+  // agree on, so an operator pointing migrations at another bucket or namespace
+  // has to reach the payload rather than only the config.
+  it('exports to the configured archive prefix', async () => {
+    const migration = makeMigration(BoxMigrationState.PENDING_EXPORT)
+    const h = makeHarness([migration], undefined, 's3://archives/tenant-a/')
+
+    await h.manager.submitMigrationJobs()
+
+    expect(h.jobService.createJob).toHaveBeenCalledWith(
+      h.entityManager,
+      JobType.EXPORT_BOX,
+      SOURCE_RUNNER,
+      ResourceType.BOX,
+      BOX_ID,
+      { arcPath: 's3://archives/tenant-a/box-1.boxlite' },
+    )
+  })
+
+  it('rolls back instead of exporting when the box was touched mid-migration', async () => {
+    // A user started the box: box.updatedAt moved past the copy the marker took.
+    const migration = makeMigration(BoxMigrationState.PENDING_EXPORT, {
+      box: makeBox({
+        desiredState: BoxDesiredState.STARTED,
+        updatedAt: new Date('2026-01-01T00:05:00.000Z'),
+      }),
+    })
+    const h = makeHarness([migration])
+
+    await h.manager.submitMigrationJobs()
+
+    expect(h.jobService.createJob).not.toHaveBeenCalled()
+    expect(h.writes).toEqual([
+      {
+        kind: 'update',
+        values: { state: BoxMigrationState.PENDING_ROLLBACK },
+        params: { boxId: BOX_ID, expected: BoxMigrationState.PENDING_EXPORT },
+      },
+    ])
+    expect(h.redisLockProvider.unlock).toHaveBeenCalledWith(getMigrateJobLockKey(BOX_ID, JobType.EXPORT_BOX))
+  })
+
+  it('skips a box whose job lock is already held', async () => {
+    const migration = makeMigration(BoxMigrationState.PENDING_EXPORT)
+    const h = makeHarness([migration])
+    h.redisLockProvider.lock.mockImplementation(
+      async (key: string) => key !== getMigrateJobLockKey(BOX_ID, JobType.EXPORT_BOX),
+    )
+
+    await h.manager.submitMigrationJobs()
+
+    expect(h.jobService.createJob).not.toHaveBeenCalled()
+    expect(h.writes).toHaveLength(0)
+  })
+
+  it('submits IMPORT_BOX to a runner other than the one being drained', async () => {
+    const migration = makeMigration(BoxMigrationState.PENDING_IMPORT, {
+      arcPath: 'box-migrations/box-1.boxlite',
+    })
+    const h = makeHarness([migration])
+
+    await h.manager.submitMigrationJobs()
+
+    expect(h.runnerService.getRandomAvailableRunner).toHaveBeenCalledWith({
+      regions: [migration.box.region],
+      boxClass: migration.box.class,
+      excludedRunnerIds: [SOURCE_RUNNER],
+    })
+    expect(h.jobService.createJob).toHaveBeenCalledWith(
+      h.entityManager,
+      JobType.IMPORT_BOX,
+      TARGET_RUNNER,
+      ResourceType.BOX,
+      BOX_ID,
+      { arcPath: 'box-migrations/box-1.boxlite' },
+    )
+  })
+
+  it('releases the lock and leaves the state alone when submission fails', async () => {
+    const migration = makeMigration(BoxMigrationState.PENDING_EXPORT)
+    const h = makeHarness([migration])
+    h.jobService.createJob.mockRejectedValue(new Error('job conflict'))
+
+    await h.manager.submitMigrationJobs()
+
+    expect(h.writes).toHaveLength(0)
+    expect(h.redisLockProvider.unlock).toHaveBeenCalledWith(getMigrateJobLockKey(BOX_ID, JobType.EXPORT_BOX))
+  })
+
+  // box_migration.updatedAt is the copy of box.updatedAt the migration took, so
+  // the scan has to run newest-first: a box the user touched recently is the one
+  // they are likeliest to start again on the runner being drained.
+  it('scans the most recently used boxes first', async () => {
+    const h = makeHarness([makeMigration(BoxMigrationState.PENDING_EXPORT)])
+
+    await h.manager.submitMigrationJobs()
+
+    expect(h.find).toHaveBeenCalledWith(expect.objectContaining({ order: { updatedAt: 'DESC' } }))
+  })
+
+  it('turns a PENDING_IMPORT migration with no archive around', async () => {
+    const migration = makeMigration(BoxMigrationState.PENDING_IMPORT)
+    const h = makeHarness([migration])
+
+    await h.manager.submitMigrationJobs()
+
+    expect(h.jobService.createJob).not.toHaveBeenCalled()
+    expect(h.writes).toEqual([
+      {
+        kind: 'update',
+        values: { state: BoxMigrationState.PENDING_ROLLBACK },
+        params: { boxId: BOX_ID, expected: BoxMigrationState.PENDING_IMPORT },
+      },
+    ])
+  })
+})
+
+describe('BoxMigrationManager rollback submitter loop', () => {
+  it('reclaims both artifacts, each on the runner that holds it', async () => {
+    const migration = makeMigration(BoxMigrationState.PENDING_ROLLBACK, {
+      arcPath: 'box-migrations/box-1.boxlite',
+      runnerId: TARGET_RUNNER,
+    })
+    const h = makeHarness([migration])
+
+    await h.manager.submitRollbackJobs()
+
+    expect(h.jobService.createJob).toHaveBeenCalledWith(
+      null,
+      JobType.ROLLBACK_EXPORT_BOX,
+      SOURCE_RUNNER,
+      ResourceType.BOX,
+      BOX_ID,
+      { arcPath: 'box-migrations/box-1.boxlite' },
+    )
+    expect(h.jobService.createJob).toHaveBeenCalledWith(
+      null,
+      JobType.ROLLBACK_IMPORT_BOX,
+      TARGET_RUNNER,
+      ResourceType.BOX,
+      BOX_ID,
+      undefined,
+    )
+    expect(h.writes).toHaveLength(0)
+  })
+
+  it('drops the migration once nothing is left to reclaim', async () => {
+    const migration = makeMigration(BoxMigrationState.PENDING_ROLLBACK)
+    const h = makeHarness([migration])
+
+    await h.manager.submitRollbackJobs()
+
+    expect(h.jobService.createJob).not.toHaveBeenCalled()
+    // The row is the migration, so ending one deletes it rather than moving it
+    // to a "not migrating" state the table does not have.
+    expect(h.writes).toEqual([
+      {
+        kind: 'delete',
+        params: { boxId: BOX_ID, expected: BoxMigrationState.PENDING_ROLLBACK },
+      },
+    ])
+  })
+
+  it('discards the exported box on the runner it was migrated away from', async () => {
+    const migration = makeMigration(BoxMigrationState.PENDING_DISCARD_EXPORTED, {
+      arcPath: 'box-migrations/box-1.boxlite',
+      runnerId: SOURCE_RUNNER,
+      box: makeBox({ runnerId: TARGET_RUNNER }),
+    })
+    const h = makeHarness([migration])
+
+    await h.manager.submitRollbackJobs()
+
+    expect(h.jobService.createJob).toHaveBeenCalledWith(
+      null,
+      JobType.DISCARD_EXPORTED_BOX,
+      SOURCE_RUNNER,
+      ResourceType.BOX,
+      BOX_ID,
+      { arcPath: 'box-migrations/box-1.boxlite' },
+    )
+  })
+})

--- a/apps/api/src/box/managers/box-migration.manager.ts
+++ b/apps/api/src/box/managers/box-migration.manager.ts
@@ -1,0 +1,442 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Injectable, Logger, OnApplicationShutdown } from '@nestjs/common'
+import { Cron, CronExpression } from '@nestjs/schedule'
+import { InjectDataSource } from '@nestjs/typeorm'
+import { DataSource, EntityManager, FindOptionsWhere, IsNull, Not } from 'typeorm'
+import { setTimeout } from 'timers/promises'
+
+import { RedisLockProvider } from '../common/redis-lock.provider'
+import { Box } from '../entities/box.entity'
+import { BoxMigration } from '../entities/box-migration.entity'
+import { BoxMigrationState } from '../enums/box-migration-state.enum'
+import { JobType } from '../enums/job-type.enum'
+import { ResourceType } from '../enums/resource-type.enum'
+import { JobService } from '../services/job.service'
+import { RunnerService } from '../services/runner.service'
+import { getMigrateJobLockKey } from '../utils/lock-key.util'
+
+import { LogExecution } from '../../common/decorators/log-execution.decorator'
+import { WithInstrumentation } from '../../common/decorators/otel.decorator'
+import { TrackJobExecution } from '../../common/decorators/track-job-execution.decorator'
+import { TrackableJobExecutions } from '../../common/interfaces/trackable-job-executions'
+import { TypedConfigService } from '../../config/typed-config.service'
+
+// Only one API replica sweeps at a time; the TTL only bounds a replica that
+// dies mid-tick, since the happy path unlocks in `finally`.
+const SUBMIT_LOOP_LOCK_KEY = 'box-migration-submit-worker-selected'
+const ROLLBACK_LOOP_LOCK_KEY = 'box-migration-rollback-worker-selected'
+const LOOP_LOCK_TTL_SECONDS = 60
+
+// A migration job's lock outlives the tick that took it — the receiver of the
+// job status releases it. This TTL is the backstop for a status that never
+// arrives, so it has to outlast the job table's own stale sweep (10 minutes,
+// JobService.handleStaleJobs); otherwise the lock would expire and a second job
+// would be submitted while the runner is still working on the first.
+const MIGRATE_JOB_LOCK_TTL_SECONDS = 15 * 60
+
+const MIGRATIONS_PER_TICK = 100
+
+/** Mirrors the runner's MigrateArchivePayload (executor/types.go). */
+interface MigrateArchivePayload {
+  arcPath: string
+}
+
+interface MigrateJobTarget {
+  runnerId: string
+  payload?: MigrateArchivePayload
+}
+
+/**
+ * Drives the two migration loops of the control plane.
+ *
+ * Submitter (10s) hands a migration its next job — export, then import — each
+ * guarded by ValidCheck, which is what catches a user touching the box
+ * mid-flight and turns the migration around.
+ *
+ * RollBackSubmitter (60s) hands out the jobs that reclaim what a migration
+ * left behind: the archive on the object store, the box on the other runner.
+ *
+ * Neither loop advances the migration's state on success — the receiver of the
+ * job status does, so a state only moves once the work behind it is done.
+ */
+@Injectable()
+export class BoxMigrationManager implements TrackableJobExecutions, OnApplicationShutdown {
+  activeJobs = new Set<string>()
+
+  private readonly logger = new Logger(BoxMigrationManager.name)
+
+  /** Read once: the prefix is validated at boot and fixed for the process. */
+  private readonly archivePrefix: string
+
+  constructor(
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
+    private readonly runnerService: RunnerService,
+    private readonly jobService: JobService,
+    private readonly redisLockProvider: RedisLockProvider,
+    configService: TypedConfigService,
+  ) {
+    this.archivePrefix = configService.getOrThrow('boxMigration.archivePrefix')
+  }
+
+  async onApplicationShutdown() {
+    //  wait for all active jobs to finish
+    while (this.activeJobs.size > 0) {
+      this.logger.log(`Waiting for ${this.activeJobs.size} active jobs to finish`)
+      await setTimeout(1000)
+    }
+  }
+
+  /**
+   * center-Submitter Loop — submit the job each waiting migration is named for.
+   */
+  @Cron(CronExpression.EVERY_10_SECONDS, { name: 'box-migration-submit' })
+  @TrackJobExecution()
+  @WithInstrumentation()
+  @LogExecution('box-migration-submit')
+  async submitMigrationJobs(): Promise<void> {
+    if (!(await this.redisLockProvider.lock(SUBMIT_LOOP_LOCK_KEY, LOOP_LOCK_TTL_SECONDS))) {
+      return
+    }
+
+    try {
+      const migrations = await this.findMigrations([
+        { state: BoxMigrationState.PENDING_EXPORT },
+        { state: BoxMigrationState.PENDING_IMPORT },
+      ])
+
+      await Promise.all(
+        migrations.map((migration) =>
+          migration.state === BoxMigrationState.PENDING_EXPORT
+            ? this.submitExport(migration)
+            : this.submitImport(migration),
+        ),
+      )
+    } finally {
+      await this.redisLockProvider.unlock(SUBMIT_LOOP_LOCK_KEY)
+    }
+  }
+
+  /**
+   * center-RollBackSubmitter Loop — reclaim what a migration left behind, and
+   * discard the exported box once the migration has committed.
+   */
+  @Cron(CronExpression.EVERY_MINUTE, { name: 'box-migration-rollback-submit' })
+  @TrackJobExecution()
+  @WithInstrumentation()
+  @LogExecution('box-migration-rollback-submit')
+  async submitRollbackJobs(): Promise<void> {
+    if (!(await this.redisLockProvider.lock(ROLLBACK_LOOP_LOCK_KEY, LOOP_LOCK_TTL_SECONDS))) {
+      return
+    }
+
+    try {
+      const migrations = await this.findMigrations([
+        { state: BoxMigrationState.PENDING_ROLLBACK },
+        // A discard is only pending while there is still something to discard;
+        // its receiver clears both fields when the job succeeds.
+        { state: BoxMigrationState.PENDING_DISCARD_EXPORTED, arcPath: Not('') },
+        { state: BoxMigrationState.PENDING_DISCARD_EXPORTED, runnerId: Not(IsNull()) },
+      ])
+
+      await Promise.all(
+        migrations.map((migration) =>
+          migration.state === BoxMigrationState.PENDING_ROLLBACK
+            ? this.reclaim(migration)
+            : this.discardExported(migration),
+        ),
+      )
+    } finally {
+      await this.redisLockProvider.unlock(ROLLBACK_LOOP_LOCK_KEY)
+    }
+  }
+
+  /**
+   * Migrations matching any of the given conditions, most recently used box
+   * first, each with the box it moves.
+   *
+   * `box_migration.updatedAt` is the copy of `box.updatedAt` the migration
+   * took, so ordering by it descending serves the boxes a user touched last
+   * before the ones parked longest. Those are the boxes most likely to be
+   * started again, and starting one on a draining runner both loses the
+   * migration to ValidCheck and puts the box back on a runner about to go away.
+   *
+   * A row whose box did not load is skipped: the foreign key cascades, so the
+   * box outlives every migration on it and a missing one is a broken row rather
+   * than a box that went away.
+   */
+  private async findMigrations(where: FindOptionsWhere<BoxMigration>[]): Promise<BoxMigration[]> {
+    const migrations = await this.dataSource.getRepository(BoxMigration).find({
+      where,
+      relations: { box: true },
+      order: { updatedAt: 'DESC' },
+      take: MIGRATIONS_PER_TICK,
+      loadEagerRelations: false,
+    })
+
+    return migrations.filter((migration) => {
+      if (!migration.box) {
+        this.logger.error(`Migration of box ${migration.boxId} has no box row`)
+        return false
+      }
+      return true
+    })
+  }
+
+  /**
+   * The object store key this migration moves the box through. Derived from the
+   * box so a retried export overwrites its own archive instead of stranding one:
+   * a box has at most one migration in flight — one `box_migration` row — and the
+   * key is dropped once that migration commits or rolls back.
+   *
+   * Only the export leg derives a key; every leg after it acts on the one the
+   * export reported, so the configured prefix may change under a migration
+   * already in flight without stranding its archive.
+   */
+  private migrateArcPath(boxId: string): string {
+    return `${this.archivePrefix}${boxId}.boxlite`
+  }
+
+  /**
+   * EXPORT_BOX — pack the box and put its archive on the object store.
+   *
+   * Submitted while the migration sits in PENDING_EXPORT: the state the marker
+   * writes the minute it claims a parked box off a draining runner, and the state
+   * the migration keeps until the export's receiver records an archive. Every 10s
+   * tick in between calls this again, and what happens then is the job lock's
+   * doing — a held lock means the runner is still working on the job this already
+   * submitted, while a submission that threw is retried by the tick after it. A
+   * failed ValidCheck is the one outcome not retried: it turns the migration
+   * around instead of exporting.
+   *
+   * The job goes to the runner still holding the box, which is the draining one:
+   * the archive can only be made where the box is.
+   */
+  private async submitExport(migration: BoxMigration): Promise<void> {
+    if (!migration.box.runnerId) {
+      // Invalid job, skipped
+      this.logger.error(`Box ${migration.boxId} is waiting to be exported but has no runner`)
+      return
+    }
+
+    await this.submitValidated(migration, JobType.EXPORT_BOX, async (box) => ({
+      runnerId: box.runnerId,
+      payload: { arcPath: this.migrateArcPath(box.id) },
+    }))
+  }
+
+  /**
+   * IMPORT_BOX — restore the box from its archive onto a second runner.
+   *
+   * Submitted while the migration sits in PENDING_IMPORT, the state the export's
+   * receiver writes together with the archive key it reported. Like the export it
+   * is retried each 10s tick until a receiver moves the state on, and the whole
+   * import — not just its first attempt — happens after the export has finished,
+   * because nothing puts a migration into this state until then.
+   */
+  private async submitImport(migration: BoxMigration): Promise<void> {
+    if (!migration.arcPath) {
+      // Nothing to import from — the export leg never recorded an archive, so
+      // this migration cannot finish. Rollback finds no artifact to reclaim and
+      // drops the row, leaving the box for the Marker to claim again.
+      this.logger.error(`Box ${migration.boxId} is waiting to be imported but has no archive; rolling back`)
+      await this.markRollback(this.dataSource.manager, migration)
+      return
+    }
+
+    await this.submitValidated(migration, JobType.IMPORT_BOX, async (box, validated) => {
+      const target = await this.runnerService.getRandomAvailableRunner({
+        regions: [box.region],
+        boxClass: box.class,
+        excludedRunnerIds: [box.runnerId],
+      })
+      return {
+        runnerId: target.id,
+        payload: { arcPath: validated.arcPath },
+      }
+    })
+  }
+
+  /**
+   * Take the job's lock, ValidCheck, submit — the shape both legs share.
+   *
+   * The lock is what says "this job is in flight", so it is kept on success and
+   * released by the receiver of the job status. Everything else — a lost race,
+   * a failed ValidCheck, a submission that threw — releases it here and leaves
+   * the migration's state for the next tick to retry.
+   *
+   * The box row is locked, not the `box_migration` row it names: `box.updatedAt`
+   * is the side of the equality that anyone may move, so holding the box is what
+   * stops a write landing between the check and the job. The `box_migration` row
+   * is re-read under that same lock, in the order the marker takes them.
+   */
+  private async submitValidated(
+    migration: BoxMigration,
+    jobType: JobType,
+    resolveTarget: (box: Box, migration: BoxMigration) => Promise<MigrateJobTarget>,
+  ): Promise<void> {
+    const lockKey = getMigrateJobLockKey(migration.boxId, jobType)
+    if (!(await this.redisLockProvider.lock(lockKey, MIGRATE_JOB_LOCK_TTL_SECONDS))) {
+      return
+    }
+
+    let submitted = false
+    try {
+      submitted = await this.dataSource.transaction(async (entityManager) => {
+        const box = await entityManager.findOne(Box, {
+          where: { id: migration.boxId },
+          lock: { mode: 'pessimistic_write' },
+          loadEagerRelations: false,
+        })
+        const current = await entityManager.findOne(BoxMigration, {
+          where: { boxId: migration.boxId },
+          lock: { mode: 'pessimistic_write' },
+          loadEagerRelations: false,
+        })
+
+        if (!box || !current || current.state !== migration.state) {
+          return false
+        }
+
+        if (!current.isUndisturbedBy(box)) {
+          this.logger.log(`Box ${box.id} was touched during its migration; rolling back instead of ${jobType}`)
+          await this.markRollback(entityManager, current)
+          return false
+        }
+
+        const target = await resolveTarget(box, current)
+        await this.jobService.createJob(
+          entityManager,
+          jobType,
+          target.runnerId,
+          ResourceType.BOX,
+          box.id,
+          target.payload,
+        )
+
+        this.logger.log(`Submitted ${jobType} for box ${box.id} to runner ${target.runnerId}`)
+        return true
+      })
+    } catch (error) {
+      this.logger.error(`Error submitting ${jobType} for box ${migration.boxId}:`, error)
+    } finally {
+      if (!submitted) {
+        await this.redisLockProvider.unlock(lockKey)
+      }
+    }
+  }
+
+  /**
+   * Reclaim whatever a turned-around migration left behind. Both artifacts can
+   * be outstanding at once — an import that succeeded and then failed
+   * ValidCheck leaves an archive on the object store and a box on the target
+   * runner — and each is reclaimed by its own job on its own runner.
+   */
+  private async reclaim(migration: BoxMigration): Promise<void> {
+    if (!migration.arcPath && !migration.runnerId) {
+      await this.finishRollback(migration)
+      return
+    }
+
+    if (migration.arcPath) {
+      await this.submitReclaimJob(migration, JobType.ROLLBACK_EXPORT_BOX, migration.box.runnerId, {
+        arcPath: migration.arcPath,
+      })
+    }
+
+    if (migration.runnerId) {
+      await this.submitReclaimJob(migration, JobType.ROLLBACK_IMPORT_BOX, migration.runnerId)
+    }
+  }
+
+  /**
+   * Discard the box the migration moved away from, along with the archive it
+   * travelled in. Runs after the commit point, so the migration's `runnerId` is
+   * the runner that gave the box up.
+   */
+  private async discardExported(migration: BoxMigration): Promise<void> {
+    if (!migration.runnerId || !migration.arcPath) {
+      // Both fields are written at the commit point and cleared together when
+      // the discard succeeds, so only an inconsistent row lands here — and a
+      // discard job without them cannot do its work.
+      this.logger.error(
+        `Box ${migration.boxId} cannot have its exported copy discarded: runner=${migration.runnerId ?? 'none'} archive=${migration.arcPath || 'none'}`,
+      )
+      return
+    }
+
+    await this.submitReclaimJob(migration, JobType.DISCARD_EXPORTED_BOX, migration.runnerId, {
+      arcPath: migration.arcPath,
+    })
+  }
+
+  /**
+   * Submit a job that reclaims an artifact. Unlike the two validated legs there
+   * is nothing to check: the artifact fields say the artifact exists, and the
+   * receiver clears the field the job reclaimed.
+   *
+   * Reached from the 60s loop for a migration whose state names cleanup —
+   * PENDING_ROLLBACK once ValidCheck turned the migration around, or
+   * PENDING_DISCARD_EXPORTED once it is past its commit point — and only for the
+   * artifacts that row still names, so a rollback carrying both an archive and an
+   * imported box submits one job per artifact in the same tick. Each keeps its own
+   * per-box-per-job lock until its receiver releases it, which is what stops the
+   * next tick from re-submitting a reclaim already running.
+   */
+  private async submitReclaimJob(
+    migration: BoxMigration,
+    jobType: JobType,
+    runnerId: string | undefined,
+    payload?: MigrateArchivePayload,
+  ): Promise<void> {
+    if (!runnerId) {
+      this.logger.error(`Box ${migration.boxId} needs ${jobType} but the runner to run it on is unknown`)
+      return
+    }
+
+    const lockKey = getMigrateJobLockKey(migration.boxId, jobType)
+    if (!(await this.redisLockProvider.lock(lockKey, MIGRATE_JOB_LOCK_TTL_SECONDS))) {
+      return
+    }
+
+    try {
+      await this.jobService.createJob(null, jobType, runnerId, ResourceType.BOX, migration.boxId, payload)
+      this.logger.log(`Submitted ${jobType} for box ${migration.boxId} to runner ${runnerId}`)
+    } catch (error) {
+      this.logger.error(`Error submitting ${jobType} for box ${migration.boxId}:`, error)
+      await this.redisLockProvider.unlock(lockKey)
+    }
+  }
+
+  /** Turn the migration around; the artifact fields drive the reclaim from here. */
+  private async markRollback(entityManager: EntityManager, migration: BoxMigration): Promise<void> {
+    await entityManager
+      .createQueryBuilder()
+      .update(BoxMigration)
+      .set({ state: BoxMigrationState.PENDING_ROLLBACK })
+      .where('"boxId" = :boxId', { boxId: migration.boxId })
+      .andWhere('"state" = :expected', { expected: migration.state })
+      .execute()
+  }
+
+  /**
+   * Nothing left to reclaim — the box is as it was before the migration, so the
+   * migration stops existing. Conditional on the state we read, so a receiver
+   * that moved the migration on between the scan and this write keeps its row.
+   */
+  private async finishRollback(migration: BoxMigration): Promise<void> {
+    await this.dataSource.manager
+      .createQueryBuilder()
+      .delete()
+      .from(BoxMigration)
+      .where('"boxId" = :boxId', { boxId: migration.boxId })
+      .andWhere('"state" = :expected', { expected: migration.state })
+      .execute()
+
+    this.logger.log(`Rollback complete for box ${migration.boxId}`)
+  }
+}

--- a/apps/api/src/box/repositories/box.repository.migrate-marker.integration.spec.ts
+++ b/apps/api/src/box/repositories/box.repository.migrate-marker.integration.spec.ts
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { randomUUID } from 'node:crypto'
+import { DataSource, Repository } from 'typeorm'
+import { CustomNamingStrategy } from '../../common/utils/naming-strategy.util'
+import { Box } from '../entities/box.entity'
+import { BoxLastActivity } from '../entities/box-last-activity.entity'
+import { BoxMigration } from '../entities/box-migration.entity'
+import { BoxDesiredState } from '../enums/box-desired-state.enum'
+import { BoxMigrationState } from '../enums/box-migration-state.enum'
+import { BoxState } from '../enums/box-state.enum'
+import { BoxRepository } from './box.repository'
+
+const describeIfDatabase = process.env.DB_HOST ? describe : describe.skip
+const schemaName = `box_migrate_marker_${process.pid}_${randomUUID().replaceAll('-', '')}`
+const drainingRunnerId = '00000000-0000-4000-8000-00000000000a'
+const healthyRunnerId = '00000000-0000-4000-8000-00000000000b'
+const organizationId = '00000000-0000-4000-8000-0000000000ff'
+
+function parkedBox(
+  name: string,
+  overrides: Partial<Pick<Box, 'runnerId' | 'state' | 'desiredState' | 'pending'>> = {},
+): Box {
+  const box = new Box('us', name)
+  box.organizationId = organizationId
+  box.osUser = 'boxlite'
+  box.runnerId = drainingRunnerId
+  box.state = BoxState.STOPPED
+  box.desiredState = BoxDesiredState.STOPPED
+  box.pending = false
+  Object.assign(box, overrides)
+  return box
+}
+
+describeIfDatabase('BoxRepository.markParkedBoxesForExport (integration, real Postgres)', () => {
+  let dataSource: DataSource
+  let boxes: Repository<Box>
+  let migrations: Repository<BoxMigration>
+  let repository: BoxRepository
+  let ownsSchema = false
+
+  beforeAll(async () => {
+    dataSource = await new DataSource({
+      type: 'postgres',
+      host: process.env.DB_HOST,
+      port: Number(process.env.DB_PORT || 5432),
+      username: process.env.DB_USERNAME,
+      password: process.env.DB_PASSWORD,
+      database: process.env.DB_DATABASE,
+      schema: schemaName,
+      entities: [Box, BoxLastActivity, BoxMigration],
+      namingStrategy: new CustomNamingStrategy(),
+      entitySkipConstructor: true,
+      synchronize: false,
+      // TypeORM creates the enum types inside `schema` but copies partial-index
+      // predicates into CREATE INDEX verbatim, so box_active_only_idx's
+      // `::box_state_enum` cast arrives unqualified and would resolve against
+      // the default search_path instead of this run's schema. Putting the schema
+      // on the search_path is what lets synchronize() build that index here.
+      extra: { options: `-c search_path=${schemaName},public` },
+    }).initialize()
+
+    await dataSource.query(`CREATE SCHEMA "${schemaName}"`)
+    ownsSchema = true
+    await dataSource.synchronize()
+    boxes = dataSource.getRepository(Box)
+    migrations = dataSource.getRepository(BoxMigration)
+    repository = new BoxRepository(
+      dataSource,
+      { emit: jest.fn() } as any,
+      {
+        invalidate: jest.fn(),
+        invalidateOrgId: jest.fn(),
+      } as any,
+    )
+  })
+
+  afterAll(async () => {
+    if (!dataSource?.isInitialized) {
+      return
+    }
+
+    try {
+      if (ownsSchema) {
+        await dataSource.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`)
+      }
+    } finally {
+      await dataSource.destroy()
+    }
+  })
+
+  beforeEach(async () => {
+    await dataSource.query(`DELETE FROM "${schemaName}"."box_migration"`)
+    await dataSource.query(`DELETE FROM "${schemaName}"."box_last_activity"`)
+    await dataSource.query(`DELETE FROM "${schemaName}"."box"`)
+  })
+
+  it('opens the migration on a copy of the box stamp, leaving the box alone', async () => {
+    const box = parkedBox('parked')
+    await boxes.insert(box)
+    const untouched = await boxes.findOneByOrFail({ id: box.id })
+
+    expect(await repository.markParkedBoxesForExport([drainingRunnerId])).toBe(1)
+
+    const migration = await migrations.findOneByOrFail({ boxId: box.id })
+    expect(migration.state).toBe(BoxMigrationState.PENDING_EXPORT)
+    // The equality every later validity check reads — and the box row it is
+    // measured against is the one that was already there. A claim that wrote the
+    // box would be indistinguishable from the interference it is watching for.
+    expect((await boxes.findOneByOrFail({ id: box.id })).updatedAt).toEqual(untouched.updatedAt)
+    expect(migration.updatedAt).toEqual(untouched.updatedAt)
+  })
+
+  it('breaks the timestamp equality on the next write from outside the migration', async () => {
+    const box = parkedBox('started-underneath')
+    await boxes.insert(box)
+    await repository.markParkedBoxesForExport([drainingRunnerId])
+
+    // What a user starting the box does to the row, minus the entity-level
+    // guards: it moves updatedAt and nothing else.
+    await repository.update(box.id, { updateData: { desiredState: BoxDesiredState.STARTED } }, true)
+
+    const interfered = await boxes.findOneByOrFail({ id: box.id })
+    const migration = await migrations.findOneByOrFail({ boxId: box.id })
+    expect(migration.state).toBe(BoxMigrationState.PENDING_EXPORT)
+    expect(migration.updatedAt).not.toEqual(interfered.updatedAt)
+    // Both stamps come from the server — TypeORM's update builder writes
+    // updatedAt as CURRENT_TIMESTAMP too — so the later write is strictly newer
+    // and this ordering carries no dependence on the test machine's clock.
+    expect(migration.updatedAt.getTime()).toBeLessThan(interfered.updatedAt.getTime())
+  })
+
+  it('claims a box a previous drain already migrated', async () => {
+    const box = parkedBox('re-drained')
+    await boxes.insert(box)
+    const finished = await boxes.findOneByOrFail({ id: box.id })
+    await migrations.insert({ boxId: box.id, state: BoxMigrationState.COMPLETED, updatedAt: finished.updatedAt })
+    // Someone stopped the box again between the two drains, so the stamp the
+    // finished migration copied is now behind the box's.
+    await repository.update(box.id, { updateData: { desiredState: BoxDesiredState.STOPPED } }, true)
+
+    expect(await repository.markParkedBoxesForExport([drainingRunnerId])).toBe(1)
+
+    const reclaimed = await migrations.findOneByOrFail({ boxId: box.id })
+    expect(reclaimed.state).toBe(BoxMigrationState.PENDING_EXPORT)
+    // The finished migration's stamp has to be replaced, not kept: the second
+    // migration is validated against the box row as it stands now, and keeping
+    // the old copy would open a migration that reads as already disturbed.
+    expect(reclaimed.updatedAt).toEqual((await boxes.findOneByOrFail({ id: box.id })).updatedAt)
+    expect(reclaimed.updatedAt.getTime()).toBeGreaterThan(finished.updatedAt.getTime())
+  })
+
+  it('passes over a box another transaction is holding', async () => {
+    const box = parkedBox('locked-elsewhere')
+    await boxes.insert(box)
+
+    const holder = dataSource.createQueryRunner()
+    await holder.connect()
+    await holder.startTransaction()
+    try {
+      await holder.query(`SELECT "id" FROM "${schemaName}"."box" WHERE "id" = $1 FOR UPDATE`, [box.id])
+
+      // Waiting for that transaction would park the whole tick — and the Redis
+      // lock it runs under — behind it, so the box is left for the next tick.
+      expect(await repository.markParkedBoxesForExport([drainingRunnerId])).toBe(0)
+      expect(await migrations.count()).toBe(0)
+    } finally {
+      await holder.rollbackTransaction()
+      await holder.release()
+    }
+
+    expect(await repository.markParkedBoxesForExport([drainingRunnerId])).toBe(1)
+  })
+
+  it('leaves alone every box the migration must not move', async () => {
+    const alreadyExporting = parkedBox('already-exporting')
+    const rollingBack = parkedBox('rolling-back')
+    await boxes.insert([
+      parkedBox('on-healthy-runner', { runnerId: healthyRunnerId }),
+      parkedBox('still-running', { state: BoxState.STARTED, desiredState: BoxDesiredState.STARTED }),
+      parkedBox('wants-to-start', { desiredState: BoxDesiredState.STARTED, pending: true }),
+      parkedBox('mid-transition', { pending: true }),
+      alreadyExporting,
+      rollingBack,
+    ])
+
+    const inFlight = [
+      { box: alreadyExporting, state: BoxMigrationState.PENDING_EXPORT },
+      { box: rollingBack, state: BoxMigrationState.PENDING_ROLLBACK },
+    ]
+    for (const { box, state } of inFlight) {
+      const stored = await boxes.findOneByOrFail({ id: box.id })
+      await migrations.insert({ boxId: box.id, state, updatedAt: stored.updatedAt })
+    }
+    const before = await boxes.find({ order: { name: 'ASC' } })
+
+    expect(await repository.markParkedBoxesForExport([drainingRunnerId])).toBe(0)
+
+    // No migration opened on the four that are not parked on a draining
+    // runner, and the two already migrating kept the state and the stamp their
+    // own migration is being validated against.
+    expect(await migrations.count()).toBe(inFlight.length)
+    for (const { box, state } of inFlight) {
+      const migration = await migrations.findOneByOrFail({ boxId: box.id })
+      expect(migration.state).toBe(state)
+      expect(migration.updatedAt).toEqual((await boxes.findOneByOrFail({ id: box.id })).updatedAt)
+    }
+    // A box left out of the claim must not have its updatedAt moved either: a
+    // bumped stamp on a box a migration already owns reads as interference.
+    expect((await boxes.find({ order: { name: 'ASC' } })).map((box) => box.updatedAt)).toEqual(
+      before.map((box) => box.updatedAt),
+    )
+  })
+
+  it('marks nothing when no runner is draining', async () => {
+    await boxes.insert(parkedBox('parked'))
+
+    expect(await repository.markParkedBoxesForExport([])).toBe(0)
+    expect(await migrations.count()).toBe(0)
+  })
+
+  it('drops the migration with the box it belongs to', async () => {
+    const box = parkedBox('deleted-mid-migration')
+    await boxes.insert(box)
+    await repository.markParkedBoxesForExport([drainingRunnerId])
+
+    await boxes.delete({ id: box.id })
+
+    // Nothing outside this table has to remember to clean it up.
+    expect(await migrations.count()).toBe(0)
+  })
+})

--- a/apps/api/src/box/repositories/box.repository.migrate-marker.spec.ts
+++ b/apps/api/src/box/repositories/box.repository.migrate-marker.spec.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { DataSource, EntityManager } from 'typeorm'
+import { BoxRepository } from './box.repository'
+
+// What the marker makes of the two steps it drives, with no database behind it.
+// The companion *.integration.spec.ts proves what Postgres does with the
+// statements the query builders produce; this covers what is decided in
+// TypeScript — that the claim runs in one transaction, that a tick with nothing
+// to claim opens no migration, and which of the two steps the count comes from.
+describe('BoxRepository.markParkedBoxesForExport', () => {
+  let repository: BoxRepository
+  let transaction: jest.Mock
+  let parkedBoxes: Array<{ id: string; updatedAt: Date }>
+  let insertedRows: Array<{ boxId: string }>
+  let insertBuilders: number
+
+  // Every builder call chains except the ones that end a step, so a step is
+  // recorded by what it returns: the locked boxes, or the rows the insert's
+  // conflict guard let through.
+  function queryBuilderStub(onInsert: () => void): Record<string, unknown> {
+    const steps: Record<string, unknown> = {
+      getRawMany: () => Promise.resolve(parkedBoxes),
+      execute: () => Promise.resolve({ raw: insertedRows }),
+      getQuery: () => '(SELECT 1)',
+      insert: () => {
+        onInsert()
+        return builder
+      },
+    }
+    const builder: Record<string, unknown> = new Proxy(steps, {
+      // Anything the builder is asked for that does not end a step chains, so a
+      // call the repository adds keeps working without touching this stub.
+      get: (target, property) => (typeof property === 'string' ? (target[property] ?? (() => builder)) : undefined),
+    })
+    return builder
+  }
+
+  beforeEach(() => {
+    parkedBoxes = []
+    insertedRows = []
+    insertBuilders = 0
+
+    const entityManager = {
+      createQueryBuilder: () => queryBuilderStub(() => insertBuilders++),
+      // The insert's conflict guard names the table it upserts into, which the
+      // manager carries the entity metadata for. What that name produces is the
+      // integration spec's to check; here it only has to be answerable.
+      connection: { getMetadata: () => ({ tableName: 'box_migration' }) },
+    } as unknown as EntityManager
+
+    transaction = jest.fn((runInTransaction: (manager: EntityManager) => Promise<number>) =>
+      runInTransaction(entityManager),
+    )
+
+    const dataSource = {
+      getRepository: () => ({ manager: { transaction } }),
+    } as unknown as DataSource
+
+    repository = new BoxRepository(
+      dataSource,
+      { emit: jest.fn() } as any,
+      {
+        invalidate: jest.fn(),
+        invalidateOrgId: jest.fn(),
+      } as any,
+    )
+  })
+
+  it('claims and opens the migrations inside one transaction', async () => {
+    parkedBoxes = [{ id: 'box-a', updatedAt: new Date() }]
+    insertedRows = [{ boxId: 'box-a' }]
+
+    expect(await repository.markParkedBoxesForExport(['runner-a'])).toBe(1)
+
+    // The select's row locks are what keep the copied stamp true until the insert
+    // lands, and those last only as long as the transaction holding them.
+    expect(transaction).toHaveBeenCalledTimes(1)
+    expect(insertBuilders).toBe(1)
+  })
+
+  it('counts the boxes the insert claimed, not the ones it locked', async () => {
+    // A box the select locked can still lose its claim: a migration opened
+    // between the two steps is invisible to the select and fails the insert's
+    // conflict guard, so the box is left for the next tick.
+    parkedBoxes = [
+      { id: 'box-a', updatedAt: new Date() },
+      { id: 'box-b', updatedAt: new Date() },
+    ]
+    insertedRows = [{ boxId: 'box-a' }]
+
+    expect(await repository.markParkedBoxesForExport(['runner-a'])).toBe(1)
+  })
+
+  it('opens no migration when no box is claimable', async () => {
+    expect(await repository.markParkedBoxesForExport(['runner-a'])).toBe(0)
+
+    // An insert built from no boxes would be a statement with an empty VALUES
+    // list, which TypeORM answers with a result that has no rows to count.
+    expect(insertBuilders).toBe(0)
+  })
+
+  it('sends nothing when no runner is draining', async () => {
+    expect(await repository.markParkedBoxesForExport([])).toBe(0)
+
+    // An empty id list would make the runner predicate match every box in the
+    // fleet, so nothing must be sent at all.
+    expect(transaction).not.toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/box/repositories/box.repository.ts
+++ b/apps/api/src/box/repositories/box.repository.ts
@@ -7,8 +7,10 @@
 import { DataSource, EntityManager, FindOptionsWhere } from 'typeorm'
 import { Box } from '../entities/box.entity'
 import { BoxLastActivity } from '../entities/box-last-activity.entity'
+import { BoxMigration } from '../entities/box-migration.entity'
 import { BoxState } from '../enums/box-state.enum'
 import { BoxDesiredState } from '../enums/box-desired-state.enum'
+import { BoxMigrationState } from '../enums/box-migration-state.enum'
 import { Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { BoxConflictError } from '../errors/box-conflict.error'
 import { InjectDataSource } from '@nestjs/typeorm'
@@ -34,6 +36,9 @@ const PROXY_START_LOCK_TIMEOUT_MS = 2000
 // SQLSTATE for `lock_not_available` — raised when a statement waits longer than
 // lock_timeout to acquire a lock.
 const PG_LOCK_TIMEOUT_CODE = '55P03'
+
+// A box the migration marker may claim, with the stamp its claim copies.
+type ParkedBox = { id: string; updatedAt: Date }
 
 @Injectable()
 export class BoxRepository extends BaseRepository<Box> {
@@ -247,6 +252,117 @@ export class BoxRepository extends BaseRepository<Box> {
       }
       throw err
     }
+  }
+
+  /**
+   * Opens a migration on every parked box currently owned by one of `runnerIds`,
+   * as a `box_migration` row the later steps drive forward.
+   *
+   * A box is parked when it is stopped and wants to stay stopped, which is the
+   * only shape a migration can move. Boxes already part-way through one are left
+   * alone; the row a COMPLETED migration left behind is taken over, so a runner
+   * that drains a second time re-migrates what it took back.
+   *
+   * The lock the select takes has to still be held when the insert copies the
+   * stamp it read, so both steps share one transaction.
+   *
+   * @returns How many boxes were marked.
+   */
+  async markParkedBoxesForExport(runnerIds: string[]): Promise<number> {
+    if (runnerIds.length === 0) {
+      return 0
+    }
+
+    return this.manager.transaction(async (entityManager) => {
+      const parked = await this.lockParkedBoxes(entityManager, runnerIds)
+      if (parked.length === 0) {
+        return 0
+      }
+
+      return this.openMigrations(entityManager, parked)
+    })
+  }
+
+  /**
+   * Locks the parked boxes owned by `runnerIds` and reads the stamp to copy.
+   *
+   * The box is locked rather than written: the lock is what stops a write landing
+   * between the read of `updatedAt` and the insert that copies it, and leaving the
+   * row untouched keeps a claim from looking like a change to everything else that
+   * watches `box.updatedAt`. The lock lives until the caller's transaction ends.
+   *
+   * SKIP LOCKED passes over the boxes another transaction is holding right now.
+   * Those are the boxes about to break the equality anyway, and blocking on one
+   * would hold the tick — and the Redis lock it runs under — open behind someone
+   * else's transaction.
+   */
+  private async lockParkedBoxes(entityManager: EntityManager, runnerIds: string[]): Promise<ParkedBox[]> {
+    // A box is claimable when no migration owns it — either no row at all, or the
+    // row a finished migration left behind — so COMPLETED reads as "not
+    // claimable" here and as "claimable" in the conflict guard on the insert.
+    const migrationInFlight = entityManager
+      .createQueryBuilder()
+      .subQuery()
+      .select('1')
+      .from(BoxMigration, 'migration')
+      .where('migration.boxId = box.id')
+      .andWhere('migration.state <> :claimable')
+
+    return entityManager
+      .createQueryBuilder(Box, 'box')
+      .select('box.id', 'id')
+      .addSelect('box.updatedAt', 'updatedAt')
+      .where('box.runnerId IN (:...runnerIds)', { runnerIds })
+      .andWhere('box.state = :state', { state: BoxState.STOPPED })
+      .andWhere('box.desiredState = :desiredState', { desiredState: BoxDesiredState.STOPPED })
+      .andWhere('box.pending = false')
+      .andWhere(`NOT EXISTS ${migrationInFlight.getQuery()}`)
+      .setParameter('claimable', BoxMigrationState.COMPLETED)
+      .setLock('pessimistic_write')
+      .setOnLocked('skip_locked')
+      .getRawMany<ParkedBox>()
+  }
+
+  /**
+   * Opens a migration on each locked box, on a copy of the stamp read under the
+   * lock.
+   *
+   * The conflict guard is what a migration opened since the select survives: the
+   * select's view of this table is a statement older than the lock, so a row
+   * inserted in between is only visible here, and DO UPDATE takes over the
+   * COMPLETED row a finished migration left while leaving a live one alone.
+   *
+   * @returns How many boxes got a migration — the rows the guard let through.
+   */
+  private async openMigrations(entityManager: EntityManager, parked: ParkedBox[]): Promise<number> {
+    // ON CONFLICT names the row already there by the table's own name, and the
+    // guard is written against that name by hand: an object-form condition is
+    // built against the builder's alias for the target instead, which is the
+    // entity's table path — under a non-default schema that is quoted whole,
+    // as "schema.box_migration", a table no clause of the statement has.
+    const conflictTarget = entityManager.connection.getMetadata(BoxMigration).tableName
+
+    const claimed = await entityManager
+      .createQueryBuilder()
+      .insert()
+      .into(BoxMigration)
+      .values(
+        parked.map(({ id, updatedAt }) => ({
+          boxId: id,
+          state: BoxMigrationState.PENDING_EXPORT,
+          updatedAt,
+        })),
+      )
+      .orUpdate(['state', 'updatedAt'], ['boxId'], {
+        overwriteCondition: {
+          where: `"${conflictTarget}"."state" = :claimable`,
+          parameters: { claimable: BoxMigrationState.COMPLETED },
+        },
+      })
+      .returning('"boxId"')
+      .execute()
+
+    return (claimed.raw as Array<{ boxId: string }>).length
   }
 
   /**

--- a/apps/api/src/box/services/box-activity.service.integration.spec.ts
+++ b/apps/api/src/box/services/box-activity.service.integration.spec.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { randomUUID } from 'node:crypto'
+import { DataSource, Repository } from 'typeorm'
+import { CustomNamingStrategy } from '../../common/utils/naming-strategy.util'
+import { Box } from '../entities/box.entity'
+import { BoxLastActivity } from '../entities/box-last-activity.entity'
+import { BoxMigration } from '../entities/box-migration.entity'
+import { BoxActivityService } from './box-activity.service'
+
+const describeIfDatabase = process.env.DB_HOST ? describe : describe.skip
+const schemaName = `box_activity_flush_${process.pid}_${randomUUID().replaceAll('-', '')}`
+const organizationId = '00000000-0000-4000-8000-0000000000ff'
+
+function box(name: string): Box {
+  const created = new Box('us', name)
+  created.organizationId = organizationId
+  created.osUser = 'boxlite'
+  return created
+}
+
+// The flush swallows what the upsert throws — a statement Postgres rejects
+// leaves no trace beyond a log line — so every case here is asserted on the
+// rows the flush left behind rather than on the call.
+describeIfDatabase('BoxActivityService.flushActivityToDb (integration, real Postgres)', () => {
+  let dataSource: DataSource
+  let boxes: Repository<Box>
+  let activity: Repository<BoxLastActivity>
+  let service: BoxActivityService
+  let buffered: Array<{ boxId: string; lastActivityAt: Date }>
+  let ownsSchema = false
+
+  beforeAll(async () => {
+    dataSource = await new DataSource({
+      type: 'postgres',
+      host: process.env.DB_HOST,
+      port: Number(process.env.DB_PORT || 5432),
+      username: process.env.DB_USERNAME,
+      password: process.env.DB_PASSWORD,
+      database: process.env.DB_DATABASE,
+      schema: schemaName,
+      entities: [Box, BoxLastActivity, BoxMigration],
+      namingStrategy: new CustomNamingStrategy(),
+      entitySkipConstructor: true,
+      synchronize: false,
+      // Partial-index predicates reach CREATE INDEX with their enum casts
+      // unqualified, so this run's schema has to be on the search_path for
+      // synchronize() to build them here.
+      extra: { options: `-c search_path=${schemaName},public` },
+    }).initialize()
+
+    await dataSource.query(`CREATE SCHEMA "${schemaName}"`)
+    ownsSchema = true
+    await dataSource.synchronize()
+    boxes = dataSource.getRepository(Box)
+    activity = dataSource.getRepository(BoxLastActivity)
+
+    service = new BoxActivityService(
+      {
+        // What the buffer holds, in the flat member/score shape WITHSCORES returns.
+        zrangebyscore: () =>
+          Promise.resolve(buffered.flatMap(({ boxId, lastActivityAt }) => [boxId, String(lastActivityAt.getTime())])),
+        zremrangebyscore: () => Promise.resolve(0),
+      } as any,
+      dataSource,
+      { lock: () => Promise.resolve(true), unlock: () => Promise.resolve() } as any,
+      { getOrThrow: () => 100 } as any,
+    )
+  })
+
+  afterAll(async () => {
+    if (!dataSource?.isInitialized) {
+      return
+    }
+
+    try {
+      if (ownsSchema) {
+        await dataSource.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`)
+      }
+    } finally {
+      await dataSource.destroy()
+    }
+  })
+
+  beforeEach(async () => {
+    buffered = []
+    await dataSource.query(`DELETE FROM "${schemaName}"."box_last_activity"`)
+    await dataSource.query(`DELETE FROM "${schemaName}"."box"`)
+  })
+
+  it('writes the buffered timestamp for a box with no activity row', async () => {
+    const target = box('first-activity')
+    await boxes.insert(target)
+    const lastActivityAt = new Date('2026-01-01T00:00:00.000Z')
+    buffered = [{ boxId: target.id, lastActivityAt }]
+
+    await service.flushActivityToDb()
+
+    expect((await activity.findOneByOrFail({ boxId: target.id })).lastActivityAt).toEqual(lastActivityAt)
+  })
+
+  it('keeps the later of the buffered and stored timestamps', async () => {
+    const advanced = box('advanced')
+    const stale = box('stale')
+    await boxes.insert([advanced, stale])
+    const stored = new Date('2026-01-01T00:00:00.000Z')
+    await activity.insert([
+      { boxId: advanced.id, lastActivityAt: stored },
+      { boxId: stale.id, lastActivityAt: stored },
+    ])
+    const newer = new Date('2026-01-02T00:00:00.000Z')
+    const older = new Date('2025-12-31T00:00:00.000Z')
+    buffered = [
+      { boxId: advanced.id, lastActivityAt: newer },
+      { boxId: stale.id, lastActivityAt: older },
+    ]
+
+    await service.flushActivityToDb()
+
+    // The guard on the upsert is the whole point of the conditional: a buffered
+    // value the database has already moved past must not travel backwards, or
+    // an idle box would look freshly used to the auto-stop lifecycle.
+    expect((await activity.findOneByOrFail({ boxId: advanced.id })).lastActivityAt).toEqual(newer)
+    expect((await activity.findOneByOrFail({ boxId: stale.id })).lastActivityAt).toEqual(stored)
+  })
+
+  it('fills a row that has no timestamp yet', async () => {
+    const target = box('never-active')
+    await boxes.insert(target)
+    await activity.insert({ boxId: target.id })
+    const lastActivityAt = new Date('2026-01-01T00:00:00.000Z')
+    buffered = [{ boxId: target.id, lastActivityAt }]
+
+    await service.flushActivityToDb()
+
+    // Null is not "later than everything" to Postgres — the comparison alone
+    // would answer NULL and drop the write, so the guard names this case.
+    expect((await activity.findOneByOrFail({ boxId: target.id })).lastActivityAt).toEqual(lastActivityAt)
+  })
+
+  it('flushes the boxes that still exist when one in the batch is gone', async () => {
+    const live = box('still-here')
+    await boxes.insert(live)
+    const lastActivityAt = new Date('2026-01-01T00:00:00.000Z')
+    // The buffer outlives the box it was written for, so the batch carries a
+    // foreign key no box row satisfies.
+    buffered = [
+      { boxId: 'box-deleted-mid-flush', lastActivityAt },
+      { boxId: live.id, lastActivityAt },
+    ]
+
+    await service.flushActivityToDb()
+
+    expect((await activity.findOneByOrFail({ boxId: live.id })).lastActivityAt).toEqual(lastActivityAt)
+    expect(await activity.count()).toBe(1)
+  })
+})

--- a/apps/api/src/box/services/box-activity.service.ts
+++ b/apps/api/src/box/services/box-activity.service.ts
@@ -7,7 +7,7 @@ import { Injectable, Logger } from '@nestjs/common'
 import { InjectRedis } from '@nestjs-modules/ioredis'
 import Redis from 'ioredis'
 import { InjectDataSource } from '@nestjs/typeorm'
-import { DataSource, IsNull, Raw } from 'typeorm'
+import { DataSource } from 'typeorm'
 import { Cron, CronExpression } from '@nestjs/schedule'
 import { RedisLockProvider } from '../common/redis-lock.provider'
 import { BoxLastActivity } from '../entities/box-last-activity.entity'
@@ -127,6 +127,14 @@ export class BoxActivityService {
    * Uses a conditional upsert that only updates when the incoming timestamp is newer, preventing updates to stale buffered values.
    */
   private buildUpsertQuery(values: BoxActivityUpdate | BoxActivityUpdate[]) {
+    // ON CONFLICT names the row already there by the table's own name, and the
+    // guard is written against that name by hand: an object-form condition is
+    // built against the builder's alias for the target instead, which is the
+    // entity's table path — under a non-default schema that is quoted whole,
+    // as "schema.box_last_activity", a table no clause of the statement has.
+    const conflictTarget = this.dataSource.getMetadata(BoxLastActivity).tableName
+    const storedAt = `"${conflictTarget}"."lastActivityAt"`
+
     return this.dataSource
       .createQueryBuilder()
       .insert()
@@ -134,10 +142,7 @@ export class BoxActivityService {
       .values(values)
       .orUpdate(['lastActivityAt'], ['boxId'], {
         overwriteCondition: {
-          where: [
-            { lastActivityAt: IsNull() },
-            { lastActivityAt: Raw((alias) => `${alias} < EXCLUDED."lastActivityAt"`) },
-          ],
+          where: `(${storedAt} IS NULL OR ${storedAt} < EXCLUDED."lastActivityAt")`,
         },
       })
   }

--- a/apps/api/src/box/services/box-migration.service.spec.ts
+++ b/apps/api/src/box/services/box-migration.service.spec.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Not } from 'typeorm'
+import { RunnerState } from '../enums/runner-state.enum'
+import { BoxMigrationService } from './box-migration.service'
+
+type Harness = {
+  service: BoxMigrationService
+  runnerFind: jest.Mock
+  markParkedBoxesForExport: jest.Mock
+  lock: jest.Mock
+  unlock: jest.Mock
+  logger: { log: jest.Mock; error: jest.Mock }
+}
+
+function createService(
+  params: { drainingRunnerIds?: string[]; acquiresLock?: boolean; marked?: number } = {},
+): Harness {
+  const { drainingRunnerIds = [], acquiresLock = true, marked = 0 } = params
+
+  const service = Object.create(BoxMigrationService.prototype) as BoxMigrationService
+  const runnerFind = jest.fn().mockResolvedValue(drainingRunnerIds.map((id) => ({ id })))
+  const markParkedBoxesForExport = jest.fn().mockResolvedValue(marked)
+  const lock = jest.fn().mockResolvedValue(acquiresLock)
+  const unlock = jest.fn().mockResolvedValue(undefined)
+  const logger = { log: jest.fn(), error: jest.fn() }
+
+  ;(service as any).logger = logger
+  ;(service as any).runnerRepository = { find: runnerFind }
+  ;(service as any).boxRepository = { markParkedBoxesForExport }
+  ;(service as any).redisLockProvider = { lock, unlock }
+
+  return { service, runnerFind, markParkedBoxesForExport, lock, unlock, logger }
+}
+
+function runMarker(service: BoxMigrationService): Promise<void> {
+  return (service as any).markBoxesOnDrainingRunners()
+}
+
+describe('BoxMigrationService marker loop', () => {
+  it('marks the parked boxes of every draining runner', async () => {
+    const { service, markParkedBoxesForExport, logger } = createService({
+      drainingRunnerIds: ['runner-a', 'runner-b'],
+      marked: 3,
+    })
+
+    await runMarker(service)
+
+    expect(markParkedBoxesForExport).toHaveBeenCalledWith(['runner-a', 'runner-b'])
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
+  it('skips runners that have already been decommissioned', async () => {
+    const { service, runnerFind } = createService({ drainingRunnerIds: ['runner-a'] })
+
+    await runMarker(service)
+
+    // A decommissioned runner cannot export anything, so marking its boxes
+    // would open migrations that can only ever roll back.
+    expect(runnerFind).toHaveBeenCalledWith({
+      where: { draining: true, state: Not(RunnerState.DECOMMISSIONED) },
+      select: ['id'],
+    })
+  })
+
+  it('does not touch the box table when no runner is draining', async () => {
+    const { service, markParkedBoxesForExport, unlock } = createService({ drainingRunnerIds: [] })
+
+    await runMarker(service)
+
+    expect(markParkedBoxesForExport).not.toHaveBeenCalled()
+    expect(unlock).toHaveBeenCalledTimes(1)
+  })
+
+  it('yields to the worker that already holds the tick', async () => {
+    const { service, runnerFind, markParkedBoxesForExport, unlock } = createService({
+      drainingRunnerIds: ['runner-a'],
+      acquiresLock: false,
+    })
+
+    await runMarker(service)
+
+    expect(runnerFind).not.toHaveBeenCalled()
+    expect(markParkedBoxesForExport).not.toHaveBeenCalled()
+    // Releasing here would hand the tick to a second worker mid-flight.
+    expect(unlock).not.toHaveBeenCalled()
+  })
+
+  it('releases the tick lock when marking fails', async () => {
+    const { service, markParkedBoxesForExport, unlock, logger } = createService({ drainingRunnerIds: ['runner-a'] })
+    markParkedBoxesForExport.mockRejectedValue(new Error('deadlock detected'))
+
+    await expect(runMarker(service)).resolves.toBeUndefined()
+
+    // A held lock would park the loop until the TTL expires, long after the
+    // failure that caused it has passed.
+    expect(unlock).toHaveBeenCalledTimes(1)
+    expect(logger.error).toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/box/services/box-migration.service.ts
+++ b/apps/api/src/box/services/box-migration.service.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Injectable, Logger } from '@nestjs/common'
+import { Cron, CronExpression } from '@nestjs/schedule'
+import { InjectRepository } from '@nestjs/typeorm'
+import { Not, Repository } from 'typeorm'
+
+import { Runner } from '../entities/runner.entity'
+import { RunnerState } from '../enums/runner-state.enum'
+import { BoxRepository } from '../repositories/box.repository'
+import { RedisLockProvider } from '../common/redis-lock.provider'
+import { LogExecution } from '../../common/decorators/log-execution.decorator'
+import { WithInstrumentation } from '../../common/decorators/otel.decorator'
+
+// One name for the loop: the cron entry, the execution log line, and the Redis
+// key that keeps two workers off the same tick.
+const MARKER_LOOP = 'migration-marker'
+
+// One tick's worth of headroom: long enough that a slow tick keeps its lock to
+// the end, short enough that a worker lost mid-tick does not park the loop for
+// more than the tick after it.
+const MARKER_LOOP_LOCK_TTL_SECONDS = 120
+
+/**
+ * Drives boxes off draining runners.
+ *
+ * This is the entry point of a migration and the only one that decides a box
+ * should move; every later step reacts to the state this leaves behind. The
+ * marking is a single conditional UPDATE rather than a read-then-write, so
+ * concurrent starts and stops either land before it and disqualify the box, or
+ * land after it and break the timestamp equality a later validity check reads.
+ */
+@Injectable()
+export class BoxMigrationService {
+  private readonly logger = new Logger(BoxMigrationService.name)
+
+  constructor(
+    @InjectRepository(Runner)
+    private readonly runnerRepository: Repository<Runner>,
+    private readonly boxRepository: BoxRepository,
+    private readonly redisLockProvider: RedisLockProvider,
+  ) {}
+
+  @Cron(CronExpression.EVERY_MINUTE, { name: MARKER_LOOP })
+  @LogExecution(MARKER_LOOP)
+  @WithInstrumentation()
+  private async markBoxesOnDrainingRunners(): Promise<void> {
+    // Two workers marking at once would be harmless — the UPDATE is idempotent
+    // and the second matches nothing — but it costs a full scan per worker.
+    if (!(await this.redisLockProvider.lock(MARKER_LOOP, MARKER_LOOP_LOCK_TTL_SECONDS))) {
+      return
+    }
+
+    try {
+      const runnerIds = await this.findDrainingRunnerIds()
+      if (runnerIds.length === 0) {
+        return
+      }
+
+      const marked = await this.boxRepository.markParkedBoxesForExport(runnerIds)
+      if (marked > 0) {
+        this.logger.log(`Marked ${marked} parked boxes on ${runnerIds.length} draining runners for migration`)
+      }
+    } catch (error) {
+      // Nothing here is half-done: the marking is one statement, so it either
+      // committed or it did not, and the next tick re-selects whatever is left.
+      this.logger.error('Error marking boxes on draining runners for migration', error)
+    } finally {
+      await this.redisLockProvider.unlock(MARKER_LOOP)
+    }
+  }
+
+  /**
+   * Runners being emptied, excluding the ones already gone — a decommissioned
+   * runner cannot export the box it no longer serves.
+   */
+  private async findDrainingRunnerIds(): Promise<string[]> {
+    const runners = await this.runnerRepository.find({
+      where: {
+        draining: true,
+        state: Not(RunnerState.DECOMMISSIONED),
+      },
+      select: ['id'],
+    })
+
+    return runners.map((runner) => runner.id)
+  }
+}

--- a/apps/api/src/box/utils/lock-key.util.ts
+++ b/apps/api/src/box/utils/lock-key.util.ts
@@ -4,10 +4,24 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
+import { JobType } from '../enums/job-type.enum'
+
 export function getStateChangeLockKey(id: string): string {
   return `box:${id}:state-change`
 }
 
 export function getRunnerAssignmentLockKey(id: string): string {
   return `runner:${id}:box-assignment`
+}
+
+/**
+ * The lock that marks one migration job as in flight for a box.
+ *
+ * It is taken by the loop that submits the job and released by the receiver of
+ * that job's status, so it spans the runner's work rather than the tick that
+ * started it — the `box_migration` row's state alone cannot tell a submitted job
+ * from a pending one. Derived from the job so both ends compute the same key.
+ */
+export function getMigrateJobLockKey(boxId: string, jobType: JobType): string {
+  return `box:${boxId}:migrate:${jobType}`
 }

--- a/apps/api/src/config/box-migration-config.spec.ts
+++ b/apps/api/src/config/box-migration-config.spec.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { boxMigrationConfig } from './configuration'
+
+describe('boxMigrationConfig', () => {
+  it('defaults to the box-migrations namespace of the runner bucket', () => {
+    expect(boxMigrationConfig({})).toEqual({ archivePrefix: 'box-migrations/' })
+  })
+
+  it.each([
+    ['a blank value', '   '],
+    ['an unset value', undefined],
+  ])('falls back to the default for %s', (_case, value) => {
+    expect(boxMigrationConfig({ BOX_MIGRATION_ARCHIVE_PREFIX: value })).toEqual({
+      archivePrefix: 'box-migrations/',
+    })
+  })
+
+  // The prefix is concatenated with "<boxId>.boxlite", so the trailing slash has
+  // to be there whether or not the operator wrote one.
+  it.each([
+    ['no trailing slash', 'migrate/archives', 'migrate/archives/'],
+    ['a trailing slash', 'migrate/archives/', 'migrate/archives/'],
+    ['repeated trailing slashes', 'migrate/archives//', 'migrate/archives/'],
+    ['surrounding whitespace', '  migrate/archives  ', 'migrate/archives/'],
+  ])('normalizes %s', (_case, value, expected) => {
+    expect(boxMigrationConfig({ BOX_MIGRATION_ARCHIVE_PREFIX: value }).archivePrefix).toBe(expected)
+  })
+
+  // A bucket-qualified prefix is what lets one migration span two runners whose
+  // own buckets differ; the runner resolves s3://<bucket>/<key> itself.
+  it.each([
+    ['a bucket and namespace', 's3://archives/tenant-a', 's3://archives/tenant-a/'],
+    ['a bucket alone', 's3://archives', 's3://archives/'],
+  ])('keeps %s bucket-qualified', (_case, value, expected) => {
+    expect(boxMigrationConfig({ BOX_MIGRATION_ARCHIVE_PREFIX: value }).archivePrefix).toBe(expected)
+  })
+
+  // Each of these either uploads to a key nobody would look under or is rejected
+  // by the runner on every job it is handed — both are worth a boot failure.
+  it.each([
+    ['a leading slash', '/box-migrations'],
+    ['a doubled slash', 'box//migrations'],
+    ['a traversal segment', 'box-migrations/../escaped'],
+    ['a bare dot segment', 'box-migrations/./here'],
+    ['an empty bucket', 's3:///box-migrations'],
+    ['nothing but the scheme', 's3://'],
+    ['only slashes', '//'],
+    ['an inner space', 'box migrations'],
+    ['a shell character', 'box-migrations;rm'],
+  ])('refuses to start on %s', (_case, value) => {
+    expect(() => boxMigrationConfig({ BOX_MIGRATION_ARCHIVE_PREFIX: value })).toThrow(
+      /BOX_MIGRATION_ARCHIVE_PREFIX must be a slash-separated object-store prefix/,
+    )
+  })
+})

--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -147,6 +147,58 @@ export function usageExportConfig(env: NodeJS.ProcessEnv = process.env) {
   return { ...settings, url: requiredHttpUrl(rawUrl, 'USAGE_EXPORT_URL') }
 }
 
+// The object-store key namespace migration archives land in by default, inside
+// whichever bucket each runner is configured with.
+const DEFAULT_MIGRATION_ARCHIVE_PREFIX = 'box-migrations/'
+
+// An arcPath that names its own bucket instead of using the runner's own
+// (runner: pkg/storage/archive_store.go, resolveArcPath).
+const S3_URI_SCHEME = 's3://'
+
+// One segment of an archive prefix: alphanumeric first, then object-store-safe
+// characters. Requiring the first character is what rejects an empty segment —
+// a leading or doubled slash — along with ".", ".." and anything whitespace.
+const ARCHIVE_PREFIX_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
+
+/**
+ * Where a box migration's archive lives in the object store: the prefix the
+ * exporting runner writes under and the importing one reads back.
+ *
+ * A bare prefix keys into the bucket each runner is configured with; an
+ * `s3://<bucket>/…` prefix carries the bucket in the key, which is what lets one
+ * migration span two runners whose own buckets differ. The runner resolves both
+ * forms, so both are accepted here.
+ *
+ * The shape is checked at boot because the alternative is learning about it one
+ * migration at a time: a prefix the runner cannot resolve fails every export job
+ * it is handed, and one with a leading or doubled slash uploads to a key nobody
+ * would look under. Only the trailing slash is normalized, so `box-migrations`
+ * and `box-migrations/` name the same namespace.
+ *
+ * Changing it with migrations in flight is safe: only the export leg derives a
+ * key, and every leg after it acts on the one recorded in `box_migration.arcPath`.
+ *
+ * Exported so its rules can be tested directly rather than through an import
+ * whose side effect is reading the process environment.
+ */
+export function boxMigrationConfig(env: NodeJS.ProcessEnv = process.env) {
+  const raw = env.BOX_MIGRATION_ARCHIVE_PREFIX?.trim()
+  if (!raw) {
+    return { archivePrefix: DEFAULT_MIGRATION_ARCHIVE_PREFIX }
+  }
+
+  const scheme = raw.startsWith(S3_URI_SCHEME) ? S3_URI_SCHEME : ''
+  const segments = raw.slice(scheme.length).replace(/\/+$/, '').split('/')
+  if (!segments.every((segment) => ARCHIVE_PREFIX_SEGMENT.test(segment))) {
+    throw new Error(
+      'BOX_MIGRATION_ARCHIVE_PREFIX must be a slash-separated object-store prefix, optionally ' +
+        `bucket-qualified — "box-migrations" or "s3://bucket/box-migrations" — got "${env.BOX_MIGRATION_ARCHIVE_PREFIX}"`,
+    )
+  }
+
+  return { archivePrefix: `${scheme}${segments.join('/')}/` }
+}
+
 const configuration = {
   production: process.env.NODE_ENV === 'production',
   version: process.env.VERSION || '0.0.0-dev',
@@ -449,6 +501,7 @@ const configuration = {
     throttleTtlSeconds: parseInt(process.env.BOX_ACTIVITY_THROTTLE_TTL_SECONDS || '5', 10),
     flushBatchSize: parseInt(process.env.BOX_ACTIVITY_FLUSH_BATCH_SIZE || '1000', 10),
   },
+  boxMigration: boxMigrationConfig(),
   boxSync: {
     // How long a claimed startup job may sit without completing before a
     // runner reporting the box as started is allowed to close it out. This is

--- a/apps/api/src/migrations/pre-deploy/1786200000000-add-box-migration-table-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1786200000000-add-box-migration-table-migration.ts
@@ -1,0 +1,32 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddBoxMigrationTable1786200000000 implements MigrationInterface {
+  name = 'AddBoxMigrationTable1786200000000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."box_migration_state_enum" AS ENUM('pending_export', 'pending_import', 'pending_discard_exported', 'pending_rollback', 'completed')`,
+    )
+    // One row per migration in flight, keyed by the box it moves. There is no
+    // "not migrating" state: that is the absence of a row, which is also what
+    // the cascade leaves behind when the box goes away.
+    //
+    // `arcPath` is empty, not null, when there is no archive to reclaim — the
+    // rollback path tests it for emptiness, and one sentinel keeps that a plain
+    // comparison instead of a null-or-empty pair. `updatedAt` is NOT NULL
+    // because the marker copies `box.updatedAt` into it in the statement that
+    // creates the row.
+    await queryRunner.query(
+      `CREATE TABLE "box_migration" ("boxId" character varying NOT NULL, "state" "public"."box_migration_state_enum" NOT NULL, "arcPath" character varying NOT NULL DEFAULT '', "runnerId" uuid, "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL, CONSTRAINT "box_migration_boxId_pk" PRIMARY KEY ("boxId"), CONSTRAINT "box_migration_boxId_fk" FOREIGN KEY ("boxId") REFERENCES "box"("id") ON DELETE CASCADE ON UPDATE NO ACTION)`,
+    )
+    // The migration loops scan by state, and every row in this table is a
+    // migration in flight, so the index covers the whole table.
+    await queryRunner.query(`CREATE INDEX "box_migration_state_idx" ON "box_migration" ("state")`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "public"."box_migration_state_idx"`)
+    await queryRunner.query(`DROP TABLE "box_migration"`)
+    await queryRunner.query(`DROP TYPE "public"."box_migration_state_enum"`)
+  }
+}

--- a/apps/infra/sst.config.ts
+++ b/apps/infra/sst.config.ts
@@ -631,6 +631,14 @@ export default $config({
         S3_ACCOUNT_ID: aws.getCallerIdentityOutput().accountId,
         S3_ROLE_NAME: s3AccessRoleName,
 
+        // Where box-migration archives are keyed. Unset means the API's own
+        // default namespace inside each runner's bucket; set it to
+        // s3://<bucket>/<prefix> when the archive has to live in a bucket the
+        // runners do not share.
+        ...(process.env.BOX_MIGRATION_ARCHIVE_PREFIX && {
+          BOX_MIGRATION_ARCHIVE_PREFIX: process.env.BOX_MIGRATION_ARCHIVE_PREFIX,
+        }),
+
         // Proxy
         PROXY_DOMAIN: proxyDomain,
         PROXY_PROTOCOL: proxyProtocol,


### PR DESCRIPTION
## Summary

The marker (#1203) opens a migration on a parked box; this adds the two control-plane loops that carry it forward, one job at a time. Stacked on #1203 — the first commit here is that PR.

## Call graph

Before

```text
markBoxesOnDrainingRunners      (BoxMigrationService · apps/api/src/box/services/box-migration.service.ts:50)   — cron, opens a migration per parked box (#1203)
  └─ markParkedBoxesForExport   (BoxRepository · apps/api/src/box/repositories/box.repository.ts:271)           — one box_migration row, state = pending_export
                                                                                                                 nothing reads that state, so the row just sits there
exportBox                       (Executor · apps/runner/pkg/runner/v2/executor/migrate.go:40)                   — never reached: no migration job is ever created
```

After

```text
submitMigrationJobs             (BoxMigrationManager · apps/api/src/box/managers/box-migration.manager.ts:104)  — cron every 10s, one replica behind a Redis lock
  ├─ findMigrations             (BoxMigrationManager · apps/api/src/box/managers/box-migration.manager.ts:175)  — pending_export / pending_import, most recently used box first
  └─ submitValidated            (BoxMigrationManager · apps/api/src/box/managers/box-migration.manager.ts:241)  — the shape both legs share
       ├─ getMigrateJobLockKey  (lock-key.util · apps/api/src/box/utils/lock-key.util.ts:21)                    — per-box-per-job lock; taken here, released by the job's receiver
       ├─ isUndisturbedBy       (BoxMigration · apps/api/src/box/entities/box-migration.entity.ts:75)           — ValidCheck under a pessimistic lock on the box row
       │    └─ markRollback     (BoxMigrationManager · apps/api/src/box/managers/box-migration.manager.ts:372)  — box was touched → turn the migration around instead
       ├─ getRandomAvailableRunner (RunnerService · apps/api/src/box/services/runner.service.ts:722)            — import leg only: a runner that is not the box's and not draining
       └─ createJob             (JobService · apps/api/src/box/services/job.service.ts:50)                      — EXPORT_BOX on the holder, then IMPORT_BOX on the target
            └─ exportBox / importBox (Executor · apps/runner/pkg/runner/v2/executor/migrate.go:40,65)           — archive to the object store, restore from it

submitRollbackJobs              (BoxMigrationManager · apps/api/src/box/managers/box-migration.manager.ts:135)  — cron every minute
  ├─ reclaim                    (BoxMigrationManager · apps/api/src/box/managers/box-migration.manager.ts:303)  — ROLLBACK_EXPORT_BOX for the archive, ROLLBACK_IMPORT_BOX for the second box
  │    └─ finishRollback        (BoxMigrationManager · apps/api/src/box/managers/box-migration.manager.ts:387)  — nothing left to reclaim → the migration row is deleted
  └─ discardExported            (BoxMigrationManager · apps/api/src/box/managers/box-migration.manager.ts:325)  — DISCARD_EXPORTED_BOX on the runner the box moved away from
```

## Changes

- The submitter hands a box the job its migration state names — `EXPORT_BOX` on the runner holding it, then `IMPORT_BOX` on a runner that is neither that one nor being drained. Neither loop advances the state on success: the receiver of the job status does, so a state only moves once the work behind it is done.
- The rollback submitter hands out the jobs that reclaim what a turned-around migration left behind — the archive on the object store, the box on the second runner — and after the commit point discards the box the migration moved away from. Both artifacts can be outstanding at once, and each is reclaimed by its own job on the runner that holds it.
- Because a migration's state names the job it waits on rather than whether that job has been submitted, a per-box-per-job Redis lock is what marks one in flight. The submitter takes it and the job-status receiver releases it, so it spans the runner's work rather than the tick that started it; its TTL (15 min) outlasts the job table's stale sweep (`JobService.handleStaleJobs`, 10 min) so an expiring lock can never put a second job on a runner still working on the first.
- Every submission is guarded by ValidCheck, taken on the box row under a pessimistic lock immediately before the irreversible step: the box has to still be parked, and `box.updatedAt` has to still equal the copy the marker took. Any write from outside the migration turns the migration around rather than letting it move a box out from under its user.
- A `PENDING_IMPORT` migration with no recorded archive cannot finish, so it is turned around rather than retried forever; rollback finds nothing to reclaim and drops the row, leaving the box for the marker to claim again.

## How to verify

```bash
cd apps
npx nx test api --testPathPatterns=box-migration.manager.spec.ts
```

`box-migration.manager.spec.ts` covers both loops against a stubbed data source: the export/import targets, ValidCheck turning a touched box around, the in-flight lock being held on success and released on failure, scan order, both artifacts reclaimed on their own runners, and the row being deleted when nothing is left.

## Risks / rollout

- Nothing is submitted until a runner is flagged `draining` and the marker opens a migration; on a fleet with none, both loops find no rows and return.
- The job-status receiver is not in this PR. Until it lands, an opened migration gets its `EXPORT_BOX` submitted and the runner will run it, but no state advances and no in-flight lock is released — so a migration stops after its first job and the box stays parked on the draining runner. Do not flag a runner `draining` on a deployment carrying this PR without the receiver.
- Rollback is dropping the two cron registrations (`BoxMigrationManager` in `box.module.ts`); no schema change of its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated box migration workflows for draining runners.
  - Added support for exporting, importing, rolling back, and discarding migration archives.
  - Added migration state tracking and recovery for interrupted or invalid migrations.
  - Added configurable archive storage locations.
  - Added safeguards for changed or otherwise ineligible boxes.

- **Bug Fixes**
  - Improved activity timestamp updates while preserving newer data.
  - Added cleanup for missing or obsolete migration artifacts.

- **Tests**
  - Added comprehensive unit and integration coverage for migration workflows, locking, recovery, and activity persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->