### PR TITLE
feat(dev): add validated BoxLite diagrams skill

### DIFF
--- a/.agents/skills/boxlite-diagrams/SKILL.md
+++ b/.agents/skills/boxlite-diagrams/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: boxlite-diagrams
+description: >
+  Draw and validate BoxLite architecture diagrams, sequence diagrams, and
+  source-grounded ASCII call graphs. Use this skill whenever a user asks how
+  BoxLite works, requests an architecture/sequence/call graph, wants an issue
+  or bug illustrated, or needs a PR, commit, branch, or working-tree change
+  explained visually. Always use it for BoxLite visualization requests about
+  an issue, bug, PR, change, or before/after behavior, even when the user asks
+  only for one view.
+compatibility: Requires git, Python 3.10+, Node.js/npm, npx, and gh for GitHub issue or PR evidence.
+---
+
+# BoxLite Diagrams
+
+Turn current BoxLite repository evidence into three mutually checking views:
+
+1. Mermaid architecture diagram
+2. Mermaid sequence diagram
+3. ASCII call graph with exact source anchors
+
+An attractive diagram with an invented hop is worse than no diagram. Generate
+an evidence manifest, run the bundled validator, and present the diagrams only
+after it passes.
+
+## Workflow
+
+1. Resolve the repository root, current revision, and requested subject.
+2. Read the actual source, nearby tests, and relevant architecture docs.
+3. If an issue or PR is named, read it with `gh` and resolve its revisions.
+4. Classify evidence sources independently from change meaning:
+   - sources: checkout, issue, PR, base/head revisions, or working-tree diff;
+   - meaning: `none`, `bug`, `feature`, `refactor`, or `docs`.
+5. Create `diagram.md` and `evidence.json` in a temporary task directory.
+6. Run `scripts/validate_diagrams.py` using the command below.
+7. On failure, read `validation.json`, correct the evidence or diagram, and
+   retry. Stop after three failed attempts and return the report instead of an
+   unverified diagram.
+8. After deterministic validation passes, use the repository's required
+   verdict-auditor workflow before presenting architectural conclusions.
+
+Do not edit BoxLite production code when the request is only for a diagram.
+Save generated files in the repository only when the user explicitly asks.
+
+## State and annotation model
+
+Choose state labels from the evidence:
+
+- overview: `Current`;
+- unimplemented issue: `Current` and `Expected (proposed)`;
+- PR, commit, branch, or working-tree change: `Before` and `After`.
+
+Apply annotations to the exact affected node or edge:
+
+- `ISSUE`: verified current gap described by a non-bug issue;
+- `BUG`: faulty hop in `Current` or `Before`;
+- `FIX`: corrected behavior in `Expected (proposed)` or `After`;
+- `PROPOSED`: behavior required by an issue but absent from source;
+- `ADDED`, `CHANGED`, `REMOVED`: behavior grounded in the corresponding diff.
+
+A PR can fix a bug reported by an issue. Do not model issue, bug, and PR as
+mutually exclusive kinds.
+
+## Required document format
+
+Use exactly these level-two view headings and one level-three heading for every
+manifest state:
+
+````markdown
+## Architecture
+
+### Current
+
+```mermaid
+flowchart LR
+  runtime["BoxliteRuntime"]
+```
+
+## Sequence
+
+### Current
+
+```mermaid
+sequenceDiagram
+  participant runtime as BoxliteRuntime
+```
+
+## Call graph
+
+### Current
+
+```text
+  create (BoxliteRuntime · src/boxlite/src/runtime/core.rs:291) — public boundary
+```
+````
+
+For bug-fix PRs, add `Fixes #<number>` after the call-graph states.
+
+Read [references/output-contract.md](references/output-contract.md) before
+authoring either output file. Validate `evidence.json` against the shape in
+[references/evidence.schema.json](references/evidence.schema.json); the script
+also performs semantic checks that JSON Schema cannot express.
+
+## Canonical IDs
+
+Use stable lowercase snake-case IDs. Reuse an ID when the same entity or
+relationship appears in more than one view or state.
+
+- Architecture node: `runtime["BoxliteRuntime"]`
+- Architecture edge: `runtime create_box@--> box`
+- Sequence participant: `participant runtime as BoxliteRuntime`
+- Sequence edge: put `%% edge:create_box` immediately before its message
+- Call graph: the validator maps a hop to one manifest node by its symbol and
+  source anchor, then derives edges from indentation.
+
+Every Mermaid edge must have a canonical ID. Do not leave sequence messages or
+architecture arrows untracked.
+
+## Source grounding
+
+- Cite the exact revision, repository-relative path, and inclusive line range.
+- Put the call graph's displayed line inside that evidence range.
+- Include narrow evidence tokens that prove the symbol or relationship.
+- For a direct call, the edge evidence must contain the callee's leaf symbol.
+- For RPC, dispatch, spawn, data flow, or state transitions, cite the concrete
+  registration, protocol call, process launch, assignment, or transition.
+- Never infer a call merely because two real functions have compatible names.
+- Never invent a future symbol for an unimplemented issue. Stop the proposed
+  call graph at the last real boundary and annotate the missing next behavior.
+- Mark issue-derived future nodes or edges `proposed: true` and support them
+  with issue evidence rather than fake source evidence.
+
+For comparisons, source anchors belong to their own state revision. A deleted
+hop cites the base revision; an added hop cites the head revision.
+
+## Visual rules
+
+- Keep all three views focused on the same behavior.
+- Architecture shows components and trust/process/storage boundaries.
+- Sequence shows time, calls, responses, alternatives, concurrency, and failure.
+- Call graph uses one hop per line:
+  `symbol (Type · path/file.ext:line) — role`.
+- Use two-space indentation per call depth and `└─` or `├─` for children.
+- Keep meaning in text. Color may reinforce but never carry an annotation.
+- Mermaid is limited to `flowchart`/`graph` and `sequenceDiagram`.
+- Do not use Mermaid initialization directives, clicks, links, raw HTML, or
+  JavaScript.
+
+## Validation command
+
+```bash
+python3 .agents/skills/boxlite-diagrams/scripts/validate_diagrams.py \
+  --repo "$(git rev-parse --show-toplevel)" \
+  --document "$TASK_DIR/diagram.md" \
+  --evidence "$TASK_DIR/evidence.json" \
+  --report "$TASK_DIR/validation.json"
+```
+
+Exit codes:
+
+- `0`: every deterministic check passed;
+- `1`: diagram or evidence is invalid;
+- `2`: a required tool is unavailable.
+
+The validator renders Mermaid with pinned on-demand
+`@mermaid-js/mermaid-cli@11.16.0`. It uses an installed Chrome/Chromium when
+available and otherwise lets Puppeteer provision its browser.
+
+## Response
+
+Lead with the ASCII call graph and one `Key:` line, matching BoxLite's normal
+code-explanation style. Then show architecture and sequence. For comparisons,
+keep `Before` and `After` adjacent within each view. End with a compact evidence
+summary and the passing validation-report path when files were requested.
+
+Do not claim that mechanical validation proves the architecture is correct.
+It proves renderability, source traceability, diff alignment, and cross-view
+consistency; the verdict audit covers the remaining interpretation.

--- a/.agents/skills/boxlite-diagrams/SKILL.md
+++ b/.agents/skills/boxlite-diagrams/SKILL.md
@@ -53,7 +53,7 @@ Choose state labels from the evidence:
 Apply annotations to the exact affected node or edge:
 
 - `ISSUE`: verified current gap described by a non-bug issue;
-- `BUG`: faulty hop in `Current` or `Before`;
+- `← BUG: <description>`: faulty hop in `Current` or `Before`;
 - `FIX`: corrected behavior in `Expected (proposed)` or `After`;
 - `PROPOSED`: behavior required by an issue but absent from source;
 - `ADDED`, `CHANGED`, `REMOVED`: behavior grounded in the corresponding diff.

--- a/.agents/skills/boxlite-diagrams/evals/evals.json
+++ b/.agents/skills/boxlite-diagrams/evals/evals.json
@@ -28,12 +28,12 @@
     {
       "id": 3,
       "prompt": "Explain bug-fix PR #1200 for split UTF-8 PTY frames. Produce diagram.md, evidence.json, and validation.json in the requested output directory. Show a complete Before and After and link the fixed issue. Do not change production source.",
-      "expected_output": "A validated bug-fix PR package with the faulty Before hop marked BUG, the corrected After path marked FIX, and Fixes #1155.",
+      "expected_output": "A validated bug-fix PR package with the faulty Before hop marked ← BUG:, the corrected After path marked FIX, and Fixes #1155.",
       "files": [],
       "expectations": [
         "The output directory contains diagram.md, evidence.json, and validation.json, and validation.json reports valid=true with exit_code=0.",
         "All three views contain complete adjacent Before and After states grounded in the PR base and head revisions.",
-        "BUG appears only on the faulty Before call-graph hop, FIX appears on the corrected After behavior, and diagram.md contains Fixes #1155.",
+        "← BUG: appears only on the faulty Before call-graph hop, FIX appears on the corrected After behavior, and diagram.md contains Fixes #1155.",
         "Every call-graph relationship has concrete source evidence and the canonical nodes and edges agree across all three views."
       ]
     }

--- a/.agents/skills/boxlite-diagrams/evals/evals.json
+++ b/.agents/skills/boxlite-diagrams/evals/evals.json
@@ -1,0 +1,41 @@
+{
+  "skill_name": "boxlite-diagrams",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "In the BoxLite repository, explain the current local runtime path for creating a box. Produce diagram.md, evidence.json, and validation.json in the requested output directory. Do not change production source.",
+      "expected_output": "A validated Current-state architecture diagram, sequence diagram, and source-grounded ASCII call graph for local box creation.",
+      "files": [],
+      "expectations": [
+        "The output directory contains diagram.md, evidence.json, and validation.json, and validation.json reports valid=true with exit_code=0.",
+        "diagram.md contains exactly the Architecture, Sequence, and Call graph views for a Current state.",
+        "The call graph uses symbol (Type · path:line) — role hops and its caller-to-callee relationships are supported by revision-aware source evidence.",
+        "Canonical node and edge IDs agree across the manifest, architecture, sequence, and call-graph views."
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Illustrate open BoxLite issue #1209 (boxlite serve volume creation and mount). Show what exists now and what the issue proposes. Produce diagram.md, evidence.json, and validation.json in the requested output directory. Do not change production source.",
+      "expected_output": "A validated Current versus Expected (proposed) package that separates source-backed behavior from issue-backed proposed behavior.",
+      "files": [],
+      "expectations": [
+        "The output directory contains diagram.md, evidence.json, and validation.json, and validation.json reports valid=true with exit_code=0.",
+        "All three views contain adjacent Current and Expected (proposed) states.",
+        "Proposed behavior is marked PROPOSED on the exact affected element, uses issue #1209 evidence, and is not represented by an invented source symbol.",
+        "Implemented behavior cites resolvable revision, path, line, symbol, and tokens, while proposed behavior is explicitly distinguished from implemented behavior."
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Explain bug-fix PR #1200 for split UTF-8 PTY frames. Produce diagram.md, evidence.json, and validation.json in the requested output directory. Show a complete Before and After and link the fixed issue. Do not change production source.",
+      "expected_output": "A validated bug-fix PR package with the faulty Before hop marked BUG, the corrected After path marked FIX, and Fixes #1155.",
+      "files": [],
+      "expectations": [
+        "The output directory contains diagram.md, evidence.json, and validation.json, and validation.json reports valid=true with exit_code=0.",
+        "All three views contain complete adjacent Before and After states grounded in the PR base and head revisions.",
+        "BUG appears only on the faulty Before call-graph hop, FIX appears on the corrected After behavior, and diagram.md contains Fixes #1155.",
+        "Every call-graph relationship has concrete source evidence and the canonical nodes and edges agree across all three views."
+      ]
+    }
+  ]
+}

--- a/.agents/skills/boxlite-diagrams/references/evidence.schema.json
+++ b/.agents/skills/boxlite-diagrams/references/evidence.schema.json
@@ -1,0 +1,158 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://boxlite.ai/schemas/diagram-evidence-v1.json",
+  "title": "BoxLite diagram evidence",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "context", "states", "nodes", "edges", "annotations"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "context": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "change_kind", "sources"],
+      "properties": {
+        "kind": {
+          "enum": ["overview", "issue", "pr", "commit", "branch", "working-tree-change"]
+        },
+        "change_kind": { "enum": ["none", "bug", "feature", "refactor", "docs"] },
+        "sources": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "repository": { "type": "string", "minLength": 1 },
+            "issue": { "type": "integer", "minimum": 1 },
+            "pr": { "type": "integer", "minimum": 1 },
+            "base_revision": { "type": "string", "minLength": 1 },
+            "head_revision": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    },
+    "states": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 2,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "label", "revision", "proposed"],
+        "properties": {
+          "id": { "$ref": "#/$defs/id" },
+          "label": { "type": "string", "minLength": 1 },
+          "revision": { "type": "string", "minLength": 1 },
+          "proposed": { "type": "boolean" }
+        }
+      }
+    },
+    "nodes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "allOf": [{ "$ref": "#/$defs/item" }],
+        "unevaluatedProperties": false
+      }
+    },
+    "edges": {
+      "type": "array",
+      "items": {
+        "allOf": [
+          { "$ref": "#/$defs/item" },
+          {
+            "type": "object",
+            "required": ["from", "to", "kind"],
+            "properties": {
+              "from": { "$ref": "#/$defs/id" },
+              "to": { "$ref": "#/$defs/id" },
+              "kind": {
+                "enum": ["call", "rpc", "dispatch", "spawn", "data", "state-transition", "proposed"]
+              }
+            }
+          }
+        ],
+        "unevaluatedProperties": false
+      }
+    },
+    "annotations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "target", "state", "text"],
+        "properties": {
+          "kind": { "enum": ["ISSUE", "BUG", "FIX", "PROPOSED", "ADDED", "CHANGED", "REMOVED"] },
+          "target": { "type": "string", "pattern": "^(node|edge):[a-z][a-z0-9_]*$" },
+          "state": { "$ref": "#/$defs/id" },
+          "text": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "id": { "type": "string", "pattern": "^[a-z][a-z0-9_]*$" },
+    "item": {
+      "type": "object",
+      "required": ["id", "label", "states", "views", "proposed", "evidence"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "label": { "type": "string", "minLength": 1 },
+        "states": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/id" },
+          "uniqueItems": true
+        },
+        "views": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "enum": ["architecture", "sequence", "call_graph"] },
+          "uniqueItems": true
+        },
+        "proposed": { "type": "boolean" },
+        "evidence": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              { "$ref": "#/$defs/sourceEvidence" },
+              { "$ref": "#/$defs/issueEvidence" }
+            ]
+          }
+        }
+      }
+    },
+    "sourceEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "state", "revision", "path", "line_start", "line_end", "symbol", "tokens"],
+      "properties": {
+        "type": { "const": "source" },
+        "state": { "$ref": "#/$defs/id" },
+        "revision": { "type": "string", "minLength": 1 },
+        "path": { "type": "string", "minLength": 1 },
+        "line_start": { "type": "integer", "minimum": 1 },
+        "line_end": { "type": "integer", "minimum": 1 },
+        "symbol": { "type": "string", "minLength": 1 },
+        "tokens": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "issueEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "state", "issue", "tokens"],
+      "properties": {
+        "type": { "const": "issue" },
+        "state": { "$ref": "#/$defs/id" },
+        "issue": { "type": "integer", "minimum": 1 },
+        "tokens": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  }
+}

--- a/.agents/skills/boxlite-diagrams/references/output-contract.md
+++ b/.agents/skills/boxlite-diagrams/references/output-contract.md
@@ -59,7 +59,7 @@ Rules:
 - a child uses `└─` or `├─` after its indentation;
 - the displayed line must be inside the matching manifest evidence range;
 - indentation creates a caller-to-callee edge that must exist in the manifest;
-- `BUG:` belongs on a faulty `Before`/`Current` hop, never on a standalone line;
+- `← BUG: <description>` belongs on a faulty `Before`/`Current` hop, never on a standalone line;
 - future behavior has no invented hop—annotate the last real boundary instead.
 
 ## Evidence types

--- a/.agents/skills/boxlite-diagrams/references/output-contract.md
+++ b/.agents/skills/boxlite-diagrams/references/output-contract.md
@@ -1,0 +1,121 @@
+# BoxLite diagram output contract
+
+## Document
+
+`diagram.md` contains exactly three level-two sections in this order:
+
+1. `Architecture`
+2. `Sequence`
+3. `Call graph`
+
+Each section contains exactly one level-three subsection for every state listed
+in `evidence.json`, in the same order. Architecture and sequence state sections
+contain one `mermaid` fence. Call-graph state sections contain one `text` fence.
+
+Architecture fences start with `flowchart` or `graph`. Sequence fences start
+with `sequenceDiagram`.
+
+## Architecture IDs
+
+Declare nodes with their manifest IDs:
+
+```mermaid
+flowchart LR
+  runtime["BoxliteRuntime"]
+  box["LiteBox"]
+  runtime create_box@-->|"create"| box
+```
+
+The Mermaid edge ID (`create_box`) is also the manifest edge ID.
+
+## Sequence IDs
+
+Participants use manifest node IDs. Every message is immediately preceded by a
+manifest edge ID comment:
+
+```mermaid
+sequenceDiagram
+  participant runtime as BoxliteRuntime
+  participant box as LiteBox
+  %% edge:create_box
+  runtime->>box: create
+```
+
+Notes and grouping statements may be untracked because they are not edges.
+
+## Call graph
+
+Each hop is a single line:
+
+```text
+  create (BoxliteRuntime · src/boxlite/src/runtime/core.rs:291) — public boundary
+    └─ create (RuntimeImpl · src/boxlite/src/runtime/rt_impl.rs:385) — persist configuration
+```
+
+Rules:
+
+- two spaces before a root hop;
+- two additional spaces for each depth;
+- a child uses `└─` or `├─` after its indentation;
+- the displayed line must be inside the matching manifest evidence range;
+- indentation creates a caller-to-callee edge that must exist in the manifest;
+- `BUG:` belongs on a faulty `Before`/`Current` hop, never on a standalone line;
+- future behavior has no invented hop—annotate the last real boundary instead.
+
+## Evidence types
+
+Source evidence:
+
+```json
+{
+  "type": "source",
+  "state": "current",
+  "revision": "HEAD",
+  "path": "src/boxlite/src/runtime/core.rs",
+  "line_start": 291,
+  "line_end": 299,
+  "symbol": "BoxliteRuntime::create",
+  "tokens": ["pub async fn create", "self.backend.create"]
+}
+```
+
+Issue evidence for behavior that is explicitly proposed:
+
+```json
+{
+  "type": "issue",
+  "state": "expected",
+  "issue": 1209,
+  "tokens": ["volume creation", "mount"]
+}
+```
+
+Tokens are exact, case-sensitive substrings of the cited source range or
+case-insensitive substrings of the issue title/body.
+
+## Manifest membership
+
+Each node and edge declares the states and views where it appears. Allowed view
+IDs are `architecture`, `sequence`, and `call_graph`. Shared entities reuse the
+same canonical ID; view-specific context is allowed when it materially improves
+that view.
+
+Every parsed Mermaid node, Mermaid edge, sequence participant/message, and call
+graph hop/relationship must map to exactly one declared manifest item.
+
+## Annotation targets
+
+Annotations target `node:<id>` or `edge:<id>` and include one state:
+
+```json
+{
+  "kind": "BUG",
+  "target": "edge:signal_pid",
+  "state": "before",
+  "text": "a recycled PID can identify another process"
+}
+```
+
+Use `ISSUE`, `BUG`, `FIX`, `PROPOSED`, `ADDED`, `CHANGED`, or `REMOVED`.
+For diff annotations, the target's evidence must intersect the correct base/head
+diff hunk.

--- a/.agents/skills/boxlite-diagrams/scripts/validate_diagrams.py
+++ b/.agents/skills/boxlite-diagrams/scripts/validate_diagrams.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
+import tempfile
 from pathlib import Path
 from typing import Sequence
 
@@ -48,12 +50,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         manifest=manifest,
     )
     validate_manifest(ctx)
-    validate_document(ctx)
-    validate_source_evidence(ctx)
-    validate_mermaid(ctx)
-    validate_call_graph(ctx)
-    validate_changes(ctx)
-    validate_consistency(ctx)
+    if not any(check.name == "manifest.shape" and check.status == "fail" for check in ctx.checks):
+        validate_document(ctx)
+        validate_source_evidence(ctx)
+        validate_mermaid(ctx)
+        validate_call_graph(ctx)
+        validate_changes(ctx)
+        validate_consistency(ctx)
     exit_code = 2 if ctx.has_tool_errors else (1 if ctx.has_failures else 0)
     summary = {status: sum(check.status == status for check in ctx.checks) for status in ("pass", "fail", "error")}
     report = {
@@ -69,9 +72,15 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 def _write_report(path: Path, report: dict[str, object]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_suffix(path.suffix + ".tmp")
-    temporary.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    temporary.replace(path)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write(json.dumps(report, indent=2, sort_keys=True) + "\n")
+        temporary.replace(path)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
 
 
 if __name__ == "__main__":

--- a/.agents/skills/boxlite-diagrams/scripts/validate_diagrams.py
+++ b/.agents/skills/boxlite-diagrams/scripts/validate_diagrams.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from validator.call_graph import validate_call_graph
+from validator.changes import validate_changes
+from validator.consistency import validate_consistency
+from validator.document import validate_document
+from validator.mermaid import validate_mermaid
+from validator.models import ValidationContext
+from validator.source import validate_manifest, validate_source_evidence
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate source-grounded BoxLite diagrams")
+    parser.add_argument("--repo", required=True, type=Path)
+    parser.add_argument("--document", required=True, type=Path)
+    parser.add_argument("--evidence", required=True, type=Path)
+    parser.add_argument("--report", required=True, type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    repo = args.repo.resolve()
+    try:
+        manifest = json.loads(args.evidence.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        report = {
+            "valid": False,
+            "exit_code": 1,
+            "summary": {"pass": 0, "fail": 1, "error": 0},
+            "checks": [{"name": "manifest.read", "status": "fail", "message": str(error), "evidence": []}],
+            "artifacts": [],
+        }
+        _write_report(args.report, report)
+        return 1
+    ctx = ValidationContext(
+        repo=repo,
+        document_path=args.document.resolve(),
+        evidence_path=args.evidence.resolve(),
+        report_path=args.report.resolve(),
+        manifest=manifest,
+    )
+    validate_manifest(ctx)
+    validate_document(ctx)
+    validate_source_evidence(ctx)
+    validate_mermaid(ctx)
+    validate_call_graph(ctx)
+    validate_changes(ctx)
+    validate_consistency(ctx)
+    exit_code = 2 if ctx.has_tool_errors else (1 if ctx.has_failures else 0)
+    summary = {status: sum(check.status == status for check in ctx.checks) for status in ("pass", "fail", "error")}
+    report = {
+        "valid": exit_code == 0,
+        "exit_code": exit_code,
+        "summary": summary,
+        "checks": [check.to_dict() for check in ctx.checks],
+        "artifacts": [str(path) for path in ctx.artifacts],
+    }
+    _write_report(args.report, report)
+    return exit_code
+
+
+def _write_report(path: Path, report: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/skills/boxlite-diagrams/scripts/validator/__init__.py
+++ b/.agents/skills/boxlite-diagrams/scripts/validator/__init__.py
@@ -1,0 +1,5 @@
+"""Deterministic validators for BoxLite diagram bundles."""
+
+from .models import Check, ValidationContext
+
+__all__ = ["Check", "ValidationContext"]

--- a/.agents/skills/boxlite-diagrams/scripts/validator/call_graph.py
+++ b/.agents/skills/boxlite-diagrams/scripts/validator/call_graph.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import re
-from typing import Any
 
 from .models import ValidationContext
 

--- a/.agents/skills/boxlite-diagrams/scripts/validator/call_graph.py
+++ b/.agents/skills/boxlite-diagrams/scripts/validator/call_graph.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from .models import ValidationContext
+
+HOP_RE = re.compile(
+    r"^(?P<indent> +)(?:(?P<branch>[├└])─ )?"
+    r"(?P<symbol>[^\s(]+) \((?P<type>[^·()]+?) · (?P<path>[^:()]+):(?P<line>[1-9][0-9]*)\) — (?P<role>.+)$"
+)
+MARKER_RE = re.compile(r"(?:^|\s)(?:←\s*)?(ISSUE|BUG|FIX|PROPOSED|ADDED|CHANGED|REMOVED):\s*(.+?)(?=$|\s+←\s*[A-Z]+:)")
+
+
+def validate_call_graph(ctx: ValidationContext) -> None:
+    if ctx.parsed is None:
+        ctx.add("call_graph.structure", "fail", "call graph cannot be checked until the document is parsed")
+        return
+    errors: list[str] = []
+    for state in ctx.state_map():
+        block = ctx.parsed.blocks.get(("call_graph", state))
+        if block is None:
+            continue
+        stack: dict[int, str] = {}
+        hop_count = 0
+        for offset, line in enumerate(block.content.splitlines(), start=0):
+            if not line.strip():
+                continue
+            match = HOP_RE.match(line)
+            if not match:
+                errors.append(
+                    f"call_graph/{state} line {block.start_line + offset + 1} must match "
+                    "symbol (Type · path/file.ext:line) — role"
+                )
+                continue
+            hop_count += 1
+            indent = len(match.group("indent"))
+            if indent < 2 or indent % 2:
+                errors.append(f"call_graph/{state} line {block.start_line + offset + 1} has invalid indentation")
+                continue
+            depth = indent // 2 - 1
+            branch = match.group("branch")
+            if depth == 0 and branch:
+                errors.append(f"call_graph/{state} root hop must not use a tree branch")
+            if depth > 0 and not branch:
+                errors.append(f"call_graph/{state} child hop requires ├─ or └─")
+            if depth > 0 and depth - 1 not in stack:
+                errors.append(f"call_graph/{state} hop skips a parent depth")
+
+            item_id = _match_node(ctx, state, match.groupdict(), errors)
+            if item_id is None:
+                continue
+            key = (state, item_id)
+            if key in ctx.parsed.call_graph_nodes:
+                errors.append(f"call_graph/{state} duplicates node {item_id!r}")
+            ctx.parsed.call_graph_nodes[key] = {
+                "symbol": match.group("symbol"),
+                "type": match.group("type").strip(),
+                "path": match.group("path"),
+                "line": int(match.group("line")),
+                "role": match.group("role"),
+                "raw": line,
+            }
+            if depth > 0 and depth - 1 in stack:
+                parent = stack[depth - 1]
+                edge_id = _match_edge(ctx, state, parent, item_id, errors)
+                if edge_id:
+                    edge_key = (state, edge_id)
+                    if edge_key in ctx.parsed.call_graph_edges:
+                        errors.append(f"call_graph/{state} duplicates relationship {edge_id!r}")
+                    ctx.parsed.call_graph_edges[edge_key] = (parent, item_id)
+            stack[depth] = item_id
+            for old_depth in [value for value in stack if value > depth]:
+                del stack[old_depth]
+        if hop_count == 0:
+            errors.append(f"call_graph/{state} must contain at least one actual hop line")
+
+    _validate_markers(ctx, errors)
+    if errors:
+        ctx.add("call_graph.structure", "fail", "ASCII call graph structure or evidence is invalid", errors)
+    else:
+        ctx.add("call_graph.structure", "pass", "all call-graph hops and relationships map to source evidence")
+
+
+def _match_node(
+    ctx: ValidationContext, state: str, hop: dict[str, str | None], errors: list[str]
+) -> str | None:
+    line = int(hop["line"] or 0)
+    candidates: list[str] = []
+    for node in ctx.manifest.get("nodes", []):
+        if state not in node.get("states", []) or "call_graph" not in node.get("views", []):
+            continue
+        for evidence in node.get("evidence", []):
+            if evidence.get("type") != "source" or evidence.get("state") != state:
+                continue
+            if evidence.get("path") != hop["path"] or not evidence["line_start"] <= line <= evidence["line_end"]:
+                continue
+            if _leaf(evidence["symbol"]) == _leaf(hop["symbol"] or ""):
+                candidates.append(node["id"])
+                break
+    if len(candidates) != 1:
+        errors.append(
+            f"call_graph/{state} hop {hop['symbol']} ({hop['path']}:{line}) maps to {len(candidates)} manifest nodes"
+        )
+        return None
+    return candidates[0]
+
+
+def _match_edge(
+    ctx: ValidationContext, state: str, source: str, target: str, errors: list[str]
+) -> str | None:
+    candidates = [
+        edge["id"] for edge in ctx.manifest.get("edges", [])
+        if state in edge.get("states", [])
+        and "call_graph" in edge.get("views", [])
+        and edge.get("from") == source
+        and edge.get("to") == target
+    ]
+    if len(candidates) != 1:
+        errors.append(
+            f"call_graph/{state} relationship {source}->{target} maps to {len(candidates)} manifest edges"
+        )
+        return None
+    return candidates[0]
+
+
+def _validate_markers(ctx: ValidationContext, errors: list[str]) -> None:
+    annotations = ctx.manifest.get("annotations", [])
+    expected = {(value["kind"], value["target"], value["state"]): value["text"] for value in annotations}
+    seen: set[tuple[str, str, str]] = set()
+    node_lookup = {(state, item_id): value for (state, item_id), value in ctx.parsed.call_graph_nodes.items()}
+    child_edges = {
+        (state, target): edge_id
+        for (state, edge_id), (_source, target) in ctx.parsed.call_graph_edges.items()
+    }
+    for (state, item_id), hop in node_lookup.items():
+        for marker in MARKER_RE.finditer(hop["role"]):
+            node_key = (marker.group(1), f"node:{item_id}", state)
+            edge_id = child_edges.get((state, item_id))
+            edge_key = (marker.group(1), f"edge:{edge_id}", state) if edge_id else None
+            key = node_key if node_key in expected else edge_key
+            if key is None or key not in expected:
+                errors.append(f"call_graph/{state} has undeclared marker {marker.group(1)} on node:{item_id}")
+            elif expected[key] not in marker.group(2):
+                errors.append(f"call_graph/{state} marker text disagrees for node:{item_id}")
+            else:
+                seen.add(key)
+    for key, text in expected.items():
+        kind, target, state = key
+        item_type, item_id = target.split(":", 1)
+        if "call_graph" not in ctx.item_map(item_type).get(item_id, {}).get("views", []):
+            continue
+        if item_type == "node" and key not in seen:
+            errors.append(f"call_graph/{state} is missing {kind}: {text} on {target}")
+        if kind == "BUG" and item_type != "edge":
+            errors.append("BUG must target the faulty call-graph edge, not a node or prose")
+        if item_type == "edge":
+            endpoints = ctx.parsed.call_graph_edges.get((state, item_id))
+            if endpoints is None:
+                continue
+            child = node_lookup.get((state, endpoints[1]))
+            if child is None:
+                continue
+            matches = list(MARKER_RE.finditer(child["role"]))
+            if not any(match.group(1) == kind and text in match.group(2) for match in matches):
+                errors.append(f"call_graph/{state} is missing {kind}: {text} on child hop for {target}")
+            else:
+                seen.add(key)
+
+
+def _leaf(symbol: str) -> str:
+    return re.split(r"::|\.", symbol)[-1].strip("<> ")

--- a/.agents/skills/boxlite-diagrams/scripts/validator/call_graph.py
+++ b/.agents/skills/boxlite-diagrams/scripts/validator/call_graph.py
@@ -8,7 +8,10 @@ HOP_RE = re.compile(
     r"^(?P<indent> +)(?:(?P<branch>[├└])─ )?"
     r"(?P<symbol>[^\s(]+) \((?P<type>[^·()]+?) · (?P<path>[^:()]+):(?P<line>[1-9][0-9]*)\) — (?P<role>.+)$"
 )
-MARKER_RE = re.compile(r"(?:^|\s)(?:←\s*)?(ISSUE|BUG|FIX|PROPOSED|ADDED|CHANGED|REMOVED):\s*(.+?)(?=$|\s+←\s*[A-Z]+:)")
+MARKER_RE = re.compile(
+    r"(?:^|\s)(?:(?P<arrow>←)\s*)?(?P<kind>ISSUE|BUG|FIX|PROPOSED|ADDED|CHANGED|REMOVED):\s*"
+    r"(?P<text>.+?)(?=$|\s+←\s*[A-Z]+:)"
+)
 
 
 def validate_call_graph(ctx: ValidationContext) -> None:
@@ -134,13 +137,16 @@ def _validate_markers(ctx: ValidationContext, errors: list[str]) -> None:
     }
     for (state, item_id), hop in node_lookup.items():
         for marker in MARKER_RE.finditer(hop["role"]):
-            node_key = (marker.group(1), f"node:{item_id}", state)
+            kind = marker.group("kind")
+            if kind == "BUG" and marker.group("arrow") is None:
+                errors.append(f"call_graph/{state} BUG marker on node:{item_id} must use '← BUG:'")
+            node_key = (kind, f"node:{item_id}", state)
             edge_id = child_edges.get((state, item_id))
-            edge_key = (marker.group(1), f"edge:{edge_id}", state) if edge_id else None
+            edge_key = (kind, f"edge:{edge_id}", state) if edge_id else None
             key = node_key if node_key in expected else edge_key
             if key is None or key not in expected:
-                errors.append(f"call_graph/{state} has undeclared marker {marker.group(1)} on node:{item_id}")
-            elif expected[key] not in marker.group(2):
+                errors.append(f"call_graph/{state} has undeclared marker {kind} on node:{item_id}")
+            elif expected[key] not in marker.group("text"):
                 errors.append(f"call_graph/{state} marker text disagrees for node:{item_id}")
             else:
                 seen.add(key)
@@ -161,7 +167,7 @@ def _validate_markers(ctx: ValidationContext, errors: list[str]) -> None:
             if child is None:
                 continue
             matches = list(MARKER_RE.finditer(child["role"]))
-            if not any(match.group(1) == kind and text in match.group(2) for match in matches):
+            if not any(match.group("kind") == kind and text in match.group("text") for match in matches):
                 errors.append(f"call_graph/{state} is missing {kind}: {text} on child hop for {target}")
             else:
                 seen.add(key)

--- a/.agents/skills/boxlite-diagrams/scripts/validator/changes.py
+++ b/.agents/skills/boxlite-diagrams/scripts/validator/changes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 from collections import defaultdict
@@ -80,7 +81,13 @@ def _load_diff(ctx: ValidationContext, errors: list[str]) -> dict[str, dict[str,
     command = ["git", "diff", "--unified=0", "--no-ext-diff", base]
     if head != "WORKTREE":
         command.append(head)
-    result = subprocess.run(command, cwd=ctx.repo, text=True, capture_output=True, check=False)
+    try:
+        result = subprocess.run(
+            command, cwd=ctx.repo, text=True, capture_output=True, check=False, timeout=_command_timeout()
+        )
+    except subprocess.TimeoutExpired:
+        errors.append(f"diff command exceeded {_command_timeout():g} seconds")
+        return None
     if result.returncode != 0:
         errors.append(f"cannot resolve diff {base}..{head}: {result.stderr.strip()}")
         return None
@@ -91,6 +98,9 @@ def _parse_diff(text: str) -> dict[str, dict[str, list[tuple[int, int]]]]:
     ranges: dict[str, dict[str, list[tuple[int, int]]]] = defaultdict(lambda: {"before": [], "after": []})
     path: str | None = None
     for line in text.splitlines():
+        if line.startswith("diff --git "):
+            path = None
+            continue
         if line.startswith("+++ b/"):
             path = line[6:]
             continue
@@ -155,3 +165,12 @@ def _validate_annotation_hunk(
 
 def _intersects(left_start: int, left_end: int, right_start: int, right_end: int) -> bool:
     return left_start <= right_end and right_start <= left_end
+
+
+def _command_timeout() -> float:
+    raw = os.environ.get("BOXLITE_DIAGRAM_COMMAND_TIMEOUT", "120")
+    try:
+        value = float(raw)
+    except ValueError:
+        return 120.0
+    return value if value > 0 else 120.0

--- a/.agents/skills/boxlite-diagrams/scripts/validator/changes.py
+++ b/.agents/skills/boxlite-diagrams/scripts/validator/changes.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import re
+import subprocess
+from collections import defaultdict
+from typing import Any
+
+from .models import ValidationContext
+
+CHANGE_CONTEXTS = {"pr", "commit", "branch", "working-tree-change"}
+DIFF_KINDS = {"ADDED", "CHANGED", "REMOVED"}
+HUNK_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+
+
+def validate_changes(ctx: ValidationContext) -> None:
+    if any(check.name == "manifest.shape" and check.status == "fail" for check in ctx.checks):
+        ctx.add("changes.alignment", "fail", "change alignment cannot be checked until the manifest is valid")
+        return
+    errors: list[str] = []
+    context = ctx.manifest["context"]
+    states = ctx.manifest["states"]
+    labels = [state["label"] for state in states]
+    kind = context["kind"]
+    if kind == "overview" and labels != ["Current"]:
+        errors.append("overview context requires exactly the Current state")
+    elif kind == "issue" and labels != ["Current", "Expected (proposed)"]:
+        errors.append("issue context requires Current and Expected (proposed) states")
+    elif kind in CHANGE_CONTEXTS and labels != ["Before", "After"]:
+        errors.append(f"{kind} context requires complete Before and After states")
+    if kind in CHANGE_CONTEXTS and len(states) == 2:
+        sources = context["sources"]
+        if states[0]["revision"] != sources.get("base_revision"):
+            errors.append("Before state revision must equal context.sources.base_revision")
+        if states[1]["revision"] != sources.get("head_revision"):
+            errors.append("After state revision must equal context.sources.head_revision")
+
+    annotations = ctx.manifest["annotations"]
+    state_by_id = ctx.state_map()
+    for annotation in annotations:
+        label = state_by_id[annotation["state"]]["label"]
+        annotation_kind = annotation["kind"]
+        if annotation_kind == "BUG" and label not in {"Before", "Current"}:
+            errors.append("BUG is allowed only in Before or Current")
+        if annotation_kind == "FIX" and label not in {"After", "Expected (proposed)"}:
+            errors.append("FIX is allowed only in After or Expected (proposed)")
+        if annotation_kind == "REMOVED" and label != "Before":
+            errors.append("REMOVED must target Before")
+        if annotation_kind in {"ADDED", "CHANGED"} and label != "After":
+            errors.append(f"{annotation_kind} must target After")
+        if annotation_kind in DIFF_KINDS and kind not in CHANGE_CONTEXTS:
+            errors.append(f"{annotation_kind} requires a PR, commit, branch, or working-tree change context")
+
+    if context["change_kind"] == "bug" and kind == "pr":
+        issue_number = context["sources"].get("issue")
+        if not isinstance(issue_number, int):
+            errors.append("bug-fix PR requires context.sources.issue")
+        elif ctx.parsed and not re.search(rf"(?im)^Fixes\s+#{issue_number}\s*$", ctx.parsed.text):
+            errors.append(f"bug-fix PR document requires a standalone 'Fixes #{issue_number}' line")
+
+    diff_annotations = [annotation for annotation in annotations if annotation["kind"] in DIFF_KINDS]
+    if diff_annotations:
+        diff = _load_diff(ctx, errors)
+        if diff is not None:
+            for annotation in diff_annotations:
+                _validate_annotation_hunk(ctx, annotation, diff, errors)
+
+    if errors:
+        ctx.add("changes.alignment", "fail", "state or diff annotations are invalid", errors)
+    else:
+        ctx.add("changes.alignment", "pass", "state labels and change annotations align with their evidence")
+
+
+def _load_diff(ctx: ValidationContext, errors: list[str]) -> dict[str, dict[str, list[tuple[int, int]]]] | None:
+    sources = ctx.manifest["context"]["sources"]
+    base = sources.get("base_revision")
+    head = sources.get("head_revision")
+    if not isinstance(base, str) or not isinstance(head, str):
+        errors.append("diff annotations require context.sources.base_revision and head_revision")
+        return None
+    command = ["git", "diff", "--unified=0", "--no-ext-diff", base]
+    if head != "WORKTREE":
+        command.append(head)
+    result = subprocess.run(command, cwd=ctx.repo, text=True, capture_output=True, check=False)
+    if result.returncode != 0:
+        errors.append(f"cannot resolve diff {base}..{head}: {result.stderr.strip()}")
+        return None
+    return _parse_diff(result.stdout)
+
+
+def _parse_diff(text: str) -> dict[str, dict[str, list[tuple[int, int]]]]:
+    ranges: dict[str, dict[str, list[tuple[int, int]]]] = defaultdict(lambda: {"before": [], "after": []})
+    path: str | None = None
+    for line in text.splitlines():
+        if line.startswith("+++ b/"):
+            path = line[6:]
+            continue
+        if line.startswith("--- a/") and path is None:
+            path = line[6:]
+            continue
+        match = HUNK_RE.match(line)
+        if not match or path is None:
+            continue
+        old_start, old_count, new_start, new_count = (int(value) if value else None for value in match.groups())
+        old_count = 1 if old_count is None else old_count
+        new_count = 1 if new_count is None else new_count
+        if old_count:
+            ranges[path]["before"].append((old_start, old_start + old_count - 1))
+        if new_count:
+            ranges[path]["after"].append((new_start, new_start + new_count - 1))
+    return ranges
+
+
+def _validate_annotation_hunk(
+    ctx: ValidationContext,
+    annotation: dict[str, Any],
+    diff: dict[str, dict[str, list[tuple[int, int]]]],
+    errors: list[str],
+) -> None:
+    item_type, item_id = annotation["target"].split(":", 1)
+    item = ctx.item_map(item_type).get(item_id)
+    if item is None:
+        return
+    state_id = annotation["state"]
+    side = "before" if annotation["kind"] == "REMOVED" else "after"
+    evidence = [
+        value for value in item["evidence"]
+        if value["type"] == "source" and value["state"] == state_id
+    ]
+    if not evidence:
+        errors.append(f"{annotation['kind']} target {annotation['target']} lacks source evidence")
+        return
+    if not any(
+        _intersects(value["line_start"], value["line_end"], start, end)
+        for value in evidence
+        for start, end in diff.get(value["path"], {}).get(side, [])
+    ):
+        errors.append(
+            f"{annotation['kind']} target {annotation['target']} does not intersect a {side} diff hunk"
+        )
+    if annotation["kind"] == "CHANGED":
+        before_states = [
+            state["id"] for state in ctx.manifest["states"] if state["label"] == "Before"
+        ]
+        before_evidence = [
+            value for value in item["evidence"]
+            if value["type"] == "source" and value["state"] in before_states
+        ]
+        if not before_evidence or not any(
+            _intersects(value["line_start"], value["line_end"], start, end)
+            for value in before_evidence
+            for start, end in diff.get(value["path"], {}).get("before", [])
+        ):
+            errors.append(f"CHANGED target {annotation['target']} must also intersect a Before diff hunk")
+
+
+def _intersects(left_start: int, left_end: int, right_start: int, right_end: int) -> bool:
+    return left_start <= right_end and right_start <= left_end

--- a/.agents/skills/boxlite-diagrams/scripts/validator/consistency.py
+++ b/.agents/skills/boxlite-diagrams/scripts/validator/consistency.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from .models import ValidationContext
+
+VIEWS = ("architecture", "sequence", "call_graph")
+
+
+def validate_consistency(ctx: ValidationContext) -> None:
+    if ctx.parsed is None:
+        ctx.add("consistency.cross_view", "fail", "cross-view consistency requires a parsed document")
+        return
+    errors: list[str] = []
+    for state in ctx.state_map():
+        for view in VIEWS:
+            expected_nodes = {
+                item["id"] for item in ctx.manifest.get("nodes", [])
+                if state in item.get("states", []) and view in item.get("views", [])
+            }
+            expected_edges = {
+                item["id"] for item in ctx.manifest.get("edges", [])
+                if state in item.get("states", []) and view in item.get("views", [])
+            }
+            actual_nodes = _actual_node_ids(ctx, view, state)
+            actual_edges = _actual_edge_ids(ctx, view, state)
+            if actual_nodes != expected_nodes:
+                errors.append(
+                    f"{view}/{state} nodes disagree: missing={sorted(expected_nodes - actual_nodes)}, "
+                    f"undeclared={sorted(actual_nodes - expected_nodes)}"
+                )
+            if actual_edges != expected_edges:
+                errors.append(
+                    f"{view}/{state} edges disagree: missing={sorted(expected_edges - actual_edges)}, "
+                    f"undeclared={sorted(actual_edges - expected_edges)}"
+                )
+            _check_endpoints(ctx, view, state, errors)
+            _check_labels(ctx, view, state, errors)
+    _check_mermaid_annotations(ctx, errors)
+    if errors:
+        ctx.add("consistency.cross_view", "fail", "diagram views disagree with the evidence manifest", errors)
+    else:
+        ctx.add("consistency.cross_view", "pass", "canonical nodes and edges agree across all declared views")
+
+
+def _actual_node_ids(ctx: ValidationContext, view: str, state: str) -> set[str]:
+    values = {
+        "architecture": ctx.parsed.architecture_nodes,
+        "sequence": ctx.parsed.sequence_nodes,
+        "call_graph": ctx.parsed.call_graph_nodes,
+    }[view]
+    return {item_id for (item_state, item_id) in values if item_state == state}
+
+
+def _actual_edge_ids(ctx: ValidationContext, view: str, state: str) -> set[str]:
+    values = {
+        "architecture": ctx.parsed.architecture_edges,
+        "sequence": ctx.parsed.sequence_edges,
+        "call_graph": ctx.parsed.call_graph_edges,
+    }[view]
+    return {item_id for (item_state, item_id) in values if item_state == state}
+
+
+def _check_endpoints(ctx: ValidationContext, view: str, state: str, errors: list[str]) -> None:
+    actual = {
+        "architecture": ctx.parsed.architecture_edges,
+        "sequence": ctx.parsed.sequence_edges,
+        "call_graph": ctx.parsed.call_graph_edges,
+    }[view]
+    manifest_edges = ctx.item_map("edge")
+    for (item_state, edge_id), endpoints in actual.items():
+        if item_state != state or edge_id not in manifest_edges:
+            continue
+        edge = manifest_edges[edge_id]
+        if endpoints != (edge["from"], edge["to"]):
+            errors.append(f"{view}/{state} edge {edge_id!r} endpoints {endpoints} disagree with manifest")
+
+
+def _check_labels(ctx: ValidationContext, view: str, state: str, errors: list[str]) -> None:
+    if view == "call_graph":
+        return
+    node_labels = ctx.parsed.architecture_nodes if view == "architecture" else ctx.parsed.sequence_nodes
+    edge_labels = ctx.parsed.architecture_edge_labels if view == "architecture" else ctx.parsed.sequence_edge_labels
+    for (item_state, item_id), label in node_labels.items():
+        if item_state == state and item_id in ctx.item_map("node"):
+            expected = ctx.item_map("node")[item_id]["label"]
+            if expected.lower() not in label.lower():
+                errors.append(f"{view}/{state} node {item_id!r} label does not contain {expected!r}")
+    for (item_state, item_id), label in edge_labels.items():
+        if item_state == state and item_id in ctx.item_map("edge"):
+            expected = ctx.item_map("edge")[item_id]["label"]
+            if expected.lower() not in label.lower():
+                errors.append(f"{view}/{state} edge {item_id!r} label does not contain {expected!r}")
+
+
+def _check_mermaid_annotations(ctx: ValidationContext, errors: list[str]) -> None:
+    for annotation in ctx.manifest.get("annotations", []):
+        item_type, item_id = annotation["target"].split(":", 1)
+        item = ctx.item_map(item_type).get(item_id, {})
+        marker = f"{annotation['kind']}: {annotation['text']}".lower()
+        for view in ("architecture", "sequence"):
+            if view not in item.get("views", []):
+                continue
+            labels = _labels_for(ctx, view, item_type)
+            label = labels.get((annotation["state"], item_id), "")
+            if marker not in label.lower():
+                errors.append(
+                    f"{view}/{annotation['state']} is missing {annotation['kind']}: "
+                    f"{annotation['text']} on {annotation['target']}"
+                )
+
+
+def _labels_for(ctx: ValidationContext, view: str, item_type: str) -> dict[tuple[str, str], str]:
+    if view == "architecture":
+        return ctx.parsed.architecture_nodes if item_type == "node" else ctx.parsed.architecture_edge_labels
+    return ctx.parsed.sequence_nodes if item_type == "node" else ctx.parsed.sequence_edge_labels

--- a/.agents/skills/boxlite-diagrams/scripts/validator/consistency.py
+++ b/.agents/skills/boxlite-diagrams/scripts/validator/consistency.py
@@ -93,7 +93,12 @@ def _check_labels(ctx: ValidationContext, view: str, state: str, errors: list[st
 
 def _check_mermaid_annotations(ctx: ValidationContext, errors: list[str]) -> None:
     for annotation in ctx.manifest.get("annotations", []):
-        item_type, item_id = annotation["target"].split(":", 1)
+        target = annotation.get("target")
+        if not isinstance(target, str) or ":" not in target:
+            continue
+        item_type, item_id = target.split(":", 1)
+        if item_type not in {"node", "edge"}:
+            continue
         item = ctx.item_map(item_type).get(item_id, {})
         marker = f"{annotation['kind']}: {annotation['text']}".lower()
         for view in ("architecture", "sequence"):

--- a/.agents/skills/boxlite-diagrams/scripts/validator/document.py
+++ b/.agents/skills/boxlite-diagrams/scripts/validator/document.py
@@ -51,7 +51,7 @@ def validate_document(ctx: ValidationContext) -> None:
     for line_number, line in enumerate(lines, start=1):
         if fence is not None:
             language, start_line, content = fence
-            if line == "```":
+            if line.rstrip() == "```":
                 if current_view is None or current_state is None or current_label is None:
                     errors.append(f"line {start_line}: fenced block is outside a view/state section")
                 else:

--- a/.agents/skills/boxlite-diagrams/scripts/validator/document.py
+++ b/.agents/skills/boxlite-diagrams/scripts/validator/document.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import re
+from collections import Counter
+
+from .models import ParsedDocument, StateBlock, ValidationContext
+
+VIEW_HEADINGS = {
+    "Architecture": "architecture",
+    "Sequence": "sequence",
+    "Call graph": "call_graph",
+}
+VIEW_ORDER = ["architecture", "sequence", "call_graph"]
+EXPECTED_LANGUAGES = {
+    "architecture": "mermaid",
+    "sequence": "mermaid",
+    "call_graph": "text",
+}
+
+H2_RE = re.compile(r"^##\s+(.+?)\s*$")
+H3_RE = re.compile(r"^###\s+(.+?)\s*$")
+FENCE_RE = re.compile(r"^```([A-Za-z0-9_-]*)\s*$")
+
+
+def validate_document(ctx: ValidationContext) -> None:
+    try:
+        text = ctx.document_path.read_text(encoding="utf-8")
+    except OSError as error:
+        ctx.add("document.read", "fail", f"cannot read diagram document: {error}")
+        return
+
+    parsed = ParsedDocument(text=text)
+    ctx.parsed = parsed
+    states = ctx.manifest.get("states", [])
+    state_by_label = {state.get("label"): state.get("id") for state in states}
+    expected_pairs = {
+        (view, state.get("id")) for view in VIEW_ORDER for state in states if state.get("id")
+    }
+
+    lines = text.splitlines()
+    current_view: str | None = None
+    current_state: str | None = None
+    current_label: str | None = None
+    view_order: list[str] = []
+    view_counts: Counter[str] = Counter()
+    fence: tuple[str, int, list[str]] | None = None
+    seen_pairs: Counter[tuple[str, str]] = Counter()
+    state_order_by_view: dict[str, list[str]] = {view: [] for view in VIEW_ORDER}
+    errors: list[str] = []
+
+    for line_number, line in enumerate(lines, start=1):
+        if fence is not None:
+            language, start_line, content = fence
+            if line == "```":
+                if current_view is None or current_state is None or current_label is None:
+                    errors.append(f"line {start_line}: fenced block is outside a view/state section")
+                else:
+                    pair = (current_view, current_state)
+                    seen_pairs[pair] += 1
+                    if pair not in parsed.blocks:
+                        parsed.blocks[pair] = StateBlock(
+                            view=current_view,
+                            state=current_state,
+                            label=current_label,
+                            language=language,
+                            content="\n".join(content).strip("\n") + "\n",
+                            start_line=start_line,
+                        )
+                fence = None
+            else:
+                content.append(line)
+            continue
+
+        fence_match = FENCE_RE.match(line)
+        if fence_match:
+            fence = (fence_match.group(1), line_number, [])
+            continue
+
+        h2_match = H2_RE.match(line)
+        if h2_match:
+            heading = h2_match.group(1)
+            if heading not in VIEW_HEADINGS:
+                errors.append(f"line {line_number}: unexpected level-two heading {heading!r}")
+                current_view = None
+                current_state = None
+                current_label = None
+                continue
+            current_view = VIEW_HEADINGS[heading]
+            current_state = None
+            current_label = None
+            view_counts[current_view] += 1
+            view_order.append(current_view)
+            continue
+
+        h3_match = H3_RE.match(line)
+        if h3_match and current_view is not None:
+            label = h3_match.group(1)
+            state_id = state_by_label.get(label)
+            if state_id is None:
+                errors.append(f"line {line_number}: unknown state heading {label!r}")
+                current_state = None
+                current_label = None
+            else:
+                current_state = state_id
+                current_label = label
+                state_order_by_view[current_view].append(state_id)
+
+    if fence is not None:
+        errors.append(f"line {fence[1]}: unterminated fenced block")
+
+    if view_order != VIEW_ORDER:
+        errors.append(f"view order must be {VIEW_ORDER}; found {view_order}")
+    for view in VIEW_ORDER:
+        if view_counts[view] != 1:
+            errors.append(f"view {view!r} must occur exactly once; found {view_counts[view]}")
+        expected_state_order = [state.get("id") for state in states if state.get("id")]
+        if state_order_by_view[view] != expected_state_order:
+            errors.append(
+                f"view {view!r} state order must be {expected_state_order}; found {state_order_by_view[view]}"
+            )
+    for pair in sorted(expected_pairs):
+        if seen_pairs[pair] != 1:
+            errors.append(f"{pair[0]}/{pair[1]} must contain exactly one fenced block; found {seen_pairs[pair]}")
+        block = parsed.blocks.get(pair)
+        if block and block.language != EXPECTED_LANGUAGES[pair[0]]:
+            errors.append(
+                f"{pair[0]}/{pair[1]} must use a {EXPECTED_LANGUAGES[pair[0]]!r} fence; "
+                f"found {block.language!r}"
+            )
+
+    unexpected = set(parsed.blocks) - expected_pairs
+    for pair in sorted(unexpected):
+        errors.append(f"unexpected view/state block {pair[0]}/{pair[1]}")
+
+    if errors:
+        ctx.add("document.structure", "fail", "diagram document structure is invalid", errors)
+    else:
+        ctx.add(
+            "document.structure",
+            "pass",
+            "all required views and states have exactly one correctly typed block",
+            [f"{view}/{state}" for view, state in sorted(expected_pairs)],
+        )
+
+    _validate_diagram_kinds(ctx)
+
+
+def _validate_diagram_kinds(ctx: ValidationContext) -> None:
+    if ctx.parsed is None:
+        return
+    errors: list[str] = []
+    for (view, state), block in ctx.parsed.blocks.items():
+        first = next((line.strip() for line in block.content.splitlines() if line.strip()), "")
+        if view == "architecture" and not re.match(r"^(flowchart|graph)\s+(LR|RL|TB|TD|BT)\b", first):
+            errors.append(f"architecture/{state} must begin with a directed flowchart or graph declaration")
+        if view == "sequence" and first != "sequenceDiagram":
+            errors.append(f"sequence/{state} must begin with 'sequenceDiagram'")
+    if errors:
+        ctx.add("document.diagram_kinds", "fail", "unsupported Mermaid diagram kind", errors)
+    else:
+        ctx.add("document.diagram_kinds", "pass", "architecture and sequence diagram kinds are supported")

--- a/.agents/skills/boxlite-diagrams/scripts/validator/mermaid.py
+++ b/.agents/skills/boxlite-diagrams/scripts/validator/mermaid.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import html
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+
+from .models import StateBlock, ValidationContext
+
+VERSION = "11.16.0"
+UNSAFE_PATTERNS = [
+    (re.compile(r"%%\{"), "initialization directives"),
+    (re.compile(r"(?im)^\s*click\s+"), "click directives"),
+    (re.compile(r"(?i)javascript\s*:"), "javascript URLs"),
+    (re.compile(r"(?i)https?://|\bhref\s*="), "external links"),
+    (re.compile(r"<\s*/?\s*[A-Za-z][^>]*>"), "raw HTML"),
+]
+NODE_RE = re.compile(r'^\s*([a-z][a-z0-9_]*)\s*(?:\[\[|\[\(|\[|\(\(|\(|\{\{\{|\{\{|\{|>)\s*["\']?(.+?)["\']?\s*(?:\]\]|\)\]|\]|\)\)|\)|\}\}\}|\}\}|\}|\])\s*$')
+EDGE_RE = re.compile(
+    r'^\s*([a-z][a-z0-9_]*)\s+([a-z][a-z0-9_]*)@(?:-->|---|-.->|==>|--o|--x|o--o|x--x|<-->|<-.->|<==>)'
+    r'(?:\|["\']?([^|]+?)["\']?\|)?\s*([a-z][a-z0-9_]*)\s*$'
+)
+PARTICIPANT_RE = re.compile(r"^\s*(?:participant|actor)\s+([a-z][a-z0-9_]*)\s+as\s+(.+?)\s*$")
+EDGE_COMMENT_RE = re.compile(r"^\s*%%\s*edge:([a-z][a-z0-9_]*)\s*$")
+MESSAGE_RE = re.compile(
+    r"^\s*([a-z][a-z0-9_]*)\s*(?:-->>|->>|-->|->|-x|--x|-\)|--\))\s*([a-z][a-z0-9_]*)\s*:\s*(.+?)\s*$"
+)
+
+
+def validate_mermaid(ctx: ValidationContext) -> None:
+    if ctx.parsed is None:
+        ctx.add("mermaid.syntax", "fail", "Mermaid cannot be checked until the document is parsed")
+        return
+    errors: list[str] = []
+    for (view, state), block in ctx.parsed.blocks.items():
+        if view not in {"architecture", "sequence"}:
+            continue
+        for pattern, description in UNSAFE_PATTERNS:
+            if pattern.search(block.content):
+                errors.append(f"{view}/{state} contains forbidden {description}")
+        if view == "architecture":
+            _parse_architecture(ctx, state, block, errors)
+        else:
+            _parse_sequence(ctx, state, block, errors)
+    if errors:
+        ctx.add("mermaid.structure_security", "fail", "Mermaid structure or security checks failed", errors)
+    else:
+        ctx.add("mermaid.structure_security", "pass", "Mermaid IDs, edges, and security rules are valid")
+    _render_all(ctx)
+
+
+def _parse_architecture(ctx: ValidationContext, state: str, block: StateBlock, errors: list[str]) -> None:
+    for offset, line in enumerate(block.content.splitlines()[1:], start=1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("%%") or stripped.startswith(("subgraph ", "end", "direction ", "classDef ", "class ")):
+            continue
+        edge = EDGE_RE.match(line)
+        if edge:
+            source, edge_id, label, target = edge.groups()
+            key = (state, edge_id)
+            if key in ctx.parsed.architecture_edges:
+                errors.append(f"architecture/{state} duplicates edge ID {edge_id!r}")
+            ctx.parsed.architecture_edges[key] = (source, target)
+            ctx.parsed.architecture_edge_labels[key] = _clean_label(label or "")
+            continue
+        node = NODE_RE.match(line)
+        if node:
+            node_id, label = node.groups()
+            key = (state, node_id)
+            if key in ctx.parsed.architecture_nodes:
+                errors.append(f"architecture/{state} duplicates node ID {node_id!r}")
+            ctx.parsed.architecture_nodes[key] = _clean_label(label)
+            continue
+        if re.search(r"(?:-->|---|-.->|==>|--o|--x)", line):
+            errors.append(f"architecture/{state} line {block.start_line + offset} has an arrow without a canonical edge ID")
+
+
+def _parse_sequence(ctx: ValidationContext, state: str, block: StateBlock, errors: list[str]) -> None:
+    pending_edge: str | None = None
+    for offset, line in enumerate(block.content.splitlines()[1:], start=1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        edge_comment = EDGE_COMMENT_RE.match(line)
+        if edge_comment:
+            if pending_edge is not None:
+                errors.append(f"sequence/{state} edge {pending_edge!r} is not followed by a message")
+            pending_edge = edge_comment.group(1)
+            continue
+        participant = PARTICIPANT_RE.match(line)
+        if participant:
+            if pending_edge is not None:
+                errors.append(f"sequence/{state} edge {pending_edge!r} is not immediately before a message")
+                pending_edge = None
+            node_id, label = participant.groups()
+            key = (state, node_id)
+            if key in ctx.parsed.sequence_nodes:
+                errors.append(f"sequence/{state} duplicates participant ID {node_id!r}")
+            ctx.parsed.sequence_nodes[key] = _clean_label(label)
+            continue
+        message = MESSAGE_RE.match(line)
+        if message:
+            source, target, label = message.groups()
+            if pending_edge is None:
+                errors.append(f"sequence/{state} line {block.start_line + offset} has a message without %% edge:<id>")
+            else:
+                key = (state, pending_edge)
+                if key in ctx.parsed.sequence_edges:
+                    errors.append(f"sequence/{state} duplicates edge ID {pending_edge!r}")
+                ctx.parsed.sequence_edges[key] = (source, target)
+                ctx.parsed.sequence_edge_labels[key] = _clean_label(label)
+            pending_edge = None
+            continue
+        if pending_edge is not None:
+            errors.append(f"sequence/{state} edge {pending_edge!r} is not immediately before a message")
+            pending_edge = None
+    if pending_edge is not None:
+        errors.append(f"sequence/{state} edge {pending_edge!r} is not followed by a message")
+
+
+def _render_all(ctx: ValidationContext) -> None:
+    if shutil.which("npx") is None:
+        ctx.add("tool.mermaid_cli", "error", "npx is required to fetch pinned Mermaid CLI")
+        return
+    if ctx.parsed is None:
+        return
+    artifacts_dir = ctx.report_path.parent / f"{ctx.report_path.stem}-artifacts"
+    try:
+        artifacts_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as error:
+        ctx.add("mermaid.render", "fail", f"cannot create render directory: {error}")
+        return
+    errors: list[str] = []
+    tool_errors: list[str] = []
+    rendered: list[str] = []
+    for (view, state), block in ctx.parsed.blocks.items():
+        if view not in {"architecture", "sequence"}:
+            continue
+        input_path = artifacts_dir / f"{view}-{state}.mmd"
+        output_path = artifacts_dir / f"{view}-{state}.svg"
+        input_path.write_text(block.content, encoding="utf-8")
+        result = _run_mmdc(input_path, output_path, artifacts_dir)
+        if result is None:
+            ctx.add("tool.mermaid_cli", "error", "pinned Mermaid CLI could not be launched")
+            return
+        if result.returncode != 0:
+            detail = result.stderr.strip() or result.stdout.strip()
+            if _looks_like_tool_failure(detail):
+                tool_errors.append(f"{view}/{state}: {detail}")
+            else:
+                errors.append(f"{view}/{state}: {detail}")
+            continue
+        try:
+            svg = output_path.read_text(encoding="utf-8")
+        except OSError as error:
+            errors.append(f"{view}/{state}: rendered SVG is missing: {error}")
+            continue
+        if "<svg" not in svg or output_path.stat().st_size == 0:
+            errors.append(f"{view}/{state}: rendered SVG is empty")
+            continue
+        expected_labels = _expected_labels(ctx, view, state)
+        visible = _visible_svg_text(svg)
+        missing = [label for label in expected_labels if _normalize(label) not in visible]
+        if missing:
+            errors.append(f"{view}/{state}: SVG is missing manifest labels {missing}")
+            continue
+        ctx.parsed.rendered_svgs[(view, state)] = output_path
+        ctx.artifacts.extend([input_path, output_path])
+        rendered.append(str(output_path))
+    if tool_errors:
+        ctx.add("tool.mermaid_cli", "error", "pinned Mermaid CLI is unavailable", tool_errors)
+    elif errors:
+        ctx.add("mermaid.render", "fail", "one or more Mermaid diagrams did not render correctly", errors)
+    else:
+        ctx.add("mermaid.render", "pass", f"rendered with @mermaid-js/mermaid-cli@{VERSION}", rendered)
+
+
+def _run_mmdc(input_path: Path, output_path: Path, artifacts_dir: Path) -> subprocess.CompletedProcess[str] | None:
+    override = os.environ.get("BOXLITE_DIAGRAM_MMDC")
+    if override:
+        command = [*shlex.split(override), "-i", str(input_path), "-o", str(output_path), "-q"]
+        try:
+            return subprocess.run(command, text=True, capture_output=True, check=False)
+        except OSError:
+            return None
+    mermaid_config = artifacts_dir / "mermaid-config.json"
+    mermaid_config.write_text(json.dumps({"securityLevel": "strict", "htmlLabels": False}), encoding="utf-8")
+    command = [
+        "npx", "--yes", f"--package=@mermaid-js/mermaid-cli@{VERSION}", "mmdc",
+        "-i", str(input_path), "-o", str(output_path), "-c", str(mermaid_config), "-q",
+    ]
+    environment = os.environ.copy()
+    chrome = _find_chrome()
+    if chrome:
+        puppeteer_config = artifacts_dir / "puppeteer-config.json"
+        puppeteer_config.write_text(
+            json.dumps({"executablePath": chrome, "args": ["--no-sandbox", "--disable-setuid-sandbox"]}),
+            encoding="utf-8",
+        )
+        command.extend(["-p", str(puppeteer_config)])
+        environment["PUPPETEER_SKIP_DOWNLOAD"] = "true"
+    try:
+        return subprocess.run(command, text=True, capture_output=True, check=False, env=environment)
+    except OSError:
+        return None
+
+
+def _find_chrome() -> str | None:
+    candidates = [
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    ]
+    for name in ("google-chrome", "google-chrome-stable", "chromium", "chromium-browser"):
+        found = shutil.which(name)
+        if found:
+            candidates.append(found)
+    return next((candidate for candidate in candidates if Path(candidate).is_file()), None)
+
+
+def _looks_like_tool_failure(detail: str) -> bool:
+    lowered = detail.lower()
+    return any(
+        marker in lowered
+        for marker in (
+            "eai_again",
+            "enotfound",
+            "network request",
+            "could not resolve",
+            "unable to download",
+            "failed to launch the browser",
+            "could not find chrome",
+            "command not found",
+        )
+    )
+
+
+def _expected_labels(ctx: ValidationContext, view: str, state: str) -> list[str]:
+    labels: list[str] = []
+    for _item_type, item in ctx.items():
+        if view in item.get("views", []) and state in item.get("states", []):
+            labels.append(item["label"])
+    return labels
+
+
+def _visible_svg_text(svg: str) -> str:
+    without_tags = re.sub(r"<[^>]+>", " ", svg)
+    return _normalize(html.unescape(without_tags))
+
+
+def _normalize(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip().lower()
+
+
+def _clean_label(value: str) -> str:
+    return value.strip().strip('"\'').strip()

--- a/.agents/skills/boxlite-diagrams/scripts/validator/mermaid.py
+++ b/.agents/skills/boxlite-diagrams/scripts/validator/mermaid.py
@@ -19,6 +19,7 @@ UNSAFE_PATTERNS = [
     (re.compile(r"(?i)https?://|\bhref\s*="), "external links"),
 ]
 MERMAID_LEFT_ARROWS = ("<-->", "<-.->", "<==>")
+MERMAID_RIGHT_ARROWS = ("-->", "---", "-.->", "==>", "--o", "--x")
 NODE_RE = re.compile(r'^\s*([a-z][a-z0-9_]*)\s*(?:\[\[|\[\(|\[|\(\(|\(|\{\{\{|\{\{|\{|>)\s*["\']?(.+?)["\']?\s*(?:\]\]|\)\]|\]|\)\)|\)|\}\}\}|\}\}|\}|\])\s*$')
 EDGE_RE = re.compile(
     r'^\s*([a-z][a-z0-9_]*)\s+([a-z][a-z0-9_]*)@(?:-->|---|-.->|==>|--o|--x|o--o|x--x|<-->|<-.->|<==>)'
@@ -77,7 +78,7 @@ def _parse_architecture(ctx: ValidationContext, state: str, block: StateBlock, e
                 errors.append(f"architecture/{state} duplicates node ID {node_id!r}")
             ctx.parsed.architecture_nodes[key] = _clean_label(label)
             continue
-        if re.search(r"(?:-->|---|-.->|==>|--o|--x)", line):
+        if any(arrow in line for arrow in MERMAID_RIGHT_ARROWS):
             errors.append(f"architecture/{state} line {block.start_line + offset} has an arrow without a canonical edge ID")
 
 

--- a/.agents/skills/boxlite-diagrams/scripts/validator/mermaid.py
+++ b/.agents/skills/boxlite-diagrams/scripts/validator/mermaid.py
@@ -59,7 +59,7 @@ def validate_mermaid(ctx: ValidationContext) -> None:
 def _parse_architecture(ctx: ValidationContext, state: str, block: StateBlock, errors: list[str]) -> None:
     for offset, line in enumerate(block.content.splitlines()[1:], start=1):
         stripped = line.strip()
-        if not stripped or stripped.startswith("%%") or stripped.startswith(("subgraph ", "end", "direction ", "classDef ", "class ")):
+        if not stripped or stripped.startswith("%%") or stripped == "end" or stripped.startswith(("subgraph ", "direction ", "classDef ", "class ")):
             continue
         edge = EDGE_RE.match(line)
         if edge:
@@ -146,7 +146,11 @@ def _render_all(ctx: ValidationContext) -> None:
         input_path = artifacts_dir / f"{view}-{state}.mmd"
         output_path = artifacts_dir / f"{view}-{state}.svg"
         input_path.write_text(block.content, encoding="utf-8")
-        result = _run_mmdc(input_path, output_path, artifacts_dir)
+        try:
+            result = _run_mmdc(input_path, output_path, artifacts_dir)
+        except subprocess.TimeoutExpired:
+            ctx.add("tool.mermaid_cli", "error", f"Mermaid rendering exceeded {_command_timeout():g} seconds")
+            return
         if result is None:
             ctx.add("tool.mermaid_cli", "error", "pinned Mermaid CLI could not be launched")
             return
@@ -187,7 +191,7 @@ def _run_mmdc(input_path: Path, output_path: Path, artifacts_dir: Path) -> subpr
     if override:
         command = [*shlex.split(override), "-i", str(input_path), "-o", str(output_path), "-q"]
         try:
-            return subprocess.run(command, text=True, capture_output=True, check=False)
+            return subprocess.run(command, text=True, capture_output=True, check=False, timeout=_command_timeout())
         except OSError:
             return None
     mermaid_config = artifacts_dir / "mermaid-config.json"
@@ -207,7 +211,9 @@ def _run_mmdc(input_path: Path, output_path: Path, artifacts_dir: Path) -> subpr
         command.extend(["-p", str(puppeteer_config)])
         environment["PUPPETEER_SKIP_DOWNLOAD"] = "true"
     try:
-        return subprocess.run(command, text=True, capture_output=True, check=False, env=environment)
+        return subprocess.run(
+            command, text=True, capture_output=True, check=False, env=environment, timeout=_command_timeout()
+        )
     except OSError:
         return None
 
@@ -257,6 +263,15 @@ def _looks_like_tool_failure(detail: str) -> bool:
             "command not found",
         )
     )
+
+
+def _command_timeout() -> float:
+    raw = os.environ.get("BOXLITE_DIAGRAM_COMMAND_TIMEOUT", "120")
+    try:
+        value = float(raw)
+    except ValueError:
+        return 120.0
+    return value if value > 0 else 120.0
 
 
 def _expected_labels(ctx: ValidationContext, view: str, state: str) -> list[str]:

--- a/.agents/skills/boxlite-diagrams/scripts/validator/mermaid.py
+++ b/.agents/skills/boxlite-diagrams/scripts/validator/mermaid.py
@@ -17,8 +17,8 @@ UNSAFE_PATTERNS = [
     (re.compile(r"(?im)^\s*click\s+"), "click directives"),
     (re.compile(r"(?i)javascript\s*:"), "javascript URLs"),
     (re.compile(r"(?i)https?://|\bhref\s*="), "external links"),
-    (re.compile(r"<\s*/?\s*[A-Za-z][^>]*>"), "raw HTML"),
 ]
+MERMAID_LEFT_ARROWS = ("<-->", "<-.->", "<==>")
 NODE_RE = re.compile(r'^\s*([a-z][a-z0-9_]*)\s*(?:\[\[|\[\(|\[|\(\(|\(|\{\{\{|\{\{|\{|>)\s*["\']?(.+?)["\']?\s*(?:\]\]|\)\]|\]|\)\)|\)|\}\}\}|\}\}|\}|\])\s*$')
 EDGE_RE = re.compile(
     r'^\s*([a-z][a-z0-9_]*)\s+([a-z][a-z0-9_]*)@(?:-->|---|-.->|==>|--o|--x|o--o|x--x|<-->|<-.->|<==>)'
@@ -42,6 +42,8 @@ def validate_mermaid(ctx: ValidationContext) -> None:
         for pattern, description in UNSAFE_PATTERNS:
             if pattern.search(block.content):
                 errors.append(f"{view}/{state} contains forbidden {description}")
+        if _contains_html_markup(block.content):
+            errors.append(f"{view}/{state} contains forbidden raw HTML")
         if view == "architecture":
             _parse_architecture(ctx, state, block, errors)
         else:
@@ -219,6 +221,24 @@ def _find_chrome() -> str | None:
         if found:
             candidates.append(found)
     return next((candidate for candidate in candidates if Path(candidate).is_file()), None)
+
+
+def _contains_html_markup(content: str) -> bool:
+    for index, character in enumerate(content):
+        if character != "<":
+            continue
+        suffix = content[index:]
+        if suffix.startswith(MERMAID_LEFT_ARROWS):
+            continue
+        candidate = content[index + 1 :].lstrip()
+        if not candidate:
+            continue
+        if candidate[0] in "/!?":
+            return True
+        tag = re.match(r"[A-Za-z][A-Za-z0-9:-]*", candidate)
+        if tag and len(candidate) > tag.end() and candidate[tag.end()] in " \t\r\n/>":
+            return True
+    return False
 
 
 def _looks_like_tool_failure(detail: str) -> bool:

--- a/.agents/skills/boxlite-diagrams/scripts/validator/models.py
+++ b/.agents/skills/boxlite-diagrams/scripts/validator/models.py
@@ -54,7 +54,7 @@ class ValidationContext:
     document_path: Path
     evidence_path: Path
     report_path: Path
-    manifest: dict[str, Any]
+    manifest: Any
     checks: list[Check] = field(default_factory=list)
     parsed: ParsedDocument | None = None
     source_windows: dict[tuple[str, str, int, int], str] = field(default_factory=dict)
@@ -80,13 +80,19 @@ class ValidationContext:
         return any(check.status == "error" for check in self.checks)
 
     def items(self) -> list[tuple[str, dict[str, Any]]]:
+        if not isinstance(self.manifest, dict):
+            return []
         return [
             ("node", item) for item in self.manifest.get("nodes", [])
         ] + [("edge", item) for item in self.manifest.get("edges", [])]
 
     def item_map(self, item_type: str) -> dict[str, dict[str, Any]]:
+        if item_type not in {"node", "edge"} or not isinstance(self.manifest, dict):
+            return {}
         key = "nodes" if item_type == "node" else "edges"
         return {item["id"]: item for item in self.manifest.get(key, []) if "id" in item}
 
     def state_map(self) -> dict[str, dict[str, Any]]:
+        if not isinstance(self.manifest, dict):
+            return {}
         return {state["id"]: state for state in self.manifest.get("states", []) if "id" in state}

--- a/.agents/skills/boxlite-diagrams/scripts/validator/models.py
+++ b/.agents/skills/boxlite-diagrams/scripts/validator/models.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+Status = Literal["pass", "fail", "error"]
+
+
+@dataclass(frozen=True)
+class Check:
+    name: str
+    status: Status
+    message: str
+    evidence: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "status": self.status,
+            "message": self.message,
+            "evidence": list(self.evidence),
+        }
+
+
+@dataclass
+class StateBlock:
+    view: str
+    state: str
+    label: str
+    language: str
+    content: str
+    start_line: int
+
+
+@dataclass
+class ParsedDocument:
+    text: str
+    blocks: dict[tuple[str, str], StateBlock] = field(default_factory=dict)
+    architecture_nodes: dict[tuple[str, str], str] = field(default_factory=dict)
+    architecture_edges: dict[tuple[str, str], tuple[str, str]] = field(default_factory=dict)
+    architecture_edge_labels: dict[tuple[str, str], str] = field(default_factory=dict)
+    sequence_nodes: dict[tuple[str, str], str] = field(default_factory=dict)
+    sequence_edges: dict[tuple[str, str], tuple[str, str]] = field(default_factory=dict)
+    sequence_edge_labels: dict[tuple[str, str], str] = field(default_factory=dict)
+    call_graph_nodes: dict[tuple[str, str], dict[str, Any]] = field(default_factory=dict)
+    call_graph_edges: dict[tuple[str, str], tuple[str, str]] = field(default_factory=dict)
+    rendered_svgs: dict[tuple[str, str], Path] = field(default_factory=dict)
+
+
+@dataclass
+class ValidationContext:
+    repo: Path
+    document_path: Path
+    evidence_path: Path
+    report_path: Path
+    manifest: dict[str, Any]
+    checks: list[Check] = field(default_factory=list)
+    parsed: ParsedDocument | None = None
+    source_windows: dict[tuple[str, str, int, int], str] = field(default_factory=dict)
+    remote_issues: dict[int, dict[str, Any]] = field(default_factory=dict)
+    remote_prs: dict[int, dict[str, Any]] = field(default_factory=dict)
+    artifacts: list[Path] = field(default_factory=list)
+
+    def add(
+        self,
+        name: str,
+        status: Status,
+        message: str,
+        evidence: list[str] | tuple[str, ...] = (),
+    ) -> None:
+        self.checks.append(Check(name, status, message, tuple(evidence)))
+
+    @property
+    def has_failures(self) -> bool:
+        return any(check.status == "fail" for check in self.checks)
+
+    @property
+    def has_tool_errors(self) -> bool:
+        return any(check.status == "error" for check in self.checks)
+
+    def items(self) -> list[tuple[str, dict[str, Any]]]:
+        return [
+            ("node", item) for item in self.manifest.get("nodes", [])
+        ] + [("edge", item) for item in self.manifest.get("edges", [])]
+
+    def item_map(self, item_type: str) -> dict[str, dict[str, Any]]:
+        key = "nodes" if item_type == "node" else "edges"
+        return {item["id"]: item for item in self.manifest.get(key, []) if "id" in item}
+
+    def state_map(self) -> dict[str, dict[str, Any]]:
+        return {state["id"]: state for state in self.manifest.get("states", []) if "id" in state}

--- a/.agents/skills/boxlite-diagrams/scripts/validator/source.py
+++ b/.agents/skills/boxlite-diagrams/scripts/validator/source.py
@@ -1,0 +1,413 @@
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from .models import ValidationContext
+
+ID_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+KINDS = {"overview", "issue", "pr", "commit", "branch", "working-tree-change"}
+CHANGE_KINDS = {"none", "bug", "feature", "refactor", "docs"}
+VIEWS = {"architecture", "sequence", "call_graph"}
+EDGE_KINDS = {"call", "rpc", "dispatch", "spawn", "data", "state-transition", "proposed"}
+ANNOTATIONS = {"ISSUE", "BUG", "FIX", "PROPOSED", "ADDED", "CHANGED", "REMOVED"}
+ROOT_KEYS = {"schema_version", "context", "states", "nodes", "edges", "annotations"}
+CONTEXT_KEYS = {"kind", "change_kind", "sources"}
+SOURCE_KEYS = {"repository", "issue", "pr", "base_revision", "head_revision"}
+STATE_KEYS = {"id", "label", "revision", "proposed"}
+ITEM_KEYS = {"id", "label", "states", "views", "proposed", "evidence"}
+EDGE_KEYS = ITEM_KEYS | {"from", "to", "kind"}
+SOURCE_EVIDENCE_KEYS = {"type", "state", "revision", "path", "line_start", "line_end", "symbol", "tokens"}
+ISSUE_EVIDENCE_KEYS = {"type", "state", "issue", "tokens"}
+ANNOTATION_KEYS = {"kind", "target", "state", "text"}
+
+
+def validate_manifest(ctx: ValidationContext) -> None:
+    errors: list[str] = []
+    manifest = ctx.manifest
+    if not isinstance(manifest, dict):
+        ctx.add("manifest.shape", "fail", "evidence root must be a JSON object")
+        return
+    if manifest.get("schema_version") != 1:
+        errors.append("schema_version must be 1")
+    _reject_extra_keys(manifest, ROOT_KEYS, "manifest", errors)
+
+    context = manifest.get("context")
+    if not isinstance(context, dict):
+        errors.append("context must be an object")
+        context = {}
+    if context.get("kind") not in KINDS:
+        errors.append(f"context.kind must be one of {sorted(KINDS)}")
+    if context.get("change_kind") not in CHANGE_KINDS:
+        errors.append(f"context.change_kind must be one of {sorted(CHANGE_KINDS)}")
+    _reject_extra_keys(context, CONTEXT_KEYS, "context", errors)
+    sources = context.get("sources")
+    if not isinstance(sources, dict):
+        errors.append("context.sources must be an object")
+    else:
+        _reject_extra_keys(sources, SOURCE_KEYS, "context.sources", errors)
+
+    states = manifest.get("states")
+    if not isinstance(states, list) or not 1 <= len(states) <= 2:
+        errors.append("states must contain one or two entries")
+        states = []
+    state_ids: list[str] = []
+    state_labels: list[str] = []
+    for index, state in enumerate(states):
+        where = f"states[{index}]"
+        if not isinstance(state, dict):
+            errors.append(f"{where} must be an object")
+            continue
+        _reject_extra_keys(state, STATE_KEYS, where, errors)
+        state_id = state.get("id")
+        label = state.get("label")
+        if not isinstance(state_id, str) or not ID_RE.fullmatch(state_id):
+            errors.append(f"{where}.id must be lowercase snake case")
+        else:
+            state_ids.append(state_id)
+        if not isinstance(label, str) or not label.strip():
+            errors.append(f"{where}.label must be non-empty")
+        else:
+            state_labels.append(label)
+        if not isinstance(state.get("revision"), str) or not state.get("revision"):
+            errors.append(f"{where}.revision must be non-empty")
+        if not isinstance(state.get("proposed"), bool):
+            errors.append(f"{where}.proposed must be boolean")
+    if len(state_ids) != len(set(state_ids)):
+        errors.append("state IDs must be unique")
+    if len(state_labels) != len(set(state_labels)):
+        errors.append("state labels must be unique")
+
+    seen_item_ids: dict[str, str] = {}
+    node_ids: set[str] = set()
+    edge_ids: set[str] = set()
+    for collection, item_type in (("nodes", "node"), ("edges", "edge")):
+        values = manifest.get(collection)
+        minimum = 1 if collection == "nodes" else 0
+        if not isinstance(values, list) or len(values) < minimum:
+            errors.append(f"{collection} must be an array with at least {minimum} entries")
+            continue
+        for index, item in enumerate(values):
+            where = f"{collection}[{index}]"
+            if not isinstance(item, dict):
+                errors.append(f"{where} must be an object")
+                continue
+            _reject_extra_keys(item, EDGE_KEYS if item_type == "edge" else ITEM_KEYS, where, errors)
+            item_id = item.get("id")
+            if not isinstance(item_id, str) or not ID_RE.fullmatch(item_id):
+                errors.append(f"{where}.id must be lowercase snake case")
+                continue
+            if item_id in seen_item_ids:
+                errors.append(f"canonical ID {item_id!r} is reused by a {seen_item_ids[item_id]} and {item_type}")
+            seen_item_ids[item_id] = item_type
+            (node_ids if item_type == "node" else edge_ids).add(item_id)
+            if not isinstance(item.get("label"), str) or not item.get("label"):
+                errors.append(f"{where}.label must be non-empty")
+            item_states = item.get("states")
+            if not _unique_nonempty_subset(item_states, set(state_ids)):
+                errors.append(f"{where}.states must be a non-empty unique subset of declared states")
+                item_states = []
+            views = item.get("views")
+            if not _unique_nonempty_subset(views, VIEWS):
+                errors.append(f"{where}.views must be a non-empty unique subset of {sorted(VIEWS)}")
+            if not isinstance(item.get("proposed"), bool):
+                errors.append(f"{where}.proposed must be boolean")
+            elif item["proposed"]:
+                non_proposed_states = [
+                    state_id for state_id in item_states
+                    if not next((state["proposed"] for state in states if state.get("id") == state_id), False)
+                ]
+                if non_proposed_states:
+                    errors.append(f"{where} is proposed but belongs to implemented states {non_proposed_states}")
+            evidence = item.get("evidence")
+            if not isinstance(evidence, list) or not evidence:
+                errors.append(f"{where}.evidence must be a non-empty array")
+                continue
+            evidence_states: set[str] = set()
+            for evidence_index, entry in enumerate(evidence):
+                evidence_where = f"{where}.evidence[{evidence_index}]"
+                _validate_evidence_shape(entry, evidence_where, set(state_ids), errors)
+                if isinstance(entry, dict) and isinstance(entry.get("state"), str):
+                    evidence_states.add(entry["state"])
+            for state_id in item_states:
+                if state_id not in evidence_states:
+                    errors.append(f"{where} has no evidence for state {state_id!r}")
+            if item_type == "edge":
+                if item.get("from") not in node_ids and item.get("from") not in {
+                    node.get("id") for node in manifest.get("nodes", []) if isinstance(node, dict)
+                }:
+                    errors.append(f"{where}.from must reference a declared node")
+                if item.get("to") not in {
+                    node.get("id") for node in manifest.get("nodes", []) if isinstance(node, dict)
+                }:
+                    errors.append(f"{where}.to must reference a declared node")
+                if item.get("kind") not in EDGE_KINDS:
+                    errors.append(f"{where}.kind must be one of {sorted(EDGE_KINDS)}")
+
+    annotations = manifest.get("annotations")
+    if not isinstance(annotations, list):
+        errors.append("annotations must be an array")
+        annotations = []
+    valid_targets = {f"node:{item_id}" for item_id in node_ids} | {f"edge:{item_id}" for item_id in edge_ids}
+    for index, annotation in enumerate(annotations):
+        where = f"annotations[{index}]"
+        if not isinstance(annotation, dict):
+            errors.append(f"{where} must be an object")
+            continue
+        _reject_extra_keys(annotation, ANNOTATION_KEYS, where, errors)
+        if annotation.get("kind") not in ANNOTATIONS:
+            errors.append(f"{where}.kind must be one of {sorted(ANNOTATIONS)}")
+        if annotation.get("target") not in valid_targets:
+            errors.append(f"{where}.target must reference a declared item")
+        if annotation.get("state") not in state_ids:
+            errors.append(f"{where}.state must reference a declared state")
+        elif annotation.get("target") in valid_targets:
+            item_type, item_id = annotation["target"].split(":", 1)
+            target = next(
+                (item for item in manifest[f"{item_type}s"] if item.get("id") == item_id),
+                None,
+            )
+            if target is not None and annotation["state"] not in target.get("states", []):
+                errors.append(f"{where}.state is not a state of {annotation['target']}")
+        if not isinstance(annotation.get("text"), str) or not annotation.get("text"):
+            errors.append(f"{where}.text must be non-empty")
+
+    if errors:
+        ctx.add("manifest.shape", "fail", "evidence manifest is invalid", errors)
+    else:
+        ctx.add("manifest.shape", "pass", "evidence manifest has valid IDs, memberships, and references")
+
+
+def validate_source_evidence(ctx: ValidationContext) -> None:
+    if any(check.name == "manifest.shape" and check.status == "fail" for check in ctx.checks):
+        ctx.add("source.evidence", "fail", "source evidence cannot be checked until the manifest is valid")
+        return
+
+    errors: list[str] = []
+    for item_type, item in ctx.items():
+        for entry in item.get("evidence", []):
+            if entry["type"] == "source":
+                window = _read_source_window(ctx, entry, errors)
+                if window is None:
+                    continue
+                symbol_leaf = _symbol_leaf(entry["symbol"])
+                if not re.search(rf"\b{re.escape(symbol_leaf)}\b", window):
+                    errors.append(
+                        f"{item_type}:{item['id']} symbol {entry['symbol']!r} does not occur in "
+                        f"{entry['revision']}:{entry['path']}:{entry['line_start']}-{entry['line_end']}"
+                    )
+                for token in entry["tokens"]:
+                    if token not in window:
+                        errors.append(
+                            f"{item_type}:{item['id']} token {token!r} is absent from "
+                            f"{entry['revision']}:{entry['path']}:{entry['line_start']}-{entry['line_end']}"
+                        )
+                if item_type == "edge" and item.get("kind") == "call":
+                    caller = ctx.item_map("node").get(item["from"], {})
+                    caller_symbols = {
+                        value["symbol"] for value in caller.get("evidence", [])
+                        if value.get("type") == "source" and value.get("state") == entry["state"]
+                    }
+                    if entry["symbol"] not in caller_symbols:
+                        errors.append(
+                            f"edge:{item['id']} direct-call evidence must be anchored to caller node:{item['from']}"
+                        )
+                    callee = ctx.item_map("node").get(item["to"], {})
+                    callee_evidence = [
+                        value for value in callee.get("evidence", [])
+                        if value.get("type") == "source" and value.get("state") == entry["state"]
+                    ]
+                    if callee_evidence:
+                        callee_leaf = _symbol_leaf(callee_evidence[0]["symbol"])
+                        if not _has_call_expression(window, callee_leaf):
+                            errors.append(
+                                f"edge:{item['id']} direct-call evidence does not contain callee {callee_leaf!r}"
+                            )
+            elif entry["type"] == "issue":
+                issue = _load_issue(ctx, entry["issue"], errors)
+                if issue is None:
+                    continue
+                searchable = f"{issue.get('title', '')}\n{issue.get('body', '')}".lower()
+                for token in entry["tokens"]:
+                    if token.lower() not in searchable:
+                        errors.append(f"{item_type}:{item['id']} issue #{entry['issue']} lacks token {token!r}")
+
+        for state_id in item["states"]:
+            state = ctx.state_map()[state_id]
+            state_evidence = [value for value in item["evidence"] if value["state"] == state_id]
+            if state["proposed"] or item["proposed"]:
+                if not any(value["type"] == "issue" for value in state_evidence):
+                    errors.append(f"{item_type}:{item['id']} proposed state {state_id!r} requires issue evidence")
+            elif not any(value["type"] == "source" for value in state_evidence):
+                errors.append(f"{item_type}:{item['id']} implemented state {state_id!r} requires source evidence")
+
+    _validate_remote_context(ctx, errors)
+    if errors:
+        ctx.add("source.evidence", "fail", "source or remote evidence is invalid", errors)
+    else:
+        ctx.add("source.evidence", "pass", "all source anchors, symbols, tokens, and remote evidence resolve")
+
+
+def _unique_nonempty_subset(value: Any, allowed: set[str]) -> bool:
+    return (
+        isinstance(value, list)
+        and bool(value)
+        and all(isinstance(item, str) and item in allowed for item in value)
+        and len(value) == len(set(value))
+    )
+
+
+def _validate_evidence_shape(entry: Any, where: str, states: set[str], errors: list[str]) -> None:
+    if not isinstance(entry, dict):
+        errors.append(f"{where} must be an object")
+        return
+    if entry.get("state") not in states:
+        errors.append(f"{where}.state must reference a declared state")
+    tokens = entry.get("tokens")
+    if not isinstance(tokens, list) or not tokens or not all(isinstance(token, str) and token for token in tokens):
+        errors.append(f"{where}.tokens must be a non-empty string array")
+    if entry.get("type") == "source":
+        _reject_extra_keys(entry, SOURCE_EVIDENCE_KEYS, where, errors)
+        for key in ("revision", "path", "symbol"):
+            if not isinstance(entry.get(key), str) or not entry.get(key):
+                errors.append(f"{where}.{key} must be non-empty")
+        for key in ("line_start", "line_end"):
+            if not isinstance(entry.get(key), int) or entry.get(key, 0) < 1:
+                errors.append(f"{where}.{key} must be a positive integer")
+        if isinstance(entry.get("line_start"), int) and isinstance(entry.get("line_end"), int):
+            if entry["line_start"] > entry["line_end"]:
+                errors.append(f"{where}.line_start must not exceed line_end")
+        path = entry.get("path")
+        if isinstance(path, str) and (PurePosixPath(path).is_absolute() or ".." in PurePosixPath(path).parts):
+            errors.append(f"{where}.path must be a safe repository-relative path")
+    elif entry.get("type") == "issue":
+        _reject_extra_keys(entry, ISSUE_EVIDENCE_KEYS, where, errors)
+        if not isinstance(entry.get("issue"), int) or entry.get("issue", 0) < 1:
+            errors.append(f"{where}.issue must be a positive integer")
+    else:
+        errors.append(f"{where}.type must be 'source' or 'issue'")
+
+
+def _read_source_window(ctx: ValidationContext, entry: dict[str, Any], errors: list[str]) -> str | None:
+    key = (entry["revision"], entry["path"], entry["line_start"], entry["line_end"])
+    if key in ctx.source_windows:
+        return ctx.source_windows[key]
+    revision = entry["revision"]
+    path = entry["path"]
+    if revision == "WORKTREE":
+        source_path = (ctx.repo / path).resolve()
+        try:
+            source_path.relative_to(ctx.repo.resolve())
+        except ValueError:
+            errors.append(f"WORKTREE:{path} escapes the repository")
+            return None
+        try:
+            source = source_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as error:
+            errors.append(f"cannot read WORKTREE:{path}: {error}")
+            return None
+    else:
+        result = _run(ctx.repo, ["git", "show", f"{revision}:{path}"])
+        if result.returncode != 0:
+            errors.append(f"cannot resolve {revision}:{path}: {result.stderr.strip()}")
+            return None
+        source = result.stdout
+    lines = source.splitlines()
+    if entry["line_end"] > len(lines):
+        errors.append(
+            f"{revision}:{path}:{entry['line_start']}-{entry['line_end']} exceeds file length {len(lines)}"
+        )
+        return None
+    window = "\n".join(lines[entry["line_start"] - 1 : entry["line_end"]])
+    ctx.source_windows[key] = window
+    return window
+
+
+def _load_issue(ctx: ValidationContext, number: int, errors: list[str]) -> dict[str, Any] | None:
+    if number in ctx.remote_issues:
+        return ctx.remote_issues[number]
+    if shutil.which("gh") is None:
+        ctx.add("tool.gh", "error", "gh is required for issue or PR evidence")
+        return None
+    result = _run(ctx.repo, ["gh", "issue", "view", str(number), "--json", "number,title,body,state,url"])
+    if result.returncode != 0:
+        errors.append(f"cannot load issue #{number}: {result.stderr.strip()}")
+        return None
+    try:
+        issue = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        errors.append(f"gh returned invalid JSON for issue #{number}: {error}")
+        return None
+    ctx.remote_issues[number] = issue
+    return issue
+
+
+def _validate_remote_context(ctx: ValidationContext, errors: list[str]) -> None:
+    context = ctx.manifest["context"]
+    sources = context["sources"]
+    if context["kind"] == "issue":
+        if not isinstance(sources.get("issue"), int):
+            errors.append("issue context requires context.sources.issue")
+        else:
+            _load_issue(ctx, sources["issue"], errors)
+    if context["kind"] == "pr":
+        number = sources.get("pr")
+        if not isinstance(number, int):
+            errors.append("PR context requires context.sources.pr")
+        elif shutil.which("gh") is None:
+            ctx.add("tool.gh", "error", "gh is required for issue or PR evidence")
+        else:
+            result = _run(ctx.repo, ["gh", "pr", "view", str(number), "--json", "number,title,body,url,baseRefOid,headRefOid"])
+            if result.returncode != 0:
+                errors.append(f"cannot load PR #{number}: {result.stderr.strip()}")
+            else:
+                try:
+                    pr = json.loads(result.stdout)
+                    ctx.remote_prs[number] = pr
+                    base = sources.get("base_revision")
+                    head = sources.get("head_revision")
+                    if base != pr.get("baseRefOid"):
+                        errors.append(
+                            f"PR #{number} base revision is {pr.get('baseRefOid')}, not declared {base}"
+                        )
+                    if head != pr.get("headRefOid"):
+                        errors.append(
+                            f"PR #{number} head revision is {pr.get('headRefOid')}, not declared {head}"
+                        )
+                except json.JSONDecodeError as error:
+                    errors.append(f"gh returned invalid JSON for PR #{number}: {error}")
+        issue_number = sources.get("issue")
+        if issue_number is not None:
+            if not isinstance(issue_number, int):
+                errors.append("context.sources.issue must be a positive integer")
+            else:
+                _load_issue(ctx, issue_number, errors)
+
+
+def _symbol_leaf(symbol: str) -> str:
+    return re.split(r"::|\.", symbol)[-1].strip("<> ")
+
+
+def _has_call_expression(window: str, symbol: str) -> bool:
+    pattern = re.compile(rf"\b{re.escape(symbol)}\s*\(")
+    for line in window.splitlines():
+        if not pattern.search(line):
+            continue
+        if re.search(rf"\b(?:def|fn|function|class)\s+{re.escape(symbol)}\s*\(", line):
+            continue
+        return True
+    return False
+
+
+def _run(repo: Path, command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, cwd=repo, text=True, capture_output=True, check=False)
+
+
+def _reject_extra_keys(value: dict[str, Any], allowed: set[str], where: str, errors: list[str]) -> None:
+    extras = sorted(set(value) - allowed)
+    if extras:
+        errors.append(f"{where} contains unsupported fields {extras}")

--- a/.agents/skills/boxlite-diagrams/scripts/validator/source.py
+++ b/.agents/skills/boxlite-diagrams/scripts/validator/source.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -50,6 +51,12 @@ def validate_manifest(ctx: ValidationContext) -> None:
         errors.append("context.sources must be an object")
     else:
         _reject_extra_keys(sources, SOURCE_KEYS, "context.sources", errors)
+        for key in ("repository", "base_revision", "head_revision"):
+            if key in sources and not _valid_non_option_string(sources[key]):
+                errors.append(f"context.sources.{key} must be a non-empty, non-option string")
+        for key in ("issue", "pr"):
+            if key in sources and not _positive_integer(sources[key]):
+                errors.append(f"context.sources.{key} must be a positive integer")
 
     states = manifest.get("states")
     if not isinstance(states, list) or not 1 <= len(states) <= 2:
@@ -73,8 +80,8 @@ def validate_manifest(ctx: ValidationContext) -> None:
             errors.append(f"{where}.label must be non-empty")
         else:
             state_labels.append(label)
-        if not isinstance(state.get("revision"), str) or not state.get("revision"):
-            errors.append(f"{where}.revision must be non-empty")
+        if not _valid_non_option_string(state.get("revision")):
+            errors.append(f"{where}.revision must be a non-empty, non-option string")
         if not isinstance(state.get("proposed"), bool):
             errors.append(f"{where}.proposed must be boolean")
     if len(state_ids) != len(set(state_ids)):
@@ -191,6 +198,13 @@ def validate_source_evidence(ctx: ValidationContext) -> None:
     for item_type, item in ctx.items():
         for entry in item.get("evidence", []):
             if entry["type"] == "source":
+                state = ctx.state_map()[entry["state"]]
+                if entry["revision"] != state["revision"]:
+                    errors.append(
+                        f"{item_type}:{item['id']} evidence revision {entry['revision']!r} does not match "
+                        f"state {entry['state']!r} revision {state['revision']!r}"
+                    )
+                    continue
                 window = _read_source_window(ctx, entry, errors)
                 if window is None:
                     continue
@@ -272,9 +286,11 @@ def _validate_evidence_shape(entry: Any, where: str, states: set[str], errors: l
         errors.append(f"{where}.tokens must be a non-empty string array")
     if entry.get("type") == "source":
         _reject_extra_keys(entry, SOURCE_EVIDENCE_KEYS, where, errors)
-        for key in ("revision", "path", "symbol"):
+        for key in ("path", "symbol"):
             if not isinstance(entry.get(key), str) or not entry.get(key):
                 errors.append(f"{where}.{key} must be non-empty")
+        if not _valid_non_option_string(entry.get("revision")):
+            errors.append(f"{where}.revision must be a non-empty, non-option string")
         for key in ("line_start", "line_end"):
             if not isinstance(entry.get(key), int) or entry.get(key, 0) < 1:
                 errors.append(f"{where}.{key} must be a positive integer")
@@ -286,7 +302,7 @@ def _validate_evidence_shape(entry: Any, where: str, states: set[str], errors: l
             errors.append(f"{where}.path must be a safe repository-relative path")
     elif entry.get("type") == "issue":
         _reject_extra_keys(entry, ISSUE_EVIDENCE_KEYS, where, errors)
-        if not isinstance(entry.get("issue"), int) or entry.get("issue", 0) < 1:
+        if not _positive_integer(entry.get("issue")):
             errors.append(f"{where}.issue must be a positive integer")
     else:
         errors.append(f"{where}.type must be 'source' or 'issue'")
@@ -311,7 +327,7 @@ def _read_source_window(ctx: ValidationContext, entry: dict[str, Any], errors: l
             errors.append(f"cannot read WORKTREE:{path}: {error}")
             return None
     else:
-        result = _run(ctx.repo, ["git", "show", f"{revision}:{path}"])
+        result = _run(ctx.repo, ["git", "show", "--end-of-options", f"{revision}:{path}"])
         if result.returncode != 0:
             errors.append(f"cannot resolve {revision}:{path}: {result.stderr.strip()}")
             return None
@@ -334,6 +350,9 @@ def _load_issue(ctx: ValidationContext, number: int, errors: list[str]) -> dict[
         ctx.add("tool.gh", "error", "gh is required for issue or PR evidence")
         return None
     result = _run(ctx.repo, ["gh", "issue", "view", str(number), "--json", "number,title,body,state,url"])
+    if result.returncode == 124:
+        ctx.add("tool.gh", "error", result.stderr.strip())
+        return None
     if result.returncode != 0:
         errors.append(f"cannot load issue #{number}: {result.stderr.strip()}")
         return None
@@ -362,6 +381,9 @@ def _validate_remote_context(ctx: ValidationContext, errors: list[str]) -> None:
             ctx.add("tool.gh", "error", "gh is required for issue or PR evidence")
         else:
             result = _run(ctx.repo, ["gh", "pr", "view", str(number), "--json", "number,title,body,url,baseRefOid,headRefOid"])
+            if result.returncode == 124:
+                ctx.add("tool.gh", "error", result.stderr.strip())
+                return
             if result.returncode != 0:
                 errors.append(f"cannot load PR #{number}: {result.stderr.strip()}")
             else:
@@ -394,7 +416,7 @@ def _symbol_leaf(symbol: str) -> str:
 
 def _has_call_expression(window: str, symbol: str) -> bool:
     pattern = re.compile(rf"\b{re.escape(symbol)}\s*\(")
-    for line in window.splitlines():
+    for line in _strip_non_code(window).splitlines():
         if not pattern.search(line):
             continue
         if re.search(rf"\b(?:def|fn|function|class)\s+{re.escape(symbol)}\s*\(", line):
@@ -404,7 +426,88 @@ def _has_call_expression(window: str, symbol: str) -> bool:
 
 
 def _run(repo: Path, command: list[str]) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(command, cwd=repo, text=True, capture_output=True, check=False)
+    try:
+        return subprocess.run(
+            command, cwd=repo, text=True, capture_output=True, check=False, timeout=_command_timeout()
+        )
+    except subprocess.TimeoutExpired as error:
+        executable = Path(command[0]).name
+        message = f"{executable} exceeded {_command_timeout():g} seconds: {error}"
+        return subprocess.CompletedProcess(command, 124, "", message)
+
+
+def _strip_non_code(source: str) -> str:
+    output: list[str] = []
+    index = 0
+    quote: str | None = None
+    block_comment = False
+    while index < len(source):
+        current = source[index]
+        following = source[index + 1] if index + 1 < len(source) else ""
+        if block_comment:
+            if current == "*" and following == "/":
+                output.extend("  ")
+                index += 2
+                block_comment = False
+            else:
+                output.append("\n" if current == "\n" else " ")
+                index += 1
+            continue
+        if quote is not None:
+            if current == "\\" and index + 1 < len(source):
+                output.extend("  ")
+                index += 2
+            elif current == quote:
+                output.append(" ")
+                index += 1
+                quote = None
+            else:
+                output.append("\n" if current == "\n" else " ")
+                index += 1
+            continue
+        if current == "/" and following == "*":
+            output.extend("  ")
+            index += 2
+            block_comment = True
+        elif current == "/" and following == "/":
+            newline = source.find("\n", index)
+            if newline < 0:
+                output.extend(" " * (len(source) - index))
+                break
+            output.extend(" " * (newline - index))
+            index = newline
+        elif current == "#":
+            newline = source.find("\n", index)
+            if newline < 0:
+                output.extend(" " * (len(source) - index))
+                break
+            output.extend(" " * (newline - index))
+            index = newline
+        elif current in {'"', "'", "`"}:
+            quote = current
+            output.append(" ")
+            index += 1
+        else:
+            output.append(current)
+            index += 1
+    return "".join(output)
+
+
+def _valid_non_option_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip()) and not value.startswith("-")
+
+
+def _positive_integer(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+
+def _command_timeout() -> float:
+    raw = os.environ.get("BOXLITE_DIAGRAM_COMMAND_TIMEOUT", "120")
+    try:
+        value = float(raw)
+    except ValueError:
+        return 120.0
+    return value if value > 0 else 120.0
 
 
 def _reject_extra_keys(value: dict[str, Any], allowed: set[str], where: str, errors: list[str]) -> None:

--- a/.agents/skills/boxlite-diagrams/tests/test_validate_diagrams.py
+++ b/.agents/skills/boxlite-diagrams/tests/test_validate_diagrams.py
@@ -188,6 +188,19 @@ class DiagramValidatorTests(unittest.TestCase):
         self.assertEqual(result.returncode, 1)
         self.assert_check_failed(report, "mermaid.structure_security")
 
+    def test_malformed_html_comment_is_rejected(self) -> None:
+        document, manifest = overview_fixture(self.head)
+        document = document.replace('start["start"]', 'start["start<!-- unsafe --!>"]', 1)
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "mermaid.structure_security")
+
+    def test_mermaid_left_arrow_is_not_treated_as_html(self) -> None:
+        document, manifest = overview_fixture(self.head)
+        document = document.replace("start_load@-->", "start_load@<-->", 1)
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 0, json.dumps(report, indent=2))
+
     def test_proposed_behavior_without_issue_evidence_is_rejected(self) -> None:
         document, manifest = issue_fixture(self.head)
         for item in manifest["nodes"] + manifest["edges"]:

--- a/.agents/skills/boxlite-diagrams/tests/test_validate_diagrams.py
+++ b/.agents/skills/boxlite-diagrams/tests/test_validate_diagrams.py
@@ -6,11 +6,17 @@ import os
 import subprocess
 import sys
 import tempfile
+import threading
 import unittest
+from unittest import mock
 from pathlib import Path
 
 SKILL_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = SKILL_ROOT / "scripts" / "validate_diagrams.py"
+sys.path.insert(0, str(SKILL_ROOT / "scripts"))
+
+from validate_diagrams import _write_report
+from validator.changes import _parse_diff
 
 
 class DiagramValidatorTests(unittest.TestCase):
@@ -93,6 +99,43 @@ class DiagramValidatorTests(unittest.TestCase):
         result, report = self.validate(document, manifest)
         self.assertEqual(result.returncode, 1)
         self.assert_check_failed(report, "manifest.shape")
+
+    def test_array_manifest_writes_machine_readable_report(self) -> None:
+        document, _manifest = overview_fixture(self.head)
+        result, report = self.validate(document, [])
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "manifest.shape")
+
+    def test_malformed_annotation_target_writes_machine_readable_report(self) -> None:
+        document, manifest = issue_fixture(self.head)
+        manifest["annotations"][0]["target"] = "edge"
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "manifest.shape")
+
+    def test_context_source_values_follow_schema_types(self) -> None:
+        document, manifest = overview_fixture(self.head)
+        manifest["context"]["sources"]["repository"] = 1
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "manifest.shape")
+
+    def test_option_like_revision_is_rejected_at_manifest_boundary(self) -> None:
+        document, manifest = overview_fixture(self.head)
+        manifest["states"][0]["revision"] = "--help"
+        for item in manifest["nodes"] + manifest["edges"]:
+            for evidence in item["evidence"]:
+                evidence["revision"] = "--help"
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "manifest.shape")
+
+    def test_source_revision_must_match_its_state(self) -> None:
+        document, manifest = feature_pr_fixture(self.base, self.head)
+        manifest["nodes"][0]["evidence"][0]["revision"] = self.head
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "source.evidence")
 
     def test_stale_line_is_rejected(self) -> None:
         document, manifest = overview_fixture(self.head)
@@ -201,6 +244,96 @@ class DiagramValidatorTests(unittest.TestCase):
         result, report = self.validate(document, manifest)
         self.assertEqual(result.returncode, 0, json.dumps(report, indent=2))
 
+    def test_closing_fence_with_trailing_whitespace_is_accepted(self) -> None:
+        document, manifest = overview_fixture(self.head)
+        document = document.replace("```\n\n## Sequence", "``` \n\n## Sequence", 1)
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 0, json.dumps(report, indent=2))
+
+    def test_architecture_ids_starting_with_end_are_parsed(self) -> None:
+        document, manifest = overview_fixture(self.head)
+        document = document.replace('start["start"]', 'endpoint["start"]')
+        document = document.replace('load["load"]', 'end_state["load"]')
+        document = document.replace('start start_load@-->|"load"| load', 'endpoint endpoint_end_state@-->|"load"| end_state')
+        document = document.replace('participant start as start', 'participant endpoint as start')
+        document = document.replace('participant load as load', 'participant end_state as load')
+        document = document.replace('%% edge:start_load', '%% edge:endpoint_end_state')
+        document = document.replace('start->>load: load', 'endpoint->>end_state: load')
+        manifest["nodes"][0]["id"] = "endpoint"
+        manifest["nodes"][1]["id"] = "end_state"
+        manifest["edges"][0].update({"id": "endpoint_end_state", "from": "endpoint", "to": "end_state"})
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 0, json.dumps(report, indent=2))
+
+    def test_direct_call_in_python_comment_is_not_evidence(self) -> None:
+        self._assert_non_code_call_is_rejected("# load()", "comments.py")
+
+    def test_direct_call_in_rust_string_is_not_evidence(self) -> None:
+        self._assert_non_code_call_is_rejected('let note = "load()";', "comments.rs")
+
+    def test_mermaid_timeout_returns_tool_error(self) -> None:
+        document, manifest = overview_fixture(self.head)
+        sleeper = self.bin / "slow-mmdc"
+        sleeper.write_text("#!/bin/sh\nsleep 1\n", encoding="utf-8")
+        sleeper.chmod(0o755)
+        environment = self.env | {
+            "BOXLITE_DIAGRAM_MMDC": str(sleeper),
+            "BOXLITE_DIAGRAM_COMMAND_TIMEOUT": "0.05",
+        }
+        result, report = self.validate(document, manifest, environment=environment)
+        self.assertEqual(result.returncode, 2)
+        self.assertEqual(report["exit_code"], 2)
+
+    def test_gh_timeout_returns_tool_error(self) -> None:
+        document, manifest = issue_fixture(self.head)
+        (self.bin / "gh").write_text("#!/bin/sh\nsleep 1\n", encoding="utf-8")
+        environment = self.env | {"BOXLITE_DIAGRAM_COMMAND_TIMEOUT": "0.05"}
+        result, report = self.validate(document, manifest, environment=environment)
+        self.assertEqual(result.returncode, 2)
+        self.assertEqual(report["exit_code"], 2)
+
+    def test_deleted_file_hunks_use_the_deleted_path(self) -> None:
+        diff = _parse_diff(
+            "diff --git a/first.py b/first.py\n--- a/first.py\n+++ b/first.py\n@@ -1 +1 @@\n"
+            "diff --git a/deleted.py b/deleted.py\n--- a/deleted.py\n+++ /dev/null\n@@ -7,2 +0,0 @@\n"
+        )
+        self.assertEqual(diff["deleted.py"]["before"], [(7, 8)])
+        self.assertNotIn((7, 8), diff["first.py"]["before"])
+
+    def test_report_writes_use_unique_temporary_files(self) -> None:
+        report_path = self.root / "concurrent" / "validation.json"
+        barrier = threading.Barrier(2)
+        failures: list[BaseException] = []
+        original_write_text = Path.write_text
+
+        def synchronized_write(path: Path, *args: object, **kwargs: object) -> int:
+            written = original_write_text(path, *args, **kwargs)
+            if path.parent == report_path.parent and path != report_path:
+                barrier.wait(timeout=2)
+            return written
+
+        def write(value: int) -> None:
+            try:
+                _write_report(report_path, {"value": value})
+            except BaseException as error:
+                failures.append(error)
+
+        with mock.patch.object(Path, "write_text", synchronized_write):
+            threads = [threading.Thread(target=write, args=(value,)) for value in (1, 2)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join(timeout=3)
+        self.assertFalse(failures)
+        self.assertIn(json.loads(report_path.read_text(encoding="utf-8"))["value"], {1, 2})
+
+    def test_bug_marker_contract_requires_left_arrow(self) -> None:
+        contract = (SKILL_ROOT / "references" / "output-contract.md").read_text(encoding="utf-8")
+        skill = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+        evals = (SKILL_ROOT / "evals" / "evals.json").read_text(encoding="utf-8")
+        for content in (contract, skill, evals):
+            self.assertIn("← BUG:", content)
+
     def test_proposed_behavior_without_issue_evidence_is_rejected(self) -> None:
         document, manifest = issue_fixture(self.head)
         for item in manifest["nodes"] + manifest["edges"]:
@@ -227,7 +360,7 @@ class DiagramValidatorTests(unittest.TestCase):
         self.assertIn("@11.16.0", render["message"])
 
     def validate(
-        self, document: str, manifest: dict[str, object], environment: dict[str, str] | None = None
+        self, document: str, manifest: object, environment: dict[str, str] | None = None
     ) -> tuple[subprocess.CompletedProcess[str], dict[str, object]]:
         case = self.root / f"case-{len(list(self.root.glob('case-*')))}"
         case.mkdir()
@@ -242,6 +375,37 @@ class DiagramValidatorTests(unittest.TestCase):
             text=True, capture_output=True, check=False, env=environment or self.env,
         )
         return result, json.loads(report_path.read_text(encoding="utf-8"))
+
+    def _assert_non_code_call_is_rejected(self, body: str, path: str) -> None:
+        (self.repo / path).write_text(f"def fake():\n    {body}\n", encoding="utf-8")
+        self._run("git", "add", path)
+        self._run("git", "commit", "-q", "-m", f"add {path}")
+        revision = self._run("git", "rev-parse", "HEAD").stdout.strip()
+        states = [{"id": "current", "label": "Current", "revision": revision, "proposed": False}]
+        nodes = [
+            node("fake", "fake", ["current"], [
+                {"type": "source", "state": "current", "revision": revision, "path": path,
+                 "line_start": 1, "line_end": 2, "symbol": "fake", "tokens": ["fake", "load()"]}
+            ]),
+            node("load", "load", ["current"], [source_evidence("current", revision, "load", 8, 9, "def load")]),
+        ]
+        edges = [edge("fake_load", "load", "fake", "load", ["current"], [
+            {"type": "source", "state": "current", "revision": revision, "path": path,
+             "line_start": 1, "line_end": 2, "symbol": "fake", "tokens": ["load()"]}
+        ])]
+        document = diagrams(
+            [("current", "Current")],
+            {"current": [f"  fake (Module · {path}:1) — entry", "    └─ load (Module · app.py:8) — result"]},
+            {"current": [("fake_load", "fake", "load", "load")]},
+            {"current": [("fake", "fake"), ("load", "load")]},
+        )
+        data = manifest(
+            {"kind": "overview", "change_kind": "none", "sources": {"repository": "local"}},
+            states, nodes, edges,
+        )
+        result, report = self.validate(document, data)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "source.evidence")
 
     def assert_check_failed(self, report: dict[str, object], name: str) -> None:
         checks = {value["name"]: value for value in report["checks"]}

--- a/.agents/skills/boxlite-diagrams/tests/test_validate_diagrams.py
+++ b/.agents/skills/boxlite-diagrams/tests/test_validate_diagrams.py
@@ -1,0 +1,397 @@
+from __future__ import annotations
+
+import copy
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = SKILL_ROOT / "scripts" / "validate_diagrams.py"
+
+
+class DiagramValidatorTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.repo = self.root / "repo"
+        self.repo.mkdir()
+        self._run("git", "init", "-q")
+        self._run("git", "config", "user.email", "test@example.com")
+        self._run("git", "config", "user.name", "Test")
+        source = "def start():\n    return load()\n\ndef load():\n    return 'base'\n"
+        (self.repo / "app.py").write_text(source, encoding="utf-8")
+        self._run("git", "add", "app.py")
+        self._run("git", "commit", "-q", "-m", "base")
+        self.base = self._run("git", "rev-parse", "HEAD").stdout.strip()
+        source = (
+            "def start():\n    validate()\n    return load()\n\ndef validate():\n"
+            "    return True\n\ndef load():\n    return 'head'\n"
+        )
+        (self.repo / "app.py").write_text(source, encoding="utf-8")
+        self._run("git", "add", "app.py")
+        self._run("git", "commit", "-q", "-m", "head")
+        self.head = self._run("git", "rev-parse", "HEAD").stdout.strip()
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        self._write_fake_mmdc()
+        self._write_fake_gh()
+        self.env = os.environ.copy()
+        self.env["PATH"] = f"{self.bin}:{self.env['PATH']}"
+        self.env["BOXLITE_DIAGRAM_MMDC"] = str(self.bin / "fake-mmdc")
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def test_valid_overview(self) -> None:
+        result, report = self.validate(*overview_fixture(self.head))
+        self.assertEqual(result.returncode, 0, result.stderr + json.dumps(report, indent=2))
+        self.assertTrue(report["valid"])
+
+    def test_valid_unimplemented_issue(self) -> None:
+        document, manifest = issue_fixture(self.head)
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 0, json.dumps(report, indent=2))
+
+    def test_valid_feature_pr(self) -> None:
+        document, manifest = feature_pr_fixture(self.base, self.head)
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 0, json.dumps(report, indent=2))
+
+    def test_valid_bug_fix_pr(self) -> None:
+        document, manifest = bug_pr_fixture(self.base, self.head)
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 0, json.dumps(report, indent=2))
+
+    def test_missing_call_graph_state_is_rejected(self) -> None:
+        document, manifest = feature_pr_fixture(self.base, self.head)
+        document = document.replace("### After\n\n```text\n  start", "### After\n\n  start", 1)
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "document.structure")
+
+    def test_malformed_call_graph_hop_is_rejected(self) -> None:
+        document, manifest = overview_fixture(self.head)
+        document = document.replace("start (Module ·", "start Module ·")
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "call_graph.structure")
+
+    def test_fabricated_symbol_is_rejected(self) -> None:
+        document, manifest = overview_fixture(self.head)
+        manifest["nodes"][0]["evidence"][0]["symbol"] = "fabricated"
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "source.evidence")
+
+    def test_unknown_manifest_field_is_rejected(self) -> None:
+        document, manifest = overview_fixture(self.head)
+        manifest["nodes"][0]["untrusted"] = "ignored"
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "manifest.shape")
+
+    def test_stale_line_is_rejected(self) -> None:
+        document, manifest = overview_fixture(self.head)
+        evidence = manifest["nodes"][0]["evidence"][0]
+        evidence["line_start"] = 99
+        evidence["line_end"] = 99
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "source.evidence")
+
+    def test_real_symbols_with_unsupported_edge_are_rejected(self) -> None:
+        document, manifest = overview_fixture(self.head)
+        edge = manifest["edges"][0]
+        edge["evidence"][0]["line_start"] = 8
+        edge["evidence"][0]["line_end"] = 9
+        edge["evidence"][0]["symbol"] = "load"
+        edge["evidence"][0]["tokens"] = ["def load"]
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "source.evidence")
+
+    def test_bug_in_after_is_rejected(self) -> None:
+        document, manifest = bug_pr_fixture(self.base, self.head)
+        bug = next(value for value in manifest["annotations"] if value["kind"] == "BUG")
+        bug["state"] = "after"
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "changes.alignment")
+
+    def test_bug_marker_in_prose_is_rejected(self) -> None:
+        document, manifest = bug_pr_fixture(self.base, self.head)
+        document = document.replace(" — load result ← BUG: stale result", " — load result\nBUG: stale result")
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "call_graph.structure")
+
+    def test_incorrect_diff_annotation_is_rejected(self) -> None:
+        document, manifest = feature_pr_fixture(self.base, self.head)
+        added = next(value for value in manifest["annotations"] if value["kind"] == "ADDED")
+        added["target"] = "node:load"
+        load = next(value for value in manifest["nodes"] if value["id"] == "load")
+        after = next(value for value in load["evidence"] if value["state"] == "after")
+        after["line_end"] = 8
+        after["tokens"] = ["def load"]
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "changes.alignment")
+
+    def test_cross_view_disagreement_is_rejected(self) -> None:
+        document, manifest = overview_fixture(self.head)
+        document = document.replace("%% edge:start_load", "%% edge:other")
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "consistency.cross_view")
+
+    def test_annotation_missing_from_mermaid_target_is_rejected(self) -> None:
+        document, manifest = issue_fixture(self.head)
+        document = document.replace("load PROPOSED: validation behavior", "load", 1)
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "consistency.cross_view")
+
+    def test_state_order_mismatch_is_rejected(self) -> None:
+        document, manifest = feature_pr_fixture(self.base, self.head)
+        before_start = document.index("### Before")
+        after_start = document.index("### After", before_start)
+        section_end = document.index("## Sequence")
+        before_block = document[before_start:after_start]
+        after_block = document[after_start:section_end]
+        document = document[:before_start] + after_block + before_block + document[section_end:]
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "document.structure")
+
+    def test_pr_revision_mismatch_is_rejected(self) -> None:
+        document, manifest = feature_pr_fixture(self.base, self.head)
+        manifest["context"]["sources"]["head_revision"] = self.base
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "source.evidence")
+
+    def test_broken_mermaid_is_rejected(self) -> None:
+        document, manifest = overview_fixture(self.head)
+        document = document.replace("flowchart LR", "flowchart LR\n  BROKEN")
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "mermaid.render")
+
+    def test_unsafe_mermaid_is_rejected(self) -> None:
+        document, manifest = overview_fixture(self.head)
+        document = document.replace("flowchart LR", "flowchart LR\n  click start href \"https://example.com\"")
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "mermaid.structure_security")
+
+    def test_proposed_behavior_without_issue_evidence_is_rejected(self) -> None:
+        document, manifest = issue_fixture(self.head)
+        for item in manifest["nodes"] + manifest["edges"]:
+            item["evidence"] = [value for value in item["evidence"] if value["type"] == "source"]
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "source.evidence")
+
+    def test_missing_mermaid_tool_returns_two(self) -> None:
+        document, manifest = overview_fixture(self.head)
+        environment = self.env | {"PATH": f"{self.bin}:/usr/bin:/bin", "BOXLITE_DIAGRAM_MMDC": ""}
+        result, report = self.validate(document, manifest, environment=environment)
+        self.assertEqual(result.returncode, 2)
+        self.assertEqual(report["exit_code"], 2)
+
+    @unittest.skipUnless(os.environ.get("BOXLITE_DIAGRAM_REAL_RENDER") == "1", "real renderer opt-in")
+    def test_real_pinned_mermaid_render(self) -> None:
+        document, manifest = overview_fixture(self.head)
+        environment = self.env.copy()
+        environment.pop("BOXLITE_DIAGRAM_MMDC", None)
+        result, report = self.validate(document, manifest, environment=environment)
+        self.assertEqual(result.returncode, 0, result.stderr + json.dumps(report, indent=2))
+        render = next(check for check in report["checks"] if check["name"] == "mermaid.render")
+        self.assertIn("@11.16.0", render["message"])
+
+    def validate(
+        self, document: str, manifest: dict[str, object], environment: dict[str, str] | None = None
+    ) -> tuple[subprocess.CompletedProcess[str], dict[str, object]]:
+        case = self.root / f"case-{len(list(self.root.glob('case-*')))}"
+        case.mkdir()
+        document_path = case / "diagram.md"
+        evidence_path = case / "evidence.json"
+        report_path = case / "validation.json"
+        document_path.write_text(document, encoding="utf-8")
+        evidence_path.write_text(json.dumps(manifest), encoding="utf-8")
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--repo", str(self.repo), "--document", str(document_path),
+             "--evidence", str(evidence_path), "--report", str(report_path)],
+            text=True, capture_output=True, check=False, env=environment or self.env,
+        )
+        return result, json.loads(report_path.read_text(encoding="utf-8"))
+
+    def assert_check_failed(self, report: dict[str, object], name: str) -> None:
+        checks = {value["name"]: value for value in report["checks"]}
+        self.assertEqual(checks[name]["status"], "fail", json.dumps(checks.get(name), indent=2))
+
+    def _run(self, *command: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(command, cwd=self.repo, text=True, capture_output=True, check=True)
+
+    def _write_fake_mmdc(self) -> None:
+        script = self.bin / "fake-mmdc"
+        script.write_text(
+            "#!/bin/sh\n"
+            "while [ \"$#\" -gt 0 ]; do\n"
+            "  case \"$1\" in -i) input=$2; shift 2;; -o) output=$2; shift 2;; *) shift;; esac\n"
+            "done\n"
+            "if grep -q BROKEN \"$input\"; then echo 'Parse error' >&2; exit 1; fi\n"
+            "{ printf '<svg><text>'; sed 's/&/\\&amp;/g; s/</\\&lt;/g; s/>/\\&gt;/g' \"$input\"; printf '</text></svg>'; } > \"$output\"\n",
+            encoding="utf-8",
+        )
+        script.chmod(0o755)
+
+    def _write_fake_gh(self) -> None:
+        script = self.bin / "gh"
+        script.write_text(
+            "#!/bin/sh\n"
+            f"if [ \"$1\" = pr ]; then printf '%s\\n' '{{\"number\":3,\"title\":\"Change flow\",\"body\":\"Fixes #7\",\"url\":\"https://example/pr/3\",\"baseRefOid\":\"{self.base}\",\"headRefOid\":\"{self.head}\"}}'; else printf '%s\\n' '{{\"number\":7,\"title\":\"Add validation\",\"body\":\"validation behavior stale result\",\"state\":\"OPEN\",\"url\":\"https://example/issues/7\"}}'; fi\n",
+            encoding="utf-8",
+        )
+        script.chmod(0o755)
+
+
+def source_evidence(state: str, revision: str, symbol: str, start: int, end: int, *tokens: str) -> dict[str, object]:
+    return {"type": "source", "state": state, "revision": revision, "path": "app.py", "line_start": start,
+            "line_end": end, "symbol": symbol, "tokens": list(tokens)}
+
+
+def node(item_id: str, label: str, states: list[str], evidence: list[dict[str, object]]) -> dict[str, object]:
+    return {"id": item_id, "label": label, "states": states,
+            "views": ["architecture", "sequence", "call_graph"], "proposed": False, "evidence": evidence}
+
+
+def edge(item_id: str, label: str, source: str, target: str, states: list[str], evidence: list[dict[str, object]]) -> dict[str, object]:
+    return {"id": item_id, "label": label, "from": source, "to": target, "kind": "call", "states": states,
+            "views": ["architecture", "sequence", "call_graph"], "proposed": False, "evidence": evidence}
+
+
+def manifest(context: dict[str, object], states: list[dict[str, object]], nodes: list[dict[str, object]],
+             edges: list[dict[str, object]], annotations: list[dict[str, object]] | None = None) -> dict[str, object]:
+    return {"schema_version": 1, "context": context, "states": states, "nodes": nodes, "edges": edges,
+            "annotations": annotations or []}
+
+
+def diagrams(states: list[tuple[str, str]], state_hops: dict[str, list[str]], state_edges: dict[str, list[tuple[str, str, str, str]]],
+             state_nodes: dict[str, list[tuple[str, str]]], footer: str = "") -> str:
+    parts = ["# Diagram", "", "## Architecture", ""]
+    for state_id, label in states:
+        parts += [f"### {label}", "", "```mermaid", "flowchart LR"]
+        parts += [f'  {item_id}["{item_label}"]' for item_id, item_label in state_nodes[state_id]]
+        parts += [f'  {source} {edge_id}@-->|"{edge_label}"| {target}' for edge_id, source, target, edge_label in state_edges[state_id]]
+        parts += ["```", ""]
+    parts += ["## Sequence", ""]
+    for state_id, label in states:
+        parts += [f"### {label}", "", "```mermaid", "sequenceDiagram"]
+        parts += [f"  participant {item_id} as {item_label}" for item_id, item_label in state_nodes[state_id]]
+        for edge_id, source, target, edge_label in state_edges[state_id]:
+            parts += [f"  %% edge:{edge_id}", f"  {source}->>{target}: {edge_label}"]
+        parts += ["```", ""]
+    parts += ["## Call graph", ""]
+    for state_id, label in states:
+        parts += [f"### {label}", "", "```text", *state_hops[state_id], "```", ""]
+    if footer:
+        parts += [footer, ""]
+    return "\n".join(parts)
+
+
+def overview_fixture(head: str) -> tuple[str, dict[str, object]]:
+    states = [{"id": "current", "label": "Current", "revision": head, "proposed": False}]
+    nodes = [
+        node("start", "start", ["current"], [source_evidence("current", head, "start", 1, 3, "def start", "load()")]),
+        node("load", "load", ["current"], [source_evidence("current", head, "load", 8, 9, "def load")]),
+    ]
+    edges = [edge("start_load", "load", "start", "load", ["current"],
+                  [source_evidence("current", head, "start", 1, 3, "load()")])]
+    doc = diagrams([("current", "Current")], {"current": [
+        "  start (Module · app.py:1) — entry", "    └─ load (Module · app.py:8) — load result"]},
+        {"current": [("start_load", "start", "load", "load")]},
+        {"current": [("start", "start"), ("load", "load")]})
+    return doc, manifest({"kind": "overview", "change_kind": "none", "sources": {"repository": "local"}}, states, nodes, edges)
+
+
+def issue_fixture(head: str) -> tuple[str, dict[str, object]]:
+    doc, data = overview_fixture(head)
+    data = copy.deepcopy(data)
+    data["context"] = {"kind": "issue", "change_kind": "feature", "sources": {"repository": "local", "issue": 7}}
+    data["states"] = [
+        {"id": "current", "label": "Current", "revision": head, "proposed": False},
+        {"id": "expected", "label": "Expected (proposed)", "revision": head, "proposed": True},
+    ]
+    for item in data["nodes"] + data["edges"]:
+        item["states"].append("expected")
+        item["evidence"].append(copy.deepcopy(item["evidence"][0]) | {"state": "expected"})
+        item["evidence"].append({"type": "issue", "state": "expected", "issue": 7, "tokens": ["validation"]})
+    data["annotations"] = [{"kind": "PROPOSED", "target": "edge:start_load", "state": "expected", "text": "validation behavior"}]
+    doc = diagrams(
+        [("current", "Current"), ("expected", "Expected (proposed)")],
+        {"current": ["  start (Module · app.py:1) — entry", "    └─ load (Module · app.py:8) — load result"],
+         "expected": ["  start (Module · app.py:1) — entry", "    └─ load (Module · app.py:8) — load result ← PROPOSED: validation behavior"]},
+        {"current": [("start_load", "start", "load", "load")],
+         "expected": [("start_load", "start", "load", "load PROPOSED: validation behavior")]},
+        {"current": [("start", "start"), ("load", "load")], "expected": [("start", "start"), ("load", "load")]},
+    )
+    return doc, data
+
+
+def feature_pr_fixture(base: str, head: str) -> tuple[str, dict[str, object]]:
+    states = [{"id": "before", "label": "Before", "revision": base, "proposed": False},
+              {"id": "after", "label": "After", "revision": head, "proposed": False}]
+    nodes = [
+        node("start", "start", ["before", "after"], [source_evidence("before", base, "start", 1, 2, "def start"), source_evidence("after", head, "start", 1, 3, "def start")]),
+        node("load", "load", ["before", "after"], [source_evidence("before", base, "load", 4, 5, "def load"), source_evidence("after", head, "load", 8, 9, "def load")]),
+        node("validate", "validate ADDED: validate input", ["after"], [source_evidence("after", head, "validate", 5, 6, "def validate")]),
+    ]
+    edges = [
+        edge("start_load", "load", "start", "load", ["before", "after"], [source_evidence("before", base, "start", 1, 2, "load()"), source_evidence("after", head, "start", 1, 3, "load()")]),
+        edge("start_validate", "validate ADDED: validate input", "start", "validate", ["after"], [source_evidence("after", head, "start", 1, 3, "validate()")]),
+    ]
+    annotations = [{"kind": "ADDED", "target": "edge:start_validate", "state": "after", "text": "validate input"}]
+    doc = diagrams(
+        [("before", "Before"), ("after", "After")],
+        {"before": ["  start (Module · app.py:1) — entry", "    └─ load (Module · app.py:4) — load result"],
+         "after": ["  start (Module · app.py:1) — entry", "    ├─ validate (Module · app.py:5) — validate input ← ADDED: validate input", "    └─ load (Module · app.py:8) — load result"]},
+        {"before": [("start_load", "start", "load", "load")],
+         "after": [("start_validate", "start", "validate", "validate ADDED: validate input"), ("start_load", "start", "load", "load")]},
+        {"before": [("start", "start"), ("load", "load")],
+         "after": [("start", "start"), ("validate", "validate ADDED: validate input"), ("load", "load")]})
+    context = {"kind": "pr", "change_kind": "feature", "sources": {"repository": "local", "pr": 3,
+               "base_revision": base, "head_revision": head}}
+    return doc, manifest(context, states, nodes, edges, annotations)
+
+
+def bug_pr_fixture(base: str, head: str) -> tuple[str, dict[str, object]]:
+    document, data = feature_pr_fixture(base, head)
+    data["context"]["change_kind"] = "bug"
+    data["context"]["sources"]["issue"] = 7
+    data["annotations"] = [
+        {"kind": "BUG", "target": "edge:start_load", "state": "before", "text": "stale result"},
+        {"kind": "FIX", "target": "edge:start_validate", "state": "after", "text": "validate input"},
+    ]
+    next(value for value in data["nodes"] if value["id"] == "validate")["label"] = "validate FIX: validate input"
+    next(value for value in data["edges"] if value["id"] == "start_validate")["label"] = "validate FIX: validate input"
+    document = document.replace(" — load result\n", " — load result ← BUG: stale result\n", 1)
+    document = document.replace('"load"| load', '"load BUG: stale result"| load', 1)
+    document = document.replace("load->>load", "load->>load", 1)
+    before_sequence = document.index("## Sequence")
+    marker_position = document.index("start->>load: load", before_sequence)
+    document = document[:marker_position] + document[marker_position:].replace(
+        "start->>load: load", "start->>load: load BUG: stale result", 1
+    )
+    document = document.replace("← ADDED: validate input", "← FIX: validate input")
+    document = document.replace("ADDED: validate input", "FIX: validate input")
+    document += "\nFixes #7\n"
+    return document, data
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/boxlite-diagrams/tests/test_validate_diagrams.py
+++ b/.agents/skills/boxlite-diagrams/tests/test_validate_diagrams.py
@@ -8,7 +8,7 @@ import sys
 import tempfile
 import threading
 import unittest
-from unittest import mock
+import unittest.mock
 from pathlib import Path
 
 SKILL_ROOT = Path(__file__).resolve().parents[1]
@@ -303,7 +303,7 @@ class DiagramValidatorTests(unittest.TestCase):
     def test_report_writes_use_unique_temporary_files(self) -> None:
         report_path = self.root / "concurrent" / "validation.json"
         barrier = threading.Barrier(2)
-        failures: list[BaseException] = []
+        failures: list[Exception] = []
         original_write_text = Path.write_text
 
         def synchronized_write(path: Path, *args: object, **kwargs: object) -> int:
@@ -315,10 +315,10 @@ class DiagramValidatorTests(unittest.TestCase):
         def write(value: int) -> None:
             try:
                 _write_report(report_path, {"value": value})
-            except BaseException as error:
+            except Exception as error:
                 failures.append(error)
 
-        with mock.patch.object(Path, "write_text", synchronized_write):
+        with unittest.mock.patch.object(Path, "write_text", synchronized_write):
             threads = [threading.Thread(target=write, args=(value,)) for value in (1, 2)]
             for thread in threads:
                 thread.start()

--- a/make/help.mk
+++ b/make/help.mk
@@ -58,6 +58,7 @@ help:
 	@echo "    make test:integration:c     - Run C SDK integration tests (requires VM)"
 	@echo "    make test:all:c             - Run C SDK full suite (unit + integration)"
 	@echo "    make test:apps              - Run the apps workspace test matrix"
+	@echo "    make test:skill:boxlite-diagrams - Run diagram skill validator tests"
 	@echo "    make test:e2e:setup         - Bootstrap local stack (PG/Redis/Registry/API/Runner) + fixture data; idempotent"
 	@echo "    make test:e2e               - Run E2E suite (SDK→API→Runner→VM); see apps/e2e/README.md"
 	@echo "    make test:e2e:two-sided     - PR_REF=<branch> required; proves test catches bug + PR fixes it"

--- a/make/test.mk
+++ b/make/test.mk
@@ -1,4 +1,4 @@
-PHONY_TARGETS += test test\:unit\:guest test\:guest-perms _ensure-infra-deps test\:apps\:infra test\:apps\:infra-config
+PHONY_TARGETS += test test\:unit\:guest test\:guest-perms _ensure-infra-deps test\:apps\:infra test\:apps\:infra-config test\:skill\:boxlite-diagrams
 
 # Mirrors GitHub Actions strategy.fail-fast. Default false: aggregator
 # targets run every sub-suite even if an earlier one fails, then exit
@@ -83,6 +83,13 @@ endef
 # Default test target runs only changed components.
 test:
 	@$(MAKE) test:changed
+
+# Repo-local BoxLite diagram skill validator. This suite is deterministic: it
+# uses local stand-ins for gh and Mermaid CLI while exercising the real parser,
+# source, diff, and cross-view validation code.
+test\:skill\:boxlite-diagrams:
+	@echo "🧪 Running BoxLite diagrams skill validator tests..."
+	@python3 -m unittest discover -s .agents/skills/boxlite-diagrams/tests -v
 
 # Smart test: only test components with changes, fall back to full matrix.
 test\:changed:


### PR DESCRIPTION
## Summary

- add a repo-local skill that generates architecture, sequence, and ASCII call-graph views from one evidence manifest
- validate source anchors, caller-to-callee evidence, revision-aware diffs, annotations, cross-view IDs, and safe Mermaid rendering
- add deterministic positive and adversarial fixtures plus a focused Make target

## Why

BoxLite change explanations require trustworthy before/after call graphs, but the repository had no reusable workflow that could distinguish source-backed behavior from proposed behavior or reject fabricated relationships. This adds one workflow for overviews, issues, bug fixes, features, and refactors while keeping issue/PR metadata separate from change meaning.

## Impact

Diagram requests can now fail closed with a machine-readable report. Mermaid rendering uses pinned `@mermaid-js/mermaid-cli@11.16.0`; missing tooling returns exit 2, and invalid evidence or diagrams return exit 1. BoxLite production behavior is unchanged.

## Call graph

Before
```text
diagram_request  (Contributor workflow · CONTRIBUTING.md:104) — manually assembles diagrams without source or cross-view validation
```

After
```text
diagram_request      (BoxLite diagrams skill · .agents/skills/boxlite-diagrams/SKILL.md:28) — gathers repository and issue or PR evidence
  └─ main             (Validator CLI · .agents/skills/boxlite-diagrams/scripts/validate_diagrams.py:28) — runs deterministic validation stages
      └─ validate_call_graph  (Call graph validator · .agents/skills/boxlite-diagrams/scripts/validator/call_graph.py:15) — verifies hop shape, source anchors, relationships, and markers
```

## Validation

- `make test:skill:boxlite-diagrams` — 22 tests, 21 passed and one opt-in real-render test skipped
- `BOXLITE_DIAGRAM_REAL_RENDER=1 python3 -m unittest discover -s .agents/skills/boxlite-diagrams/tests -p 'test_validate_diagrams.py' -k test_real_pinned_mermaid_render -v` — passed
- `python3 .../skill-creator/scripts/quick_validate.py .agents/skills/boxlite-diagrams` — passed
- three with-skill evaluations revalidated with 9 passing checks, 0 failures, and 0 tool errors each


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a source-grounded workflow for generating architecture, sequence, and call-graph diagrams.
  - Added structured evidence requirements and validation reports for diagram artifacts.
  - Added checks for diagram structure, Mermaid rendering, source evidence, annotations, and cross-view consistency.

- **Tests**
  - Added comprehensive coverage for valid diagrams, proposed changes, bug fixes, malformed content, and invalid evidence.

- **Documentation**
  - Added workflow guidance and a dedicated command for running diagram validation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->