### PR TITLE
feat(infra): split stage deployment configuration

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -249,7 +249,10 @@ Required Environment configuration (per stage):
 
 - Variable `AWS_DEPLOY_ROLE_ARN`
 - Variable `AWS_REGION` (defaults to `ap-southeast-1`)
-- Secret `DEPLOY_ENV` containing the stage's dotenv configuration
+- Dedicated variables for stage configuration (`STACK_DOMAIN`, `OIDC_*`, proxy,
+  billing, image, and feature settings)
+- AWS-backed SST secrets for application credentials
+- Secret `DEPLOY_ENV` retained as an inactive compatibility payload
 
 Bootstrap the scoped role, runtime permissions boundary, immutable API ECR
 repository, and private Runner artifact bucket with

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -238,6 +238,19 @@ jobs:
       AWS_REGION: ${{ vars.AWS_REGION || 'ap-southeast-1' }}
       AWS_DEFAULT_REGION: ${{ vars.AWS_REGION || 'ap-southeast-1' }}
       STAGE: ${{ inputs.stage }}
+      # Public stage configuration is owned separately from the bundled DEPLOY_ENV secret.
+      BILLING_API_URL: ${{ vars.BILLING_API_URL }}
+      BOXLITE_SYSTEM_IMAGES: ${{ vars.BOXLITE_SYSTEM_IMAGES }}
+      OIDC_AUDIENCE: ${{ vars.OIDC_AUDIENCE }}
+      OIDC_ISSUER_BASE_URL: ${{ vars.OIDC_ISSUER_BASE_URL }}
+      OIDC_MANAGEMENT_API_AUDIENCE: ${{ vars.OIDC_MANAGEMENT_API_AUDIENCE }}
+      OIDC_MANAGEMENT_API_ENABLED: ${{ vars.OIDC_MANAGEMENT_API_ENABLED }}
+      POSTHOG_HOST: ${{ vars.POSTHOG_HOST }}
+      PROXY_DOMAIN: ${{ vars.PROXY_DOMAIN }}
+      PROXY_PROTOCOL: ${{ vars.PROXY_PROTOCOL }}
+      PROXY_TEMPLATE_URL: ${{ vars.PROXY_TEMPLATE_URL }}
+      PUBLIC_OIDC_DOMAIN: ${{ vars.PUBLIC_OIDC_DOMAIN }}
+      STACK_DOMAIN: ${{ vars.STACK_DOMAIN }}
       IAM_PERMISSIONS_BOUNDARY_STAGE: ${{ inputs.stage }}
       BOXLITE_ARTIFACT_SOURCE: build
       API_ARTIFACT_SOURCE: build

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -55,6 +55,19 @@ jobs:
       AWS_REGION: ${{ vars.AWS_REGION || 'ap-southeast-1' }}
       AWS_DEFAULT_REGION: ${{ vars.AWS_REGION || 'ap-southeast-1' }}
       STAGE: ${{ inputs.stage }}
+      # Public stage configuration is owned separately from the bundled DEPLOY_ENV secret.
+      BILLING_API_URL: ${{ vars.BILLING_API_URL }}
+      BOXLITE_SYSTEM_IMAGES: ${{ vars.BOXLITE_SYSTEM_IMAGES }}
+      OIDC_AUDIENCE: ${{ vars.OIDC_AUDIENCE }}
+      OIDC_ISSUER_BASE_URL: ${{ vars.OIDC_ISSUER_BASE_URL }}
+      OIDC_MANAGEMENT_API_AUDIENCE: ${{ vars.OIDC_MANAGEMENT_API_AUDIENCE }}
+      OIDC_MANAGEMENT_API_ENABLED: ${{ vars.OIDC_MANAGEMENT_API_ENABLED }}
+      POSTHOG_HOST: ${{ vars.POSTHOG_HOST }}
+      PROXY_DOMAIN: ${{ vars.PROXY_DOMAIN }}
+      PROXY_PROTOCOL: ${{ vars.PROXY_PROTOCOL }}
+      PROXY_TEMPLATE_URL: ${{ vars.PROXY_TEMPLATE_URL }}
+      PUBLIC_OIDC_DOMAIN: ${{ vars.PUBLIC_OIDC_DOMAIN }}
+      STACK_DOMAIN: ${{ vars.STACK_DOMAIN }}
       VERSION: ${{ inputs.version }}
       BOXLITE_ARTIFACT_SOURCE: release
       API_ARTIFACT_SOURCE: release

--- a/apps/infra/.env.example
+++ b/apps/infra/.env.example
@@ -231,12 +231,14 @@ OIDC_AUDIENCE=https://dev.example.com/api
 # Set SVIX_AUTH_TOKEN through `npm run sst -- secret set`, not in this file.
 # SVIX_SERVER_URL=
 
-# 4j-2. Billing — points the API, and through GET /api/config the dashboard, at
-# a billing service. [optional]; this stack deploys none, so unset means the
-# dashboard's whole billing surface stays gated off and shows its placeholder
+# 4j-2. Billing — hosted stages take BILLING_API_URL from a dedicated GitHub
+# Environment variable, never from DEPLOY_ENV. Export it in the shell only for
+# a direct local deploy. It points the API, and through GET /api/config the
+# dashboard, at a billing service. [optional]; this stack deploys none, so unset
+# means the dashboard's whole billing surface stays gated off and shows its placeholder
 # instead of advertising a service that would fail every request. Suspension
 # does not key off it (REQUIRE_PAYMENT_METHOD does).
-# BILLING_API_URL=https://billing.example.com/api/billing
+# export BILLING_API_URL=https://billing.example.com/api/billing
 #   Setting it also arms usage export to that same service, since a stage with
 #   somewhere to bill has somewhere to send usage. USAGE_EXPORT_URL defaults to
 #   BILLING_API_URL's origin and rarely needs setting: the publisher appends

--- a/apps/infra/README.md
+++ b/apps/infra/README.md
@@ -213,8 +213,10 @@ runs before deployment.
 
 The workflows are manual/serialized, restricted to `main`, and bound to protected
 GitHub Environments. GitHub OIDC supplies short-lived AWS credentials; no AWS
-access keys are stored in GitHub. `DEPLOY_ENV` materializes the stage's gitignored
-`.env` only for the job and is deleted even if deployment fails.
+access keys are stored in GitHub. Dedicated Environment variables provide active
+stage configuration. The inactive `DEPLOY_ENV` compatibility payload still
+materializes a gitignored `.env` only for the job and is deleted even if deployment
+fails.
 
 `ci/github-deploy-role.yaml` bootstraps three things that must exist **before** an
 SST deploy: the OIDC role, the immutable Api ECR repository, and the private
@@ -243,10 +245,19 @@ each stage you run.
 | --- | --- | --- |
 | App secrets (`OIDC_CLIENT_ID`, Auth0 Management API, Svix, PostHog, `USAGE_EXPORT_TOKEN`) | SST secret store | `npm run bootstrap`; others via `npm run sst -- secret set <NAME> --stage <stage>` reading stdin |
 | Cloudflare creds (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_DEFAULT_ACCOUNT_ID`) | AWS SSM SecureString, or GitHub Environment secrets (which win) | `npm run bootstrap` |
-| Stage config (`STACK_DOMAIN`, `OIDC_*`, toggles) | GitHub Environment secret `DEPLOY_ENV` | `npm run bootstrap` |
+| Stage config (`STACK_DOMAIN`, `OIDC_*`, billing, proxy, and feature toggles) | Dedicated GitHub Environment variables | `npm run bootstrap`; operator-managed values are preserved when absent locally |
+| Compatibility fallback | GitHub Environment secret `DEPLOY_ENV` | `npm run bootstrap`; contains no active configuration |
 
-Never pass secret values as command arguments or echo them. Rotate on any
-suspected disclosure. `npm run secrets -- --stage dev` lists what is set.
+Never pass secret values as command arguments or echo them. Do not use a secret
+listing command that prints values; verify presence through AWS secret metadata
+only. Rotate on any suspected disclosure.
+
+Both dev-capable deployment workflows read public stage configuration from
+dedicated Environment variables. `DEPLOY_ENV` remains as an inactive compatibility
+fallback and must contain no migrated configuration. Runtime credentials — including
+`OIDC_CLIENT_ID`, Auth0 Management API credentials, PostHog, Svix, and
+`USAGE_EXPORT_TOKEN` — remain AWS-backed SST secrets and must never be stored in a
+GitHub variable or in `DEPLOY_ENV`.
 
 Run SST through the npm scripts, never bare `npx sst` — the wrapper loads
 Cloudflare creds from SSM, enforces the Runner safety policy, and scrubs

--- a/apps/infra/scripts/bootstrap-environment.mjs
+++ b/apps/infra/scripts/bootstrap-environment.mjs
@@ -74,6 +74,7 @@ import {
 } from './auth0-provisioning.mjs'
 import {
   environmentApiPath,
+  configuredGithubStageVariables,
   githubEnvironmentPayload,
   isProtectionUnavailableError,
   parseReviewerIds,
@@ -634,15 +635,12 @@ function ghVariableSet({ repo, stage, name, value }) {
 /*
  * The gh installed here (2.92.0) has no --body-file, and passing it makes gh
  * print usage and exit non-zero. It takes --body, or reads the value from
- * stdin when --body is omitted; --env-file is a different feature entirely
- * (many secrets named by a dotenv file, not one secret whose value is that
- * file). Passing the whole file on stdin is what stores DEPLOY_ENV as a single
- * secret, and keeps the contents out of argv where other processes could read
- * them.
+ * stdin when --body is omitted. The compatibility payload goes through stdin so
+ * future secret content cannot accidentally become process-list-visible.
  */
-function ghSecretSetFromFile({ repo, stage, name, filePath }) {
+function ghSecretSet({ repo, stage, name, value }) {
   execFileSync('gh', ['secret', 'set', name, '--repo', repo, '--env', stage], {
-    input: readFileSync(filePath),
+    input: value,
     stdio: ['pipe', 'inherit', 'inherit'],
     timeout: 30_000,
     killSignal: 'SIGTERM',
@@ -652,8 +650,16 @@ function ghSecretSetFromFile({ repo, stage, name, filePath }) {
 function wireGithubEnvironment({ repo, stage, region, roleArn }) {
   ghVariableSet({ repo, stage, name: 'AWS_DEPLOY_ROLE_ARN', value: roleArn })
   ghVariableSet({ repo, stage, name: 'AWS_REGION', value: region })
-  ghSecretSetFromFile({ repo, stage, name: 'DEPLOY_ENV', filePath: requireStageEnvFile() })
-  console.log(`[${SCRIPT_NAME}] GitHub ${stage} environment ... AWS_DEPLOY_ROLE_ARN, AWS_REGION, DEPLOY_ENV set`)
+  for (const [name, value] of Object.entries(configuredGithubStageVariables())) {
+    ghVariableSet({ repo, stage, name, value })
+  }
+  ghSecretSet({
+    repo,
+    stage,
+    name: 'DEPLOY_ENV',
+    value: '# Compatibility fallback only; stage configuration uses dedicated GitHub variables.\n',
+  })
+  console.log(`[${SCRIPT_NAME}] GitHub ${stage} environment ... dedicated variables and DEPLOY_ENV fallback set`)
 }
 
 async function main() {

--- a/apps/infra/scripts/deploy-environment-validation.mjs
+++ b/apps/infra/scripts/deploy-environment-validation.mjs
@@ -45,6 +45,28 @@ const FORBIDDEN_DEPLOYMENT_KEYS = new Set([
   'SST_BIN_PATH',
 ])
 
+const EXTERNAL_STAGE_KEYS = new Set([
+  'BILLING_API_URL',
+  'BOXLITE_SYSTEM_IMAGES',
+  'CLOUDFLARE_API_TOKEN',
+  'OIDC_AUDIENCE',
+  'OIDC_CLIENT_ID',
+  'OIDC_ISSUER_BASE_URL',
+  'OIDC_MANAGEMENT_API_AUDIENCE',
+  'OIDC_MANAGEMENT_API_CLIENT_ID',
+  'OIDC_MANAGEMENT_API_CLIENT_SECRET',
+  'OIDC_MANAGEMENT_API_ENABLED',
+  'POSTHOG_API_KEY',
+  'POSTHOG_HOST',
+  'PROXY_DOMAIN',
+  'PROXY_PROTOCOL',
+  'PROXY_TEMPLATE_URL',
+  'PUBLIC_OIDC_DOMAIN',
+  'STACK_DOMAIN',
+  'SVIX_AUTH_TOKEN',
+  'USAGE_EXPORT_TOKEN',
+])
+
 export function validateDeployEnvironment(source) {
   for (const [index, rawLine] of source.split(/\r?\n/).entries()) {
     const line = rawLine.trim()
@@ -55,6 +77,12 @@ export function validateDeployEnvironment(source) {
   }
 
   const configuredKeys = Object.keys(parse(source))
+  const externalKeys = configuredKeys.filter((key) => EXTERNAL_STAGE_KEYS.has(key)).sort()
+  if (externalKeys.length > 0) {
+    throw new Error(
+      `${externalKeys.join(', ')} must not be stored in DEPLOY_ENV; use dedicated GitHub variables or AWS/SST secrets`,
+    )
+  }
   const forbiddenKeys = configuredKeys
     .filter((key) => FORBIDDEN_DEPLOYMENT_KEYS.has(key) || key.startsWith('AWS_ENDPOINT_URL_'))
     .sort()

--- a/apps/infra/scripts/deploy-environment-validation.test.mjs
+++ b/apps/infra/scripts/deploy-environment-validation.test.mjs
@@ -6,12 +6,10 @@ import test from 'node:test'
 
 import { validateDeployEnvironment } from './deploy-environment-validation.mjs'
 
-test('accepts ordinary dotenv deployment configuration', () => {
+test('accepts an inactive compatibility payload', () => {
   assert.doesNotThrow(() =>
     validateDeployEnvironment(`
-STACK_DOMAIN=dev.boxlite.ai
-OIDC_AUDIENCE=https://dev.boxlite.ai/api
-RUNNERS=1
+# Dedicated GitHub variables own active stage configuration.
 `),
   )
 })
@@ -56,6 +54,37 @@ test('rejects every forbidden workflow override', () => {
         assert.equal(error.message.includes(secretValue), false)
         return true
       },
+    )
+  }
+})
+
+test('rejects configuration migrated to dedicated GitHub variables or AWS secrets', () => {
+  const migratedKeys = [
+    'BILLING_API_URL',
+    'BOXLITE_SYSTEM_IMAGES',
+    'CLOUDFLARE_API_TOKEN',
+    'OIDC_AUDIENCE',
+    'OIDC_CLIENT_ID',
+    'OIDC_ISSUER_BASE_URL',
+    'OIDC_MANAGEMENT_API_AUDIENCE',
+    'OIDC_MANAGEMENT_API_CLIENT_ID',
+    'OIDC_MANAGEMENT_API_CLIENT_SECRET',
+    'OIDC_MANAGEMENT_API_ENABLED',
+    'POSTHOG_API_KEY',
+    'POSTHOG_HOST',
+    'PROXY_DOMAIN',
+    'PROXY_PROTOCOL',
+    'PROXY_TEMPLATE_URL',
+    'PUBLIC_OIDC_DOMAIN',
+    'STACK_DOMAIN',
+    'SVIX_AUTH_TOKEN',
+    'USAGE_EXPORT_TOKEN',
+  ]
+
+  for (const key of migratedKeys) {
+    assert.throws(
+      () => validateDeployEnvironment(`${key}=synthetic-value`),
+      new RegExp(`${key}.*must not be stored in DEPLOY_ENV`),
     )
   }
 })

--- a/apps/infra/scripts/environment-bootstrap.test.mjs
+++ b/apps/infra/scripts/environment-bootstrap.test.mjs
@@ -21,6 +21,22 @@ import {
   sstPlatformState,
   validateGitHubRepo,
 } from './environment-bootstrap.mjs'
+import { configuredGithubStageVariables } from './github-environment.mjs'
+
+test('configuredGithubStageVariables exports public stage config but no runtime secrets', () => {
+  assert.deepEqual(
+    configuredGithubStageVariables({
+      STACK_DOMAIN: 'dev.example.test',
+      BILLING_API_URL: 'https://billing.example.test/api/billing',
+      OIDC_CLIENT_ID: 'must-stay-in-sst',
+      SVIX_AUTH_TOKEN: 'must-stay-in-sst',
+    }),
+    {
+      BILLING_API_URL: 'https://billing.example.test/api/billing',
+      STACK_DOMAIN: 'dev.example.test',
+    },
+  )
+})
 
 test('runtimeBoundaryPolicyArn matches sst.config.ts interpolation', () => {
   assert.equal(

--- a/apps/infra/scripts/github-environment.mjs
+++ b/apps/infra/scripts/github-environment.mjs
@@ -19,6 +19,30 @@
 // unprotected environment — so a 422 here must not abort the bootstrap.
 const PROTECTION_UNAVAILABLE_PATTERN = /(only available|not available|upgrade|advanced security|payment)/i
 
+const GITHUB_STAGE_VARIABLES = [
+  'BILLING_API_URL',
+  'BOXLITE_SYSTEM_IMAGES',
+  'OIDC_AUDIENCE',
+  'OIDC_ISSUER_BASE_URL',
+  'OIDC_MANAGEMENT_API_AUDIENCE',
+  'OIDC_MANAGEMENT_API_ENABLED',
+  'POSTHOG_HOST',
+  'PROXY_DOMAIN',
+  'PROXY_PROTOCOL',
+  'PROXY_TEMPLATE_URL',
+  'PUBLIC_OIDC_DOMAIN',
+  'STACK_DOMAIN',
+]
+
+export function configuredGithubStageVariables(environment = process.env) {
+  return Object.fromEntries(
+    GITHUB_STAGE_VARIABLES.flatMap((name) => {
+      const value = environment[name]?.trim()
+      return value ? [[name, value]] : []
+    }),
+  )
+}
+
 export function githubEnvironmentPayload({ reviewerIds = [] } = {}) {
   if (!Array.isArray(reviewerIds)) throw new Error('reviewerIds must be an array of numeric GitHub actor ids')
   for (const id of reviewerIds) {

--- a/apps/infra/scripts/release-deployment-safety.test.mjs
+++ b/apps/infra/scripts/release-deployment-safety.test.mjs
@@ -42,6 +42,20 @@ const CLOUDFORMATION_SCHEMA = DEFAULT_SCHEMA.extend([
   }),
 ])
 const requireFromTest = createRequire(import.meta.url)
+const DEDICATED_STAGE_VARIABLES = [
+  'BILLING_API_URL',
+  'BOXLITE_SYSTEM_IMAGES',
+  'OIDC_AUDIENCE',
+  'OIDC_ISSUER_BASE_URL',
+  'OIDC_MANAGEMENT_API_AUDIENCE',
+  'OIDC_MANAGEMENT_API_ENABLED',
+  'POSTHOG_HOST',
+  'PROXY_DOMAIN',
+  'PROXY_PROTOCOL',
+  'PROXY_TEMPLATE_URL',
+  'PUBLIC_OIDC_DOMAIN',
+  'STACK_DOMAIN',
+]
 
 // One decision per artifact kind, made where the text is read (see live-source.mjs).
 const liveShell = (run) => liveText('shell', run)
@@ -190,6 +204,10 @@ test('deployment previews and reconciles the full stack in guarded GitHub CI', (
   })
   assert.equal(workflow.on.workflow_dispatch.inputs.runner_create_allowlist, undefined)
   assert.match(source, /environment: \$\{\{ inputs\.stage \}\}/)
+  for (const name of DEDICATED_STAGE_VARIABLES) {
+    assert.equal(workflow.jobs.deploy.env[name], `\${{ vars.${name} }}`)
+  }
+  assert.doesNotMatch(source, /secrets\.BILLING_API_URL/)
   assert.equal(workflow.permissions['id-token'], 'write')
   assert.equal(workflow.jobs.deploy['runs-on'], 'ubuntu-24.04')
 
@@ -707,6 +725,10 @@ test('release deployment consumes one published version for both components', ()
   assert.equal(workflow.jobs.deploy.env.ALLOW_DOWNGRADE, "${{ inputs.allow_downgrade && '1' || '' }}")
   assert.equal(workflow.jobs.deploy.env.VERSION, '${{ inputs.version }}')
   assert.match(source, /environment: \$\{\{ inputs\.stage \}\}/)
+  for (const name of DEDICATED_STAGE_VARIABLES) {
+    assert.equal(workflow.jobs.deploy.env[name], `\${{ vars.${name} }}`)
+  }
+  assert.doesNotMatch(source, /secrets\.BILLING_API_URL/)
   // `stage` picks the protected Environment holding the AWS role, so it must be untypable
   // rather than merely wrong — the same allowlist rule deploy-infra.yml follows.
   assert.equal(workflow.on.workflow_dispatch.inputs.stage.type, 'choice')


### PR DESCRIPTION
## What changed

- passes public stage configuration through dedicated GitHub Environment variables in both deployment workflows
- keeps runtime credentials in AWS-backed SST secrets
- retains `DEPLOY_ENV` as an inactive compatibility payload
- rejects migrated configuration if it is reintroduced into `DEPLOY_ENV`
- updates bootstrap, documentation, and deployment regression coverage

## Why

The bundled `DEPLOY_ENV` secret mixed public configuration with credential-shaped values and made individual settings difficult to manage or audit. Dedicated variables give each public value one owner, while AWS remains the credential boundary.

## Before

```text
GitHub Environment DEPLOY_ENV
  -> materialized apps/infra/.env
  -> SST reads public config mixed with secret-shaped entries
  -> API task and dashboard config
```

## After

```text
GitHub Environment vars
  -> deploy-infra / deploy-release job env
  -> SST reads public stage config
  -> API task and dashboard config

AWS/SST secrets
  -> ECS secret injection
  -> API runtime credentials

DEPLOY_ENV
  -> inactive compatibility payload only
```

## Validation

- `make test:apps:infra`: 312/312 passed
- pre-change regression proof: dedicated-variable workflow and validation assertions failed before implementation
- full pre-push apps matrix remains blocked by unchanged `main` failures: `apps/api/src/box/services/job.service.ts:491` has an argument-count type error, and local Postgres/Redis services are unavailable

## Deployment impact

The `dev` Environment variables have been populated and the BoxLite/Commerce usage secrets match. `DEPLOY_ENV` and the live stack remain unchanged until this PR is merged and the guarded deployment preview is reviewed.
