### PR TITLE
fix(ci): support both deploy verifier layouts

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -402,7 +402,17 @@ jobs:
 
       - name: Verify deploy role IAM boundary permissions
         working-directory: apps/infra
-        run: node scripts/verify-deploy-role-boundary.mjs
+        shell: bash
+        run: |
+          set -euo pipefail
+          if node -e "const pkg = require('./package.json'); process.exit(pkg.scripts?.['verify-deploy-role'] ? 0 : 1)"; then
+            npm run --silent verify-deploy-role
+          elif [ -f scripts/verify-deploy-role-boundary.mjs ]; then
+            node scripts/verify-deploy-role-boundary.mjs
+          else
+            echo 'selected commit has no supported deploy-role verifier' >&2
+            exit 1
+          fi
 
       - name: Materialize stage configuration
         shell: bash

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -106,7 +106,17 @@ jobs:
 
       - name: Verify deploy role IAM boundary permissions
         working-directory: apps/infra
-        run: node scripts/verify-deploy-role-boundary.mjs
+        shell: bash
+        run: |
+          set -euo pipefail
+          if node -e "const pkg = require('./package.json'); process.exit(pkg.scripts?.['verify-deploy-role'] ? 0 : 1)"; then
+            npm run --silent verify-deploy-role
+          elif [ -f scripts/verify-deploy-role-boundary.mjs ]; then
+            node scripts/verify-deploy-role-boundary.mjs
+          else
+            echo 'selected release has no supported deploy-role verifier' >&2
+            exit 1
+          fi
 
       - name: Materialize stage configuration
         shell: bash


### PR DESCRIPTION
## Summary

- make commit and release deployment workflows support both infrastructure verifier layouts
- prefer the package-level verifier command and retain the historical script fallback
- fail closed when a selected tree exposes neither verifier contract

## Root cause

The deployment workflow definition comes from `main`, but it checks out the selected PR merge before running infrastructure commands. The workflow on `main` invoked the historical verifier file directly, while PR #1222 moves that verifier to a TypeScript package command. The result was `MODULE_NOT_FOUND` before preview or deploy.

## Before

```text
main workflow
  -> selected commit checkout
  -> historical verifier path only
  -> MODULE_NOT_FOUND
```

## After

```text
main workflow
  -> selected commit or release checkout
  -> package verifier when declared
  -> historical file fallback
  -> fail closed if neither exists
```

## Verification

- `make test:apps:infra` (310 tests)
- `make test:apps:infra-config`

This PR changes workflow compatibility only. It does not deploy infrastructure or alter application code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment validation by supporting both current and legacy verification checks.
  * Deployments now fail clearly when no deploy-role verification check is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->