### PR TITLE
feat(rest): accept name on POST /v1/volumes

### DIFF
--- a/apps/api/src/boxlite-rest/boxlite-volume.controller.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-volume.controller.spec.ts
@@ -36,10 +36,13 @@ describe('BoxliteVolumeController', () => {
     const organization = { id: 'org-1' }
 
     await expect(
-      controller.create({
-        organization,
-        organizationId: organization.id,
-      } as never),
+      controller.create(
+        {
+          organization,
+          organizationId: organization.id,
+        } as never,
+        {},
+      ),
     ).resolves.toEqual({
       id: volume.id,
       name: volume.name,
@@ -51,6 +54,21 @@ describe('BoxliteVolumeController', () => {
     })
     expect(volumeService.create).toHaveBeenCalledWith(organization, {})
     expect(volumeService.waitForReady).toHaveBeenCalledWith(volume.id, 30)
+  })
+
+  it('passes a caller-provided name through to the volume service', async () => {
+    const { controller, volumeService } = createController()
+    const organization = { id: 'org-1' }
+
+    await controller.create(
+      {
+        organization,
+        organizationId: organization.id,
+      } as never,
+      { name: 'my-volume' },
+    )
+
+    expect(volumeService.create).toHaveBeenCalledWith(organization, { name: 'my-volume' })
   })
 
   it('lists volumes for the authenticated organization', async () => {

--- a/apps/api/src/boxlite-rest/boxlite-volume.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-volume.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Delete, Get, HttpCode, Param, Post, Query, UseGuards } from '@nestjs/common'
+import { Body, Controller, Delete, Get, HttpCode, Param, Post, Query, UseGuards } from '@nestjs/common'
 import { ApiExcludeController } from '@nestjs/swagger'
 import { CombinedAuthGuard } from '../auth/combined-auth.guard'
 import { OrganizationResourceActionGuard } from '../organization/guards/organization-resource-action.guard'
@@ -9,6 +9,7 @@ import { RequiredOrganizationResourcePermissions } from '../organization/decorat
 import { OrganizationResourcePermission } from '../organization/enums/organization-resource-permission.enum'
 import { VolumeAccessGuard } from '../box/guards/volume-access.guard'
 import { VolumeState } from '../box/enums/volume-state.enum'
+import { CreateVolumeDto } from './dto/create-volume.dto'
 
 type RestVolumeSummary = {
   id: string
@@ -31,8 +32,11 @@ export class BoxliteVolumeController {
 
   @Post()
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_VOLUMES])
-  async create(@AuthContext() authContext: OrganizationAuthContext): Promise<RestVolumeResponse> {
-    const volume = await this.volumeService.create(authContext.organization, {})
+  async create(
+    @AuthContext() authContext: OrganizationAuthContext,
+    @Body() body: CreateVolumeDto,
+  ): Promise<RestVolumeResponse> {
+    const volume = await this.volumeService.create(authContext.organization, body)
     return this.toResponse(await this.volumeService.waitForReady(volume.id, 30))
   }
 

--- a/apps/api/src/boxlite-rest/dto/create-volume.dto.spec.ts
+++ b/apps/api/src/boxlite-rest/dto/create-volume.dto.spec.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import 'reflect-metadata'
+import { validate } from 'class-validator'
+import { plainToInstance } from 'class-transformer'
+import { CreateVolumeDto } from './create-volume.dto'
+
+// Same guard as the classic POST /volumes DTO's own spec
+// (apps/api/src/box/dto/create-volume.dto.spec.ts): a name shaped like a
+// UUID could collide with a different volume's real id in the same
+// organization and make VolumeService.findOneByIdOrName's lookup ambiguous.
+describe('CreateVolumeDto name', () => {
+  it('rejects a UUID-shaped name', async () => {
+    const errors = await validate(plainToInstance(CreateVolumeDto, { name: '550e8400-e29b-41d4-a716-446655440000' }))
+
+    const fieldError = errors.find((e) => e.property === 'name')
+    expect(fieldError?.constraints).toHaveProperty('isNotUuidShaped')
+  })
+
+  it('accepts an ordinary name', async () => {
+    const errors = await validate(plainToInstance(CreateVolumeDto, { name: 'my-vol' }))
+
+    expect(errors).toHaveLength(0)
+  })
+
+  it('accepts a request that omits name (defaults to the server-assigned id)', async () => {
+    const errors = await validate(plainToInstance(CreateVolumeDto, {}))
+
+    expect(errors).toHaveLength(0)
+  })
+
+  it('rejects an empty name instead of silently falling back to the default', async () => {
+    const errors = await validate(plainToInstance(CreateVolumeDto, { name: '' }))
+
+    const fieldError = errors.find((e) => e.property === 'name')
+    expect(fieldError?.constraints).toHaveProperty('isNotEmpty')
+  })
+})

--- a/apps/api/src/boxlite-rest/dto/create-volume.dto.ts
+++ b/apps/api/src/boxlite-rest/dto/create-volume.dto.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Validate,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator'
+import { validate as isUuid } from 'uuid'
+
+// Same guard as the classic POST /volumes DTO (apps/api/src/box/dto/create-volume.dto.ts):
+// VolumeService.findOneByIdOrName/validateVolumes match a caller's string against
+// both the id and name columns in one lookup, so a name shaped like a UUID could
+// collide with a different volume's real id in the same organization.
+@ValidatorConstraint({ name: 'isNotUuidShaped', async: false })
+class IsNotUuidShapedConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown): boolean {
+    return typeof value !== 'string' || !isUuid(value)
+  }
+
+  defaultMessage(): string {
+    return 'name must not be a UUID - that shape is reserved for server-assigned volume ids'
+  }
+}
+
+export class CreateVolumeDto {
+  // Optional — VolumeService.create() defaults an absent name to the
+  // server-assigned id. IsNotEmpty (not just IsOptional + IsString) rejects
+  // an explicit `name: ''` instead of silently falling through to that
+  // default.
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @Validate(IsNotUuidShapedConstraint)
+  name?: string
+}

--- a/openapi/box.openapi.yaml
+++ b/openapi/box.openapi.yaml
@@ -194,6 +194,11 @@ paths:
       summary: Create a managed persistent volume
       description: Creates a volume and waits until its backing object storage is ready.
       tags: [Volumes]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateVolumeRequest"
       responses:
         "201":
           description: Volume created and ready for use
@@ -1851,6 +1856,18 @@ components:
       type: string
       description: Managed volume lifecycle state
       enum: [creating, ready, pending_create, pending_delete, deleting, deleted, error]
+
+    CreateVolumeRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          minLength: 1
+          description: |
+            Unique within the organization. Defaults to the server-assigned
+            id when omitted. Must not be shaped like a UUID (reserved for
+            server-assigned ids).
 
     VolumeSummary:
       type: object


### PR DESCRIPTION
## Summary

`POST /v1/volumes` now honors a caller-supplied `name` instead of silently ignoring the request body. Split out of #1208, which bundled this with two unrelated concerns — see #1220/#1223/#1102/#1216/#1221 for related work.

## Call graph

**Before:**
```
POST /v1/volumes {name: "my-vol"}
  -> BoxliteVolumeController.create(authContext) — no @Body() at all
  -> this.volumeService.create(authContext.organization, {})
       ← BUG: the caller's body is silently ignored; name always
         defaults to the server-assigned id
```

**After:**
```
POST /v1/volumes {name: "my-vol"}
  -> BoxliteVolumeController.create(authContext, @Body() body: CreateVolumeDto)
  -> this.volumeService.create(authContext.organization, body)
       name is honored, still defaults to the id when omitted
       (VolumeService.create(), unchanged)
```

`CreateVolumeDto` also rejects a UUID-shaped name — same guard as #1221's fix to the classic `POST /volumes` DTO. `VolumeService.findOneByIdOrName` matches a caller's string against both the `id` and `name` columns in one lookup, so an unguarded name shaped like a UUID could collide with a different volume's real id in the same organization. This endpoint would have reopened that exact gap without it.

## Testing

- `yarn nx run api:test --testPathPatterns=create-volume.dto.spec.ts` — 4/4 pass. Two-side verified: removing the UUID-shape decorator makes exactly that one test fail (the other 3 unaffected), restoring it makes all 4 pass.
- `yarn nx run api:test --testPathPatterns=boxlite-volume.controller.spec.ts` — 8/8 pass
- `npx prettier --check` on the new/changed files

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
