### PR TITLE
feat(diagrams): validate cloud architecture containment

### DIFF
--- a/.agents/skills/boxlite-diagrams/SKILL.md
+++ b/.agents/skills/boxlite-diagrams/SKILL.md
@@ -1,46 +1,103 @@
 ---
 name: boxlite-diagrams
 description: >
-  Draw and validate BoxLite architecture diagrams, sequence diagrams, and
-  source-grounded ASCII call graphs. Use this skill whenever a user asks how
-  BoxLite works, requests an architecture/sequence/call graph, wants an issue
-  or bug illustrated, or needs a PR, commit, branch, or working-tree change
-  explained visually. Always use it for BoxLite visualization requests about
-  an issue, bug, PR, change, or before/after behavior, even when the user asks
-  only for one view.
-compatibility: Requires git, Python 3.10+, Node.js/npm, npx, and gh for GitHub issue or PR evidence.
+  Create, render, visually inspect, and source-ground clear BoxLite
+  architecture, cloud-deployment, sequence, and call-graph diagrams. Use this
+  skill whenever a user asks how BoxLite works, requests a diagram or rendered
+  picture, wants an issue or bug illustrated, or needs a PR, commit, branch, or
+  working-tree change explained visually. Search for and reuse the nearest
+  canonical BoxLite diagram before authoring a new one, and choose only the
+  views that answer the request.
 ---
 
 # BoxLite Diagrams
 
-Turn current BoxLite repository evidence into three mutually checking views:
-
-1. Mermaid architecture diagram
-2. Mermaid sequence diagram
-3. ASCII call graph with exact source anchors
-
-An attractive diagram with an invented hop is worse than no diagram. Generate
-an evidence manifest, run the bundled validator, and present the diagrams only
-after it passes.
+Produce the smallest source-grounded diagram set that answers the user's
+question and is readable as a rendered picture. Evidence correctness and visual
+composition are separate gates: pass both.
 
 ## Workflow
 
-1. Resolve the repository root, current revision, and requested subject.
-2. Read the actual source, nearby tests, and relevant architecture docs.
-3. If an issue or PR is named, read it with `gh` and resolve its revisions.
-4. Classify evidence sources independently from change meaning:
-   - sources: checkout, issue, PR, base/head revisions, or working-tree diff;
-   - meaning: `none`, `bug`, `feature`, `refactor`, or `docs`.
-5. Create `diagram.md` and `evidence.json` in a temporary task directory.
-6. Run `scripts/validate_diagrams.py` using the command below.
-7. On failure, read `validation.json`, correct the evidence or diagram, and
-   retry. Stop after three failed attempts and return the report instead of an
-   unverified diagram.
-8. After deterministic validation passes, use the repository's required
-   verdict-auditor workflow before presenting architectural conclusions.
+1. Resolve the repository root, current revision, requested subject, output
+   location, and reader.
+2. Search before drawing. Look for the nearest maintained diagram in READMEs and
+   architecture or deployment docs:
+
+   ```bash
+   rg -n '^## .*Architecture|^```mermaid|flowchart|sequenceDiagram' \
+     README.md apps docs .github
+   ```
+
+3. Open the closest diagram and its surrounding prose. If it already answers
+   the question, reuse its composition and verify it rather than reconstructing
+   the system from low-level source.
+4. Select only the useful views with the decision table below. Three views are
+   not a default.
+5. If the request is an architecture, cloud deployment, topology, overview, or
+   rendered picture, read
+   [references/architecture-composition.md](references/architecture-composition.md)
+   completely before authoring.
+6. Read the actual source, IaC, nearby tests, and relevant docs needed to verify
+   the selected altitude. If an issue or PR is named, read it with `gh` and
+   resolve its revisions.
+7. Create `diagram.md` and `evidence.json` in a temporary task directory. Add
+   stable canonical IDs for nodes, edges, and architecture boundaries. Declare
+   immediate boundary membership so containment is validated rather than
+   inferred from indentation.
+8. Run the bundled validator. On failure, read `validation.json`, correct the
+   evidence or diagram, and retry. Stop after three failed attempts and return
+   the report instead of an unverified diagram.
+9. Open every generated PNG and inspect the actual render at normal fit-to-page
+   size. Fix overlaps, misleading boundaries, clipped labels, poor routing, or
+   unreadable density, then re-render. Explicitly state that visual QA was done.
+10. Use the repository's required verdict-auditor workflow before presenting
+    architectural conclusions.
 
 Do not edit BoxLite production code when the request is only for a diagram.
 Save generated files in the repository only when the user explicitly asks.
+
+## Choose the view from the question
+
+| User needs | Default output |
+| --- | --- |
+| Architecture, deployment, topology, boundaries, or a rendered picture | Architecture only |
+| Request order, retries, concurrency, callbacks, or failure | Sequence only |
+| Source mechanics, function path, or "how does this code work?" | ASCII call graph; add sequence only if time matters |
+| Issue, bug, PR, or before/after change | Smallest view set that makes the change unambiguous |
+| User explicitly requests named views | Exactly those views |
+
+Add another view only when it answers a materially different question. Do not
+repeat the same component inventory as architecture, sequence, and call graph.
+
+## Reference-first architecture
+
+For the hosted BoxLite cloud deployment, start from
+[`apps/infra/docs/deployment.md#architecture`](../../../apps/infra/docs/deployment.md#architecture).
+It is the house reference for deployment altitude and composition: external
+actors, public edge, private VPC, nested state and observability, semantic
+shapes, operational labels, and only the important routes.
+
+Treat an existing diagram as a maintained hypothesis, not proof. Verify any
+drift-prone label or route against current IaC and source. Preserve the useful
+layout when adding a missing requirement; do not replace a clear canonical
+overview with a larger infrastructure inventory.
+
+"Entire cloud deployment architecture" means full coverage at one deployment
+altitude. Include users/SDKs, external dependencies, public ingress, network and
+trust boundaries, deployed compute, the box execution boundary, durable state,
+observability, and the main request/control/data/image paths. It does not mean
+every security group, route table, function, or SDK call.
+
+Model ownership with surrounding boundaries, not arrows. For the hosted runner
+path, preserve this hierarchy when current source confirms it:
+
+`Runner fleet → EC2 instance × N → Runner daemon → embedded BoxLite runtime → box microVMs`
+
+Use nested Mermaid subgraphs and matching manifest `boundaries[].members` for
+each immediate containment step. Do not draw peers when one component owns,
+hosts, or embeds the other. Keep external services outside AWS/VPC boundaries,
+and place VPC resources inside their actual public or private deployment
+boundary. Read the composition reference for the complete placement rules.
 
 ## State and annotation model
 
@@ -53,7 +110,8 @@ Choose state labels from the evidence:
 Apply annotations to the exact affected node or edge:
 
 - `ISSUE`: verified current gap described by a non-bug issue;
-- `← BUG: <description>`: faulty hop in `Current` or `Before`;
+- `← BUG: <description>`: faulty call-graph hop in `Current` or `Before`;
+- `BUG: <description>`: faulty architecture or sequence element;
 - `FIX`: corrected behavior in `Expected (proposed)` or `After`;
 - `PROPOSED`: behavior required by an issue but absent from source;
 - `ADDED`, `CHANGED`, `REMOVED`: behavior grounded in the corresponding diff.
@@ -61,50 +119,34 @@ Apply annotations to the exact affected node or edge:
 A PR can fix a bug reported by an issue. Do not model issue, bug, and PR as
 mutually exclusive kinds.
 
-## Required document format
+## Document and manifest
 
-Use exactly these level-two view headings and one level-three heading for every
-manifest state:
+Declare selected views at the evidence-manifest root in canonical order:
 
-````markdown
-## Architecture
-
-### Current
-
-```mermaid
-flowchart LR
-  runtime["BoxliteRuntime"]
+```json
+{
+  "schema_version": 1,
+  "views": ["architecture"]
+}
 ```
 
-## Sequence
+If `views` is omitted, the validator selects all three for backward
+compatibility. New diagrams should declare it explicitly. `diagram.md` contains
+exactly the selected level-two sections, with one level-three subsection for
+each state. An architecture-only document is expected for a deployment-picture
+request.
 
-### Current
-
-```mermaid
-sequenceDiagram
-  participant runtime as BoxliteRuntime
-```
-
-## Call graph
-
-### Current
-
-```text
-  create (BoxliteRuntime · src/boxlite/src/runtime/core.rs:291) — public boundary
-```
-````
-
-For bug-fix PRs, add `Fixes #<number>` after the call-graph states.
-
-Read [references/output-contract.md](references/output-contract.md) before
-authoring either output file. Validate `evidence.json` against the shape in
+Read [references/output-contract.md](references/output-contract.md) completely
+before authoring `diagram.md` or `evidence.json`. The schema is
 [references/evidence.schema.json](references/evidence.schema.json); the script
 also performs semantic checks that JSON Schema cannot express.
+
+For bug-fix PRs, add `Fixes #<number>` after the last selected view.
 
 ## Canonical IDs
 
 Use stable lowercase snake-case IDs. Reuse an ID when the same entity or
-relationship appears in more than one view or state.
+relationship appears in more than one selected view or state.
 
 - Architecture node: `runtime["BoxliteRuntime"]`
 - Architecture edge: `runtime create_box@--> box`
@@ -113,15 +155,14 @@ relationship appears in more than one view or state.
 - Call graph: the validator maps a hop to one manifest node by its symbol and
   source anchor, then derives edges from indentation.
 
-Every Mermaid edge must have a canonical ID. Do not leave sequence messages or
-architecture arrows untracked.
+Every selected Mermaid edge has a canonical ID. Do not add untracked arrows or
+messages.
 
 ## Source grounding
 
 - Cite the exact revision, repository-relative path, and inclusive line range.
-- Put the call graph's displayed line inside that evidence range.
-- Include narrow evidence tokens that prove the symbol or relationship.
-- For a direct call, the edge evidence must contain the callee's leaf symbol.
+- Include narrow evidence tokens that prove each node or relationship.
+- For a direct call, the edge evidence contains the callee's leaf symbol.
 - For RPC, dispatch, spawn, data flow, or state transitions, cite the concrete
   registration, protocol call, process launch, assignment, or transition.
 - Never infer a call merely because two real functions have compatible names.
@@ -133,18 +174,28 @@ architecture arrows untracked.
 For comparisons, source anchors belong to their own state revision. A deleted
 hop cites the base revision; an added hop cites the head revision.
 
-## Visual rules
+## Visual composition
 
-- Keep all three views focused on the same behavior.
-- Architecture shows components and trust/process/storage boundaries.
+- Keep every node at the selected altitude and in service of one scope sentence.
+- Architecture shows ownership, network, trust, process, and storage boundaries.
 - Sequence shows time, calls, responses, alternatives, concurrency, and failure.
 - Call graph uses one hop per line:
   `symbol (Type · path/file.ext:line) — role`.
-- Use two-space indentation per call depth and `└─` or `├─` for children.
-- Keep meaning in text. Color may reinforce but never carry an annotation.
+- Prefer `flowchart TB` for a whole cloud deployment and `LR` for a short path.
+- Use subgraphs only for real boundaries. Make each parent physically surround
+  its immediate members; nested and sibling boundaries must be visually
+  disjoint in the rendered image.
+- Use short labels with domain, protocol, port, implementation, or constraint
+  details only where they change understanding.
+- Use semantic shapes consistently: rounded actors, rectangles for services,
+  cylinders for state, and a distinct VM/runtime shape.
+- Keep meaning in text. Color may reinforce it but never carry it.
+- Keep README Mermaid unstyled so its host controls light/dark rendering. Do
+  not set a theme, `classDef`, `class`, `style`, or `linkStyle`; exported PNGs
+  are static previews, not adaptive replacements.
 - Mermaid is limited to `flowchart`/`graph` and `sequenceDiagram`.
-- Do not use Mermaid initialization directives, clicks, links, raw HTML, or
-  JavaScript.
+- `<br/>` is allowed for deliberate label wrapping. Initialization directives,
+  clicks, links, other raw HTML, and JavaScript are forbidden.
 
 ## Validation command
 
@@ -162,17 +213,23 @@ Exit codes:
 - `1`: diagram or evidence is invalid;
 - `2`: a required tool is unavailable.
 
-The validator renders Mermaid with pinned on-demand
-`@mermaid-js/mermaid-cli@11.16.0`. It uses an installed Chrome/Chromium when
-available and otherwise lets Puppeteer provision its browser.
+The validator uses pinned on-demand `@mermaid-js/mermaid-cli@11.16.0` and emits
+`.mmd`, `.svg`, and `.png` artifacts. Open the PNG with the available image-view
+tool. Do not substitute source inspection for render inspection.
 
 ## Response
 
-Lead with the ASCII call graph and one `Key:` line, matching BoxLite's normal
-code-explanation style. Then show architecture and sequence. For comparisons,
-keep `Before` and `After` adjacent within each view. End with a compact evidence
-summary and the passing validation-report path when files were requested.
+Lead with what the user requested:
 
-Do not claim that mechanical validation proves the architecture is correct.
-It proves renderability, source traceability, diff alignment, and cross-view
-consistency; the verdict audit covers the remaining interpretation.
+- rendered picture: show or link the PNG first;
+- architecture: show architecture first;
+- code-path explanation: show the ASCII call graph and one `Key:` line first;
+- comparison: keep `Before` and `After` adjacent within each selected view.
+
+End with a compact evidence summary, visual-QA statement, and the passing
+validation-report path when files were requested.
+
+Mechanical validation proves renderability, source traceability, diff alignment,
+and consistency across selected views. It does not prove that the picture is
+well composed or that the architectural interpretation is complete; visual QA
+and the verdict audit cover those separate judgments.

--- a/.agents/skills/boxlite-diagrams/evals/evals.json
+++ b/.agents/skills/boxlite-diagrams/evals/evals.json
@@ -3,38 +3,40 @@
   "evals": [
     {
       "id": 1,
-      "prompt": "In the BoxLite repository, explain the current local runtime path for creating a box. Produce diagram.md, evidence.json, and validation.json in the requested output directory. Do not change production source.",
-      "expected_output": "A validated Current-state architecture diagram, sequence diagram, and source-grounded ASCII call graph for local box creation.",
+      "prompt": "Create the entire BoxLite cloud deployment architecture in apps/README.md and give me a rendered picture. There is already a good architecture in apps/infra/docs/deployment.md#architecture; use it as the standard. Do not change production source.",
+      "expected_output": "A validated, visually inspected architecture-only overview that starts from the canonical deployment diagram, preserves one deployment altitude, uses truthful nested boundaries, and includes the complete hosted-cloud boundary and main paths without redundant views. The execution hierarchy is Runner fleet → EC2 instance × N → Runner daemon → embedded BoxLite runtime → box microVMs, and the README Mermaid remains light/dark adaptive.",
       "files": [],
       "expectations": [
-        "The output directory contains diagram.md, evidence.json, and validation.json, and validation.json reports valid=true with exit_code=0.",
-        "diagram.md contains exactly the Architecture, Sequence, and Call graph views for a Current state.",
-        "The call graph uses symbol (Type · path:line) — role hops and its caller-to-callee relationships are supported by revision-aware source evidence.",
-        "Canonical node and edge IDs agree across the manifest, architecture, sequence, and call-graph views."
+        "The agent searches existing BoxLite docs first and identifies apps/infra/docs/deployment.md#architecture as the composition baseline instead of rebuilding the system from low-level calls.",
+        "evidence.json explicitly selects only the architecture view, and diagram.md does not add unrequested Sequence or Call graph sections.",
+        "The architecture covers user and SDK entry points, external dependencies, public ingress, private compute and box execution, state, observability, and the main request/control/data/image routes at one deployment altitude.",
+        "The Runner fleet surrounds a representative EC2 instance × N; EC2 surrounds the Runner daemon; Runner surrounds the embedded BoxLite runtime; BoxLite surrounds box microVMs. These immediate memberships are declared in evidence.json boundaries and validated against Mermaid nesting.",
+        "The README Mermaid contains no fixed theme or styling directives, remains light/dark adaptive on GitHub, and uses the PNG only as a static preview.",
+        "validation.json reports valid=true and emits both SVG and PNG artifacts; the agent opens the PNG and checks readability, truthful containment, disjoint boundaries, routing, and label clipping before presenting it."
       ]
     },
     {
       "id": 2,
-      "prompt": "Illustrate open BoxLite issue #1209 (boxlite serve volume creation and mount). Show what exists now and what the issue proposes. Produce diagram.md, evidence.json, and validation.json in the requested output directory. Do not change production source.",
-      "expected_output": "A validated Current versus Expected (proposed) package that separates source-backed behavior from issue-backed proposed behavior.",
+      "prompt": "In the BoxLite repository, explain the current local runtime path for creating a box. Produce diagram.md, evidence.json, and validation.json in the requested output directory. Do not change production source.",
+      "expected_output": "A validated source-grounded ASCII call graph for local box creation, with a sequence view only if ordering or lazy initialization materially helps the explanation.",
       "files": [],
       "expectations": [
-        "The output directory contains diagram.md, evidence.json, and validation.json, and validation.json reports valid=true with exit_code=0.",
-        "All three views contain adjacent Current and Expected (proposed) states.",
-        "Proposed behavior is marked PROPOSED on the exact affected element, uses issue #1209 evidence, and is not represented by an invented source symbol.",
-        "Implemented behavior cites resolvable revision, path, line, symbol, and tokens, while proposed behavior is explicitly distinguished from implemented behavior."
+        "The selected view set follows the question and does not mechanically include all three views.",
+        "The call graph uses symbol (Type · path:line) — role hops and its caller-to-callee relationships are supported by revision-aware source evidence.",
+        "Any added sequence view explains a temporal concern that the call graph cannot show; an architecture inventory is not added without a distinct need.",
+        "The output directory contains diagram.md, evidence.json, and validation.json, and validation.json reports valid=true with exit_code=0."
       ]
     },
     {
       "id": 3,
       "prompt": "Explain bug-fix PR #1200 for split UTF-8 PTY frames. Produce diagram.md, evidence.json, and validation.json in the requested output directory. Show a complete Before and After and link the fixed issue. Do not change production source.",
-      "expected_output": "A validated bug-fix PR package with the faulty Before hop marked ← BUG:, the corrected After path marked FIX, and Fixes #1155.",
+      "expected_output": "A validated, focused Before/After explanation using only the views needed to expose the faulty buffering hop and corrected behavior, with the fixed issue linked.",
       "files": [],
       "expectations": [
-        "The output directory contains diagram.md, evidence.json, and validation.json, and validation.json reports valid=true with exit_code=0.",
-        "All three views contain complete adjacent Before and After states grounded in the PR base and head revisions.",
-        "← BUG: appears only on the faulty Before call-graph hop, FIX appears on the corrected After behavior, and diagram.md contains Fixes #1155.",
-        "Every call-graph relationship has concrete source evidence and the canonical nodes and edges agree across all three views."
+        "The selected views contain complete adjacent Before and After states grounded in the PR base and head revisions without repeating the same content in an unnecessary third view.",
+        "← BUG: appears only on the faulty Before call-graph hop when a call graph is selected, FIX appears on the corrected After behavior, and diagram.md contains Fixes #1155.",
+        "Every displayed relationship has concrete revision-aware source evidence and canonical IDs agree across the selected views.",
+        "Every Mermaid view renders to SVG and PNG and is visually inspected before presentation."
       ]
     }
   ]

--- a/.agents/skills/boxlite-diagrams/references/architecture-composition.md
+++ b/.agents/skills/boxlite-diagrams/references/architecture-composition.md
@@ -1,0 +1,178 @@
+# Architecture composition
+
+Read this reference whenever the requested output is an architecture,
+deployment, topology, overview, or rendered picture.
+
+## Contents
+
+- [BoxLite house reference](#boxlite-house-reference)
+- [Pick one altitude](#pick-one-altitude)
+- [Model containment before routes](#model-containment-before-routes)
+- [Place hosted-cloud components](#place-hosted-cloud-components)
+- [Compose for a normal-width render](#compose-for-a-normal-width-render)
+- [Preserve adaptive themes](#preserve-adaptive-themes)
+- [Run visual QA](#run-visual-qa)
+
+## BoxLite house reference
+
+Start with the existing diagram closest to the request. For the hosted cloud
+deployment, use
+[`apps/infra/docs/deployment.md#architecture`](../../../../apps/infra/docs/deployment.md#architecture)
+as the composition baseline. It establishes the BoxLite house style:
+
+- keep users and external dependencies outside owned infrastructure;
+- separate public ingress from private compute;
+- group state and observability by operational role;
+- distinguish actors, services, storage, and box microVMs by shape;
+- put only useful domain, protocol, port, runtime, and constraint details in
+  labels;
+- draw only high-value request, control, image, telemetry, and data routes.
+
+Reuse the canonical layout when it answers the question, but treat its
+containment as a hypothesis. Verify every deployment boundary against current
+IaC and source before copying it. Do not reconstruct the system from low-level
+call paths merely because more source exists.
+
+## Pick one altitude
+
+State the diagram's question in one sentence before drawing. Examples:
+
+- "How public traffic reaches private BoxLite services and boxes."
+- "How the runner creates and starts one box."
+- "What changed between the PR base and head."
+
+Every node must help answer that sentence. A deployment overview names deployed
+systems and boundaries, not individual functions. A source call graph names
+functions, not every cloud resource.
+
+"Entire deployment architecture" means complete coverage at the deployment
+altitude, not every AWS resource. Include:
+
+1. user and SDK entry points;
+2. external identity, DNS, registry, or telemetry dependencies that affect the
+   main path;
+3. public ingress and routing;
+4. network, host, process, and trust boundaries needed to understand ownership;
+5. deployed compute and the box execution boundary;
+6. durable state and caches;
+7. the main control, data, image, and observability routes.
+
+Combine siblings with the same boundary and role when their individual identity
+does not change a route. Add a second diagram only when the user asks for a
+different altitude.
+
+## Model containment before routes
+
+Distinguish containment from communication:
+
+- "inside," "runs on," "owns," and "embeds" require surrounding subgraphs;
+- "calls," "routes to," "polls," "mounts," and "exports" require arrows;
+- never use an arrow as a substitute for ownership;
+- never place an embedded component beside its host.
+
+Give every real boundary a canonical lowercase snake-case Mermaid subgraph ID.
+Declare the same boundary and each immediate member in
+`evidence.json.boundaries`. The validator compares the manifest with the actual
+nesting; indentation alone is not evidence.
+
+For the hosted runner path, preserve this source-backed containment:
+
+`Runner fleet → EC2 instance × N → Runner daemon → embedded BoxLite runtime → box microVMs`
+
+Draw one representative EC2 unit and label the repeated layer `× N`; do not
+clone identical instances. Use this shape:
+
+```mermaid
+flowchart TB
+subgraph runner_fleet["Runner fleet · × N"]
+  subgraph ec2_runner["EC2 instance · representative"]
+    subgraph runner_process["Runner daemon"]
+      runner_api["Runner API · :3003"]
+      subgraph embedded_boxlite["embedded BoxLite runtime"]
+        boxlite_core["BoxLite"]
+        boxes[["box microVMs"]]
+      end
+    end
+  end
+end
+```
+
+Model every step, not merely the outer fleet. `Runner fleet` surrounds the
+representative `EC2` boundary; EC2 surrounds the Runner process; Runner
+surrounds the embedded BoxLite runtime; BoxLite surrounds the microVMs it
+creates and manages.
+
+Deep nesting is justified for this ownership chain because flattening it changes
+the architecture's meaning. Keep unrelated state, telemetry, and ingress
+grouping shallow so the overall picture remains readable.
+
+## Place hosted-cloud components
+
+Verify these placements against current IaC before drawing because they can
+drift:
+
+- keep the browser, SDK/CLI, Cloudflare DNS, OIDC provider, and image registry
+  outside BoxLite-owned AWS boundaries;
+- keep CloudFront in the AWS/global edge but outside the VPC;
+- surround ALB/NLB resources with the VPC public-ingress boundary;
+- surround ECS/Fargate API, Proxy, and internal tools with the VPC private
+  service boundary;
+- surround the Runner fleet with the VPC public-runner-subnet boundary;
+- place RDS and Redis inside their VPC state boundary;
+- keep regional S3 outside the VPC; draw its VPC gateway endpoint or route only
+  when that access distinction matters.
+
+Do not label a box "public edge" and then use it to imply that every enclosed
+resource is outside the VPC. A route category and a deployment boundary are
+different concepts.
+
+## Compose for a normal-width render
+
+- Prefer `flowchart TB` for a whole deployment and `LR` for a short path.
+- Put the main request/control path near the center and supporting systems
+  around it.
+- Keep sibling boundaries disjoint. If Mermaid overlaps them, change direction,
+  edge placement, or grouping and render again.
+- Use short labels. Add a second or third line only for a domain, port,
+  protocol, implementation, scale marker, or operational constraint.
+- Use rounded actors, rectangles for services, cylinders for state, and a
+  distinct shape for microVMs.
+- Label important edges with traffic or control meaning. Leave obvious
+  forwarding edges unlabeled only when the relationship remains unambiguous.
+- Aim for roughly 12–20 nodes. Boundaries do not consume the same budget when
+  they replace misleading ownership arrows.
+- Avoid service logos, decorative icons, and dense legends.
+
+Mermaid may ignore a subgraph's requested direction when its nodes connect
+outside that subgraph. Treat the rendered result—not source indentation or a
+`direction` statement—as the layout truth.
+
+## Preserve adaptive themes
+
+For GitHub README output, leave Mermaid unstyled so the host selects light/dark
+colors. Do not add initialization directives, fixed themes, `themeVariables`,
+`classDef`, `class`, `style`, or `linkStyle`. Use shapes, labels, and boundaries
+instead of color for meaning.
+
+An exported SVG or PNG is static and does not auto-switch. Keep the live Mermaid
+block as the README source of truth, and use PNG only as a preview or download.
+When theme contrast matters, inspect a light and dark render before delivery.
+
+## Run visual QA
+
+After deterministic validation, open every generated PNG at normal fit-to-page
+size and check the picture:
+
+1. The title or prose states the scope.
+2. The main path can be followed in a few seconds.
+3. Each parent visibly surrounds every declared immediate member.
+4. External, AWS, VPC, subnet, host, process, runtime, state, and telemetry
+   boundaries are truthful and disjoint.
+5. Labels remain legible without zooming and are not clipped.
+6. Arrows do not cross unrelated nodes or imply false ownership/direction.
+7. No large empty region or long return edge distorts the layout.
+8. Every item promised by the scope sentence appears.
+9. The unstyled Mermaid remains readable in light/dark themes.
+
+If any check fails, revise and render again. Syntax success and source evidence
+do not constitute a visual-quality pass.

--- a/.agents/skills/boxlite-diagrams/references/evidence.schema.json
+++ b/.agents/skills/boxlite-diagrams/references/evidence.schema.json
@@ -7,6 +7,12 @@
   "required": ["schema_version", "context", "states", "nodes", "edges", "annotations"],
   "properties": {
     "schema_version": { "const": 1 },
+    "views": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "enum": ["architecture", "sequence", "call_graph"] },
+      "uniqueItems": true
+    },
     "context": {
       "type": "object",
       "additionalProperties": false,
@@ -66,6 +72,26 @@
               "to": { "$ref": "#/$defs/id" },
               "kind": {
                 "enum": ["call", "rpc", "dispatch", "spawn", "data", "state-transition", "proposed"]
+              }
+            }
+          }
+        ],
+        "unevaluatedProperties": false
+      }
+    },
+    "boundaries": {
+      "type": "array",
+      "items": {
+        "allOf": [
+          { "$ref": "#/$defs/item" },
+          {
+            "type": "object",
+            "required": ["members"],
+            "properties": {
+              "members": {
+                "type": "array",
+                "minItems": 1,
+                "items": { "$ref": "#/$defs/membership" }
               }
             }
           }
@@ -151,6 +177,23 @@
           "type": "array",
           "minItems": 1,
           "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "membership": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target", "states"],
+      "properties": {
+        "target": {
+          "type": "string",
+          "pattern": "^(node|boundary):[a-z][a-z0-9_]*$"
+        },
+        "states": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/id" },
+          "uniqueItems": true
         }
       }
     }

--- a/.agents/skills/boxlite-diagrams/references/output-contract.md
+++ b/.agents/skills/boxlite-diagrams/references/output-contract.md
@@ -1,19 +1,58 @@
 # BoxLite diagram output contract
 
+## Select only the useful views
+
+`evidence.json` may declare a non-empty `views` array in this canonical order:
+
+1. `architecture`
+2. `sequence`
+3. `call_graph`
+
+Omitting `views` keeps backward compatibility and selects all three. Every
+node and edge membership must be a subset of the selected views.
+
+Choose views from the user's question:
+
+- deployment, topology, boundary, overview, or rendered picture:
+  `['architecture']` by default;
+- ordering, retries, concurrency, or failure: `['sequence']`;
+- source mechanics or a function path: `['call_graph']`, adding sequence only
+  when time or concurrency matters;
+- before/after change: the smallest view set that makes the change unambiguous.
+
+Three views are useful only when each answers a different question. Repeating
+the same inventory three ways makes the result harder to understand.
+
 ## Document
 
-`diagram.md` contains exactly three level-two sections in this order:
-
-1. `Architecture`
-2. `Sequence`
-3. `Call graph`
-
-Each section contains exactly one level-three subsection for every state listed
-in `evidence.json`, in the same order. Architecture and sequence state sections
-contain one `mermaid` fence. Call-graph state sections contain one `text` fence.
+`diagram.md` contains exactly the selected level-two sections in canonical
+order. Each section contains exactly one level-three subsection for every state
+listed in `evidence.json`, in the same order. Architecture and sequence state
+sections contain one `mermaid` fence. Call-graph state sections contain one
+`text` fence.
 
 Architecture fences start with `flowchart` or `graph`. Sequence fences start
 with `sequenceDiagram`.
+
+An architecture-only overview is valid:
+
+````markdown
+## Architecture
+
+### Current
+
+```mermaid
+flowchart TB
+  browser(["Browser"])
+  subgraph private["VPC · private subnets"]
+    api["Api · NestJS<br/>:3000"]
+  end
+  browser browser_api@-->|"/api/*"| api
+```
+````
+
+For bug-fix PRs, put `Fixes #<number>` on a standalone line after the last
+selected view.
 
 ## Architecture IDs
 
@@ -26,7 +65,53 @@ flowchart LR
   runtime create_box@-->|"create"| box
 ```
 
-The Mermaid edge ID (`create_box`) is also the manifest edge ID.
+The Mermaid edge ID (`create_box`) is also the manifest edge ID. `<br/>` is the
+only allowed HTML-like tag and is used only for deliberate label wrapping.
+
+## Architecture boundaries
+
+Give every meaningful subgraph a lowercase snake-case ID and declare it in the
+manifest. Use nested subgraphs for hosting or embedding, and arrows only for
+communication. The BoxLite deployment's execution containment is:
+
+`Runner fleet → EC2 instance × N → Runner daemon → embedded BoxLite runtime → box microVMs`
+
+```mermaid
+flowchart TB
+subgraph runner_fleet["Runner fleet · × N"]
+  subgraph ec2_runner["EC2 instance · representative"]
+    subgraph runner_process["Runner daemon"]
+      runner_api["Runner API · :3003"]
+      subgraph embedded_boxlite["embedded BoxLite runtime"]
+        boxlite_core["BoxLite"]
+        boxes[["box microVMs"]]
+      end
+    end
+  end
+end
+```
+
+Declare each immediate parent-child relationship; do not skip from fleet
+directly to Runner or place BoxLite beside Runner:
+
+```json
+{
+  "id": "runner_process",
+  "label": "Runner daemon",
+  "states": ["current"],
+  "views": ["architecture"],
+  "proposed": false,
+  "members": [
+    {"target": "node:runner_api", "states": ["current"]},
+    {"target": "boundary:embedded_boxlite", "states": ["current"]}
+  ],
+  "evidence": []
+}
+```
+
+In a real manifest, every boundary has revision-aware source or issue evidence,
+just like a node or edge. One target may have only one immediate parent per
+state, and boundary cycles are invalid.
 
 ## Sequence IDs
 
@@ -59,7 +144,8 @@ Rules:
 - a child uses `└─` or `├─` after its indentation;
 - the displayed line must be inside the matching manifest evidence range;
 - indentation creates a caller-to-callee edge that must exist in the manifest;
-- `← BUG: <description>` belongs on a faulty `Before`/`Current` hop, never on a standalone line;
+- `← BUG: <description>` belongs on a faulty `Before`/`Current` hop, never on a
+  standalone line;
 - future behavior has no invented hop—annotate the last real boundary instead.
 
 ## Evidence types
@@ -95,13 +181,14 @@ case-insensitive substrings of the issue title/body.
 
 ## Manifest membership
 
-Each node and edge declares the states and views where it appears. Allowed view
-IDs are `architecture`, `sequence`, and `call_graph`. Shared entities reuse the
-same canonical ID; view-specific context is allowed when it materially improves
-that view.
+Each node, edge, and boundary declares the states and selected views where it
+appears. Shared entities reuse the same canonical ID; view-specific context is
+allowed when it materially improves that view.
 
 Every parsed Mermaid node, Mermaid edge, sequence participant/message, and call
-graph hop/relationship must map to exactly one declared manifest item.
+graph hop/relationship must map to exactly one declared manifest item. When the
+manifest declares `boundaries`, every Mermaid subgraph and every immediate
+node/subgraph parent must match it exactly.
 
 ## Annotation targets
 
@@ -116,6 +203,15 @@ Annotations target `node:<id>` or `edge:<id>` and include one state:
 }
 ```
 
-Use `ISSUE`, `BUG`, `FIX`, `PROPOSED`, `ADDED`, `CHANGED`, or `REMOVED`.
-For diff annotations, the target's evidence must intersect the correct base/head
+Use `ISSUE`, `BUG`, `FIX`, `PROPOSED`, `ADDED`, `CHANGED`, or `REMOVED`. For
+diff annotations, the target's evidence must intersect the correct base/head
 diff hunk.
+
+## Rendered artifacts
+
+The validator emits `.mmd`, `.svg`, and `.png` artifacts for every Mermaid
+block. The PNG exists for visual inspection. A successful validation report
+proves syntax and traceability, not composition; inspect the PNG before calling
+the result ready. Keep README Mermaid free of fixed themes and styles so GitHub
+controls light/dark rendering. Treat a PNG as a static preview and inspect both
+light and dark renders when the destination's contrast is important.

--- a/.agents/skills/boxlite-diagrams/scripts/validator/call_graph.py
+++ b/.agents/skills/boxlite-diagrams/scripts/validator/call_graph.py
@@ -18,6 +18,9 @@ def validate_call_graph(ctx: ValidationContext) -> None:
     if ctx.parsed is None:
         ctx.add("call_graph.structure", "fail", "call graph cannot be checked until the document is parsed")
         return
+    if "call_graph" not in ctx.view_ids():
+        ctx.add("call_graph.structure", "pass", "call-graph view was not selected")
+        return
     errors: list[str] = []
     for state in ctx.state_map():
         block = ctx.parsed.blocks.get(("call_graph", state))

--- a/.agents/skills/boxlite-diagrams/scripts/validator/consistency.py
+++ b/.agents/skills/boxlite-diagrams/scripts/validator/consistency.py
@@ -2,16 +2,13 @@ from __future__ import annotations
 
 from .models import ValidationContext
 
-VIEWS = ("architecture", "sequence", "call_graph")
-
-
 def validate_consistency(ctx: ValidationContext) -> None:
     if ctx.parsed is None:
         ctx.add("consistency.cross_view", "fail", "cross-view consistency requires a parsed document")
         return
     errors: list[str] = []
     for state in ctx.state_map():
-        for view in VIEWS:
+        for view in ctx.view_ids():
             expected_nodes = {
                 item["id"] for item in ctx.manifest.get("nodes", [])
                 if state in item.get("states", []) and view in item.get("views", [])
@@ -32,13 +29,19 @@ def validate_consistency(ctx: ValidationContext) -> None:
                     f"{view}/{state} edges disagree: missing={sorted(expected_edges - actual_edges)}, "
                     f"undeclared={sorted(actual_edges - expected_edges)}"
                 )
+            if view == "architecture" and "boundaries" in ctx.manifest:
+                _check_boundaries(ctx, state, errors)
             _check_endpoints(ctx, view, state, errors)
             _check_labels(ctx, view, state, errors)
     _check_mermaid_annotations(ctx, errors)
     if errors:
         ctx.add("consistency.cross_view", "fail", "diagram views disagree with the evidence manifest", errors)
     else:
-        ctx.add("consistency.cross_view", "pass", "canonical nodes and edges agree across all declared views")
+        ctx.add(
+            "consistency.cross_view",
+            "pass",
+            "canonical nodes, edges, boundaries, and immediate containment agree across all declared views",
+        )
 
 
 def _actual_node_ids(ctx: ValidationContext, view: str, state: str) -> set[str]:
@@ -89,6 +92,54 @@ def _check_labels(ctx: ValidationContext, view: str, state: str, errors: list[st
             expected = ctx.item_map("edge")[item_id]["label"]
             if expected.lower() not in label.lower():
                 errors.append(f"{view}/{state} edge {item_id!r} label does not contain {expected!r}")
+
+
+def _check_boundaries(ctx: ValidationContext, state: str, errors: list[str]) -> None:
+    expected_boundaries = {
+        item["id"] for item in ctx.manifest.get("boundaries", [])
+        if state in item.get("states", []) and "architecture" in item.get("views", [])
+    }
+    actual_boundaries = {
+        boundary_id
+        for (boundary_state, boundary_id) in ctx.parsed.architecture_boundaries
+        if boundary_state == state
+    }
+    if actual_boundaries != expected_boundaries:
+        errors.append(
+            f"architecture/{state} boundaries disagree: "
+            f"missing={sorted(expected_boundaries - actual_boundaries)}, "
+            f"undeclared={sorted(actual_boundaries - expected_boundaries)}"
+        )
+
+    expected_parents: dict[str, str] = {}
+    for boundary in ctx.manifest.get("boundaries", []):
+        if state not in boundary.get("states", []):
+            continue
+        for membership in boundary.get("members", []):
+            if state in membership.get("states", []):
+                expected_parents[membership["target"]] = boundary["id"]
+    actual_parents = {
+        target: parent
+        for (parent_state, target), parent in ctx.parsed.architecture_parents.items()
+        if parent_state == state
+    }
+    if actual_parents != expected_parents:
+        differences = sorted(
+            f"{target}: expected={expected_parents.get(target)!r}, actual={actual_parents.get(target)!r}"
+            for target in set(expected_parents) | set(actual_parents)
+            if expected_parents.get(target) != actual_parents.get(target)
+        )
+        errors.append(f"architecture/{state} immediate containment disagrees: {differences}")
+
+    boundary_map = ctx.item_map("boundary")
+    for (boundary_state, boundary_id), label in ctx.parsed.architecture_boundaries.items():
+        if boundary_state != state or boundary_id not in boundary_map:
+            continue
+        expected = boundary_map[boundary_id]["label"]
+        if expected.lower() not in label.lower():
+            errors.append(
+                f"architecture/{state} boundary {boundary_id!r} label does not contain {expected!r}"
+            )
 
 
 def _check_mermaid_annotations(ctx: ValidationContext, errors: list[str]) -> None:

--- a/.agents/skills/boxlite-diagrams/scripts/validator/document.py
+++ b/.agents/skills/boxlite-diagrams/scripts/validator/document.py
@@ -32,9 +32,10 @@ def validate_document(ctx: ValidationContext) -> None:
     parsed = ParsedDocument(text=text)
     ctx.parsed = parsed
     states = ctx.manifest.get("states", [])
+    selected_views = ctx.view_ids()
     state_by_label = {state.get("label"): state.get("id") for state in states}
     expected_pairs = {
-        (view, state.get("id")) for view in VIEW_ORDER for state in states if state.get("id")
+        (view, state.get("id")) for view in selected_views for state in states if state.get("id")
     }
 
     lines = text.splitlines()
@@ -86,6 +87,12 @@ def validate_document(ctx: ValidationContext) -> None:
                 current_label = None
                 continue
             current_view = VIEW_HEADINGS[heading]
+            if current_view not in selected_views:
+                errors.append(f"line {line_number}: view {current_view!r} is not selected by the manifest")
+                current_view = None
+                current_state = None
+                current_label = None
+                continue
             current_state = None
             current_label = None
             view_counts[current_view] += 1
@@ -108,9 +115,9 @@ def validate_document(ctx: ValidationContext) -> None:
     if fence is not None:
         errors.append(f"line {fence[1]}: unterminated fenced block")
 
-    if view_order != VIEW_ORDER:
-        errors.append(f"view order must be {VIEW_ORDER}; found {view_order}")
-    for view in VIEW_ORDER:
+    if view_order != selected_views:
+        errors.append(f"view order must be {selected_views}; found {view_order}")
+    for view in selected_views:
         if view_counts[view] != 1:
             errors.append(f"view {view!r} must occur exactly once; found {view_counts[view]}")
         expected_state_order = [state.get("id") for state in states if state.get("id")]
@@ -138,7 +145,7 @@ def validate_document(ctx: ValidationContext) -> None:
         ctx.add(
             "document.structure",
             "pass",
-            "all required views and states have exactly one correctly typed block",
+            "all selected views and states have exactly one correctly typed block",
             [f"{view}/{state}" for view, state in sorted(expected_pairs)],
         )
 
@@ -158,4 +165,4 @@ def _validate_diagram_kinds(ctx: ValidationContext) -> None:
     if errors:
         ctx.add("document.diagram_kinds", "fail", "unsupported Mermaid diagram kind", errors)
     else:
-        ctx.add("document.diagram_kinds", "pass", "architecture and sequence diagram kinds are supported")
+        ctx.add("document.diagram_kinds", "pass", "all selected Mermaid diagram kinds are supported")

--- a/.agents/skills/boxlite-diagrams/scripts/validator/mermaid.py
+++ b/.agents/skills/boxlite-diagrams/scripts/validator/mermaid.py
@@ -15,12 +15,20 @@ VERSION = "11.16.0"
 UNSAFE_PATTERNS = [
     (re.compile(r"%%\{"), "initialization directives"),
     (re.compile(r"(?im)^\s*click\s+"), "click directives"),
+    (
+        re.compile(r"(?im)^\s*(?:classDef|class|style|linkStyle)\b"),
+        "fixed styling that breaks host-controlled light/dark themes",
+    ),
+    (re.compile(r"(?i)\bthemeVariables\b"), "fixed theme variables"),
     (re.compile(r"(?i)javascript\s*:"), "javascript URLs"),
     (re.compile(r"(?i)https?://|\bhref\s*="), "external links"),
 ]
 MERMAID_LEFT_ARROWS = ("<-->", "<-.->", "<==>")
 MERMAID_RIGHT_ARROWS = ("-->", "---", "-.->", "==>", "--o", "--x")
 NODE_RE = re.compile(r'^\s*([a-z][a-z0-9_]*)\s*(?:\[\[|\[\(|\[|\(\(|\(|\{\{\{|\{\{|\{|>)\s*["\']?(.+?)["\']?\s*(?:\]\]|\)\]|\]|\)\)|\)|\}\}\}|\}\}|\}|\])\s*$')
+SUBGRAPH_RE = re.compile(
+    r'^\s*subgraph\s+([a-z][a-z0-9_]*)\s*(?:\[\s*["\']?(.+?)["\']?\s*\])?\s*$'
+)
 EDGE_RE = re.compile(
     r'^\s*([a-z][a-z0-9_]*)\s+([a-z][a-z0-9_]*)@(?:-->|---|-.->|==>|--o|--x|o--o|x--x|<-->|<-.->|<==>)'
     r'(?:\|["\']?([^|]+?)["\']?\|)?\s*([a-z][a-z0-9_]*)\s*$'
@@ -57,9 +65,33 @@ def validate_mermaid(ctx: ValidationContext) -> None:
 
 
 def _parse_architecture(ctx: ValidationContext, state: str, block: StateBlock, errors: list[str]) -> None:
+    boundary_stack: list[str] = []
     for offset, line in enumerate(block.content.splitlines()[1:], start=1):
         stripped = line.strip()
-        if not stripped or stripped.startswith("%%") or stripped == "end" or stripped.startswith(("subgraph ", "direction ", "classDef ", "class ")):
+        if not stripped or stripped.startswith("%%") or stripped.startswith("direction "):
+            continue
+        if stripped == "end":
+            if not boundary_stack:
+                errors.append(f"architecture/{state} line {block.start_line + offset} has an unmatched 'end'")
+            else:
+                boundary_stack.pop()
+            continue
+        if stripped.startswith("subgraph "):
+            boundary = SUBGRAPH_RE.match(line)
+            if boundary is None:
+                errors.append(
+                    f"architecture/{state} line {block.start_line + offset} has a subgraph without a "
+                    "lowercase snake-case boundary ID"
+                )
+                continue
+            boundary_id, label = boundary.groups()
+            key = (state, boundary_id)
+            if key in ctx.parsed.architecture_boundaries:
+                errors.append(f"architecture/{state} duplicates boundary ID {boundary_id!r}")
+            ctx.parsed.architecture_boundaries[key] = _clean_label(label or boundary_id)
+            if boundary_stack:
+                ctx.parsed.architecture_parents[(state, f"boundary:{boundary_id}")] = boundary_stack[-1]
+            boundary_stack.append(boundary_id)
             continue
         edge = EDGE_RE.match(line)
         if edge:
@@ -77,9 +109,15 @@ def _parse_architecture(ctx: ValidationContext, state: str, block: StateBlock, e
             if key in ctx.parsed.architecture_nodes:
                 errors.append(f"architecture/{state} duplicates node ID {node_id!r}")
             ctx.parsed.architecture_nodes[key] = _clean_label(label)
+            if boundary_stack:
+                ctx.parsed.architecture_parents[(state, f"node:{node_id}")] = boundary_stack[-1]
             continue
         if any(arrow in line for arrow in MERMAID_RIGHT_ARROWS):
             errors.append(f"architecture/{state} line {block.start_line + offset} has an arrow without a canonical edge ID")
+    if boundary_stack:
+        errors.append(
+            f"architecture/{state} leaves boundaries open at end of block: {boundary_stack}"
+        )
 
 
 def _parse_sequence(ctx: ValidationContext, state: str, block: StateBlock, errors: list[str]) -> None:
@@ -126,10 +164,18 @@ def _parse_sequence(ctx: ValidationContext, state: str, block: StateBlock, error
 
 
 def _render_all(ctx: ValidationContext) -> None:
+    if ctx.parsed is None:
+        return
+    blocks = [
+        ((view, state), block)
+        for (view, state), block in ctx.parsed.blocks.items()
+        if view in {"architecture", "sequence"}
+    ]
+    if not blocks:
+        ctx.add("mermaid.render", "pass", "no Mermaid view was selected")
+        return
     if shutil.which("npx") is None:
         ctx.add("tool.mermaid_cli", "error", "npx is required to fetch pinned Mermaid CLI")
-        return
-    if ctx.parsed is None:
         return
     artifacts_dir = ctx.report_path.parent / f"{ctx.report_path.stem}-artifacts"
     try:
@@ -140,11 +186,10 @@ def _render_all(ctx: ValidationContext) -> None:
     errors: list[str] = []
     tool_errors: list[str] = []
     rendered: list[str] = []
-    for (view, state), block in ctx.parsed.blocks.items():
-        if view not in {"architecture", "sequence"}:
-            continue
+    for (view, state), block in blocks:
         input_path = artifacts_dir / f"{view}-{state}.mmd"
         output_path = artifacts_dir / f"{view}-{state}.svg"
+        preview_path = artifacts_dir / f"{view}-{state}.png"
         input_path.write_text(block.content, encoding="utf-8")
         try:
             result = _run_mmdc(input_path, output_path, artifacts_dir)
@@ -175,9 +220,27 @@ def _render_all(ctx: ValidationContext) -> None:
         if missing:
             errors.append(f"{view}/{state}: SVG is missing manifest labels {missing}")
             continue
+        try:
+            preview_result = _run_mmdc(input_path, preview_path, artifacts_dir)
+        except subprocess.TimeoutExpired:
+            ctx.add("tool.mermaid_cli", "error", f"Mermaid preview rendering exceeded {_command_timeout():g} seconds")
+            return
+        if preview_result is None:
+            ctx.add("tool.mermaid_cli", "error", "pinned Mermaid CLI could not render a PNG preview")
+            return
+        if preview_result.returncode != 0:
+            detail = preview_result.stderr.strip() or preview_result.stdout.strip()
+            if _looks_like_tool_failure(detail):
+                tool_errors.append(f"{view}/{state} PNG: {detail}")
+            else:
+                errors.append(f"{view}/{state} PNG: {detail}")
+            continue
+        if not preview_path.is_file() or preview_path.stat().st_size == 0:
+            errors.append(f"{view}/{state}: rendered PNG preview is empty")
+            continue
         ctx.parsed.rendered_svgs[(view, state)] = output_path
-        ctx.artifacts.extend([input_path, output_path])
-        rendered.append(str(output_path))
+        ctx.artifacts.extend([input_path, output_path, preview_path])
+        rendered.extend([str(output_path), str(preview_path)])
     if tool_errors:
         ctx.add("tool.mermaid_cli", "error", "pinned Mermaid CLI is unavailable", tool_errors)
     elif errors:
@@ -236,6 +299,8 @@ def _contains_html_markup(content: str) -> bool:
             continue
         suffix = content[index:]
         if suffix.startswith(MERMAID_LEFT_ARROWS):
+            continue
+        if re.match(r"(?i)^<br\s*/?>", suffix):
             continue
         candidate = content[index + 1 :].lstrip()
         if not candidate:

--- a/.agents/skills/boxlite-diagrams/scripts/validator/models.py
+++ b/.agents/skills/boxlite-diagrams/scripts/validator/models.py
@@ -40,6 +40,8 @@ class ParsedDocument:
     architecture_nodes: dict[tuple[str, str], str] = field(default_factory=dict)
     architecture_edges: dict[tuple[str, str], tuple[str, str]] = field(default_factory=dict)
     architecture_edge_labels: dict[tuple[str, str], str] = field(default_factory=dict)
+    architecture_boundaries: dict[tuple[str, str], str] = field(default_factory=dict)
+    architecture_parents: dict[tuple[str, str], str] = field(default_factory=dict)
     sequence_nodes: dict[tuple[str, str], str] = field(default_factory=dict)
     sequence_edges: dict[tuple[str, str], tuple[str, str]] = field(default_factory=dict)
     sequence_edge_labels: dict[tuple[str, str], str] = field(default_factory=dict)
@@ -84,15 +86,27 @@ class ValidationContext:
             return []
         return [
             ("node", item) for item in self.manifest.get("nodes", [])
-        ] + [("edge", item) for item in self.manifest.get("edges", [])]
+        ] + [
+            ("edge", item) for item in self.manifest.get("edges", [])
+        ] + [
+            ("boundary", item) for item in self.manifest.get("boundaries", [])
+        ]
 
     def item_map(self, item_type: str) -> dict[str, dict[str, Any]]:
-        if item_type not in {"node", "edge"} or not isinstance(self.manifest, dict):
+        if item_type not in {"node", "edge", "boundary"} or not isinstance(self.manifest, dict):
             return {}
-        key = "nodes" if item_type == "node" else "edges"
+        key = {"node": "nodes", "edge": "edges", "boundary": "boundaries"}[item_type]
         return {item["id"]: item for item in self.manifest.get(key, []) if "id" in item}
 
     def state_map(self) -> dict[str, dict[str, Any]]:
         if not isinstance(self.manifest, dict):
             return {}
         return {state["id"]: state for state in self.manifest.get("states", []) if "id" in state}
+
+    def view_ids(self) -> list[str]:
+        if not isinstance(self.manifest, dict):
+            return []
+        views = self.manifest.get("views")
+        if isinstance(views, list):
+            return [view for view in views if isinstance(view, str)]
+        return ["architecture", "sequence", "call_graph"]

--- a/.agents/skills/boxlite-diagrams/scripts/validator/source.py
+++ b/.agents/skills/boxlite-diagrams/scripts/validator/source.py
@@ -14,14 +14,18 @@ ID_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 KINDS = {"overview", "issue", "pr", "commit", "branch", "working-tree-change"}
 CHANGE_KINDS = {"none", "bug", "feature", "refactor", "docs"}
 VIEWS = {"architecture", "sequence", "call_graph"}
+VIEW_ORDER = ["architecture", "sequence", "call_graph"]
 EDGE_KINDS = {"call", "rpc", "dispatch", "spawn", "data", "state-transition", "proposed"}
 ANNOTATIONS = {"ISSUE", "BUG", "FIX", "PROPOSED", "ADDED", "CHANGED", "REMOVED"}
-ROOT_KEYS = {"schema_version", "context", "states", "nodes", "edges", "annotations"}
+ROOT_KEYS = {"schema_version", "context", "views", "states", "nodes", "edges", "boundaries", "annotations"}
 CONTEXT_KEYS = {"kind", "change_kind", "sources"}
 SOURCE_KEYS = {"repository", "issue", "pr", "base_revision", "head_revision"}
 STATE_KEYS = {"id", "label", "revision", "proposed"}
 ITEM_KEYS = {"id", "label", "states", "views", "proposed", "evidence"}
 EDGE_KEYS = ITEM_KEYS | {"from", "to", "kind"}
+BOUNDARY_KEYS = ITEM_KEYS | {"members"}
+MEMBERSHIP_KEYS = {"target", "states"}
+MEMBERSHIP_TARGET_RE = re.compile(r"^(node|boundary):([a-z][a-z0-9_]*)$")
 SOURCE_EVIDENCE_KEYS = {"type", "state", "revision", "path", "line_start", "line_end", "symbol", "tokens"}
 ISSUE_EVIDENCE_KEYS = {"type", "state", "issue", "tokens"}
 ANNOTATION_KEYS = {"kind", "target", "state", "text"}
@@ -36,6 +40,13 @@ def validate_manifest(ctx: ValidationContext) -> None:
     if manifest.get("schema_version") != 1:
         errors.append("schema_version must be 1")
     _reject_extra_keys(manifest, ROOT_KEYS, "manifest", errors)
+
+    selected_views = manifest.get("views", VIEW_ORDER)
+    if not _unique_nonempty_subset(selected_views, VIEWS):
+        errors.append(f"views must be a non-empty unique subset of {sorted(VIEWS)}")
+        selected_views = []
+    elif selected_views != [view for view in VIEW_ORDER if view in selected_views]:
+        errors.append(f"views must use canonical order {VIEW_ORDER}")
 
     context = manifest.get("context")
     if not isinstance(context, dict):
@@ -89,12 +100,15 @@ def validate_manifest(ctx: ValidationContext) -> None:
     if len(state_labels) != len(set(state_labels)):
         errors.append("state labels must be unique")
 
+    collections = (
+        ("nodes", "node", 1, ITEM_KEYS),
+        ("edges", "edge", 0, EDGE_KEYS),
+        ("boundaries", "boundary", 0, BOUNDARY_KEYS),
+    )
+    declared_ids: dict[str, set[str]] = {"node": set(), "edge": set(), "boundary": set()}
     seen_item_ids: dict[str, str] = {}
-    node_ids: set[str] = set()
-    edge_ids: set[str] = set()
-    for collection, item_type in (("nodes", "node"), ("edges", "edge")):
-        values = manifest.get(collection)
-        minimum = 1 if collection == "nodes" else 0
+    for collection, item_type, minimum, _allowed_keys in collections:
+        values = manifest.get(collection, [])
         if not isinstance(values, list) or len(values) < minimum:
             errors.append(f"{collection} must be an array with at least {minimum} entries")
             continue
@@ -103,7 +117,6 @@ def validate_manifest(ctx: ValidationContext) -> None:
             if not isinstance(item, dict):
                 errors.append(f"{where} must be an object")
                 continue
-            _reject_extra_keys(item, EDGE_KEYS if item_type == "edge" else ITEM_KEYS, where, errors)
             item_id = item.get("id")
             if not isinstance(item_id, str) or not ID_RE.fullmatch(item_id):
                 errors.append(f"{where}.id must be lowercase snake case")
@@ -111,7 +124,27 @@ def validate_manifest(ctx: ValidationContext) -> None:
             if item_id in seen_item_ids:
                 errors.append(f"canonical ID {item_id!r} is reused by a {seen_item_ids[item_id]} and {item_type}")
             seen_item_ids[item_id] = item_type
-            (node_ids if item_type == "node" else edge_ids).add(item_id)
+            declared_ids[item_type].add(item_id)
+
+    target_states: dict[str, set[str]] = {}
+    for collection, item_type, _minimum, _allowed_keys in collections:
+        for item in manifest.get(collection, []) if isinstance(manifest.get(collection, []), list) else []:
+            if isinstance(item, dict) and isinstance(item.get("id"), str):
+                target_states[f"{item_type}:{item['id']}"] = set(item.get("states", []))
+
+    membership_parents: dict[tuple[str, str], str] = {}
+    for collection, item_type, _minimum, allowed_keys in collections:
+        values = manifest.get(collection, [])
+        if not isinstance(values, list):
+            continue
+        for index, item in enumerate(values):
+            where = f"{collection}[{index}]"
+            if not isinstance(item, dict):
+                continue
+            _reject_extra_keys(item, allowed_keys, where, errors)
+            item_id = item.get("id")
+            if not isinstance(item_id, str) or not ID_RE.fullmatch(item_id):
+                continue
             if not isinstance(item.get("label"), str) or not item.get("label"):
                 errors.append(f"{where}.label must be non-empty")
             item_states = item.get("states")
@@ -121,6 +154,10 @@ def validate_manifest(ctx: ValidationContext) -> None:
             views = item.get("views")
             if not _unique_nonempty_subset(views, VIEWS):
                 errors.append(f"{where}.views must be a non-empty unique subset of {sorted(VIEWS)}")
+            elif not set(views).issubset(set(selected_views)):
+                errors.append(f"{where}.views must be a subset of manifest views")
+            if item_type == "boundary" and views != ["architecture"]:
+                errors.append(f"{where}.views must be exactly ['architecture']")
             if not isinstance(item.get("proposed"), bool):
                 errors.append(f"{where}.proposed must be boolean")
             elif item["proposed"]:
@@ -133,27 +170,37 @@ def validate_manifest(ctx: ValidationContext) -> None:
             evidence = item.get("evidence")
             if not isinstance(evidence, list) or not evidence:
                 errors.append(f"{where}.evidence must be a non-empty array")
-                continue
-            evidence_states: set[str] = set()
-            for evidence_index, entry in enumerate(evidence):
-                evidence_where = f"{where}.evidence[{evidence_index}]"
-                _validate_evidence_shape(entry, evidence_where, set(state_ids), errors)
-                if isinstance(entry, dict) and isinstance(entry.get("state"), str):
-                    evidence_states.add(entry["state"])
-            for state_id in item_states:
-                if state_id not in evidence_states:
-                    errors.append(f"{where} has no evidence for state {state_id!r}")
+            else:
+                evidence_states: set[str] = set()
+                for evidence_index, entry in enumerate(evidence):
+                    evidence_where = f"{where}.evidence[{evidence_index}]"
+                    _validate_evidence_shape(entry, evidence_where, set(state_ids), errors)
+                    if isinstance(entry, dict) and isinstance(entry.get("state"), str):
+                        evidence_states.add(entry["state"])
+                for state_id in item_states:
+                    if state_id not in evidence_states:
+                        errors.append(f"{where} has no evidence for state {state_id!r}")
             if item_type == "edge":
-                if item.get("from") not in node_ids and item.get("from") not in {
-                    node.get("id") for node in manifest.get("nodes", []) if isinstance(node, dict)
-                }:
+                if item.get("from") not in declared_ids["node"]:
                     errors.append(f"{where}.from must reference a declared node")
-                if item.get("to") not in {
-                    node.get("id") for node in manifest.get("nodes", []) if isinstance(node, dict)
-                }:
+                if item.get("to") not in declared_ids["node"]:
                     errors.append(f"{where}.to must reference a declared node")
                 if item.get("kind") not in EDGE_KINDS:
                     errors.append(f"{where}.kind must be one of {sorted(EDGE_KINDS)}")
+            elif item_type == "boundary":
+                _validate_boundary_members(
+                    item,
+                    where,
+                    set(item_states),
+                    target_states,
+                    membership_parents,
+                    errors,
+                )
+
+    _validate_boundary_cycles(membership_parents, state_ids, errors)
+
+    node_ids = declared_ids["node"]
+    edge_ids = declared_ids["edge"]
 
     annotations = manifest.get("annotations")
     if not isinstance(annotations, list):
@@ -187,6 +234,83 @@ def validate_manifest(ctx: ValidationContext) -> None:
         ctx.add("manifest.shape", "fail", "evidence manifest is invalid", errors)
     else:
         ctx.add("manifest.shape", "pass", "evidence manifest has valid IDs, memberships, and references")
+
+
+def _validate_boundary_members(
+    boundary: dict[str, Any],
+    where: str,
+    boundary_states: set[str],
+    target_states: dict[str, set[str]],
+    membership_parents: dict[tuple[str, str], str],
+    errors: list[str],
+) -> None:
+    members = boundary.get("members")
+    if not isinstance(members, list) or not members:
+        errors.append(f"{where}.members must be a non-empty array")
+        return
+    covered_states: set[str] = set()
+    for index, membership in enumerate(members):
+        member_where = f"{where}.members[{index}]"
+        if not isinstance(membership, dict):
+            errors.append(f"{member_where} must be an object")
+            continue
+        _reject_extra_keys(membership, MEMBERSHIP_KEYS, member_where, errors)
+        target = membership.get("target")
+        match = MEMBERSHIP_TARGET_RE.fullmatch(target) if isinstance(target, str) else None
+        if match is None:
+            errors.append(f"{member_where}.target must be node:<id> or boundary:<id>")
+            continue
+        target_type, target_id = match.groups()
+        if target not in target_states:
+            errors.append(f"{member_where}.target must reference a declared node or boundary")
+            continue
+        if target == f"boundary:{boundary['id']}":
+            errors.append(f"{member_where}.target cannot contain its own boundary")
+            continue
+        states = membership.get("states")
+        allowed_states = boundary_states & target_states[target]
+        if not _unique_nonempty_subset(states, allowed_states):
+            errors.append(
+                f"{member_where}.states must be a non-empty unique subset of both the container and target states"
+            )
+            continue
+        for state in states:
+            parent_key = (state, target)
+            previous = membership_parents.get(parent_key)
+            if previous is not None:
+                errors.append(
+                    f"{member_where} gives {target} two immediate parents in {state!r}: "
+                    f"{previous!r} and {boundary['id']!r}"
+                )
+            else:
+                membership_parents[parent_key] = boundary["id"]
+            covered_states.add(state)
+    missing_states = boundary_states - covered_states
+    if missing_states:
+        errors.append(f"{where}.members leave the boundary empty in states {sorted(missing_states)}")
+
+
+def _validate_boundary_cycles(
+    membership_parents: dict[tuple[str, str], str],
+    state_ids: list[str],
+    errors: list[str],
+) -> None:
+    for state in state_ids:
+        parent_by_boundary = {
+            target.removeprefix("boundary:"): parent
+            for (membership_state, target), parent in membership_parents.items()
+            if membership_state == state and target.startswith("boundary:")
+        }
+        for start in parent_by_boundary:
+            seen: list[str] = []
+            current = start
+            while current in parent_by_boundary:
+                if current in seen:
+                    cycle = seen[seen.index(current):] + [current]
+                    errors.append(f"boundary containment cycle in {state!r}: {' -> '.join(cycle)}")
+                    break
+                seen.append(current)
+                current = parent_by_boundary[current]
 
 
 def validate_source_evidence(ctx: ValidationContext) -> None:

--- a/.agents/skills/boxlite-diagrams/tests/test_validate_diagrams.py
+++ b/.agents/skills/boxlite-diagrams/tests/test_validate_diagrams.py
@@ -57,6 +57,81 @@ class DiagramValidatorTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr + json.dumps(report, indent=2))
         self.assertTrue(report["valid"])
 
+    def test_valid_architecture_only_overview(self) -> None:
+        document, manifest = architecture_only_fixture(self.head)
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 0, result.stderr + json.dumps(report, indent=2))
+        self.assertTrue(report["valid"])
+        artifacts = [Path(value).suffix for value in report["artifacts"]]
+        self.assertIn(".svg", artifacts)
+        self.assertIn(".png", artifacts)
+
+    def test_valid_source_grounded_boundary_containment(self) -> None:
+        result, report = self.validate(*contained_architecture_fixture(self.head))
+        self.assertEqual(result.returncode, 0, result.stderr + json.dumps(report, indent=2))
+        consistency = next(check for check in report["checks"] if check["name"] == "consistency.cross_view")
+        self.assertIn("boundaries", consistency["message"])
+
+    def test_wrong_immediate_boundary_is_rejected(self) -> None:
+        document, manifest = contained_architecture_fixture(self.head)
+        document = document.replace(
+            '    start["start"]\n    load["load"]\n  end',
+            '    start["start"]\n  end\n  load["load"]',
+            1,
+        )
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "consistency.cross_view")
+
+    def test_undeclared_mermaid_boundary_is_rejected(self) -> None:
+        document, manifest = contained_architecture_fixture(self.head)
+        document = document.replace(
+            '  subgraph inner["Inner"]',
+            '  subgraph extra["Extra"]\n    subgraph inner["Inner"]',
+            1,
+        ).replace('  end\nend', '    end\n  end\nend', 1)
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "consistency.cross_view")
+
+    def test_member_cannot_have_two_immediate_boundaries(self) -> None:
+        document, manifest = contained_architecture_fixture(self.head)
+        manifest["boundaries"][0]["members"].append({"target": "node:start", "states": ["current"]})
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "manifest.shape")
+
+    def test_boundary_cycle_is_rejected(self) -> None:
+        document, manifest = contained_architecture_fixture(self.head)
+        manifest["boundaries"][1]["members"].append(
+            {"target": "boundary:outer", "states": ["current"]}
+        )
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "manifest.shape")
+
+    def test_unselected_view_is_rejected(self) -> None:
+        document, manifest = architecture_only_fixture(self.head)
+        document += "\n## Sequence\n\n### Current\n\n```mermaid\nsequenceDiagram\n```\n"
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "document.structure")
+
+    def test_item_view_outside_selected_views_is_rejected(self) -> None:
+        document, manifest = architecture_only_fixture(self.head)
+        manifest["nodes"][0]["views"] = ["sequence"]
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "manifest.shape")
+
+    def test_valid_call_graph_only_without_mermaid_tool(self) -> None:
+        document, manifest = call_graph_only_fixture(self.head)
+        environment = self.env | {"PATH": f"{self.bin}:/usr/bin:/bin", "BOXLITE_DIAGRAM_MMDC": ""}
+        result, report = self.validate(document, manifest, environment=environment)
+        self.assertEqual(result.returncode, 0, result.stderr + json.dumps(report, indent=2))
+        render = next(check for check in report["checks"] if check["name"] == "mermaid.render")
+        self.assertEqual(render["message"], "no Mermaid view was selected")
+
     def test_valid_unimplemented_issue(self) -> None:
         document, manifest = issue_fixture(self.head)
         result, report = self.validate(document, manifest)
@@ -231,12 +306,25 @@ class DiagramValidatorTests(unittest.TestCase):
         self.assertEqual(result.returncode, 1)
         self.assert_check_failed(report, "mermaid.structure_security")
 
+    def test_fixed_mermaid_styling_is_rejected_for_adaptive_themes(self) -> None:
+        document, manifest = architecture_only_fixture(self.head)
+        document = document.replace("flowchart LR", "flowchart LR\n  classDef fixed fill:#fff,color:#000")
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "mermaid.structure_security")
+
     def test_malformed_html_comment_is_rejected(self) -> None:
         document, manifest = overview_fixture(self.head)
         document = document.replace('start["start"]', 'start["start<!-- unsafe --!>"]', 1)
         result, report = self.validate(document, manifest)
         self.assertEqual(result.returncode, 1)
         self.assert_check_failed(report, "mermaid.structure_security")
+
+    def test_mermaid_br_line_break_is_accepted(self) -> None:
+        document, manifest = architecture_only_fixture(self.head)
+        document = document.replace('start["start"]', 'start["start<br/>entry"]')
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 0, json.dumps(report, indent=2))
 
     def test_mermaid_left_arrow_is_not_treated_as_html(self) -> None:
         document, manifest = overview_fixture(self.head)
@@ -333,6 +421,17 @@ class DiagramValidatorTests(unittest.TestCase):
         evals = (SKILL_ROOT / "evals" / "evals.json").read_text(encoding="utf-8")
         for content in (contract, skill, evals):
             self.assertIn("← BUG:", content)
+
+    def test_cloud_architecture_contract_requires_real_containment_and_adaptive_theme(self) -> None:
+        skill = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+        composition = (SKILL_ROOT / "references" / "architecture-composition.md").read_text(encoding="utf-8")
+        contract = (SKILL_ROOT / "references" / "output-contract.md").read_text(encoding="utf-8")
+        evals = (SKILL_ROOT / "evals" / "evals.json").read_text(encoding="utf-8")
+        for content in (skill, composition, contract, evals):
+            self.assertIn("Runner fleet", content)
+            self.assertIn("EC2", content)
+            self.assertIn("embedded BoxLite", content)
+            self.assertIn("light/dark", content)
 
     def test_proposed_behavior_without_issue_evidence_is_rejected(self) -> None:
         document, manifest = issue_fixture(self.head)
@@ -452,6 +551,12 @@ def edge(item_id: str, label: str, source: str, target: str, states: list[str], 
             "views": ["architecture", "sequence", "call_graph"], "proposed": False, "evidence": evidence}
 
 
+def boundary(item_id: str, label: str, states: list[str], evidence: list[dict[str, object]],
+             members: list[dict[str, object]]) -> dict[str, object]:
+    return {"id": item_id, "label": label, "states": states, "views": ["architecture"],
+            "proposed": False, "evidence": evidence, "members": members}
+
+
 def manifest(context: dict[str, object], states: list[dict[str, object]], nodes: list[dict[str, object]],
              edges: list[dict[str, object]], annotations: list[dict[str, object]] | None = None) -> dict[str, object]:
     return {"schema_version": 1, "context": context, "states": states, "nodes": nodes, "edges": edges,
@@ -494,6 +599,67 @@ def overview_fixture(head: str) -> tuple[str, dict[str, object]]:
         {"current": [("start_load", "start", "load", "load")]},
         {"current": [("start", "start"), ("load", "load")]})
     return doc, manifest({"kind": "overview", "change_kind": "none", "sources": {"repository": "local"}}, states, nodes, edges)
+
+
+def architecture_only_fixture(head: str) -> tuple[str, dict[str, object]]:
+    document, data = overview_fixture(head)
+    data = copy.deepcopy(data)
+    data["views"] = ["architecture"]
+    for item in data["nodes"] + data["edges"]:
+        item["views"] = ["architecture"]
+    document = document[:document.index("## Sequence")].rstrip() + "\n"
+    return document, data
+
+
+def contained_architecture_fixture(head: str) -> tuple[str, dict[str, object]]:
+    document, data = architecture_only_fixture(head)
+    document = """# Diagram
+
+## Architecture
+
+### Current
+
+```mermaid
+flowchart TB
+subgraph outer["Outer"]
+  subgraph inner["Inner"]
+    start["start"]
+    load["load"]
+  end
+end
+start start_load@-->|"load"| load
+```
+"""
+    data["boundaries"] = [
+        boundary(
+            "outer",
+            "Outer",
+            ["current"],
+            [source_evidence("current", head, "start", 1, 3, "def start")],
+            [{"target": "boundary:inner", "states": ["current"]}],
+        ),
+        boundary(
+            "inner",
+            "Inner",
+            ["current"],
+            [source_evidence("current", head, "load", 8, 9, "def load")],
+            [
+                {"target": "node:start", "states": ["current"]},
+                {"target": "node:load", "states": ["current"]},
+            ],
+        ),
+    ]
+    return document, data
+
+
+def call_graph_only_fixture(head: str) -> tuple[str, dict[str, object]]:
+    document, data = overview_fixture(head)
+    data = copy.deepcopy(data)
+    data["views"] = ["call_graph"]
+    for item in data["nodes"] + data["edges"]:
+        item["views"] = ["call_graph"]
+    call_graph = document[document.index("## Call graph"):]
+    return f"# Diagram\n\n{call_graph}", data
 
 
 def issue_fixture(head: str) -> tuple[str, dict[str, object]]:

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,0 +1,96 @@
+# BoxLite cloud applications
+
+The applications under this directory form BoxLite's hosted control plane and
+runner data plane. This view shows how public traffic reaches private services,
+how the control plane schedules boxes, and where state and telemetry flow.
+
+## Architecture
+
+### Current
+
+```mermaid
+flowchart TB
+    browser(["Browser"])
+    sdk(["SDK / CLI"])
+    cloudflare(["Cloudflare DNS"])
+    idp(["OIDC IdP<br/>Auth0 · Okta · Keycloak · Dex"])
+    ghcr(["ghcr.io"])
+    telemetry(["External telemetry<br/>organization OTLP · optional ClickHouse"])
+
+    subgraph aws_cloud["AWS cloud"]
+        cf["CloudFront<br/>STACK_DOMAIN"]
+        s3[("S3<br/>storage + box volumes")]
+
+        subgraph vpc["VPC"]
+            subgraph public_ingress["public ingress · public subnets"]
+                alb["API ALB<br/>api.STACK_DOMAIN · TLS 443"]
+                nlb["Proxy NLB<br/>proxy + *.proxy.STACK_DOMAIN · TLS 443"]
+            end
+
+            subgraph private_services["private services · ECS Fargate"]
+                api["API + Dashboard · NestJS<br/>:3000"]
+                proxy["Proxy<br/>:4000"]
+
+                subgraph obs["internal observability + tools"]
+                    otel["OTel Collector<br/>:4318"]
+                    jaeger["Jaeger<br/>:16686"]
+                    ops["PgAdmin + MailDev<br/>internal only"]
+                end
+            end
+
+            subgraph state["state · VPC private"]
+                pg[("RDS Postgres")]
+                redis[("ElastiCache Redis")]
+            end
+
+            s3_endpoint["S3 gateway endpoint<br/>private route tables"]
+
+            subgraph runner_fleet["Runner fleet · public subnet"]
+                subgraph ec2_runner["EC2 instance · repeated × N"]
+                    subgraph runner_process["Runner daemon · one per EC2"]
+                        runner_api["Runner API<br/>:3003"]
+
+                        subgraph embedded_boxlite["embedded BoxLite runtime"]
+                            boxlite_core["BoxLite runtime<br/>nested KVM"]
+                            boxes[["box microVMs"]]
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    cloudflare dns_to_cf@-.->|"root domain"| cf
+    cloudflare dns_to_alb@-.->|"api domain"| alb
+    cloudflare dns_to_nlb@-.->|"wildcard proxy domain"| nlb
+
+    browser browser_to_cf@-->|"dashboard SPA"| cf
+    cf cf_to_alb@-->|"dashboard origin"| alb
+    browser browser_to_alb@-->|"/api/* · WS · SSE"| alb
+    sdk sdk_to_alb@-->|"/api/*"| alb
+    browser browser_to_nlb@-->|"box port preview"| nlb
+
+    alb alb_to_api@-->|"API traffic"| api
+    nlb nlb_to_proxy@-->|"proxy traffic"| proxy
+    proxy proxy_to_runner@-->|"box port tunnel"| runner_api
+
+    api api_to_pg@-->|"durable state"| pg
+    api api_to_redis@-->|"queues + cache"| redis
+    api api_to_s3_endpoint@-->|"private S3 route"| s3_endpoint
+    s3_endpoint endpoint_to_s3@-->|"gateway access"| s3
+    api api_to_runner@<-->|"jobs + status"| runner_api
+    api api_to_idp@-.->|"JWT via JWKS"| idp
+    api api_to_otel@-->|"OTLP"| otel
+
+    runner_api runner_to_boxlite@-->|"embedded calls"| boxlite_core
+    runner_api runner_to_otel@-->|"host + box OTLP"| otel
+    boxlite_core boxlite_to_boxes@-->|"create + run"| boxes
+    boxlite_core boxlite_to_s3@-->|"mount volumes"| s3
+    boxlite_core boxlite_to_ghcr@-->|"pull images"| ghcr
+
+    otel otel_to_jaeger@-->|"traces"| jaeger
+    otel otel_to_telemetry@-.->|"configured export"| telemetry
+```
+
+The deployment runbook and operational constraints live in
+[`infra/docs/deployment.md`](./infra/docs/deployment.md).


### PR DESCRIPTION
## What changed

- add a full hosted-cloud architecture to `apps/README.md`
- make the BoxLite diagram skill reuse the canonical deployment architecture and select only useful views
- model AWS, VPC, subnet, fleet, EC2, Runner, embedded BoxLite, and microVM containment explicitly
- extend the evidence schema and validator to compare exact immediate boundary membership
- reject duplicate parents, containment cycles, undeclared or incorrect nesting, and fixed Mermaid styling
- require light/dark rendering and visual inspection for GitHub-targeted diagrams

## Why

A diagram could previously be source-grounded and syntactically valid while still flattening ownership or placing components beside the infrastructure that hosts them. That made the rendered cloud architecture materially misleading.

## Impact

The applications README now shows the complete cloud deployment at one altitude. Future architecture diagrams fail validation when their physical containment differs from the evidence manifest, while unstyled Mermaid remains adaptive to GitHub light and dark themes.

## Before: end-to-end call graph

```text
diagram request
  └─ SKILL.md — generate the fixed view set
      └─ validator/mermaid.py — parse nodes and edges
          └─ validator/consistency.py — compare node and edge IDs
              └─ rendered diagram — containment remains unchecked
```

## After: end-to-end call graph

```text
diagram request
  └─ SKILL.md — select the smallest useful view and canonical reference
      └─ references/architecture-composition.md — define physical containment
          └─ validator/mermaid._parse_architecture — record immediate parents
              └─ validator/source.validate_manifest — validate membership and cycles
                  └─ validator/consistency._check_boundaries — compare evidence with Mermaid nesting
                      └─ apps/README.md — render the host-adaptive deployment architecture
```

## Validation

- diagram validator: 9 pass, 0 fail, 0 error with real Mermaid 11.16.0 rendering
- diagram-skill suite: 50 tests passed; 1 opt-in real-render test skipped
- skill package quick validation: passed
- light and dark 3168×1600 renders inspected at original resolution
- apps workspace lint: passed with 34 pre-existing warnings
- `git diff --check`: passed

The full pre-push matrix could not complete because this worktree lacks `src/deps/libkrun-sys/vendor/libkrun`; the runtime build stopped with “Vendored sources not found.” The focused diagram validation and tests above completed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting architecture, sequence, and call-graph diagram views.
  * Added deployment boundary and containment modeling for clearer architecture diagrams.
  * Added PNG preview generation and visual inspection during diagram validation.
  * Added documentation of the cloud application architecture and deployment flow.

* **Bug Fixes**
  * Improved validation for selected views, nested boundaries, Mermaid styling, and diagram consistency.
  * Call-graph-only and architecture-only diagrams now validate correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->