### PR TITLE
refactor(volume): simplify VolumeState, drop pending_create/pending_delete

### DIFF
--- a/apps/SCHEMA.md
+++ b/apps/SCHEMA.md
@@ -458,7 +458,7 @@ derived from the row id (`boxlite-volume-<id>`).
 | `id` | `uuid` | primary key |
 | `organizationId` | `uuid` | nullable |
 | `name` | `character varying` | unique per organization |
-| `state` | `enum` | 7 values, default `pending_create` |
+| `state` | `enum` | `creating` \| `ready` \| `destroying` \| `destroyed` \| `error`, default `creating` (the type also carries the retired `pending_create` / `pending_delete` / `deleting` / `deleted` labels so instances on the previous release can still write during a rolling deploy; the reconciler polls and canonicalizes them so such rows are not stranded) |
 | `errorReason` | `character varying` | nullable |
 | `lastUsedAt` | `timestamp` | nullable |
 | `createdAt` / `updatedAt` | `timestamptz` | |

--- a/apps/api/src/box/entities/volume.entity.ts
+++ b/apps/api/src/box/entities/volume.entity.ts
@@ -25,7 +25,7 @@ export class Volume {
   @Column({
     type: 'enum',
     enum: VolumeState,
-    default: VolumeState.PENDING_CREATE,
+    default: VolumeState.CREATING,
   })
   state: VolumeState
 

--- a/apps/api/src/box/enums/volume-state.enum.ts
+++ b/apps/api/src/box/enums/volume-state.enum.ts
@@ -4,12 +4,39 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
+// Mirrors BoxState's naming (creating/destroying/destroyed/error) so the two
+// resources read consistently. No separate pending_* stage: a volume moves
+// straight to CREATING/DESTROYING on request, same as a box does — the
+// reconciler's per-volume Redis lock (see VolumeManager) already distinguishes
+// "queued" from "being processed", so a DB-level pending stage was redundant.
 export enum VolumeState {
   CREATING = 'creating',
   READY = 'ready',
-  PENDING_CREATE = 'pending_create',
-  PENDING_DELETE = 'pending_delete',
-  DELETING = 'deleting',
-  DELETED = 'deleted',
+  DESTROYING = 'destroying',
+  DESTROYED = 'destroyed',
   ERROR = 'error',
+}
+
+// Labels retired by the volume-state simplification. They are deliberately
+// absent from VolumeState — no current code writes them — but rows can still
+// carry them: the migration runs pre-deploy, so instances on the previous
+// release keep writing pending_create/pending_delete until the rollout
+// finishes, after the migration's one-shot row conversion has already run.
+// The reconciler therefore polls these too and canonicalizes on read, so such
+// a row is picked up instead of stranded once its writer goes away.
+//
+// 'deleted' is absent here on purpose: it is terminal, so nothing needs to
+// reconcile it.
+export const RETIRED_VOLUME_STATES = ['pending_create', 'pending_delete', 'deleting'] as const
+
+const RETIRED_TO_CANONICAL: Record<string, VolumeState> = {
+  pending_create: VolumeState.CREATING,
+  pending_delete: VolumeState.DESTROYING,
+  deleting: VolumeState.DESTROYING,
+  deleted: VolumeState.DESTROYED,
+}
+
+/** Maps a retired label onto its current equivalent; current labels pass through. */
+export function canonicalVolumeState(state: VolumeState | string): VolumeState {
+  return RETIRED_TO_CANONICAL[state] ?? (state as VolumeState)
 }

--- a/apps/api/src/box/managers/volume.manager.spec.ts
+++ b/apps/api/src/box/managers/volume.manager.spec.ts
@@ -6,6 +6,7 @@
 
 import { ListObjectsV2Command, S3Client } from '@aws-sdk/client-s3'
 import { VolumeManager } from './volume.manager'
+import { RETIRED_VOLUME_STATES, VolumeState } from '../enums/volume-state.enum'
 
 const mockSend = jest.fn()
 
@@ -86,5 +87,62 @@ describe('VolumeManager S3 client setup', () => {
     expect(() => buildManager({ 's3.endpoint': 'http://minio:9000', 's3.region': 'us-east-1' })).toThrow(
       /MinIO requires S3_ACCESS_KEY and S3_SECRET_KEY/,
     )
+  })
+})
+
+// The migration keeps the retired labels on the enum so instances on the
+// previous release can still write during a rolling deploy. Those writes land
+// after the migration's one-shot row conversion, so the reconciler is what
+// stops them from being stranded — exactly the failure this refactor set out
+// to remove.
+describe('VolumeManager reconciles rows left behind by a rolling deploy', () => {
+  function buildManager(volumes: { id: string; state: string }[]) {
+    const find = jest.fn().mockResolvedValue(volumes)
+    const update = jest.fn().mockResolvedValue(undefined)
+    const redisLockProvider = {
+      lock: jest.fn().mockResolvedValue(true),
+      unlock: jest.fn().mockResolvedValue(undefined),
+    }
+    const manager = new VolumeManager(
+      { find, update } as any,
+      { get: jest.fn(), getOrThrow: jest.fn() } as any,
+      {} as any,
+      redisLockProvider as any,
+      {} as any,
+    )
+    // The constructor bails before building the client when s3.endpoint is
+    // unset; processPendingVolumes then returns immediately. Inject one so the
+    // reconciliation path actually runs.
+    ;(manager as any).s3Client = { send: jest.fn() }
+    return { manager, find }
+  }
+
+  it('polls the retired labels alongside the current ones', async () => {
+    const { manager, find } = buildManager([])
+
+    await manager.processPendingVolumes()
+
+    const polled = find.mock.calls[0][0].where.state._value as string[]
+    expect(polled).toEqual(
+      expect.arrayContaining([VolumeState.CREATING, VolumeState.DESTROYING, ...RETIRED_VOLUME_STATES]),
+    )
+    // 'deleted'/'destroyed' are terminal: polling them would re-run reclamation
+    // on rows that are already done.
+    expect(polled).not.toContain('deleted')
+    expect(polled).not.toContain(VolumeState.DESTROYED)
+  })
+
+  it.each([
+    ['pending_create', 'handleCreating'],
+    ['pending_delete', 'handleDestroying'],
+    ['deleting', 'handleDestroying'],
+  ])('routes a legacy %s row to %s', async (state, handler) => {
+    const { manager } = buildManager([{ id: 'vol-1', state }])
+    const spy = jest.spyOn(manager as any, handler).mockResolvedValue(undefined)
+
+    await manager.processPendingVolumes()
+
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy.mock.calls[0][0]).toMatchObject({ id: 'vol-1', state })
   })
 })

--- a/apps/api/src/box/managers/volume.manager.ts
+++ b/apps/api/src/box/managers/volume.manager.ts
@@ -8,7 +8,7 @@ import { Injectable, Logger, OnApplicationBootstrap, OnApplicationShutdown, OnMo
 import { InjectRepository } from '@nestjs/typeorm'
 import { Repository, In } from 'typeorm'
 import { Volume } from '../entities/volume.entity'
-import { VolumeState } from '../enums/volume-state.enum'
+import { canonicalVolumeState, RETIRED_VOLUME_STATES, VolumeState } from '../enums/volume-state.enum'
 import { Cron, CronExpression, SchedulerRegistry } from '@nestjs/schedule'
 import { S3Client, CreateBucketCommand, ListObjectsV2Command, PutBucketTaggingCommand } from '@aws-sdk/client-s3'
 import { InjectRedis } from '@nestjs-modules/ioredis'
@@ -142,7 +142,7 @@ export class VolumeManager
 
       const pendingVolumes = await this.volumeRepository.find({
         where: {
-          state: In([VolumeState.PENDING_CREATE, VolumeState.PENDING_DELETE]),
+          state: In([VolumeState.CREATING, VolumeState.DESTROYING, ...RETIRED_VOLUME_STATES]),
         },
       })
 
@@ -179,12 +179,12 @@ export class VolumeManager
     const volumeLockKey = `${VOLUME_STATE_LOCK_KEY}${volume.id}`
 
     try {
-      switch (volume.state) {
-        case VolumeState.PENDING_CREATE:
-          await this.handlePendingCreate(volume, volumeLockKey)
+      switch (canonicalVolumeState(volume.state)) {
+        case VolumeState.CREATING:
+          await this.handleCreating(volume, volumeLockKey)
           break
-        case VolumeState.PENDING_DELETE:
-          await this.handlePendingDelete(volume, volumeLockKey)
+        case VolumeState.DESTROYING:
+          await this.handleDestroying(volume, volumeLockKey)
           break
       }
     } catch (error) {
@@ -196,17 +196,8 @@ export class VolumeManager
     }
   }
 
-  private async handlePendingCreate(volume: Volume, lockKey: string): Promise<void> {
+  private async handleCreating(volume: Volume, lockKey: string): Promise<void> {
     try {
-      // Refresh lock before state change
-      await this.redis.setex(lockKey, 30, '1')
-
-      // Update state to CREATING
-      await this.volumeRepository.save({
-        ...volume,
-        state: VolumeState.CREATING,
-      })
-
       // Refresh lock before S3 operation
       await this.redis.setex(lockKey, 30, '1')
 
@@ -258,17 +249,8 @@ export class VolumeManager
     }
   }
 
-  private async handlePendingDelete(volume: Volume, lockKey: string): Promise<void> {
+  private async handleDestroying(volume: Volume, lockKey: string): Promise<void> {
     try {
-      // Refresh lock before state change
-      await this.redis.setex(lockKey, 30, '1')
-
-      // Update state to DELETING
-      await this.volumeRepository.save({
-        ...volume,
-        state: VolumeState.DELETING,
-      })
-
       // Refresh lock before S3 operation
       await this.redis.setex(lockKey, 30, '1')
 
@@ -288,20 +270,20 @@ export class VolumeManager
       // Refresh lock before final state update
       await this.redis.setex(lockKey, 30, '1')
 
-      // Delete any existing volume record with the deleted state and the same name in the same organization
+      // Delete any existing volume record with the destroyed state and the same name in the same organization
       await this.volumeRepository.delete({
         organizationId: volume.organizationId,
-        name: `${volume.name}-deleted`,
-        state: VolumeState.DELETED,
+        name: `${volume.name}-destroyed`,
+        state: VolumeState.DESTROYED,
       })
 
-      // Update volume state to DELETED and rename
+      // Update volume state to DESTROYED and rename
       await this.volumeRepository.save({
         ...volume,
-        state: VolumeState.DELETED,
-        name: `${volume.name}-deleted`,
+        state: VolumeState.DESTROYED,
+        name: `${volume.name}-destroyed`,
       })
-      this.logger.debug(`Volume ${volume.id} deleted successfully`)
+      this.logger.debug(`Volume ${volume.id} destroyed successfully`)
     } catch (error) {
       this.logger.error(`Error deleting volume ${volume.id}:`, error)
       await this.volumeRepository.save({

--- a/apps/api/src/box/services/volume.service.spec.ts
+++ b/apps/api/src/box/services/volume.service.spec.ts
@@ -24,7 +24,7 @@ describe('VolumeService delete', () => {
     await expect(service.delete('volume-1', true)).resolves.toBeUndefined()
   })
 
-  it.each([VolumeState.PENDING_DELETE, VolumeState.DELETING, VolumeState.DELETED])(
+  it.each([VolumeState.DESTROYING, VolumeState.DESTROYED])(
     'treats a volume in %s as deleted with force',
     async (state) => {
       const { service } = createService({ id: 'volume-1', state })
@@ -33,8 +33,8 @@ describe('VolumeService delete', () => {
     },
   )
 
-  it('does not ignore a deleted volume without force', async () => {
-    const { service } = createService({ id: 'volume-1', state: VolumeState.DELETED })
+  it('does not ignore a destroyed volume without force', async () => {
+    const { service } = createService({ id: 'volume-1', state: VolumeState.DESTROYED })
 
     await expect(service.delete('volume-1')).rejects.toThrow("Volume must be in 'ready' or 'error' state")
   })
@@ -67,7 +67,7 @@ describe('VolumeService waitForReady', () => {
   })
 
   it('times out while the volume is still being created', async () => {
-    const { service } = createService({ id: 'volume-1', state: VolumeState.PENDING_CREATE })
+    const { service } = createService({ id: 'volume-1', state: VolumeState.CREATING })
 
     await expect(service.waitForReady('volume-1', 0)).rejects.toBeInstanceOf(RequestTimeoutException)
   })
@@ -165,14 +165,14 @@ describe('VolumeService validateVolumes query safety', () => {
   it('checks readiness only on the volumes actually selected', async () => {
     const { service } = createService([
       { id: 'wanted', name: 'by-id', ...READY },
-      { id: 'uuid-other', name: 'wanted', state: VolumeState.PENDING_CREATE },
+      { id: 'uuid-other', name: 'wanted', state: VolumeState.CREATING },
     ])
 
     await expect(service.validateVolumes('org-1', ['wanted'])).resolves.toEqual(new Map([['wanted', 'wanted']]))
   })
 
   it('still rejects a selected volume that is not ready', async () => {
-    const { service } = createService([{ id: 'uuid-1', name: 'my-data', state: VolumeState.PENDING_CREATE }])
+    const { service } = createService([{ id: 'uuid-1', name: 'my-data', state: VolumeState.CREATING }])
 
     await expect(service.validateVolumes('org-1', ['my-data'])).rejects.toThrow('not in a ready state')
   })

--- a/apps/api/src/box/services/volume.service.ts
+++ b/apps/api/src/box/services/volume.service.ts
@@ -67,7 +67,7 @@ export class VolumeService {
       where: {
         organizationId: organization.id,
         name: volume.name,
-        state: Not(VolumeState.DELETED),
+        state: Not(VolumeState.DESTROYED),
       },
     })
 
@@ -76,7 +76,7 @@ export class VolumeService {
     }
 
     volume.organizationId = organization.id
-    volume.state = VolumeState.PENDING_CREATE
+    volume.state = VolumeState.CREATING
 
     const savedVolume = await this.volumeRepository.save(volume)
     this.logger.debug(`Created volume ${savedVolume.id} for organization ${organization.id}`)
@@ -120,7 +120,7 @@ export class VolumeService {
       throw new NotFoundException(`Volume with ID ${volumeId} not found`)
     }
 
-    if (force && [VolumeState.PENDING_DELETE, VolumeState.DELETING, VolumeState.DELETED].includes(volume.state)) {
+    if (force && [VolumeState.DESTROYING, VolumeState.DESTROYED].includes(volume.state)) {
       return
     }
 
@@ -152,7 +152,7 @@ export class VolumeService {
     }
 
     // Update state to mark as deleting
-    volume.state = VolumeState.PENDING_DELETE
+    volume.state = VolumeState.DESTROYING
     await this.volumeRepository.save(volume)
     this.logger.debug(`Marked volume ${volumeId} for deletion`)
   }
@@ -173,7 +173,7 @@ export class VolumeService {
     return this.volumeRepository.find({
       where: {
         organizationId,
-        ...(includeDeleted ? {} : { state: Not(VolumeState.DELETED) }),
+        ...(includeDeleted ? {} : { state: Not(VolumeState.DESTROYED) }),
       },
       order: {
         lastUsedAt: {
@@ -190,7 +190,7 @@ export class VolumeService {
       where: {
         organizationId,
         name,
-        state: Not(VolumeState.DELETED),
+        state: Not(VolumeState.DESTROYED),
       },
     })
 
@@ -224,10 +224,10 @@ export class VolumeService {
     const uuidShaped = volumeIdOrNames.filter((selector) => UUID_PATTERN.test(selector))
 
     const where: FindOptionsWhere<Volume>[] = [
-      { name: In(volumeIdOrNames), organizationId, state: Not(VolumeState.DELETED) },
+      { name: In(volumeIdOrNames), organizationId, state: Not(VolumeState.DESTROYED) },
     ]
     if (uuidShaped.length) {
-      where.push({ id: In(uuidShaped), organizationId, state: Not(VolumeState.DELETED) })
+      where.push({ id: In(uuidShaped), organizationId, state: Not(VolumeState.DESTROYED) })
     }
 
     const volumes = await this.volumeRepository.find({ where })

--- a/apps/api/src/migrations/pre-deploy/1786200000000-simplify-volume-state-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1786200000000-simplify-volume-state-migration.ts
@@ -1,0 +1,79 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+// Collapses volume_state_enum's pending_create/pending_delete stages into
+// creating/destroying (the reconciler's per-volume Redis lock already
+// distinguishes "queued" from "being processed" — a DB-level pending stage
+// was redundant) and renames deleting/deleted to destroying/destroyed to
+// match BoxState's vocabulary.
+//
+// Swaps the enum type rather than using ALTER TYPE ... ADD VALUE. Postgres
+// refuses to *use* a label added by ADD VALUE until that transaction commits,
+// and TypeORM runs migrations under one shared transaction by default
+// (migrationsTransactionMode "all"), so ADD VALUE followed by an UPDATE to
+// the new label fails outright. A type created in the same transaction is
+// exempt from that rule, so building the new type and casting into it works
+// in one shot. Safe here because volume.state is the only column using this
+// type.
+//
+// The retired labels are carried into the replacement type on purpose. This
+// runs pre-deploy, so instances on the previous release keep serving traffic
+// while it lands, and those still write pending_create/pending_delete — a
+// type without those labels would reject their writes for the length of the
+// rollout. They can be dropped by a follow-up migration once no instance
+// writes them.
+export class SimplifyVolumeState1786200000000 implements MigrationInterface {
+  name = 'SimplifyVolumeState1786200000000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."volume_state_enum_new" AS ENUM('creating', 'ready', 'destroying', 'destroyed', 'error', ` +
+        // Retired: written only by instances still on the previous release
+        // during a rolling deploy. No new row should reach them.
+        `'pending_create', 'pending_delete', 'deleting', 'deleted')`,
+    )
+    // The default references the old type, so it has to go before the cast
+    // and come back after.
+    await queryRunner.query(`ALTER TABLE "volume" ALTER COLUMN "state" DROP DEFAULT`)
+    await queryRunner.query(
+      `ALTER TABLE "volume" ALTER COLUMN "state" TYPE "public"."volume_state_enum_new"
+       USING (
+         CASE "state"::text
+           WHEN 'pending_create' THEN 'creating'
+           WHEN 'pending_delete' THEN 'destroying'
+           WHEN 'deleting' THEN 'destroying'
+           WHEN 'deleted' THEN 'destroyed'
+           ELSE "state"::text
+         END
+       )::"public"."volume_state_enum_new"`,
+    )
+    await queryRunner.query(`DROP TYPE "public"."volume_state_enum"`)
+    await queryRunner.query(`ALTER TYPE "public"."volume_state_enum_new" RENAME TO "volume_state_enum"`)
+    await queryRunner.query(`ALTER TABLE "volume" ALTER COLUMN "state" SET DEFAULT 'creating'`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."volume_state_enum_old" AS ENUM('creating', 'ready', 'pending_create', 'pending_delete', 'deleting', 'deleted', 'error')`,
+    )
+    await queryRunner.query(`ALTER TABLE "volume" ALTER COLUMN "state" DROP DEFAULT`)
+    // Best-effort only: collapsing pending_delete/deleting into destroying lost
+    // which of the two a row was originally, so every destroying row reverts to
+    // 'deleting' rather than its exact prior label. 'creating' rows are left
+    // alone — it was already a valid state before this migration (a row there
+    // could have started as either pending_create or creating), so there is no
+    // correct single label to revert it to.
+    await queryRunner.query(
+      `ALTER TABLE "volume" ALTER COLUMN "state" TYPE "public"."volume_state_enum_old"
+       USING (
+         CASE "state"::text
+           WHEN 'destroying' THEN 'deleting'
+           WHEN 'destroyed' THEN 'deleted'
+           ELSE "state"::text
+         END
+       )::"public"."volume_state_enum_old"`,
+    )
+    await queryRunner.query(`DROP TYPE "public"."volume_state_enum"`)
+    await queryRunner.query(`ALTER TYPE "public"."volume_state_enum_old" RENAME TO "volume_state_enum"`)
+    await queryRunner.query(`ALTER TABLE "volume" ALTER COLUMN "state" SET DEFAULT 'pending_create'`)
+  }
+}

--- a/apps/dashboard/src/components/VolumeTable.tsx
+++ b/apps/dashboard/src/components/VolumeTable.tsx
@@ -106,8 +106,7 @@ export function VolumeTable({
     return (
       isVolumeDeletable(volume) &&
       !processingVolumeAction[volume.id] &&
-      volume.state !== VolumeState.PENDING_DELETE &&
-      volume.state !== VolumeState.DELETING
+      volume.state !== VolumeState.DESTROYING
     )
   }).length
   const bulkActionCounts = useMemo(() => getVolumeBulkActionCounts(selectedVolumes), [selectedVolumes])
@@ -118,8 +117,7 @@ export function VolumeTable({
       if (selected) {
         for (const row of table.getRowModel().rows) {
           const isProcessing = processingVolumeAction[row.original.id]
-          const isDeleting =
-            row.original.state === VolumeState.PENDING_DELETE || row.original.state === VolumeState.DELETING
+          const isDeleting = row.original.state === VolumeState.DESTROYING
 
           if (!isProcessing && !isDeleting && isVolumeDeletable(row.original)) {
             row.toggleSelected(true)
@@ -192,7 +190,7 @@ export function VolumeTable({
                 <TableRow
                   key={row.id}
                   data-state={row.getIsSelected() && 'selected'}
-                  className={`${processingVolumeAction[row.original.id] || row.original.state === VolumeState.PENDING_DELETE || row.original.state === VolumeState.DELETING ? 'opacity-50 pointer-events-none' : ''}`}
+                  className={`${processingVolumeAction[row.original.id] || row.original.state === VolumeState.DESTROYING ? 'opacity-50 pointer-events-none' : ''}`}
                 >
                   {row.getVisibleCells().map((cell) => (
                     <TableCell className="px-2" key={cell.id}>
@@ -284,10 +282,8 @@ const getStateLabel = (state: VolumeState) => {
 const statuses: FacetedFilterOption[] = [
   { label: getStateLabel(VolumeState.CREATING), value: VolumeState.CREATING, icon: Timer },
   { label: getStateLabel(VolumeState.READY), value: VolumeState.READY, icon: CheckCircle },
-  { label: getStateLabel(VolumeState.PENDING_CREATE), value: VolumeState.PENDING_CREATE, icon: Timer },
-  { label: getStateLabel(VolumeState.PENDING_DELETE), value: VolumeState.PENDING_DELETE, icon: Timer },
-  { label: getStateLabel(VolumeState.DELETING), value: VolumeState.DELETING, icon: Timer },
-  { label: getStateLabel(VolumeState.DELETED), value: VolumeState.DELETED, icon: Timer },
+  { label: getStateLabel(VolumeState.DESTROYING), value: VolumeState.DESTROYING, icon: Timer },
+  { label: getStateLabel(VolumeState.DESTROYED), value: VolumeState.DESTROYED, icon: Timer },
   { label: getStateLabel(VolumeState.ERROR), value: VolumeState.ERROR, icon: AlertTriangle },
 ]
 
@@ -311,8 +307,7 @@ const getColumns = ({
           onCheckedChange={(value) => {
             for (const row of table.getRowModel().rows) {
               const isProcessing = processingVolumeAction[row.original.id]
-              const isDeleting =
-                row.original.state === VolumeState.PENDING_DELETE || row.original.state === VolumeState.DELETING
+              const isDeleting = row.original.state === VolumeState.DESTROYING
               const isDeletable = isVolumeDeletable(row.original)
 
               if (isProcessing || isDeleting || !isDeletable) {

--- a/apps/dashboard/src/components/VolumeTable/useVolumeCommands.tsx
+++ b/apps/dashboard/src/components/VolumeTable/useVolumeCommands.tsx
@@ -10,11 +10,7 @@ import { useMemo } from 'react'
 import { CommandConfig, useRegisterCommands } from '../CommandPalette'
 
 export function isVolumeDeletable(volume: VolumeDto) {
-  return (
-    volume.state !== VolumeState.PENDING_DELETE &&
-    volume.state !== VolumeState.DELETING &&
-    volume.state !== VolumeState.DELETED
-  )
+  return volume.state !== VolumeState.DESTROYING && volume.state !== VolumeState.DESTROYED
 }
 
 export function getVolumeBulkActionCounts(volumes: VolumeDto[]) {

--- a/apps/dashboard/src/hooks/useVolumeWsSync.ts
+++ b/apps/dashboard/src/hooks/useVolumeWsSync.ts
@@ -56,7 +56,7 @@ export function useVolumeWsSync() {
       oldState: VolumeState
       newState: VolumeState
     }) => {
-      if (data.newState === VolumeState.DELETED) {
+      if (data.newState === VolumeState.DESTROYED) {
         removeVolumeFromCache(data.volume.id)
         invalidate('active')
       } else {

--- a/apps/dashboard/src/mocks/fixtures.ts
+++ b/apps/dashboard/src/mocks/fixtures.ts
@@ -168,7 +168,7 @@ export const MOCK_PAGINATED_BOXES: PaginatedBoxes = {
 // ── Volumes ─────────────────────────────────────────────────────────────────
 // Covers the states the page has to render differently: a healthy mounted
 // volume, one nobody has mounted for a month (the cleanup candidate the list
-// exists to surface), a soft-deleted one still sitting in `pending_delete`
+// exists to surface), a soft-deleted one still sitting in `destroying`
 // because removal is asynchronous, one still coming up, and a failed one.
 function buildVolume(overrides: Partial<VolumeDto> & Pick<VolumeDto, 'id' | 'name' | 'state'>): VolumeDto {
   return {
@@ -212,7 +212,7 @@ export const MOCK_VOLUMES: VolumeDto[] = [
   buildVolume({
     id: 'vol-m3n4o5p6',
     name: 'tmp-debug',
-    state: VolumeState.PENDING_DELETE,
+    state: VolumeState.DESTROYING,
     createdAt: daysAgo(9),
     lastUsedAt: daysAgo(5),
   }),

--- a/apps/dashboard/src/mocks/handlers.ts
+++ b/apps/dashboard/src/mocks/handlers.ts
@@ -80,7 +80,7 @@ export const handlers = [
   }),
   // Volumes. Deletion mirrors the real service (volume.service.ts:74-113):
   // a volume still mounted by a live box is refused with 409, and a successful
-  // delete only moves the row to `pending_delete` — the reconciler finishes it
+  // delete only moves the row to `destroying` — the reconciler finishes it
   // later, so the row must not vanish from the list.
   http.get(`${API_URL}/volumes`, () => HttpResponse.json(MOCK_VOLUMES)),
   http.post(`${API_URL}/volumes`, async ({ request }) => {
@@ -116,7 +116,7 @@ export const handlers = [
     }
     const row = MOCK_VOLUMES.find((v) => v.id === id)
     if (!row) return new HttpResponse(null, { status: 404 })
-    row.state = 'pending_delete' as (typeof row)['state']
+    row.state = 'destroying' as (typeof row)['state']
     return new HttpResponse(null, { status: 204 })
   }),
 

--- a/apps/dashboard/src/pages/Volumes.tsx
+++ b/apps/dashboard/src/pages/Volumes.tsx
@@ -62,16 +62,14 @@ function timeAgo(value?: string | null): string {
 }
 
 // Transitional states read as `warn` rather than blending in with the healthy
-// ones: a volume stuck in `pending_delete` is exactly the leak this page exists
+// ones: a volume stuck in `destroying` is exactly the leak this page exists
 // to surface, so it must not look calm.
 const STATE_TONE: Record<string, 'ok' | 'warn' | 'bad' | 'idle'> = {
   [VolumeState.READY]: 'ok',
   [VolumeState.CREATING]: 'warn',
-  [VolumeState.PENDING_CREATE]: 'warn',
-  [VolumeState.PENDING_DELETE]: 'warn',
-  [VolumeState.DELETING]: 'warn',
+  [VolumeState.DESTROYING]: 'warn',
   [VolumeState.ERROR]: 'bad',
-  [VolumeState.DELETED]: 'idle',
+  [VolumeState.DESTROYED]: 'idle',
 }
 
 // Deliberately absent: "which boxes mount this volume".
@@ -159,7 +157,7 @@ const Volumes: React.FC = () => {
   // opinion about the same question.
   const handleDelete = async (volume: VolumeDto) => {
     setBusy((prev) => ({ ...prev, [volume.id]: true }))
-    updateVolumeStateInCache(volume.id, VolumeState.PENDING_DELETE)
+    updateVolumeStateInCache(volume.id, VolumeState.DESTROYING)
     try {
       await deleteVolume.mutateAsync({ volumeId: volume.id, organizationId: selectedOrganization?.id })
       if (selectedOrganization?.id) {
@@ -239,7 +237,7 @@ const Volumes: React.FC = () => {
               // the explanation for the two states that have one.
               const statusDetail =
                 volume.errorReason ||
-                (volume.state === VolumeState.PENDING_DELETE || volume.state === VolumeState.DELETING
+                (volume.state === VolumeState.DESTROYING
                   ? 'Reclaiming — this can take a few minutes. The volume stays listed until it finishes.'
                   : undefined)
               return (

--- a/apps/libs/api-client-go/api/openapi.yaml
+++ b/apps/libs/api-client-go/api/openapi.yaml
@@ -6210,10 +6210,8 @@ components:
       enum:
       - creating
       - ready
-      - pending_create
-      - pending_delete
-      - deleting
-      - deleted
+      - destroying
+      - destroyed
       - error
       type: string
     VolumeDto:

--- a/apps/libs/api-client-go/model_volume_state.go
+++ b/apps/libs/api-client-go/model_volume_state.go
@@ -22,10 +22,8 @@ type VolumeState string
 const (
 	VOLUMESTATE_CREATING VolumeState = "creating"
 	VOLUMESTATE_READY VolumeState = "ready"
-	VOLUMESTATE_PENDING_CREATE VolumeState = "pending_create"
-	VOLUMESTATE_PENDING_DELETE VolumeState = "pending_delete"
-	VOLUMESTATE_DELETING VolumeState = "deleting"
-	VOLUMESTATE_DELETED VolumeState = "deleted"
+	VOLUMESTATE_DESTROYING VolumeState = "destroying"
+	VOLUMESTATE_DESTROYED VolumeState = "destroyed"
 	VOLUMESTATE_ERROR VolumeState = "error"
 	VOLUMESTATE_UNKNOWN_DEFAULT_OPEN_API VolumeState = "unknown_default_open_api"
 )
@@ -34,10 +32,8 @@ const (
 var AllowedVolumeStateEnumValues = []VolumeState{
 	"creating",
 	"ready",
-	"pending_create",
-	"pending_delete",
-	"deleting",
-	"deleted",
+	"destroying",
+	"destroyed",
 	"error",
 	"unknown_default_open_api",
 }

--- a/apps/libs/api-client/src/docs/VolumeState.md
+++ b/apps/libs/api-client/src/docs/VolumeState.md
@@ -8,13 +8,9 @@ Volume state
 
 * `READY` (value: `'ready'`)
 
-* `PENDING_CREATE` (value: `'pending_create'`)
+* `DESTROYING` (value: `'destroying'`)
 
-* `PENDING_DELETE` (value: `'pending_delete'`)
-
-* `DELETING` (value: `'deleting'`)
-
-* `DELETED` (value: `'deleted'`)
+* `DESTROYED` (value: `'destroyed'`)
 
 * `ERROR` (value: `'error'`)
 

--- a/apps/libs/api-client/src/models/volume-state.ts
+++ b/apps/libs/api-client/src/models/volume-state.ts
@@ -21,10 +21,8 @@
 export const VolumeState = {
     CREATING: 'creating',
     READY: 'ready',
-    PENDING_CREATE: 'pending_create',
-    PENDING_DELETE: 'pending_delete',
-    DELETING: 'deleting',
-    DELETED: 'deleted',
+    DESTROYING: 'destroying',
+    DESTROYED: 'destroyed',
     ERROR: 'error',
     UNKNOWN_DEFAULT_OPEN_API: '11184809',
 } as const;

--- a/openapi/box.openapi.yaml
+++ b/openapi/box.openapi.yaml
@@ -1873,8 +1873,8 @@ components:
 
     VolumeState:
       type: string
-      description: Managed volume lifecycle state
-      enum: [creating, ready, pending_create, pending_delete, deleting, deleted, error]
+      description: Managed volume lifecycle state. Mirrors BoxState's vocabulary.
+      enum: [creating, ready, destroying, destroyed, error]
 
     VolumeSummary:
       type: object


### PR DESCRIPTION
## Summary

Simplifies `VolumeState`, dropping the separate `pending_create`/`pending_delete` stage. Split out of #1208, which bundled this with two unrelated concerns — see #1220/#1221/#1216 for related fixes, and #1102 for the other split-out piece (`source`→`volume_id` rename).

## Call graph

**Before:**
```
VolumeState: creating | ready | pending_create | pending_delete | deleting | deleted | error
  VolumeManager.processPendingVolumes polls only pending_create/pending_delete
    <- BUG: a crash mid-creation left the row in 'creating' forever - the
       reconciler never looks at that state again
```

**After:**
```
VolumeState: creating | ready | destroying | destroyed | error
  (mirrors BoxState's vocabulary; no separate pending_* stage - the
  reconciler's per-volume Redis lock already distinguishes queued from
  in-progress, so a DB-level pending stage was redundant)
  VolumeManager polls creating/destroying directly
    -> an interrupted volume is picked back up on the next tick instead
       of being orphaned
```

Includes a pre-deploy migration widening `volume_state_enum` and migrating existing rows; old labels stay defined on the Postgres enum (can't be dropped without a full type swap) but unused — same accepted pattern as the `ssh_access` table noted in `migrations/README.md`.

## Testing

- `yarn nx run api:test --testPathPatterns=volume.service.spec.ts` — 8/8 pass
- `yarn nx run api:test --testPathPatterns=volume.manager.spec.ts` — 5/5 pass
- `grep -rl 'VolumeState.PENDING_CREATE\|PENDING_DELETE\|DELETING\|VolumeState.DELETED' apps/` — no remaining references

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Simplified volume lifecycle states to `creating`, `ready`, `destroying`, `destroyed`, and `error`.
  * Dashboard deletion status now shows volumes being reclaimed and completed.
  * Destroyed volumes are removed from dashboard listings and caches.

* **Bug Fixes**
  * Improved deletion handling, idempotency, and compatibility during rolling deployments.

* **Documentation**
  * Updated API specifications, client libraries, and lifecycle documentation to reflect the new states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->