### PR TITLE
fix(api): namespace box migration jobs under BACKUP

### DIFF
--- a/apps/api/src/box/dto/job-type-map.dto.ts
+++ b/apps/api/src/box/dto/job-type-map.dto.ts
@@ -11,6 +11,12 @@ import { ResourceType } from '../enums/resource-type.enum'
  * Type-safe mapping between JobType and its corresponding ResourceType(s) + Payload
  * This ensures compile-time safety when creating jobs
  * resourceType is an array of allowed ResourceTypes - the user can supply any of them
+ *
+ * The resource type is also a namespace: IDX_UNIQUE_INCOMPLETE_JOB allows one
+ * incomplete job per (resourceType, resourceId, runnerId). A migration's jobs act
+ * on the archive the box travels in rather than on the box itself, and they run
+ * against a box a user may start or stop at the same time, so they are namespaced
+ * under BACKUP to keep out of the box's own lifecycle slot.
  */
 export interface JobTypeMap {
   [JobType.CREATE_BOX]: {
@@ -26,19 +32,19 @@ export interface JobTypeMap {
     resourceType: [ResourceType.BOX]
   }
   [JobType.EXPORT_BOX]: {
-    resourceType: [ResourceType.BOX]
+    resourceType: [ResourceType.BACKUP]
   }
   [JobType.IMPORT_BOX]: {
-    resourceType: [ResourceType.BOX]
+    resourceType: [ResourceType.BACKUP]
   }
   [JobType.ROLLBACK_EXPORT_BOX]: {
-    resourceType: [ResourceType.BOX]
+    resourceType: [ResourceType.BACKUP]
   }
   [JobType.ROLLBACK_IMPORT_BOX]: {
-    resourceType: [ResourceType.BOX]
+    resourceType: [ResourceType.BACKUP]
   }
   [JobType.DISCARD_EXPORTED_BOX]: {
-    resourceType: [ResourceType.BOX]
+    resourceType: [ResourceType.BACKUP]
   }
 }
 

--- a/apps/api/src/box/managers/box-migration.manager.spec.ts
+++ b/apps/api/src/box/managers/box-migration.manager.spec.ts
@@ -133,7 +133,7 @@ describe('BoxMigrationManager submitter loop', () => {
       h.entityManager,
       JobType.EXPORT_BOX,
       SOURCE_RUNNER,
-      ResourceType.BOX,
+      ResourceType.BACKUP,
       BOX_ID,
       { arcPath: 'box-migrations/box-1.boxlite' },
     )
@@ -154,7 +154,7 @@ describe('BoxMigrationManager submitter loop', () => {
       h.entityManager,
       JobType.EXPORT_BOX,
       SOURCE_RUNNER,
-      ResourceType.BOX,
+      ResourceType.BACKUP,
       BOX_ID,
       { arcPath: 's3://archives/tenant-a/box-1.boxlite' },
     )
@@ -213,7 +213,7 @@ describe('BoxMigrationManager submitter loop', () => {
       h.entityManager,
       JobType.IMPORT_BOX,
       TARGET_RUNNER,
-      ResourceType.BOX,
+      ResourceType.BACKUP,
       BOX_ID,
       { arcPath: 'box-migrations/box-1.boxlite' },
     )
@@ -272,7 +272,7 @@ describe('BoxMigrationManager rollback submitter loop', () => {
       null,
       JobType.ROLLBACK_EXPORT_BOX,
       SOURCE_RUNNER,
-      ResourceType.BOX,
+      ResourceType.BACKUP,
       BOX_ID,
       { arcPath: 'box-migrations/box-1.boxlite' },
     )
@@ -280,7 +280,7 @@ describe('BoxMigrationManager rollback submitter loop', () => {
       null,
       JobType.ROLLBACK_IMPORT_BOX,
       TARGET_RUNNER,
-      ResourceType.BOX,
+      ResourceType.BACKUP,
       BOX_ID,
       undefined,
     )
@@ -318,7 +318,7 @@ describe('BoxMigrationManager rollback submitter loop', () => {
       null,
       JobType.DISCARD_EXPORTED_BOX,
       SOURCE_RUNNER,
-      ResourceType.BOX,
+      ResourceType.BACKUP,
       BOX_ID,
       { arcPath: 'box-migrations/box-1.boxlite' },
     )

--- a/apps/api/src/box/managers/box-migration.manager.ts
+++ b/apps/api/src/box/managers/box-migration.manager.ts
@@ -313,7 +313,7 @@ export class BoxMigrationManager implements TrackableJobExecutions, OnApplicatio
           entityManager,
           jobType,
           target.runnerId,
-          ResourceType.BOX,
+          ResourceType.BACKUP,
           box.id,
           target.payload,
         )
@@ -404,7 +404,7 @@ export class BoxMigrationManager implements TrackableJobExecutions, OnApplicatio
     }
 
     try {
-      await this.jobService.createJob(null, jobType, runnerId, ResourceType.BOX, migration.boxId, payload)
+      await this.jobService.createJob(null, jobType, runnerId, ResourceType.BACKUP, migration.boxId, payload)
       this.logger.log(`Submitted ${jobType} for box ${migration.boxId} to runner ${runnerId}`)
     } catch (error) {
       this.logger.error(`Error submitting ${jobType} for box ${migration.boxId}:`, error)

--- a/apps/api/src/box/services/box-migration-job-receiver.service.spec.ts
+++ b/apps/api/src/box/services/box-migration-job-receiver.service.spec.ts
@@ -54,7 +54,7 @@ function makeJob(type: JobType, overrides: Partial<ConstructorParameters<typeof 
     type,
     status: JobStatus.COMPLETED,
     runnerId: TARGET_RUNNER,
-    resourceType: ResourceType.BOX,
+    resourceType: ResourceType.BACKUP,
     resourceId: BOX_ID,
     ...overrides,
   })

--- a/apps/api/src/box/services/job.service.migration-namespace.integration.spec.ts
+++ b/apps/api/src/box/services/job.service.migration-namespace.integration.spec.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { randomUUID } from 'node:crypto'
+import { DataSource, IsNull, Repository } from 'typeorm'
+import { CustomNamingStrategy } from '../../common/utils/naming-strategy.util'
+import { JobType, ResourceType } from '../dto/job.dto'
+import { Job } from '../entities/job.entity'
+import { JobConflictError } from '../errors/job-conflict.error'
+import { JobService } from './job.service'
+
+const describeIfDatabase = process.env.DB_HOST ? describe : describe.skip
+const schemaName = `job_namespace_${process.pid}_${randomUUID().replaceAll('-', '')}`
+const boxId = 'box-migration-namespace'
+const runnerId = 'runner-migration-namespace'
+const lifecycleJobId = '00000000-0000-4000-8000-000000000011'
+
+/**
+ * The job a user's start leaves incomplete on the runner still holding the box
+ * — the row a migration job for the same box has to fit alongside.
+ */
+function incompleteLifecycleJob(): Job {
+  return new Job({
+    id: lifecycleJobId,
+    type: JobType.START_BOX,
+    runnerId,
+    resourceType: ResourceType.BOX,
+    resourceId: boxId,
+  })
+}
+
+describeIfDatabase('JobService.createJob resource namespaces (integration, real Postgres)', () => {
+  let dataSource: DataSource
+  let repository: Repository<Job>
+  let service: JobService
+
+  beforeAll(async () => {
+    dataSource = await new DataSource({
+      type: 'postgres',
+      host: process.env.DB_HOST,
+      port: Number(process.env.DB_PORT || 5432),
+      username: process.env.DB_USERNAME,
+      password: process.env.DB_PASSWORD,
+      database: process.env.DB_DATABASE,
+      schema: schemaName,
+      entities: [Job],
+      namingStrategy: new CustomNamingStrategy(),
+      entitySkipConstructor: true,
+      synchronize: false,
+    }).initialize()
+
+    await dataSource.query(`CREATE SCHEMA "${schemaName}"`)
+    await dataSource.synchronize()
+    repository = dataSource.getRepository(Job)
+    // Redis only carries the "new job" nudge, and createJob already treats a
+    // failed nudge as harmless: the runner polls for what it missed.
+    service = new JobService(repository, {} as any, {} as any)
+  })
+
+  afterAll(async () => {
+    if (!dataSource?.isInitialized) {
+      return
+    }
+
+    try {
+      await dataSource.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`)
+    } finally {
+      await dataSource.destroy()
+    }
+  })
+
+  beforeEach(async () => {
+    await repository.clear()
+    await repository.insert(incompleteLifecycleJob())
+  })
+
+  it('accepts a migration job for a box whose runner already has an incomplete lifecycle job', async () => {
+    await service.createJob(null, JobType.ROLLBACK_EXPORT_BOX, runnerId, ResourceType.BACKUP, boxId)
+
+    const incomplete = await repository.find({
+      where: { resourceId: boxId, completedAt: IsNull() },
+      order: { type: 'ASC' },
+    })
+    expect(incomplete.map((job) => [job.type, job.resourceType])).toEqual([
+      [JobType.ROLLBACK_EXPORT_BOX, ResourceType.BACKUP],
+      [JobType.START_BOX, ResourceType.BOX],
+    ])
+  })
+
+  it('still rejects a second incomplete job in the namespace the lifecycle job holds', async () => {
+    await expect(service.createJob(null, JobType.STOP_BOX, runnerId, ResourceType.BOX, boxId)).rejects.toBeInstanceOf(
+      JobConflictError,
+    )
+  })
+})

--- a/apps/api/src/migrations/post-deploy/1786320000000-namespace-migration-jobs-under-backup-migration.spec.ts
+++ b/apps/api/src/migrations/post-deploy/1786320000000-namespace-migration-jobs-under-backup-migration.spec.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { randomUUID } from 'node:crypto'
+import { DataSource, Repository } from 'typeorm'
+import { CustomNamingStrategy } from '../../common/utils/naming-strategy.util'
+import { JobStatus, JobType, ResourceType } from '../../box/dto/job.dto'
+import { Job } from '../../box/entities/job.entity'
+import { NamespaceMigrationJobsUnderBackup1786320000000 } from './1786320000000-namespace-migration-jobs-under-backup-migration'
+
+const describeIfDatabase = process.env.DB_HOST ? describe : describe.skip
+const schemaName = `job_backup_ns_${process.pid}_${randomUUID().replaceAll('-', '')}`
+const runnerId = 'runner-namespace-migration'
+const stamped = new Date('2026-01-01T00:00:00.000Z')
+
+const inFlightMigrationJobId = '00000000-0000-4000-8000-000000000021'
+const completedMigrationJobId = '00000000-0000-4000-8000-000000000022'
+const inFlightLifecycleJobId = '00000000-0000-4000-8000-000000000023'
+
+function job(overrides: ConstructorParameters<typeof Job>[0]): Job {
+  const created = new Job(overrides)
+  // The staleness sweep measures its timeout from updatedAt, so the migration has
+  // to leave it alone — which only means something if it starts out in the past.
+  created.createdAt = stamped
+  created.updatedAt = stamped
+  return created
+}
+
+describeIfDatabase('NamespaceMigrationJobsUnderBackup1786320000000 (integration, real Postgres)', () => {
+  let dataSource: DataSource
+  let repository: Repository<Job>
+
+  beforeAll(async () => {
+    dataSource = await new DataSource({
+      type: 'postgres',
+      host: process.env.DB_HOST,
+      port: Number(process.env.DB_PORT || 5432),
+      username: process.env.DB_USERNAME,
+      password: process.env.DB_PASSWORD,
+      database: process.env.DB_DATABASE,
+      schema: schemaName,
+      entities: [Job],
+      namingStrategy: new CustomNamingStrategy(),
+      entitySkipConstructor: true,
+      synchronize: false,
+    }).initialize()
+
+    await dataSource.query(`CREATE SCHEMA "${schemaName}"`)
+    await dataSource.synchronize()
+    repository = dataSource.getRepository(Job)
+  })
+
+  afterAll(async () => {
+    if (!dataSource?.isInitialized) {
+      return
+    }
+
+    try {
+      await dataSource.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`)
+    } finally {
+      await dataSource.destroy()
+    }
+  })
+
+  it('moves only the still-open migration jobs into the BACKUP namespace', async () => {
+    await repository.insert([
+      job({
+        id: inFlightMigrationJobId,
+        type: JobType.EXPORT_BOX,
+        status: JobStatus.IN_PROGRESS,
+        runnerId,
+        resourceType: ResourceType.BOX,
+        resourceId: 'box-being-migrated',
+      }),
+      job({
+        id: completedMigrationJobId,
+        type: JobType.EXPORT_BOX,
+        status: JobStatus.COMPLETED,
+        runnerId,
+        resourceType: ResourceType.BOX,
+        resourceId: 'box-being-migrated',
+        completedAt: stamped,
+      }),
+      job({
+        id: inFlightLifecycleJobId,
+        type: JobType.START_BOX,
+        status: JobStatus.IN_PROGRESS,
+        runnerId,
+        resourceType: ResourceType.BOX,
+        resourceId: 'box-being-started',
+      }),
+    ])
+
+    const queryRunner = dataSource.createQueryRunner()
+    try {
+      // The migration names "job" unqualified, the way it will run against the
+      // deployed schema. Point this connection at the throwaway schema so it
+      // cannot reach a real one.
+      await queryRunner.query(`SET search_path TO "${schemaName}"`)
+      await new NamespaceMigrationJobsUnderBackup1786320000000().up(queryRunner)
+    } finally {
+      await queryRunner.release()
+    }
+
+    const rows = await repository.find({ order: { id: 'ASC' } })
+    expect(rows.map((row) => [row.id, row.resourceType])).toEqual([
+      [inFlightMigrationJobId, ResourceType.BACKUP],
+      [completedMigrationJobId, ResourceType.BOX],
+      [inFlightLifecycleJobId, ResourceType.BOX],
+    ])
+
+    const moved = rows.find((row) => row.id === inFlightMigrationJobId)
+    expect(moved?.updatedAt.getTime()).toBe(stamped.getTime())
+  })
+})

--- a/apps/api/src/migrations/post-deploy/1786320000000-namespace-migration-jobs-under-backup-migration.ts
+++ b/apps/api/src/migrations/post-deploy/1786320000000-namespace-migration-jobs-under-backup-migration.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class NamespaceMigrationJobsUnderBackup1786320000000 implements MigrationInterface {
+  name = 'NamespaceMigrationJobsUnderBackup1786320000000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Migration jobs now take the BACKUP slot of IDX_UNIQUE_INCOMPLETE_JOB so they
+    // stop competing with the box's own lifecycle jobs. Jobs submitted before this
+    // deploy still hold the BOX slot, and a box whose migration job is in flight
+    // could not be started or stopped until it completed, so move the ones still
+    // open. Completed rows are left as they were: the index only covers incomplete
+    // rows, and nothing reads resourceType off a finished job.
+    //
+    // `updatedAt` is deliberately untouched — JobService.handleStaleJobs measures
+    // its 10-minute timeout from it, and stamping it here would grant every
+    // in-flight migration job a fresh timeout.
+    await queryRunner.query(
+      `UPDATE "job" SET "resourceType" = 'BACKUP' WHERE "completedAt" IS NULL AND "resourceType" = 'BOX' AND "type" IN ('EXPORT_BOX', 'IMPORT_BOX', 'ROLLBACK_EXPORT_BOX', 'ROLLBACK_IMPORT_BOX', 'DISCARD_EXPORTED_BOX')`,
+    )
+  }
+
+  public down(): Promise<void> {
+    // Not reversed: moving these rows back into the BOX slot can collide with the
+    // lifecycle job the split just allowed alongside them. Nothing needs it —
+    // migration job status is applied by job type and resource id, never by
+    // resource type, so either API version drives a BACKUP-namespaced job.
+    return Promise.resolve()
+  }
+}

--- a/apps/runner/pkg/runner/v2/executor/migrate_test.go
+++ b/apps/runner/pkg/runner/v2/executor/migrate_test.go
@@ -219,7 +219,7 @@ func newHarness(t *testing.T, configure func(*harness)) *harness {
 		// actually made.
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_, _ = fmt.Fprintf(w, `{"id":%q,"type":"EXPORT_BOX","status":%q,"resourceType":"box","resourceId":%q,"createdAt":"2026-01-01T00:00:00Z"}`,
+		_, _ = fmt.Fprintf(w, `{"id":%q,"type":"EXPORT_BOX","status":%q,"resourceType":"backup","resourceId":%q,"createdAt":"2026-01-01T00:00:00Z"}`,
 			testJobId, body.Status, testBoxId)
 	}))
 	t.Cleanup(server.Close)


### PR DESCRIPTION
`IDX_UNIQUE_INCOMPLETE_JOB` is unique on `(resourceType, resourceId, runnerId) WHERE completedAt IS NULL`, so it allows exactly one incomplete job per resource per runner. The five box-migration job types were mapped to `ResourceType.BOX` and keyed by `box.id`, so a migration job and the box's own lifecycle job competed for the same slot on the same runner.

The rollback path makes that collision routine: `ROLLBACK_EXPORT_BOX` is submitted to the box's own runner — exactly where the start that triggered the rollback has to run. Whichever arrives second gets `23505` → `JobConflictError`, and the manager's retry loop re-submits against the same occupied slot every 10s/60s.

A migration's jobs act on the archive the box travels in, not on the box itself, so they get their own namespace: `ResourceType.BACKUP`. A post-deploy migration moves the jobs still in flight, leaving `updatedAt` alone because `JobService.handleStaleJobs` measures its 10-minute timeout from it.

Related to #1226.

## Call graph

**Before**

```
BoxMigrationManager.submitValidated      (box-migration.manager.ts:277)      — submit export/import leg
  └─ JobService.createJob(…, ResourceType.BOX, box.id, …)
                                         (box-migration.manager.ts:312)      ← BUG: migration job claims the box's own uniqueness slot
       └─ IDX_UNIQUE_INCOMPLETE_JOB  (resourceType, resourceId, runnerId)
                                         (job.entity.ts:25)                  — one incomplete job per (BOX, boxId, runnerId)

RunnerAdapterV2.startBox                 (runnerAdapter.v2.ts:151)           — user / proxy start of the same box
  └─ JobService.createJob(START_BOX, …, ResourceType.BOX, boxId, …)
                                         (runnerAdapter.v2.ts:156)
       └─ 23505 → JobConflictError        (job.service.ts:82-92)             ← start (or stop) rejected while any migration job is open
            └─ caught + retried forever   (box-migration.manager.ts:328, :414)
```

**After**

```
BoxMigrationManager.submitValidated      (box-migration.manager.ts:277)
  └─ JobService.createJob(…, ResourceType.BACKUP, box.id, …)
                                         (box-migration.manager.ts:312)      — BACKUP slot
BoxMigrationManager.submitReclaimJob     (box-migration.manager.ts:390)
  └─ JobService.createJob(…, ResourceType.BACKUP, migration.boxId, …)
                                         (box-migration.manager.ts:407)      — BACKUP slot
       └─ IDX_UNIQUE_INCOMPLETE_JOB       (job.entity.ts:25)                 — (BACKUP, boxId, runnerId) …

RunnerAdapterV2.startBox                 (runnerAdapter.v2.ts:151)
  └─ JobService.createJob(START_BOX, …, ResourceType.BOX, boxId, …)
                                         (runnerAdapter.v2.ts:156)           — … disjoint from (BOX, boxId, runnerId): both coexist
```

**Key:** `resourceType` is the uniqueness namespace, not just a label — migration jobs and box lifecycle jobs are independent lifecycles and must not share one.

## Changes

- `JobTypeMap` (`job-type-map.dto.ts`): the five migration job types now declare `ResourceType.BACKUP`; the doc comment states why the field is a namespace.
- `BoxMigrationManager` (`box-migration.manager.ts:315`, `:407`): both `createJob` call sites pass `BACKUP`.
- Post-deploy migration `1786320000000-namespace-migration-jobs-under-backup`: moves incomplete migration jobs from `BOX` to `BACKUP`; completed rows untouched (the index only covers incomplete rows); `down()` is a deliberate no-op.
- Runner `migrate_test.go` fixture reports `"resourceType":"backup"` to match what the API now issues.

## Tests

- `job.service.migration-namespace.integration.spec.ts` — real Postgres, exercises the index directly: a migration job is accepted for a box whose runner already holds an incomplete lifecycle job, and a second job in the *same* namespace is still rejected. Skipped without `DB_HOST`.
- `1786320000000-…-migration.spec.ts` — the post-deploy UPDATE moves only incomplete migration-typed `BOX` rows, and leaves `updatedAt` untouched.
- `box-migration.manager.spec.ts`, `box-migration-job-receiver.service.spec.ts` — expectations updated to `BACKUP`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Backup migration jobs are now correctly classified under the backup resource category instead of the box category.
  - Existing incomplete migration jobs are automatically reassigned to the correct backup category during deployment.
  - Migration job conflict detection now distinguishes backup migrations from regular box lifecycle jobs, preventing incorrect conflicts.
  - Migration status responses consistently report the backup resource type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->