### PR TITLE
fix(runtime): derive RLIMIT_FSIZE from disk_size_gb

### DIFF
--- a/src/boxlite/src/disk/constants.rs
+++ b/src/boxlite/src/disk/constants.rs
@@ -23,6 +23,14 @@ pub mod qcow2 {
     /// Default disk size in GB (sparse, grows as needed)
     pub const DEFAULT_DISK_SIZE_GB: u64 = 10;
 
+    /// How many times the box's disk size the jailed shim's `RLIMIT_FSIZE` is
+    /// set to. Not a qcow2 format parameter: the shim is the sole writer of
+    /// these disks, so its per-file limit has to clear the disk it grows, and
+    /// this is the slack over it. Deliberately loose — the limit is a
+    /// runaway-write backstop, not a capacity policy (capacity is the qcow2
+    /// virtual size, where a full disk gives the guest a clean `ENOSPC`).
+    pub const FSIZE_DISK_MULTIPLIER: u64 = 2;
+
     /// QCOW2 cluster size in bits (64KB = 2^16)
     pub const CLUSTER_BITS: usize = 16;
 

--- a/src/boxlite/src/runtime/import.rs
+++ b/src/boxlite/src/runtime/import.rs
@@ -120,6 +120,14 @@ fn options_from_manifest(
         return Err(rejected_upload("host volume mounts"));
     }
     options.advanced.security = SecurityOptions::default();
+    // That reset also restores the default's hardcoded 1 GiB RLIMIT_FSIZE —
+    // the ceiling #1152 is about — because it replaces the whole struct rather
+    // than just the isolation fields it means to. The box still boots on a
+    // disk sized from its own `disk_size_gb`, so re-derive the limit.
+    // `sanitize` assigns it outright, so running it twice is idempotent.
+    options.sanitize().map_err(|error| {
+        BoxliteError::InvalidArgument(format!("invalid archive box_options: {error}"))
+    })?;
 
     Ok(options)
 }
@@ -221,6 +229,7 @@ pub(crate) fn validate_no_backing_references(disk_path: &Path) -> BoxliteResult<
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runtime::types::Bytes;
     use tempfile::TempDir;
 
     fn v3_manifest(options: BoxOptions) -> ArchiveManifest {
@@ -366,7 +375,32 @@ mod tests {
             options_from_manifest(&v3_manifest(options), ArchiveImportPolicy::UntrustedRemote)
                 .unwrap();
 
-        assert_eq!(resolved.advanced.security, SecurityOptions::default());
+        // Everything but the file-size ceiling is the server default; that one
+        // is derived from the box's own disk (#1152), so it is the default's
+        // stale 1 GiB that must NOT come back.
+        let mut expected = SecurityOptions::default();
+        expected.resource_limits.max_file_size = Some(Bytes::from_gib(20).as_bytes());
+        assert_eq!(resolved.advanced.security, expected);
+    }
+
+    /// The server-default reset must not put the 1 GiB ceiling back: an
+    /// uploaded archive's box boots on a disk sized from its own
+    /// `disk_size_gb` and needs a limit that covers it.
+    #[test]
+    fn untrusted_import_derives_the_fsize_limit_from_the_disk() {
+        let options = BoxOptions {
+            disk_size_gb: Some(20),
+            ..BoxOptions::default()
+        };
+
+        let resolved =
+            options_from_manifest(&v3_manifest(options), ArchiveImportPolicy::UntrustedRemote)
+                .unwrap();
+
+        assert_eq!(
+            resolved.advanced.security.resource_limits.max_file_size,
+            Some(Bytes::from_gib(40).as_bytes())
+        );
     }
 
     #[test]
@@ -385,7 +419,13 @@ mod tests {
 
         assert!(resolved.advanced.nested_virtualization);
         assert!(resolved.advanced.privileged);
-        assert_eq!(resolved.advanced.security, SecurityOptions::disabled());
+
+        // `sanitize` derives RLIMIT_FSIZE from `disk_size_gb` (#1152), so the
+        // one security field a trusted import does not carry over verbatim is
+        // the file-size ceiling. Everything else is preserved.
+        let mut expected = SecurityOptions::disabled();
+        expected.resource_limits.max_file_size = Some(Bytes::from_gib(20).as_bytes());
+        assert_eq!(resolved.advanced.security, expected);
     }
 
     #[test]

--- a/src/boxlite/src/runtime/options.rs
+++ b/src/boxlite/src/runtime/options.rs
@@ -8,7 +8,9 @@ use serde::{Deserialize, Serialize};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::{Path, PathBuf};
 
+use crate::disk::constants::qcow2::{DEFAULT_DISK_SIZE_GB, FSIZE_DISK_MULTIPLIER};
 use crate::runtime::advanced_options::AdvancedBoxOptions;
+use crate::runtime::types::Bytes;
 use std::fmt;
 
 // ============================================================================
@@ -627,12 +629,34 @@ impl BoxOptions {
         Ok(())
     }
 
-    pub fn sanitize(&self) -> BoxliteResult<()> {
+    pub fn sanitize(&mut self) -> BoxliteResult<()> {
         self.sanitize_common()?;
 
         if let Some(kernel) = &self.advanced.kernel {
             kernel.sanitize()?;
         }
+
+        // The jailed shim is the sole writer of this box's qcow2 disks, so its
+        // per-file RLIMIT_FSIZE caps their growth: a write past it fails with
+        // `EFBIG` and takes the guest down. `SecurityOptions::default()` cannot
+        // pick that number — it runs for a box that does not exist yet and
+        // cannot see `disk_size_gb` — which is how a fixed 1 GiB ceiling ended
+        // up contradicting every larger disk (#1152). Derive it here, next to
+        // the size it comes from.
+        //
+        // `FSIZE_DISK_MULTIPLIER` is deliberately loose: this is a
+        // runaway-write backstop, not a capacity policy. Capacity is the qcow2
+        // virtual size, where a guest that fills its disk gets a clean `ENOSPC`
+        // inside the box rather than a host-side `SIGXFSZ` that kills the VM.
+        self.advanced.security.resource_limits.max_file_size = Some(
+            Bytes::from_gib(
+                self.disk_size_gb
+                    .unwrap_or(DEFAULT_DISK_SIZE_GB)
+                    .saturating_mul(FSIZE_DISK_MULTIPLIER),
+            )
+            .as_bytes(),
+        );
+
         Ok(())
     }
 }
@@ -1003,6 +1027,7 @@ mod tests {
     use crate::runtime::advanced_options::{
         ContainerCapabilities, SecurityOptions, SecurityOptionsBuilder,
     };
+    use crate::runtime::types::Bytes;
 
     #[test]
     fn legacy_ports_keep_old_same_port_and_last_write_wins_semantics() {
@@ -1138,7 +1163,7 @@ mod tests {
                 drop: vec!["NET_RAW".into()],
             }))
             .unwrap();
-        let opts = BoxOptions {
+        let mut opts = BoxOptions {
             advanced,
             ..Default::default()
         };
@@ -1156,7 +1181,7 @@ mod tests {
                 ..Default::default()
             }))
             .unwrap();
-        let opts = BoxOptions {
+        let mut opts = BoxOptions {
             advanced,
             ..Default::default()
         };
@@ -1189,7 +1214,7 @@ mod tests {
         for capabilities in malformed {
             let mut advanced = AdvancedBoxOptions::default();
             advanced.set_capabilities(Some(capabilities)).unwrap();
-            let opts = BoxOptions {
+            let mut opts = BoxOptions {
                 advanced,
                 ..Default::default()
             };
@@ -1233,7 +1258,7 @@ mod tests {
                 .with_initramfs(&initramfs)
                 .with_command_line("console=ttyS0 panic=-1"),
         );
-        let opts = BoxOptions {
+        let mut opts = BoxOptions {
             advanced,
             ..Default::default()
         };
@@ -1251,7 +1276,7 @@ mod tests {
     fn custom_kernel_must_be_a_file() {
         let mut advanced = AdvancedBoxOptions::default();
         advanced.kernel = Some(KernelOptions::new("/definitely/missing/vmlinux"));
-        let opts = BoxOptions {
+        let mut opts = BoxOptions {
             advanced,
             ..Default::default()
         };
@@ -1274,7 +1299,7 @@ mod tests {
                 .with_format(format)
                 .with_command_line("console=ttyS0"),
         );
-        let opts = BoxOptions {
+        let mut opts = BoxOptions {
             advanced,
             ..Default::default()
         };
@@ -1294,7 +1319,7 @@ mod tests {
                 .with_format(KernelFormat::Elf)
                 .with_initramfs(temp.path().join("missing-initramfs")),
         );
-        let opts = BoxOptions {
+        let mut opts = BoxOptions {
             advanced,
             ..Default::default()
         };
@@ -1523,7 +1548,7 @@ mod tests {
     fn test_sanitize_rejects_unsupported_inbound_allow_net() {
         // FFI callers (C/Go) set the spec directly, bypassing try_from —
         // sanitize() is the create-time backstop for those paths.
-        let opts = BoxOptions {
+        let mut opts = BoxOptions {
             inbound_network: NetworkSpec::Enabled {
                 allow_net: vec!["10.0.0.0/8".to_string()],
             },
@@ -1560,7 +1585,7 @@ mod tests {
 
     #[test]
     fn test_sanitize_remove_on_stop_detach_incompatible() {
-        let opts = BoxOptions {
+        let mut opts = BoxOptions {
             auto_delete: Some(1),
             detach: true,
             ..Default::default()
@@ -1571,20 +1596,20 @@ mod tests {
 
     #[test]
     fn test_sanitize_valid_combinations() {
-        let remove = BoxOptions {
+        let mut remove = BoxOptions {
             auto_delete: Some(1),
             ..Default::default()
         };
         assert!(remove.sanitize().is_ok());
 
-        let keep_detached = BoxOptions {
+        let mut keep_detached = BoxOptions {
             auto_delete: Some(0),
             detach: true,
             ..Default::default()
         };
         assert!(keep_detached.sanitize().is_ok());
 
-        let keep_attached = BoxOptions {
+        let mut keep_attached = BoxOptions {
             auto_delete: Some(0),
             ..Default::default()
         };
@@ -1599,7 +1624,7 @@ mod tests {
             protocol: PortProtocol::Tcp,
             host_ip: None,
         };
-        let opts = BoxOptions {
+        let mut opts = BoxOptions {
             ports: vec![
                 duplicate.clone(),
                 PortSpec {
@@ -2112,5 +2137,36 @@ mod tests {
         // Only opts2 should have max_processes
         assert!(opts1.resource_limits.max_processes.is_none());
         assert_eq!(opts2.resource_limits.max_processes, Some(50));
+    }
+
+    /// The whole point of #1152: the ceiling has to follow the box's own
+    /// `--disk-size`, not a constant picked before the box existed.
+    #[test]
+    fn sanitize_scales_fsize_with_the_requested_disk() {
+        let mut options = BoxOptions {
+            disk_size_gb: Some(20),
+            ..BoxOptions::default()
+        };
+        options.sanitize().unwrap();
+
+        assert_eq!(
+            options.advanced.security.resource_limits.max_file_size,
+            Some(Bytes::from_gib(40).as_bytes()),
+            "a 20 GiB box gets a 40 GiB ceiling"
+        );
+    }
+
+    /// No explicit size: the disk is created at `DEFAULT_DISK_SIZE_GB`, so the
+    /// ceiling tracks that.
+    #[test]
+    fn sanitize_falls_back_to_the_default_disk_size() {
+        let mut options = BoxOptions::default();
+        options.sanitize().unwrap();
+
+        assert_eq!(
+            options.advanced.security.resource_limits.max_file_size,
+            Some(Bytes::from_gib(20).as_bytes()),
+            "the default 10 GiB disk gets a 20 GiB ceiling"
+        );
     }
 }

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -1757,6 +1757,7 @@ async fn sanitize_local_options(
 ) -> BoxliteResult<BoxOptions> {
     features.require_for_options(&options)?;
     tokio::task::spawn_blocking(move || {
+        let mut options = options;
         options.sanitize()?;
         Ok(options)
     })


### PR DESCRIPTION
Fixes #1152

Derives the jailed shim's `RLIMIT_FSIZE` from the box's own `disk_size_gb` instead of the fixed 1 GiB in `SecurityOptions::default()`, which cannot see it.

## Where

In `BoxOptions::sanitize` (`src/boxlite/src/runtime/options.rs`), next to the field it derives from:

```rust
self.advanced.security.resource_limits.max_file_size = Some(
    self.disk_size_gb
        .unwrap_or(DEFAULT_DISK_SIZE_GB)
        .saturating_mul(FSIZE_DISK_MULTIPLIER)
        .saturating_mul(1024 * 1024 * 1024),
);
```

`spawn.rs` and `advanced_options.rs` are untouched by this PR now. The earlier revision's `min_file_size()`, its qcow2 header reads, its margin constant, and the `ResourceLimits::ensure_min_file_size` helper with its three tests are all gone.

## Why loose slack rather than an exact size

`RLIMIT_FSIZE` is a runaway-write backstop, not a capacity policy. Capacity is the qcow2 virtual size, where a guest that fills its disk gets a clean `ENOSPC` inside the box; enforcing capacity through the rlimit instead degrades that into a host-side `SIGXFSZ` that kills the VM and reaches the client as an opaque h2 transport error. Slack costs nothing here. Being a few hundred MiB short costs the box.

No other project ships a fixed `fsize` default for the VMM process — Firecracker's jailer leaves `file_size: None`, gVisor uses `RLimInfinity`, runc/OCI is pass-through. Whether boxlite should keep this ceiling at all is a fair question; this PR keeps it and makes the number follow the disk.

## `sanitize` now takes `&mut self`

Two consequences worth reviewing:

1. One runtime call site changes (`rt_impl`'s create path, which already owns the options and returns them). The rest are tests.
2. An explicit caller-supplied `max_file_size` is **overwritten**, not respected as a floor — a plain assignment, per review. The disk-derived value is authoritative.
3. A **trusted archive import** no longer gets its security options back verbatim. `options_from_manifest` runs `sanitize` and then returns a trusted archive's options unchanged, so the file-size ceiling is now the one field that gets rewritten. `trusted_import_preserves_archive_configuration` is updated to state that exemption instead of asserting blanket preservation.

## Accepted regression

`create_cow_disk` sizes the COW disk at `max(disk_size_gb, base image size)`, so a box whose image is more than 2x its requested size still lands under the ceiling — `diskSizeGb: 4` on a 10 GiB image gets a 10 GiB disk under an 8 GiB limit and dies with the same `EFBIG`.

The right fix is at the other end: asking for a disk smaller than the image should be rejected at create rather than silently widened. Until that lands, this case fails. The unit test that covered it is removed with the header read.

## Test plan

- [x] `cargo test -p boxlite --lib sanitize_` — the two new cases pass. Two-side verified: with the multiplier at 1, both size assertions fail with the exact byte counts; restored, green.
- [x] `cargo test -p boxlite --lib` — 994 passed, 2 failed. Both failures are environmental and pre-existing: `net::socket_path::tests::vendored_libkrun_still_derives_krun_sock_suffix` reads the absent libkrun submodule, and `jailer::sandbox::seatbelt::tests::test_seatbelt_runtime_denies_write_outside_writable_path` expects a denial that does not materialise on an already-sandboxed host. CI is the authority.
- [x] `cargo clippy -p boxlite --lib --tests -- -D warnings` and `cargo fmt` — clean.
- [ ] Not re-run end to end on a real box. The earlier revision's manual repro (apt + a large npm/Playwright install, 85+ minutes clean on a default box) covers the default-size path, which this revision widens rather than narrows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disk usage protection by applying a file-size limit based on the configured disk capacity.
  * Added a safe default limit when no disk size is specified.
  * Ensured trusted and untrusted archive imports receive appropriate disk-derived file-size protection while preserving applicable security settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->