### PR TITLE
fix(box): persist the resolved volume id, not the caller's name, at create

### DIFF
--- a/apps/api/src/box/services/box.service.spec.ts
+++ b/apps/api/src/box/services/box.service.spec.ts
@@ -8,6 +8,7 @@ import { BoxService } from './box.service'
 import { BoxState } from '../enums/box-state.enum'
 import { BoxDesiredState } from '../enums/box-desired-state.enum'
 import { RunnerState } from '../enums/runner-state.enum'
+import { VolumeState } from '../enums/volume-state.enum'
 import { BoxEvents } from '../constants/box-events.constants'
 
 // ensureStartedForProxy touches boxRepository + eventEmitter +
@@ -305,6 +306,7 @@ describe('BoxService public defaults', () => {
         release: jest.fn().mockResolvedValue(undefined),
       }),
     }
+    const volumeService = { validateVolumes: jest.fn().mockResolvedValue([]) }
     const service = Object.create(BoxService.prototype) as BoxService
     Object.assign(service as any, {
       getValidatedOrDefaultRegion: jest.fn().mockResolvedValue({ id: 'region-1' }),
@@ -318,10 +320,11 @@ describe('BoxService public defaults', () => {
       runnerService,
       redisLockProvider,
       boxRepository,
+      volumeService,
       eventEmitter: { emitAsync: jest.fn().mockResolvedValue(undefined) },
       toBoxDto: jest.fn((box) => box),
     })
-    return { service, boxRepository, runnerService, redisLockProvider }
+    return { service, boxRepository, runnerService, redisLockProvider, volumeService }
   }
 
   it.each([
@@ -388,6 +391,46 @@ describe('BoxService public defaults', () => {
     expect(update).toHaveBeenCalledWith(
       'warm-box',
       expect.objectContaining({ updateData: expect.objectContaining({ public: expectedPublic }) }),
+    )
+  })
+
+  // Regression: validateVolumes confirms a name/id resolves and is READY,
+  // but create() used to persist the caller's raw string verbatim instead
+  // of the resolved id — so a box created with a volume *name* stored that
+  // name as volumeId, and the runner could never find the matching S3
+  // bucket (named by id, not by the human-readable name).
+  it('persists the volume real id, not the name, when requested by name', async () => {
+    const { service, boxRepository, volumeService } = makeCreateService()
+    const readyVolume = { id: 'vol-uuid-1', name: 'my-vol', state: VolumeState.READY } as any
+    volumeService.validateVolumes.mockResolvedValue([readyVolume])
+
+    await service.create(
+      { name: 'box-with-named-volume', volumes: [{ volumeId: 'my-vol', mountPath: '/data' }] } as any,
+      { id: 'org-1' } as any,
+    )
+
+    expect(volumeService.validateVolumes).toHaveBeenCalledWith('org-1', ['my-vol'])
+    expect(boxRepository.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        volumes: [{ volumeId: 'vol-uuid-1', mountPath: '/data' }],
+      }),
+    )
+  })
+
+  it('persists the volume id unchanged when requested by id', async () => {
+    const { service, boxRepository, volumeService } = makeCreateService()
+    const readyVolume = { id: 'vol-uuid-1', name: 'my-vol', state: VolumeState.READY } as any
+    volumeService.validateVolumes.mockResolvedValue([readyVolume])
+
+    await service.create(
+      { name: 'box-with-volume-by-id', volumes: [{ volumeId: 'vol-uuid-1', mountPath: '/data' }] } as any,
+      { id: 'org-1' } as any,
+    )
+
+    expect(boxRepository.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        volumes: [{ volumeId: 'vol-uuid-1', mountPath: '/data' }],
+      }),
     )
   })
 })

--- a/apps/api/src/box/services/box.service.ts
+++ b/apps/api/src/box/services/box.service.ts
@@ -42,6 +42,7 @@ import { BoxDto, BoxVolume } from '../dto/box.dto'
 import { RunnerAdapterFactory } from '../runner-adapter/runnerAdapter'
 import { validateNetworkAllowList } from '../utils/network-validation.util'
 import { VolumeService } from './volume.service'
+import { Volume } from '../entities/volume.entity'
 import { PaginatedList } from '../../common/interfaces/paginated-list.interface'
 import {
   BoxSortField,
@@ -234,9 +235,16 @@ export class BoxService {
         gpu,
       )
 
+      // Keyed by both id and name so the create-time substitution below can
+      // resolve either back to the volume's real id.
+      const volumeByIdOrName = new Map<string, Volume>()
       if (createBoxDto.volumes && createBoxDto.volumes.length > 0) {
         const volumeIdOrNames = createBoxDto.volumes.map((v) => v.volumeId)
-        await this.volumeService.validateVolumes(organization.id, volumeIdOrNames)
+        const volumes = await this.volumeService.validateVolumes(organization.id, volumeIdOrNames)
+        for (const volume of volumes) {
+          volumeByIdOrName.set(volume.id, volume)
+          volumeByIdOrName.set(volume.name, volume)
+        }
       } else if (image) {
         //  No volumes requested — try to claim a pre-warmed box matching this image/spec
         //  before creating a fresh one.
@@ -299,7 +307,16 @@ export class BoxService {
       box.autoResume = lifecyclePolicy.autoResume
 
       if (createBoxDto.volumes !== undefined) {
-        box.volumes = this.resolveVolumes(createBoxDto.volumes)
+        // Persist the volume's real id, not whatever the caller passed
+        // (id or name) — validateVolumes above guarantees every entry
+        // resolved, so this lookup cannot miss. Storing the caller's
+        // string verbatim would silently break the runner's lookup of
+        // the volume's backing S3 bucket whenever a name was used.
+        const withResolvedIds = createBoxDto.volumes.map((v) => ({
+          ...v,
+          volumeId: volumeByIdOrName.get(v.volumeId)?.id ?? v.volumeId,
+        }))
+        box.volumes = this.resolveVolumes(withResolvedIds)
       }
 
       box.pending = true

--- a/apps/api/src/box/services/volume.service.ts
+++ b/apps/api/src/box/services/volume.service.ts
@@ -197,9 +197,14 @@ export class VolumeService {
     return volume
   }
 
-  async validateVolumes(organizationId: string, volumeIdOrNames: string[]): Promise<void> {
+  /**
+   * Validates that every id-or-name resolves to a READY volume in this
+   * organization, and returns the resolved entities so callers can persist
+   * the volume's real id instead of whatever the caller passed in.
+   */
+  async validateVolumes(organizationId: string, volumeIdOrNames: string[]): Promise<Volume[]> {
     if (!volumeIdOrNames.length) {
-      return
+      return []
     }
 
     const volumes = await this.volumeRepository.find({
@@ -224,6 +229,8 @@ export class VolumeService {
         throw new BadRequestError(`Volume '${volume.name}' is not in a ready state. Current state: ${volume.state}`)
       }
     }
+
+    return volumes
   }
 
   async getOrganizationId(params: { id: string } | { name: string; organizationId: string }): Promise<string> {


### PR DESCRIPTION
## Summary

Fixes a pre-existing bug in the managed-volume-at-create feature (#1056/#1192): creating a box with a volume referenced by *name* (`source: volume://<name>`) silently persisted the name as `volumeId` instead of the volume's real id, so the runner could never find the matching S3 bucket (named by id). Referencing by id already worked.

Found while verifying #1216 (`-v` now accepts a bare managed-volume name/id) end to end against a live deployment: the same create request succeeds and mounts with the real uuid, but 500s with the name.

## Call graph

**Before:**
```
POST /boxes {volumes:[{source:'volume://myvolume', guest_path:'/data'}]}
  -> BoxService.create()
      -> VolumeService.validateVolumes(orgId, ['myvolume'])
           checks 'myvolume' exists + is ready, returns void
      -> box.volumes = resolveVolumes(createBoxDto.volumes)
           ← BUG: volumeId stays 'myvolume' (raw caller string), never
             substituted with the volume's real id
      -> next start(): runner looks up the S3 bucket by 'myvolume'
         instead of the real id -> mount fails, box errors
```

**After:**
```
POST /boxes {volumes:[{source:'volume://myvolume', guest_path:'/data'}]}
  -> BoxService.create()
      -> VolumeService.validateVolumes(orgId, ['myvolume'])
           now returns the resolved Volume[] (existence + ready checks unchanged)
      -> builds an id/name -> Volume map from the resolved entities
      -> box.volumes stores volume.id for every entry, whether the
         caller passed an id or a name
```

## Testing

- Two new `BoxService.create()` unit tests (`box.service.spec.ts`): one confirms a name-based volume request persists the resolved id, one confirms an id-based request is unaffected.
- Two-side verified: reverted both files, confirmed the name-based test fails with `"volumeId": "my-vol"` (the bug, verbatim) instead of the real id, restored, confirmed both new tests + the rest of the file (29/29) pass.
- `VolumeService.validateVolumes`'s existing 9 tests unaffected by the return-type change (`Promise<void>` → `Promise<Volume[]>`; no test asserted on the old return value).
- Repro'd directly against a live deployment via curl before writing the fix: `source: volume://<uuid>` → box created and mounted successfully (verified by exec'ing in and reading back a written file); `source: volume://<name>` → 500. Not re-verified live post-fix (this branch isn't deployed anywhere).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed box creation with volume names so mounts are saved using the correct volume identifiers.
  * Preserved volume identifiers when volumes are provided directly.
  * Improved volume validation to consistently resolve requested volumes and prevent invalid or unavailable volumes from being attached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->