### PR TITLE
fix(ci): support versioned deploy scope capability

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -275,24 +275,26 @@ jobs:
       # Runs before the AWS credential step on purpose: an unsupported scope is knowable from the
       # checkout alone, so it should never reach the deploy role.
       #
-      # Probes the export rather than grepping for it: the capability is what matters, and the
-      # module is pure, so importing it costs nothing.
-      #
-      # Absence is checked before the probe, not inferred from an import failure. The module only
-      # exists from PR #1095 onward, so a `ref` older than that has no such file — the ordinary
-      # "too old" case, sharing a remedy with a module that lacks the export. Folding it into the
-      # load-failure arm instead would answer "the module is present but unreadable" for a file
-      # that is simply not there.
+      # New trees declare capabilities as data. Historical trees fall back to the original pure
+      # module probe so supported commits remain deployable without teaching them the new layout.
       - name: Require component selection support in the selected commit
         if: ${{ env.DEPLOY_EXCLUDE != '' }}
         shell: bash
         run: |
           set -euo pipefail
-          module=apps/infra/scripts/deployment-scope.mjs
-          if [ ! -f "$module" ]; then
-            status=unsupported
+          capability=apps/infra/deployment/capabilities.json
+          legacy_module=apps/infra/scripts/deployment-scope.mjs
+          if [ -f "$capability" ]; then
+            if ! status=$(node -e "const fs=require('node:fs'); const c=JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); console.log(c.version === 1 && c.componentSelection === true ? 'supported' : 'unsupported')" "$capability"); then
+              status=unreadable
+            fi
+            source_path=$capability
+          elif [ -f "$legacy_module" ]; then
+            status=$(node -e "import('./$legacy_module').then(m => console.log(typeof m.resolveDeployScope === 'function' ? 'supported' : 'unsupported')).catch(e => { console.log('unreadable'); console.error(e.message) })")
+            source_path=$legacy_module
           else
-            status=$(node -e "import('./$module').then(m => console.log(typeof m.resolveDeployScope === 'function' ? 'supported' : 'unsupported')).catch(e => { console.log('unreadable'); console.error(e.message) })")
+            status=unsupported
+            source_path=$capability
           fi
           case "$status" in
             supported) ;;
@@ -300,11 +302,11 @@ jobs:
               echo "commit $BOXLITE_ARTIFACT_REF predates component selection, so it cannot honour" >&2
               echo "--exclude $DEPLOY_EXCLUDE and would deploy the full stack instead." >&2
               echo "Redispatch with components=api+runner, or name a newer ref: this needs a commit" >&2
-              echo "whose $module exports resolveDeployScope." >&2
+              echo "whose $source_path declares component selection support." >&2
               exit 1
               ;;
             *)
-              echo "$module exists at commit $BOXLITE_ARTIFACT_REF but failed to load (reason" >&2
+              echo "$source_path exists at commit $BOXLITE_ARTIFACT_REF but failed to load (reason" >&2
               echo "above). That is not an age problem, so fix the module rather than widening" >&2
               echo "the scope to api+runner." >&2
               exit 1

--- a/apps/infra/scripts/release-deployment-safety.test.mjs
+++ b/apps/infra/scripts/release-deployment-safety.test.mjs
@@ -353,13 +353,17 @@ test('deployment previews and reconciles the full stack in guarded GitHub CI', (
   )
   assert.ok(scopeSupportStep, 'the component-selection capability check is missing')
   assert.equal(scopeSupportStep.if, "${{ env.DEPLOY_EXCLUDE != '' }}", 'the check must run only for a narrowed scope')
-  // Probing the export, not grepping for it: a checkout can carry the identifier in a comment.
+  // Current commits use versioned data; historical commits retain the executable capability
+  // probe. Both paths inspect behavior rather than grepping source comments.
+  assertShellLine(scopeSupportStep.run, /capability=apps\/infra\/deployment\/capabilities\.json/)
+  assertShellLine(scopeSupportStep.run, /if \[ -f "\$capability" \]; then/)
+  assertShellLine(scopeSupportStep.run, /if ! status=\$\(node -e .* "\$capability"\); then/)
+  assertShellLine(scopeSupportStep.run, /status=unreadable/)
+  assertShellLine(scopeSupportStep.run, /c\.version === 1 && c\.componentSelection === true/)
+  assertShellLine(scopeSupportStep.run, /elif \[ -f "\$legacy_module" \]; then/)
   assertShellLine(scopeSupportStep.run, /typeof m\.resolveDeployScope === 'function'/)
-  // Absence is its own decision, taken before the probe. The module only exists from PR #1095
-  // onward, so most open pull-request heads do not have it at all — inferring that from an import
-  // failure lands them in the load-failure arm, which answers "present but failed to load" about
-  // a file that is not there and points at the wrong remedy.
-  assertShellLine(scopeSupportStep.run, /if \[ ! -f "\$module" \]; then/)
+  // Absence of both formats is its own decision, not an import failure.
+  assertShellLine(scopeSupportStep.run, /else\s+status=unsupported/)
   assertShellLine(scopeSupportStep.run, /status=unsupported/)
   // Each arm, and the claim that distinguishes it. Pinning only the `if` leaves an arm free to
   // carry another arm's message, which a passing suite would not notice: the arms differ solely


### PR DESCRIPTION
## Summary

- recognize the versioned deployment capability manifest used by current infra trees
- preserve the executable scope probe for historical commits
- fail closed when neither supported format exists

## Root cause

The dispatch workflow is loaded from `main`, but it deploys a selected commit. PR #1222 moved component-scope support from `scripts/deployment-scope.mjs` to `deployment/capabilities.json`; the workflow on `main` only knew the historical path and rejected the valid selected tree before preview.

## Before

```text
workflow_dispatch(main)
  -> selected PR merge
  -> scripts/deployment-scope.mjs only  <- BUG: current tree removed this path
  -> fail before preview
```

## After

```text
workflow_dispatch(main)
  -> selected PR merge
  -> deployment/capabilities.json
       or scripts/deployment-scope.mjs for historical commits
  -> guarded component preview
```

## Verification

- test-only `make test:apps:infra`: 309 passed, 1 failed on the missing JSON capability check
- fixed `make test:apps:infra`: 310 passed
- `make test:apps:infra-config`: passed
- pre-push changed-app matrix: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment compatibility checks to recognize both current capability metadata and legacy deployment configurations.
  * Deployments now clearly distinguish unsupported or missing capabilities from configuration-loading failures.
  * Added validation to prevent deployments when component-selection support is unavailable or incorrectly defined.
  * Improved error messages to identify the source of capability information when deployment support cannot be confirmed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->