### PR TITLE
fix(box): reject UUID-shaped volume names

### DIFF
--- a/apps/api/src/box/dto/create-volume.dto.spec.ts
+++ b/apps/api/src/box/dto/create-volume.dto.spec.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import 'reflect-metadata'
+import { validate } from 'class-validator'
+import { plainToInstance } from 'class-transformer'
+import { CreateVolumeDto } from './create-volume.dto'
+
+// VolumeService.findOneByIdOrName/validateVolumes match ids and names
+// through the same lookup, so a name shaped like a UUID could collide with
+// another volume's real id in the same organization and make that lookup
+// ambiguous. Rejecting the UUID shape at the request boundary keeps the two
+// namespaces disjoint by construction.
+describe('CreateVolumeDto name', () => {
+  it('rejects a UUID-shaped name', async () => {
+    const errors = await validate(plainToInstance(CreateVolumeDto, { name: '550e8400-e29b-41d4-a716-446655440000' }))
+
+    const fieldError = errors.find((e) => e.property === 'name')
+    expect(fieldError?.constraints).toHaveProperty('isNotUuidShaped')
+  })
+
+  it('accepts an ordinary name', async () => {
+    const errors = await validate(plainToInstance(CreateVolumeDto, { name: 'my-vol' }))
+
+    expect(errors).toHaveLength(0)
+  })
+
+  it('accepts a request that omits name (defaults to the server-assigned id)', async () => {
+    const errors = await validate(plainToInstance(CreateVolumeDto, {}))
+
+    expect(errors).toHaveLength(0)
+  })
+})

--- a/apps/api/src/box/dto/create-volume.dto.ts
+++ b/apps/api/src/box/dto/create-volume.dto.ts
@@ -5,11 +5,31 @@
  */
 
 import { ApiProperty, ApiSchema } from '@nestjs/swagger'
-import { IsString } from 'class-validator'
+import { IsOptional, IsString, Validate, ValidatorConstraint, ValidatorConstraintInterface } from 'class-validator'
+import { validate as isUuid } from 'uuid'
+
+// Volume ids and names share one id-or-name lookup (VolumeService.findOneByIdOrName,
+// validateVolumes): both are matched against the same input string. A name that
+// happens to look like a UUID could collide with another volume's real id in the
+// same organization, making that lookup ambiguous. Reserving the UUID shape
+// entirely for server-assigned ids keeps the two namespaces disjoint by
+// construction, rather than only catching collisions that already exist.
+@ValidatorConstraint({ name: 'isNotUuidShaped', async: false })
+class IsNotUuidShapedConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown): boolean {
+    return typeof value !== 'string' || !isUuid(value)
+  }
+
+  defaultMessage(): string {
+    return 'name must not be a UUID - that shape is reserved for server-assigned volume ids'
+  }
+}
 
 @ApiSchema({ name: 'CreateVolume' })
 export class CreateVolumeDto {
   @ApiProperty()
+  @IsOptional()
   @IsString()
+  @Validate(IsNotUuidShapedConstraint)
   name?: string
 }


### PR DESCRIPTION
## Summary

Rejects a `name` shaped like a UUID when creating a volume. Surfaced while looking at #1220: `VolumeService.findOneByIdOrName`/`validateVolumes` resolve a caller-supplied string against *both* the `id` and `name` columns in one query — nothing stops a name from colliding with a different volume's real id in the same org, making that lookup ambiguously match two rows.

## Call graph

**Before:**
```
POST /volumes {name: "<some other volume's real uuid>"}
  -> VolumeService.create(): only checks for an existing volume with that *name*
     (organizationId, name unique constraint) — never checks it against other
     volumes' ids
  -> later: findOneByIdOrName("<that uuid>", org) / validateVolumes(...)
       where: [{id: In([uuid])}, {name: In([uuid])}]
     <- BUG: matches two rows (the real owner by id, this one by name);
        which one "wins" depends on array/Map iteration order, not any
        defined rule
```

**After:**
```
POST /volumes {name: "<anything UUID-shaped>"}
  -> CreateVolumeDto.name: @Validate(IsNotUuidShapedConstraint) -> 400
     (uuid's own `validate()`, not a hand-rolled regex)
  -> the id and name namespaces stay disjoint by construction, so the
     ambiguous double-match above can no longer happen
```

Also adds the missing `@IsOptional()` on `name` — without it, omitting `name` entirely (the common case; the volume then defaults its name to its own id) fails `@IsString()` under class-validator's default undefined handling, confirmed with a probe test before writing the real one.

## Testing

- 3 new tests (`create-volume.dto.spec.ts`): rejects a UUID-shaped name, accepts an ordinary name, accepts an omitted name.
- Two-side verified: reverted the file, confirmed 2 of the 3 tests fail (the UUID-rejection one accepts the malicious name; the omitted-name one now genuinely needs `@IsOptional()` back), restored, confirmed all 3 pass.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
