### PR TITLE
fix(ci): support relocated deploy environment validator

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -425,7 +425,14 @@ jobs:
           test -n "$DEPLOY_ENV"
           umask 077
           printf '%s\n' "$DEPLOY_ENV" > apps/infra/.env
-          node apps/infra/scripts/deploy-environment-validation.mjs apps/infra/.env
+          if node -e "const pkg = require('./apps/infra/package.json'); process.exit(pkg.scripts?.['validate-environment'] ? 0 : 1)"; then
+            npm --prefix apps/infra run --silent validate-environment -- .env
+          elif [ -f apps/infra/scripts/deploy-environment-validation.mjs ]; then
+            node apps/infra/scripts/deploy-environment-validation.mjs apps/infra/.env
+          else
+            echo 'selected commit has no supported deployment environment validator' >&2
+            exit 1
+          fi
 
       - name: Install SST providers
         working-directory: apps/infra

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -127,7 +127,14 @@ jobs:
           test -n "$DEPLOY_ENV"
           umask 077
           printf '%s\n' "$DEPLOY_ENV" > apps/infra/.env
-          node apps/infra/scripts/deploy-environment-validation.mjs apps/infra/.env
+          if node -e "const pkg = require('./apps/infra/package.json'); process.exit(pkg.scripts?.['validate-environment'] ? 0 : 1)"; then
+            npm --prefix apps/infra run --silent validate-environment -- .env
+          elif [ -f apps/infra/scripts/deploy-environment-validation.mjs ]; then
+            node apps/infra/scripts/deploy-environment-validation.mjs apps/infra/.env
+          else
+            echo 'selected commit has no supported deployment environment validator' >&2
+            exit 1
+          fi
 
       - name: Deploy published API and Runner artifacts
         working-directory: apps/infra

--- a/apps/infra/scripts/release-deployment-safety.test.mjs
+++ b/apps/infra/scripts/release-deployment-safety.test.mjs
@@ -50,6 +50,29 @@ const assertShellLine = (run, pattern, message) =>
 const assertLiveLine = (text, pattern, message) =>
   assert.match(liveText('script', text), pattern, message ?? `missing live line: ${pattern}`)
 
+function assertEnvironmentValidatorCompatibility(materializeStep) {
+  assert.ok(materializeStep, 'the stage configuration step is missing')
+  assertShellLine(
+    materializeStep.run,
+    /if node -e .*scripts\?\.\['validate-environment'\].*; then/,
+    'the workflow must prefer the selected commit validator facade',
+  )
+  assertShellLine(
+    materializeStep.run,
+    /npm --prefix apps\/infra run --silent validate-environment -- \.env/,
+  )
+  assertShellLine(
+    materializeStep.run,
+    /elif \[ -f apps\/infra\/scripts\/deploy-environment-validation\.mjs \]; then/,
+    'the workflow must support historical commits',
+  )
+  assertShellLine(
+    materializeStep.run,
+    /node apps\/infra\/scripts\/deploy-environment-validation\.mjs apps\/infra\/\.env/,
+  )
+  assertShellLine(materializeStep.run, /selected commit has no supported deployment environment validator/)
+}
+
 function readDeployTemplate() {
   return load(readFileSync(DEV_DEPLOY_ROLE, 'utf8'), { schema: CLOUDFORMATION_SCHEMA })
 }
@@ -440,16 +463,13 @@ test('deployment previews and reconciles the full stack in guarded GitHub CI', (
   // run with an empty stage.
   assert.equal(workflow.jobs.deploy.env.STAGE, '${{ inputs.stage }}')
   assert.equal(workflow.jobs.deploy.env.IAM_PERMISSIONS_BOUNDARY_STAGE, '${{ inputs.stage }}')
-  assert.match(source, /node apps\/infra\/scripts\/deploy-environment-validation\.mjs apps\/infra\/\.env/)
+  assertEnvironmentValidatorCompatibility(materializeStep)
   assert.doesNotMatch(materializeStep.run, /grep/)
   assert.ok(safetyTestStep, 'the deployment safety test step is missing')
   assert.equal(safetyTestStep.run, 'npm test')
-  assert.ok(materializeStep, 'the stage configuration step is missing')
   const liveMaterialize = liveShell(materializeStep.run)
   const materializeConfigIndex = liveMaterialize.indexOf('printf \'%s\\n\' "$DEPLOY_ENV" > apps/infra/.env')
-  const validateConfigIndex = liveMaterialize.indexOf(
-    'node apps/infra/scripts/deploy-environment-validation.mjs apps/infra/.env',
-  )
+  const validateConfigIndex = liveMaterialize.indexOf("if node -e")
   assert.notEqual(materializeConfigIndex, -1, 'the stage configuration is not materialized')
   assert.ok(validateConfigIndex > materializeConfigIndex, 'DEPLOY_ENV must be validated after it is materialized')
   assert.ok(installStep, 'the SST provider installation step is missing')
@@ -691,6 +711,7 @@ test('the cloud E2E suite is reachable only from a deploy or a human', () => {
 test('release deployment consumes one published version for both components', () => {
   const source = readFileSync(RELEASE_DEPLOY_WORKFLOW, 'utf8')
   const workflow = load(source)
+  const materializeStep = workflow.jobs.deploy.steps.find((step) => step.name === 'Materialize stage configuration')
   const deployStep = workflow.jobs.deploy.steps.find(
     (step) => step.name === 'Deploy published API and Runner artifacts',
   )
@@ -716,6 +737,7 @@ test('release deployment consumes one published version for both components', ()
   assert.equal(workflow.on.workflow_dispatch.inputs.stage.type, 'choice')
   assert.deepEqual(workflow.on.workflow_dispatch.inputs.stage.options, ['dev', 'prod'])
   assert.ok(deployStep)
+  assertEnvironmentValidatorCompatibility(materializeStep)
   // The same guarded wrapper and the same pre-deploy gates the build path uses: a release
   // deploy reconciles the identical stack, so it owes the identical safety checks.
   assert.equal(deployStep.run, 'npm run deploy -- --stage "$STAGE" --policy .')


### PR DESCRIPTION
## Summary

- prefer the selected commit's `validate-environment` npm facade
- fall back to the historical JavaScript validator for older commits
- fail closed when neither validator contract exists
- cover both commit and release deployment workflows

## Before

```text
workflow on main
  -> selected commit checkout
  -> scripts/deploy-environment-validation.mjs  <- BUG: moved commits fail before preview
```

## After

```text
workflow on main
  -> selected commit checkout
  -> package exposes validate-environment?
     -> yes: npm validate-environment facade
     -> no: historical scripts/deploy-environment-validation.mjs
     -> neither: fail closed
```

## Verification

- test-only run: 308 passed, 2 failed on the missing compatibility selector
- fixed run: 310 passed, 0 failed
- normal pre-push changed-component matrix passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Deployment validation now uses the selected release’s environment check when available.
  - Retains compatibility with the legacy validation process.
  - Deployments now fail clearly when no supported validation method is available.

- **Tests**
  - Added coverage to verify validation order, fallback behavior, and safeguards for both infrastructure and release deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->