### PR TITLE
fix(ci): support relocated deployment preview

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -457,11 +457,21 @@ jobs:
           # SST would read as a component name. The fixed arguments seed it because expanding an
           # EMPTY array under `set -u` is an unbound-variable error before bash 4.4 — seeded, it
           # is never empty, so the line does not depend on the runner image's bash version.
-          args=(diff --stage "$STAGE" --policy .)
+          if node -e "const pkg = require('./package.json'); process.exit(pkg.scripts?.['validate-preview'] ? 0 : 1)" && [ -f policies/runner/PulumiPolicy.yaml ]; then
+            policy=policies/runner
+            validator=(npm run --silent validate-preview)
+          elif [ -f scripts/deployment-preview.mjs ] && [ -f PulumiPolicy.yaml ]; then
+            policy=.
+            validator=(node scripts/deployment-preview.mjs)
+          else
+            echo 'selected commit has no supported deployment preview contract' >&2
+            exit 1
+          fi
+          args=(diff --stage "$STAGE" --policy "$policy")
           [ -z "$DEPLOY_EXCLUDE" ] || args+=(--exclude "$DEPLOY_EXCLUDE")
           args+=(--json)
           npm run --silent sst -- "${args[@]}" |
-            node scripts/deployment-preview.mjs
+            "${validator[@]}"
 
       - name: Deploy the selected components
         if: ${{ inputs.apply }}
@@ -473,7 +483,15 @@ jobs:
         run: |
           set -euo pipefail
           # Seeded for the same reason as the preview above: an empty array must never be expanded.
-          args=(--stage "$STAGE" --policy .)
+          if node -e "const pkg = require('./package.json'); process.exit(pkg.scripts?.['validate-preview'] ? 0 : 1)" && [ -f policies/runner/PulumiPolicy.yaml ]; then
+            policy=policies/runner
+          elif [ -f scripts/deployment-preview.mjs ] && [ -f PulumiPolicy.yaml ]; then
+            policy=.
+          else
+            echo 'selected commit has no supported deployment preview contract' >&2
+            exit 1
+          fi
+          args=(--stage "$STAGE" --policy "$policy")
           [ -z "$DEPLOY_EXCLUDE" ] || args+=(--exclude "$DEPLOY_EXCLUDE")
           npm run deploy -- "${args[@]}"
 

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -138,7 +138,18 @@ jobs:
 
       - name: Deploy published API and Runner artifacts
         working-directory: apps/infra
-        run: npm run deploy -- --stage "$STAGE" --policy .
+        shell: bash
+        run: |
+          set -euo pipefail
+          if node -e "const pkg = require('./package.json'); process.exit(pkg.scripts?.['validate-preview'] ? 0 : 1)" && [ -f policies/runner/PulumiPolicy.yaml ]; then
+            policy=policies/runner
+          elif [ -f scripts/deployment-preview.mjs ] && [ -f PulumiPolicy.yaml ]; then
+            policy=.
+          else
+            echo 'selected commit has no supported deployment preview contract' >&2
+            exit 1
+          fi
+          npm run deploy -- --stage "$STAGE" --policy "$policy"
 
       - name: Remove materialized configuration
         if: always()

--- a/apps/infra/scripts/release-deployment-safety.test.mjs
+++ b/apps/infra/scripts/release-deployment-safety.test.mjs
@@ -487,17 +487,35 @@ test('deployment previews and reconciles the full stack in guarded GitHub CI', (
   // bash rather than on anything about this stack. Verified against bash 3.2.
   assert.deepEqual(liveCommands(previewStep.run), [
     'set -euo pipefail',
-    'args=(diff --stage "$STAGE" --policy .)',
+    'if node -e "const pkg = require(\'./package.json\'); process.exit(pkg.scripts?.[\'validate-preview\'] ? 0 : 1)" && [ -f policies/runner/PulumiPolicy.yaml ]; then',
+    '  policy=policies/runner',
+    '  validator=(npm run --silent validate-preview)',
+    'elif [ -f scripts/deployment-preview.mjs ] && [ -f PulumiPolicy.yaml ]; then',
+    '  policy=.',
+    '  validator=(node scripts/deployment-preview.mjs)',
+    'else',
+    "  echo 'selected commit has no supported deployment preview contract' >&2",
+    '  exit 1',
+    'fi',
+    'args=(diff --stage "$STAGE" --policy "$policy")',
     '[ -z "$DEPLOY_EXCLUDE" ] || args+=(--exclude "$DEPLOY_EXCLUDE")',
     'args+=(--json)',
     'npm run --silent sst -- "${args[@]}" |',
-    '  node scripts/deployment-preview.mjs',
+    '  "${validator[@]}"',
   ])
   assert.ok(deployStep, 'the deployment step is missing')
   assert.equal(deployStep.if, '${{ inputs.apply }}')
   assert.deepEqual(liveCommands(deployStep.run), [
     'set -euo pipefail',
-    'args=(--stage "$STAGE" --policy .)',
+    'if node -e "const pkg = require(\'./package.json\'); process.exit(pkg.scripts?.[\'validate-preview\'] ? 0 : 1)" && [ -f policies/runner/PulumiPolicy.yaml ]; then',
+    '  policy=policies/runner',
+    'elif [ -f scripts/deployment-preview.mjs ] && [ -f PulumiPolicy.yaml ]; then',
+    '  policy=.',
+    'else',
+    "  echo 'selected commit has no supported deployment preview contract' >&2",
+    '  exit 1',
+    'fi',
+    'args=(--stage "$STAGE" --policy "$policy")',
     '[ -z "$DEPLOY_EXCLUDE" ] || args+=(--exclude "$DEPLOY_EXCLUDE")',
     'npm run deploy -- "${args[@]}"',
   ])
@@ -740,7 +758,19 @@ test('release deployment consumes one published version for both components', ()
   assertEnvironmentValidatorCompatibility(materializeStep)
   // The same guarded wrapper and the same pre-deploy gates the build path uses: a release
   // deploy reconciles the identical stack, so it owes the identical safety checks.
-  assert.equal(deployStep.run, 'npm run deploy -- --stage "$STAGE" --policy .')
+  assert.equal(deployStep.shell, 'bash')
+  assert.deepEqual(liveShell(deployStep.run).split('\n').filter(Boolean), [
+    'set -euo pipefail',
+    'if node -e "const pkg = require(\'./package.json\'); process.exit(pkg.scripts?.[\'validate-preview\'] ? 0 : 1)" && [ -f policies/runner/PulumiPolicy.yaml ]; then',
+    '  policy=policies/runner',
+    'elif [ -f scripts/deployment-preview.mjs ] && [ -f PulumiPolicy.yaml ]; then',
+    '  policy=.',
+    'else',
+    "  echo 'selected commit has no supported deployment preview contract' >&2",
+    '  exit 1',
+    'fi',
+    'npm run deploy -- --stage "$STAGE" --policy "$policy"',
+  ])
   assert.ok(workflow.jobs.deploy.steps.find((step) => step.name === 'Run deployment safety tests'))
   const boundaryStep = workflow.jobs.deploy.steps.find(
     (step) => step.name === 'Verify deploy role IAM boundary permissions',


### PR DESCRIPTION
## Summary

- select the preview validator and Runner policy root from the selected commit layout
- keep historical deployments using the legacy validator and root policy pack
- fail closed when the validator and policy layout do not match
- apply the same policy selection to commit and release deploys

## Before

```text
workflow on main
  -> selected commit checkout
  -> policy root . + scripts/deployment-preview.mjs
     <- BUG: relocated commits fail before SST preview
```

## After

```text
workflow on main
  -> selected commit checkout
  -> validate-preview facade + policies/runner available?
     -> yes: new preview contract
     -> no: historical validator + root policy pack
     -> neither or mixed: fail closed
```

## Verification

- test-only run: 308 passed, 2 failed on the missing compatibility contract
- fixed run: 310 passed, 0 failed
- normal pre-push changed-component matrix passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved infrastructure preview and deployment compatibility with both current and legacy policy layouts.
  * Added clear failures when supported policy or validation contracts are missing or unreadable.
  * Ensured preview and deployment commands use the correct policy location and validator automatically.

* **Tests**
  * Expanded deployment safety coverage for current, legacy, and unsupported repository configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->