### PR TITLE
feat(network): add tunnel listener forwarding

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -380,9 +380,9 @@ QEMU's user-mode networking stack.
 ### Service Access Across Runtimes
 
 The box network tunnel API is portable across local and REST runtimes, but its
-transport is backend-specific. Local tunnels return a prepared gvproxy
-connection; REST tunnels connect through the remote service proxy and also
-carry its public URI. Each SDK tunnel handle represents one connection.
+transport is backend-specific. `tunnel()` eagerly prepares one local gvproxy or
+remote service-proxy connection. `uri()` inspects its public URI, while `connect()`
+or `forward()` consumes that prepared one-shot tunnel into a byte stream or listener.
 
 Explicit host port publication is a separate local-runtime feature that owns a
 TCP listener and accepts repeated connections.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -284,8 +284,8 @@ curl http://localhost:8080
 
 Port publication is local-only and TCP-only. It creates a listener that ordinary
 host applications can use for repeated connections. Remote runtimes reject
-`ports`; use `box.network.tunnel(port)` for portable SDK access. Each tunnel
-handle carries one connection.
+`ports`; use `box.network.tunnel(port)` for portable SDK access. Each tunnel is
+a prepared one-shot connection; call `forward()` to turn it into a listener.
 Image `EXPOSE` declarations do not publish host ports.
 
 See [Configuring Networking](./guides/README.md#configuring-networking) for details.

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -276,8 +276,8 @@ is appropriate for browsers, database clients, and other programs that expect a
 normal host address.
 
 For SDK code that must work with local and remote runtimes, use
-`box.network.tunnel(port)` and consume its byte stream with `connect()`. A tunnel
-handle represents one connection; request another handle for another connection.
+`box.network.tunnel(port)` and open byte streams with `connect()`. A tunnel
+can be consumed by `connect()` or by `forward()` to bind a local listener.
 Remote CLI users can run `boxlite network tunnel BOX PORT` to obtain the public
 service URL.
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -366,7 +366,7 @@ ports=[
 - TCP is supported; UDP is rejected
 - Port publication is local-only and owns a listener that accepts repeated
   connections. For portable local/remote SDK code, use
-  `box.network.tunnel(port)`; each tunnel handle represents one connection.
+  `box.network.tunnel(port)`; each returned tunnel is one-shot.
 - OCI `EXPOSE` is metadata and does not publish a host port.
 - Port mappings are only for host → box traffic. Use
   `host.boxlite.internal:<port>` for box → host loopback traffic.

--- a/docs/reference/c/README.md
+++ b/docs/reference/c/README.md
@@ -720,19 +720,43 @@ BoxliteErrorCode boxlite_tunnel_connect(
     CBoxliteError* out_error
 );
 void boxlite_tunnel_free(CBoxTunnelHandle* tunnel);
+
+BoxliteErrorCode boxlite_tunnel_forward(
+    CBoxTunnelHandle* tunnel,
+    const BoxliteSocketAddress* listen,
+    CTunnelForwarderHandle** out_forwarder,
+    CBoxliteError* out_error
+);
+BoxliteErrorCode boxlite_tunnel_forwarder_address(
+    CTunnelForwarderHandle* forwarder,
+    char** out_address,
+    CBoxliteError* out_error
+);
+BoxliteErrorCode boxlite_tunnel_forwarder_wait(
+    CTunnelForwarderHandle* forwarder,
+    CTunnelForwarderWaitCb cb,
+    void* user_data,
+    CBoxliteError* out_error
+);
+BoxliteErrorCode boxlite_tunnel_forwarder_close(
+    CTunnelForwarderHandle* forwarder,
+    CTunnelForwarderCloseCb cb,
+    void* user_data,
+    CBoxliteError* out_error
+);
+void boxlite_tunnel_forwarder_free(CTunnelForwarderHandle* forwarder);
 ```
 
-Each `CBoxTunnelHandle` owns exactly one connection.
-`boxlite_tunnel_connect()` consumes that connection and returns an owned file
-descriptor that the caller must close; a second call returns `InvalidState`.
-Release the tunnel handle with `boxlite_tunnel_free()` after connecting or when
-discarding an unconsumed tunnel.
+Each `CBoxTunnelHandle` is one-shot. Choose `boxlite_tunnel_connect()` or
+`boxlite_tunnel_forward()`; either consumes the prepared tunnel.
 `boxlite_tunnel_uri()` reports where a remotely served tunnel can be reached, as
 an allocated string the caller frees with `boxlite_free_string()`. It writes NULL
-for a local tunnel, whose descriptor is already a live connection rather than an
-address — reach those with `boxlite_tunnel_connect()`.
+for a local tunnel.
 
-Create another tunnel handle for each additional or concurrent connection.
+`boxlite_tunnel_forward()` creates a TCP or Unix listener from the tunnel. Its
+wait and close callbacks are posted exactly once through the parent runtime's
+drain queue; freeing the caller handle requests non-blocking cancellation while
+already accepted operations retain their callback state.
 This differs from `boxlite_options_add_port()`, which creates a persistent,
 local-only host listener that accepts repeated connections.
 

--- a/docs/reference/cli/README.md
+++ b/docs/reference/cli/README.md
@@ -554,10 +554,23 @@ Display resource usage statistics for a box.
 
 ### `boxlite network tunnel`
 
-**Synopsis:** `boxlite network tunnel BOX PORT`
+**Synopsis:** `boxlite network tunnel BOX GUEST_PORT [--listen ADDRESS]`
 
 Print the public URL for a box service port. Requires a remote REST profile
-(`--url` or `--profile`); local boxes have no public ingress.
+(`--url` or `--profile`); local boxes have no public ingress. With `--listen`,
+bind a local listener and open one tunnel per accepted connection instead:
+
+```bash
+boxlite network tunnel mybox 3000 --listen 8080
+boxlite network tunnel mybox 3000 --listen 127.0.0.1:8080
+boxlite network tunnel mybox 3000 --listen '[::1]:8080'
+boxlite network tunnel mybox 3000 --listen unix:/tmp/app.sock
+```
+
+A bare port binds `127.0.0.1`; listener port `0` asks the OS to allocate a
+port. The canonical bound address is printed to stdout before clients are
+accepted. Ctrl-C closes the listener and active connections. TCP hosts must be
+numeric addresses, and Unix socket paths must be absolute.
 
 ---
 
@@ -718,7 +731,7 @@ Ports must be in `1..=65535`. TCP is the only supported protocol; UDP is rejecte
 `-p` is explicit local publication and is rejected for remote REST runtimes.
 For a remote box, use `boxlite network tunnel BOX PORT` to obtain its public
 service URL. For SDK code that must run with either runtime, use the box network
-tunnel API; each tunnel handle represents one connection.
+tunnel API; each returned tunnel is one-shot.
 Image `EXPOSE` declarations remain metadata and do not open host listeners.
 
 ---

--- a/docs/reference/nodejs/README.md
+++ b/docs/reference/nodejs/README.md
@@ -168,7 +168,7 @@ interface JsPortSpec {
 
 Port publication is available only with a local runtime. For code that should
 work with both local and remote runtimes, use `box.network.tunnel(port)`; each
-tunnel handle represents one connection.
+tunnel is one-shot; call `forward()` to consume it into a listener.
 OCI `EXPOSE` declarations do not publish host ports.
 
 #### `Secret`
@@ -261,14 +261,19 @@ live binding data yet, so box, get, or list info may report
 
 | Operation | Signature | Description |
 |-----------|-----------|-------------|
-| Prepare | `await box.network.tunnel(port)` | Return a `JsBoxTunnel` or `BoxTunnel` for one TCP connection |
-| Inspect | `tunnel.uri(): string \| null` | Public URL of a remotely served tunnel; `null` for a local one |
-| Connect | `await tunnel.connect()` | Consume the tunnel and return its bidirectional connection |
+| Tunnel | `await box.network.tunnel(port)` | Prepare a one-shot `JsBoxTunnel` or `BoxTunnel` |
+| Forward | `await tunnel.forward(listen)` | Return a listener-backed `TunnelForwarder` |
+| Inspect | `tunnel.uri(): string \| null` | Read the prepared public URL; `null` for a local box |
+| Connect | `await tunnel.connect()` | Consume the prepared tunnel into its connection |
 | Read/write | `await connection.read(maxBytes)`, `await connection.write(data)` | Exchange bytes with the service |
 | Close | `await connection.close()` | Close the connection |
 
-Each tunnel handle carries exactly one connection. Call `tunnel()` again for
-each additional or concurrent connection. This differs from `ports`, which
+`listen` is `{ type: "tcp", host?: string, port: number }` or
+`{ type: "unix", path: string }`. The forwarder exposes `localAddr()`, `wait()`,
+and repeatable `close()`.
+
+Each tunnel is one-shot. Choose `connect()` or `forward()`; a forwarder opens
+fresh tunnels for additional clients. This differs from `ports`, which
 creates a persistent, local-only host listener that accepts repeated
 connections from ordinary host applications.
 

--- a/docs/reference/python/README.md
+++ b/docs/reference/python/README.md
@@ -192,7 +192,7 @@ ports=[
 ```
 
 Port publication is local-only and TCP-only. For portable local/remote access,
-use `box.network.tunnel(port)`; each tunnel handle represents one connection.
+use `box.network.tunnel(port)`; each returned tunnel is one-shot.
 
 #### Secret Format
 
@@ -291,16 +291,21 @@ Both `boxlite.Box` and `boxlite.SimpleBox` expose `box.network`.
 
 | Operation | Signature | Description |
 |-----------|-----------|-------------|
-| Prepare | `await box.network.tunnel(port) -> BoxTunnel` | Prepare one connection to a TCP service in the box |
-| Inspect | `tunnel.uri() -> str \| None` | Public URL of a remotely served tunnel; `None` for a local one |
-| Connect | `await tunnel.connect() -> BoxConnection` | Consume the tunnel and return its bidirectional byte stream |
+| Tunnel | `await box.network.tunnel(port) -> BoxTunnel` | Prepare a one-shot tunnel to a TCP service in the box |
+| Forward | `await tunnel.forward(listen) -> TunnelForwarder` | Bind one local listener and forward every client |
+| Inspect | `tunnel.uri() -> str \| None` | Read the prepared public URL; `None` for a local box |
+| Connect | `await tunnel.connect() -> BoxConnection` | Consume the prepared tunnel into its byte stream |
 | Read/write | `await connection.read(max_bytes)`, `await connection.write(data)` | Exchange bytes with the service |
 | Close | `await connection.close()` | Close the connection |
 
-Each `BoxTunnel` carries exactly one connection. Call `tunnel()` again for each
-additional or concurrent connection. This differs from `BoxOptions.ports`,
-which creates a persistent, local-only host listener that accepts repeated
-connections from ordinary host applications.
+Use `SocketAddress.tcp(host="127.0.0.1", port=0)` or
+`SocketAddress.unix(path)`. A forwarder exposes `local_addr()`, `await
+wait()`, and repeatable `await close()`; synchronous and `SimpleBox` wrappers
+provide the same operations.
+
+Each `BoxTunnel` is one-shot: choose `connect()` or `forward()`. This differs
+from `BoxOptions.ports`, which creates a persistent, local-only host listener
+that accepts repeated connections from ordinary host applications.
 
 ---
 

--- a/docs/reference/rust/README.md
+++ b/docs/reference/rust/README.md
@@ -364,18 +364,23 @@ pub struct BoxState {
 | Operation | Signature | Description |
 |-----------|-----------|-------------|
 | Get handle | `LiteBox::network(&self) -> NetworkHandle` | Get box-scoped network operations |
-| Prepare | `async fn tunnel(&self, target: SocketAddr) -> BoxliteResult<BoxTunnel>` | Prepare one TCP connection |
-| Inspect | `BoxTunnel::uri(&self) -> Option<&str>` | Public URL of a remotely served tunnel; `None` for a local one |
+| Tunnel | `async fn tunnel(&self, target: SocketAddr) -> BoxliteResult<BoxTunnel>` | Prepare a one-shot tunnel to one guest TCP service |
+| Forward | `async fn BoxTunnel::forward(self, listen: SocketAddress) -> BoxliteResult<TunnelForwarder>` | Consume the tunnel into a TCP or Unix listener |
+| Inspect | `BoxTunnel::uri(&self) -> Option<&str>` | Read the prepared public URL; `None` for a local box |
 | Descriptor | `BoxConnection::raw_fd(&self) -> Option<RawFd>` | Borrowed fd; `None` for a remotely served connection |
 | Take fd | `BoxConnection::into_fd(self) -> BoxliteResult<OwnedFd>` | Consume the connection and own its descriptor |
-| Connect | `BoxTunnel::connect(self) -> BoxliteResult<BoxConnection>` | Consume the tunnel into its bidirectional byte stream |
+| Connect | `BoxTunnel::connect(self) -> BoxliteResult<BoxConnection>` | Consume the prepared tunnel into its byte stream |
 | Split | `BoxConnection::into_split(self) -> (BoxReader, BoxWriter)` | Halves that read and write concurrently |
 | Half-close | `BoxWriter::shutdown(&mut self) -> BoxliteResult<()>` | Signal EOF; a peer that already hung up is success, not an error |
 
-`BoxTunnel` represents exactly one connection; its consuming `connect(self)`
-enforces that at the type boundary. Request another tunnel for each additional
-or concurrent connection. This differs from `BoxOptions.ports`, which creates a
-persistent, local-only host listener that accepts repeated connections.
+`BoxTunnel` remains one-shot: choose either `connect()` or `forward()`. A
+forwarder privately prepares a fresh tunnel for each later accepted client.
+This differs from `BoxOptions.ports`, which publishes a local port for
+the lifetime of the box.
+
+`TunnelForwarder::local_addr()` reports the canonical bound address, while
+repeatable `wait()` and `close()` share the listener's cached terminal result.
+Dropping the final handle requests cancellation.
 
 ---
 

--- a/sdks/c/README.md
+++ b/sdks/c/README.md
@@ -521,17 +521,12 @@ BoxliteErrorCode boxlite_tunnel_connect(
 void boxlite_tunnel_free(CBoxTunnelHandle* tunnel);
 ```
 
-Each `CBoxTunnelHandle` owns exactly one connection.
-`boxlite_tunnel_connect()` consumes it and returns an owned file descriptor that
-the caller must close; a second call returns `InvalidState`. Release the tunnel
-handle with `boxlite_tunnel_free()` after connecting or when discarding an
-unconsumed tunnel.
+Each `CBoxTunnelHandle` is one-shot. Choose `boxlite_tunnel_connect()` or
+`boxlite_tunnel_forward()`; either consumes the prepared tunnel.
 `boxlite_tunnel_uri()` reports where a remotely served tunnel can be reached, as
 an allocated string the caller frees with `boxlite_free_string()`. It writes NULL
-for a local tunnel, whose descriptor is already a live connection rather than an
-address — reach those with `boxlite_tunnel_connect()`.
+for a local tunnel.
 
-Create another tunnel handle for every additional or concurrent connection.
 This differs from `boxlite_options_add_port()`, which creates a persistent,
 local-only host listener that accepts repeated connections.
 

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -97,7 +97,7 @@ typedef struct BoxNetworkHandle BoxNetworkHandle;
 // Opaque handle for Runner API (auto-manages runtime)
 typedef struct BoxRunner BoxRunner;
 
-// Opaque handle for a one-shot box service tunnel.
+// Opaque handle for a one-shot prepared tunnel.
 typedef struct BoxTunnelHandle BoxTunnelHandle;
 
 // Opaque credential handle. Wraps a core `Arc<dyn Credential>` so the
@@ -121,6 +121,9 @@ typedef struct RestOptionsHandle RestOptionsHandle;
 // Opaque handle to a BoxliteRuntime instance with its Tokio runtime and the
 // per-runtime event queue used by the post-and-drain callback API.
 typedef struct RuntimeHandle RuntimeHandle;
+
+// Opaque long-lived listener handle.
+typedef struct TunnelForwarderHandle TunnelForwarderHandle;
 
 // Opaque handle to runtime named-volume operations.
 //
@@ -370,7 +373,25 @@ typedef void (*CRuntimeMetricsCb)(struct CRuntimeMetrics*, CBoxliteError*, void*
 
 typedef struct BoxNetworkHandle CBoxNetworkHandle;
 
+typedef struct TunnelForwarderHandle CTunnelForwarderHandle;
+
+// Tunnel forwarder wait completion.
+typedef void (*CTunnelForwarderWaitCb)(CBoxliteError*, void*);
+
+// Tunnel forwarder close completion.
+typedef void (*CTunnelForwarderCloseCb)(CBoxliteError*, void*);
+
 typedef struct BoxTunnelHandle CBoxTunnelHandle;
+
+typedef uint32_t BoxliteSocketAddressKind;
+
+// Listener address. Input strings are borrowed for the duration of a call.
+typedef struct BoxliteSocketAddress {
+  BoxliteSocketAddressKind kind;
+  const char *host;
+  uint16_t port;
+  const char *path;
+} BoxliteSocketAddress;
 
 typedef struct CredentialHandle CBoxliteCredential;
 
@@ -433,6 +454,10 @@ typedef void (*CBoxVolumeGetCb)(struct CVolumeInfo*, CBoxliteError*, void*);
 // Volume remove completion. The error pointer is borrowed for callback dispatch
 // only and no result allocation is produced.
 typedef void (*CBoxVolumeRemoveCb)(CBoxliteError*, void*);
+
+#define BoxliteSocketTcp 0
+
+#define BoxliteSocketUnix 1
 
 #ifdef __cplusplus
 extern "C" {
@@ -696,6 +721,24 @@ enum BoxliteErrorCode boxlite_box_network(CBoxHandle *handle,
                                           CBoxNetworkHandle **out_network,
                                           CBoxliteError *out_error);
 
+// Return a newly allocated canonical address string.
+enum BoxliteErrorCode boxlite_tunnel_forwarder_address(CTunnelForwarderHandle *forwarder,
+                                                       char **out_address,
+                                                       CBoxliteError *out_error);
+
+enum BoxliteErrorCode boxlite_tunnel_forwarder_wait(CTunnelForwarderHandle *forwarder,
+                                                    CTunnelForwarderWaitCb cb,
+                                                    void *user_data,
+                                                    CBoxliteError *out_error);
+
+enum BoxliteErrorCode boxlite_tunnel_forwarder_close(CTunnelForwarderHandle *forwarder,
+                                                     CTunnelForwarderCloseCb cb,
+                                                     void *user_data,
+                                                     CBoxliteError *out_error);
+
+// Initiate non-blocking cancellation and release the caller's handle.
+void boxlite_tunnel_forwarder_free(CTunnelForwarderHandle *forwarder);
+
 // Release a network handle. Accepts NULL and does not affect the box handle.
 void boxlite_network_free(CBoxNetworkHandle *network);
 
@@ -709,7 +752,7 @@ enum BoxliteErrorCode boxlite_network_tunnel(CBoxNetworkHandle *network,
                                              CBoxTunnelHandle **out_tunnel,
                                              CBoxliteError *out_error);
 
-// Release a tunnel handle and any unconsumed connection. Accepts NULL.
+// Release an unconsumed tunnel. Existing connections and forwarders remain alive.
 void boxlite_tunnel_free(CBoxTunnelHandle *tunnel);
 
 // Read the public URL of a remotely served tunnel, without consuming it.
@@ -723,13 +766,19 @@ enum BoxliteErrorCode boxlite_tunnel_uri(CBoxTunnelHandle *tunnel,
                                          char **out_uri,
                                          CBoxliteError *out_error);
 
-// Consume a tunnel's single connection and return its owned file descriptor.
+// Consume the tunnel and return its owned file descriptor.
 //
-// On success, the caller owns `*out_fd` and must close it. A second call
-// returns `InvalidState`. On failure `*out_fd` remains -1 and `out_error`
+// On success, the caller owns `*out_fd` and must close it.
+// On failure `*out_fd` remains -1 and `out_error`
 // receives details when provided.
 enum BoxliteErrorCode boxlite_tunnel_connect(CBoxTunnelHandle *tunnel,
                                              int32_t *out_fd,
+                                             CBoxliteError *out_error);
+
+// Bind a local listener synchronously and start forwarding accepted clients.
+enum BoxliteErrorCode boxlite_tunnel_forward(CBoxTunnelHandle *tunnel,
+                                             const struct BoxliteSocketAddress *listen,
+                                             CTunnelForwarderHandle **out_forwarder,
                                              CBoxliteError *out_error);
 
 enum BoxliteErrorCode boxlite_options_new(const char *image,

--- a/sdks/c/src/event_queue.rs
+++ b/sdks/c/src/event_queue.rs
@@ -209,6 +209,14 @@ pub(crate) type CExecutionSignalFn = extern "C" fn(*mut crate::CBoxliteError, *m
 pub type CExecutionResizeCb = Option<extern "C" fn(*mut crate::CBoxliteError, *mut c_void)>;
 pub(crate) type CExecutionResizeFn = extern "C" fn(*mut crate::CBoxliteError, *mut c_void);
 
+/// Tunnel forwarder wait completion.
+pub type CTunnelForwarderWaitCb = Option<extern "C" fn(*mut crate::CBoxliteError, *mut c_void)>;
+pub(crate) type CTunnelForwarderWaitFn = extern "C" fn(*mut crate::CBoxliteError, *mut c_void);
+
+/// Tunnel forwarder close completion.
+pub type CTunnelForwarderCloseCb = Option<extern "C" fn(*mut crate::CBoxliteError, *mut c_void)>;
+pub(crate) type CTunnelForwarderCloseFn = extern "C" fn(*mut crate::CBoxliteError, *mut c_void);
+
 // ─── Owned FFI payload ─────────────────────────────────────────────────────
 //
 // Wraps a `Box::into_raw`'d FFI struct that will eventually be transferred
@@ -438,6 +446,16 @@ pub enum RuntimeEvent {
     },
     Resize {
         cb: CExecutionResizeFn,
+        user_data: usize,
+        result: Result<(), BoxliteError>,
+    },
+    TunnelForwarderWait {
+        cb: CTunnelForwarderWaitFn,
+        user_data: usize,
+        result: Result<(), BoxliteError>,
+    },
+    TunnelForwarderClose {
+        cb: CTunnelForwarderCloseFn,
         user_data: usize,
         result: Result<(), BoxliteError>,
     },

--- a/sdks/c/src/lib.rs
+++ b/sdks/c/src/lib.rs
@@ -47,6 +47,7 @@ pub type CBoxliteRuntime = runtime::RuntimeHandle;
 pub type CBoxHandle = box_handle::BoxHandle;
 pub type CBoxNetworkHandle = network::BoxNetworkHandle;
 pub type CBoxTunnelHandle = network::BoxTunnelHandle;
+pub type CTunnelForwarderHandle = network::TunnelForwarderHandle;
 pub type CBoxliteImageHandle = images::ImageHandle;
 pub type CBoxliteVolumeHandle = volumes::VolumeHandle;
 pub type CBoxliteOptions = options::OptionsHandle;

--- a/sdks/c/src/network.rs
+++ b/sdks/c/src/network.rs
@@ -1,19 +1,28 @@
 //! Network operations for the BoxLite C SDK.
 
-use std::ffi::CString;
-use std::net::SocketAddr;
+use std::ffi::{CStr, CString};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::os::fd::IntoRawFd;
-use std::os::raw::c_char;
+use std::os::raw::{c_char, c_void};
+use std::path::PathBuf;
 use std::ptr;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use tokio::runtime::Runtime as TokioRuntime;
 
-use boxlite::litebox::{BoxTunnel as CoreBoxTunnel, NetworkHandle as CoreNetworkHandle};
+use boxlite::litebox::{
+    BoxTunnel as CoreBoxTunnel, NetworkHandle as CoreNetworkHandle, SocketAddress,
+    TunnelForwarder as CoreTunnelForwarder,
+};
 use boxlite::{BoxConnection, BoxliteError};
 
 use crate::error::{BoxliteErrorCode, error_to_code, null_pointer_error, write_error};
-use crate::{CBoxHandle, CBoxNetworkHandle, CBoxTunnelHandle, CBoxliteError};
+use crate::event_queue::{
+    CTunnelForwarderCloseCb, CTunnelForwarderWaitCb, EventQueue, RuntimeEvent, push_event,
+};
+use crate::{
+    CBoxHandle, CBoxNetworkHandle, CBoxTunnelHandle, CBoxliteError, CTunnelForwarderHandle,
+};
 
 async fn connection_fd(
     mut connection: BoxConnection,
@@ -36,12 +45,50 @@ async fn connection_fd(
 pub struct BoxNetworkHandle {
     handle: CoreNetworkHandle,
     tokio_rt: Arc<TokioRuntime>,
+    queue: Arc<EventQueue>,
 }
 
-/// Opaque handle for a one-shot box service tunnel.
-pub struct BoxTunnelHandle {
-    handle: Option<CoreBoxTunnel>,
+/// Opaque long-lived listener handle.
+pub struct TunnelForwarderHandle {
+    handle: CoreTunnelForwarder,
     tokio_rt: Arc<TokioRuntime>,
+    queue: Arc<EventQueue>,
+}
+
+pub type BoxliteSocketAddressKind = u32;
+
+#[allow(non_upper_case_globals)]
+pub const BoxliteSocketTcp: BoxliteSocketAddressKind = 0;
+#[allow(non_upper_case_globals)]
+pub const BoxliteSocketUnix: BoxliteSocketAddressKind = 1;
+
+/// Listener address. Input strings are borrowed for the duration of a call.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct BoxliteSocketAddress {
+    pub kind: BoxliteSocketAddressKind,
+    pub host: *const c_char,
+    pub port: u16,
+    pub path: *const c_char,
+}
+
+/// Opaque handle for a one-shot prepared tunnel.
+pub struct BoxTunnelHandle {
+    handle: Mutex<Option<CoreBoxTunnel>>,
+    tokio_rt: Arc<TokioRuntime>,
+    queue: Arc<EventQueue>,
+}
+
+impl BoxTunnelHandle {
+    fn take(&self) -> Result<CoreBoxTunnel, BoxliteError> {
+        self.handle
+            .lock()
+            .map_err(|_| BoxliteError::Internal("tunnel lock poisoned".into()))?
+            .take()
+            .ok_or_else(|| {
+                BoxliteError::InvalidState("tunnel connection has already been consumed".into())
+            })
+    }
 }
 
 /// Borrow the box's network capability into a new owned handle.
@@ -70,8 +117,166 @@ pub unsafe extern "C" fn boxlite_box_network(
         *out_network = Box::into_raw(Box::new(BoxNetworkHandle {
             handle: handle_ref.handle.network(),
             tokio_rt: handle_ref.tokio_rt.clone(),
+            queue: handle_ref.queue.clone(),
         }));
         BoxliteErrorCode::Ok
+    }
+}
+
+unsafe fn parse_socket_address(
+    address: *const BoxliteSocketAddress,
+) -> Result<SocketAddress, BoxliteError> {
+    if address.is_null() {
+        return Err(null_pointer_error("listen"));
+    }
+    let address = unsafe { &*address };
+    match address.kind {
+        kind if kind == BoxliteSocketTcp => {
+            if !address.path.is_null() {
+                return Err(BoxliteError::InvalidArgument(
+                    "TCP listener path must be null".into(),
+                ));
+            }
+            let host = if address.host.is_null() {
+                ""
+            } else {
+                unsafe { CStr::from_ptr(address.host) }
+                    .to_str()
+                    .map_err(|_| {
+                        BoxliteError::InvalidArgument("listener host is not UTF-8".into())
+                    })?
+            };
+            let ip = if host.is_empty() {
+                IpAddr::V4(Ipv4Addr::LOCALHOST)
+            } else {
+                host.parse::<IpAddr>().map_err(|_| {
+                    BoxliteError::InvalidArgument("TCP listener host must be a numeric IP".into())
+                })?
+            };
+            Ok(SocketAddress::Tcp(SocketAddr::new(ip, address.port)))
+        }
+        kind if kind == BoxliteSocketUnix => {
+            if !address.host.is_null() || address.port != 0 {
+                return Err(BoxliteError::InvalidArgument(
+                    "Unix listener host must be null and port must be zero".into(),
+                ));
+            }
+            if address.path.is_null() {
+                return Err(null_pointer_error("listen.path"));
+            }
+            let path = PathBuf::from(
+                unsafe { CStr::from_ptr(address.path) }
+                    .to_str()
+                    .map_err(|_| {
+                        BoxliteError::InvalidArgument("listener path is not UTF-8".into())
+                    })?,
+            );
+            if !path.is_absolute() {
+                return Err(BoxliteError::InvalidArgument(
+                    "Unix listener path must be absolute".into(),
+                ));
+            }
+            Ok(SocketAddress::Unix(path))
+        }
+        kind => Err(BoxliteError::InvalidArgument(format!(
+            "unknown tunnel listener address kind: {kind}"
+        ))),
+    }
+}
+
+/// Return a newly allocated canonical address string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_tunnel_forwarder_address(
+    forwarder: *mut CTunnelForwarderHandle,
+    out_address: *mut *mut c_char,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if forwarder.is_null() {
+            write_error(out_error, null_pointer_error("forwarder"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        if out_address.is_null() {
+            write_error(out_error, null_pointer_error("out_address"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        *out_address = CString::new((*forwarder).handle.local_addr().to_string())
+            .expect("rendered listener address has no NUL")
+            .into_raw();
+        BoxliteErrorCode::Ok
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_tunnel_forwarder_wait(
+    forwarder: *mut CTunnelForwarderHandle,
+    cb: CTunnelForwarderWaitCb,
+    user_data: *mut c_void,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    if forwarder.is_null() {
+        unsafe { write_error(out_error, null_pointer_error("forwarder")) };
+        return BoxliteErrorCode::InvalidArgument;
+    }
+    let cb = crate::unwrap_cb_or_return!(cb, out_error);
+    let forwarder = unsafe { &*forwarder };
+    let handle = forwarder.handle.clone();
+    let queue = forwarder.queue.clone();
+    let user_data = user_data as usize;
+    forwarder.tokio_rt.spawn(async move {
+        push_event(
+            &queue,
+            RuntimeEvent::TunnelForwarderWait {
+                cb,
+                user_data,
+                result: handle.wait().await,
+            },
+        )
+        .await;
+    });
+    BoxliteErrorCode::Ok
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_tunnel_forwarder_close(
+    forwarder: *mut CTunnelForwarderHandle,
+    cb: CTunnelForwarderCloseCb,
+    user_data: *mut c_void,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    if forwarder.is_null() {
+        unsafe { write_error(out_error, null_pointer_error("forwarder")) };
+        return BoxliteErrorCode::InvalidArgument;
+    }
+    let cb = crate::unwrap_cb_or_return!(cb, out_error);
+    let forwarder = unsafe { &*forwarder };
+    let handle = forwarder.handle.clone();
+    let queue = forwarder.queue.clone();
+    let user_data = user_data as usize;
+    forwarder.tokio_rt.spawn(async move {
+        push_event(
+            &queue,
+            RuntimeEvent::TunnelForwarderClose {
+                cb,
+                user_data,
+                result: handle.close().await,
+            },
+        )
+        .await;
+    });
+    BoxliteErrorCode::Ok
+}
+
+/// Initiate non-blocking cancellation and release the caller's handle.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_tunnel_forwarder_free(forwarder: *mut CTunnelForwarderHandle) {
+    if !forwarder.is_null() {
+        let forwarder = unsafe { Box::from_raw(forwarder) };
+        let handle = forwarder.handle.clone();
+        forwarder.tokio_rt.spawn(async move {
+            let _ = handle.close().await;
+        });
+        drop(forwarder);
     }
 }
 
@@ -132,8 +337,9 @@ pub unsafe extern "C" fn boxlite_network_tunnel(
         {
             Ok(handle) => {
                 *out_tunnel = Box::into_raw(Box::new(BoxTunnelHandle {
-                    handle: Some(handle),
+                    handle: Mutex::new(Some(handle)),
                     tokio_rt: network_ref.tokio_rt.clone(),
+                    queue: network_ref.queue.clone(),
                 }));
                 BoxliteErrorCode::Ok
             }
@@ -146,7 +352,7 @@ pub unsafe extern "C" fn boxlite_network_tunnel(
     }
 }
 
-/// Release a tunnel handle and any unconsumed connection. Accepts NULL.
+/// Release an unconsumed tunnel. Existing connections and forwarders remain alive.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_tunnel_free(tunnel: *mut CBoxTunnelHandle) {
     if !tunnel.is_null() {
@@ -179,41 +385,43 @@ pub unsafe extern "C" fn boxlite_tunnel_uri(
         *out_uri = ptr::null_mut();
 
         let tunnel_ref = &*tunnel;
-        match tunnel_ref.handle.as_ref() {
-            Some(handle) => {
-                let Some(uri) = handle.uri() else {
-                    return BoxliteErrorCode::Ok;
-                };
-                match CString::new(uri) {
-                    Ok(uri) => {
-                        *out_uri = uri.into_raw();
-                        BoxliteErrorCode::Ok
-                    }
-                    Err(_) => {
-                        write_error(
-                            out_error,
-                            BoxliteError::Internal("tunnel URI contains a NUL byte".into()),
-                        );
-                        BoxliteErrorCode::Internal
-                    }
-                }
-            }
-            None => {
-                let error = BoxliteError::InvalidState(
-                    "tunnel connection has already been consumed".into(),
-                );
-                let code = error_to_code(&error);
+        let guard = match tunnel_ref.handle.lock() {
+            Ok(guard) => guard,
+            Err(_) => {
+                let error = BoxliteError::Internal("tunnel lock poisoned".into());
                 write_error(out_error, error);
-                code
+                return BoxliteErrorCode::Internal;
             }
+        };
+        let Some(handle) = guard.as_ref() else {
+            let error =
+                BoxliteError::InvalidState("tunnel connection has already been consumed".into());
+            write_error(out_error, error);
+            return BoxliteErrorCode::InvalidState;
+        };
+        match handle.uri() {
+            Some(uri) => match CString::new(uri) {
+                Ok(uri) => {
+                    *out_uri = uri.into_raw();
+                    BoxliteErrorCode::Ok
+                }
+                Err(_) => {
+                    write_error(
+                        out_error,
+                        BoxliteError::Internal("tunnel URI contains a NUL byte".into()),
+                    );
+                    BoxliteErrorCode::Internal
+                }
+            },
+            None => BoxliteErrorCode::Ok,
         }
     }
 }
 
-/// Consume a tunnel's single connection and return its owned file descriptor.
+/// Consume the tunnel and return its owned file descriptor.
 ///
-/// On success, the caller owns `*out_fd` and must close it. A second call
-/// returns `InvalidState`. On failure `*out_fd` remains -1 and `out_error`
+/// On success, the caller owns `*out_fd` and must close it.
+/// On failure `*out_fd` remains -1 and `out_error`
 /// receives details when provided.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_tunnel_connect(
@@ -232,18 +440,17 @@ pub unsafe extern "C" fn boxlite_tunnel_connect(
         }
         *out_fd = -1;
 
-        let tunnel_ref = &mut *tunnel;
-        let Some(handle) = tunnel_ref.handle.take() else {
-            let error =
-                BoxliteError::InvalidState("tunnel connection has already been consumed".into());
-            let code = error_to_code(&error);
-            write_error(out_error, error);
-            return code;
+        let tunnel_ref = &*tunnel;
+        let prepared = match tunnel_ref.take() {
+            Ok(tunnel) => tunnel,
+            Err(error) => {
+                let code = error_to_code(&error);
+                write_error(out_error, error);
+                return code;
+            }
         };
-        // `connect` registers the descriptor with the reactor, so it needs the
-        // runtime even though it is not itself async.
         let owned_fd = tunnel_ref.tokio_rt.block_on(async {
-            let connection = handle.connect()?;
+            let connection = prepared.connect()?;
             // A socket-backed connection already owns exactly the descriptor
             // the caller wants, so surrender it instead of inserting another
             // socket pair and copy task. Only the remote transport, whose
@@ -265,5 +472,114 @@ pub unsafe extern "C" fn boxlite_tunnel_connect(
                 code
             }
         }
+    }
+}
+
+/// Bind a local listener synchronously and start forwarding accepted clients.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_tunnel_forward(
+    tunnel: *mut CBoxTunnelHandle,
+    listen: *const BoxliteSocketAddress,
+    out_forwarder: *mut *mut CTunnelForwarderHandle,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if tunnel.is_null() {
+            write_error(out_error, null_pointer_error("tunnel"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        if out_forwarder.is_null() {
+            write_error(out_error, null_pointer_error("out_forwarder"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        *out_forwarder = ptr::null_mut();
+        let listen = match parse_socket_address(listen) {
+            Ok(address) => address,
+            Err(error) => {
+                let code = error_to_code(&error);
+                write_error(out_error, error);
+                return code;
+            }
+        };
+        let tunnel = &*tunnel;
+        let prepared = match tunnel.take() {
+            Ok(tunnel) => tunnel,
+            Err(error) => {
+                let code = error_to_code(&error);
+                write_error(out_error, error);
+                return code;
+            }
+        };
+        match tunnel.tokio_rt.block_on(prepared.forward(listen)) {
+            Ok(handle) => {
+                *out_forwarder = Box::into_raw(Box::new(TunnelForwarderHandle {
+                    handle,
+                    tokio_rt: tunnel.tokio_rt.clone(),
+                    queue: tunnel.queue.clone(),
+                }));
+                BoxliteErrorCode::Ok
+            }
+            Err(error) => {
+                let code = error_to_code(&error);
+                write_error(out_error, error);
+                code
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn socket_address_rejects_irrelevant_fields() {
+        let path = CString::new("/tmp/app.sock").unwrap();
+        let tcp = BoxliteSocketAddress {
+            kind: BoxliteSocketTcp,
+            host: ptr::null(),
+            port: 0,
+            path: path.as_ptr(),
+        };
+        assert!(unsafe { parse_socket_address(&tcp) }.is_err());
+
+        let host = CString::new("127.0.0.1").unwrap();
+        let unix = BoxliteSocketAddress {
+            kind: BoxliteSocketUnix,
+            host: host.as_ptr(),
+            port: 0,
+            path: path.as_ptr(),
+        };
+        assert!(unsafe { parse_socket_address(&unix) }.is_err());
+    }
+
+    #[test]
+    fn listener_address_defaults_empty_tcp_host_to_loopback() {
+        let address = BoxliteSocketAddress {
+            kind: BoxliteSocketTcp,
+            host: ptr::null(),
+            port: 0,
+            path: ptr::null(),
+        };
+        assert_eq!(
+            unsafe { parse_socket_address(&address) }.unwrap(),
+            SocketAddress::Tcp("127.0.0.1:0".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn listener_address_rejects_unknown_kind() {
+        let address = BoxliteSocketAddress {
+            kind: 42,
+            host: ptr::null(),
+            port: 0,
+            path: ptr::null(),
+        };
+        let error = unsafe { parse_socket_address(&address) }.unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("unknown tunnel listener address kind")
+        );
     }
 }

--- a/sdks/c/src/runtime.rs
+++ b/sdks/c/src/runtime.rs
@@ -675,6 +675,16 @@ unsafe fn dispatch_event(event: RuntimeEvent) {
                 user_data,
                 result,
             } => dispatch_unit_event(result, user_data, cb),
+            RuntimeEvent::TunnelForwarderWait {
+                cb,
+                user_data,
+                result,
+            } => dispatch_unit_event(result, user_data, cb),
+            RuntimeEvent::TunnelForwarderClose {
+                cb,
+                user_data,
+                result,
+            } => dispatch_unit_event(result, user_data, cb),
         }
     }
 }

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -136,20 +136,24 @@ for _, image := range cached {
   ```
 
 Port publication is local-only. Remote runtimes reject it with guidance to use
-the existing network tunnel API. Each tunnel handle represents one connection.
+the existing network tunnel API. Each tunnel handle is one-shot.
 OCI `EXPOSE` metadata does not publish ports.
 
 ## Service Tunnels
 
-The same one-connection workflow works with local and remote runtimes:
+The same route workflow works with local and remote runtimes:
 
 - `box.Network() (*Network, error)` returns box-scoped network operations.
-- `network.Tunnel(ctx, port) (*BoxTunnel, error)` prepares one TCP connection.
+- `network.Tunnel(ctx, port) (*BoxTunnel, error)` prepares a one-shot tunnel.
+- `TCPListenAddress(host, port)` and `UnixListenAddress(path)` return validated
+  standard `net.Addr` values for `tunnel.Forward(ctx, addr)`. The returned
+  `TunnelForwarder` has `Addr() net.Addr`, `Wait(ctx) error`, and repeatable
+  `Close() error`; canceling a wait context does not close the listener.
 - `tunnel.URI() (string, error)` returns the public URL of a remotely served tunnel, or an empty string for a local one.
-- `tunnel.Connect(ctx) (net.Conn, error)` consumes the tunnel's single connection.
+- `tunnel.Connect(ctx) (net.Conn, error)` consumes the prepared connection.
 
-Call `Tunnel` again for each additional or concurrent connection, and close the
-returned `net.Conn`. This differs from `WithPort`, which creates a persistent,
+Choose `Connect` or `Forward`; a forwarder prepares fresh tunnels for later
+clients. This differs from `WithPort`, which creates a persistent,
 local-only host listener that accepts repeated connections.
 
 ## Development

--- a/sdks/go/bridge.c
+++ b/sdks/go/bridge.c
@@ -41,6 +41,8 @@ extern void goBoxliteOnExecutionWait(int exit_code, CBoxliteError *err, void *ud
 extern void goBoxliteOnExecutionKill(CBoxliteError *err, void *ud);
 extern void goBoxliteOnExecutionSignal(CBoxliteError *err, void *ud);
 extern void goBoxliteOnExecutionResize(CBoxliteError *err, void *ud);
+extern void goBoxliteOnTunnelForwarderWait(CBoxliteError *err, void *ud);
+extern void goBoxliteOnTunnelForwarderClose(CBoxliteError *err, void *ud);
 
 CBoxStdoutCb cbStdout(void) { return (CBoxStdoutCb)goBoxliteOnStdout; }
 CBoxStderrCb cbStderr(void) { return (CBoxStderrCb)goBoxliteOnStderr; }
@@ -82,3 +84,5 @@ CExecutionWaitCb cbExecutionWait(void) { return (CExecutionWaitCb)goBoxliteOnExe
 CExecutionKillCb cbExecutionKill(void) { return (CExecutionKillCb)goBoxliteOnExecutionKill; }
 CExecutionSignalCb cbExecutionSignal(void) { return (CExecutionSignalCb)goBoxliteOnExecutionSignal; }
 CExecutionResizeCb cbExecutionResize(void) { return (CExecutionResizeCb)goBoxliteOnExecutionResize; }
+CTunnelForwarderWaitCb cbTunnelForwarderWait(void) { return (CTunnelForwarderWaitCb)goBoxliteOnTunnelForwarderWait; }
+CTunnelForwarderCloseCb cbTunnelForwarderClose(void) { return (CTunnelForwarderCloseCb)goBoxliteOnTunnelForwarderClose; }

--- a/sdks/go/bridge.h
+++ b/sdks/go/bridge.h
@@ -41,5 +41,7 @@ extern CExecutionWaitCb cbExecutionWait(void);
 extern CExecutionKillCb cbExecutionKill(void);
 extern CExecutionSignalCb cbExecutionSignal(void);
 extern CExecutionResizeCb cbExecutionResize(void);
+extern CTunnelForwarderWaitCb cbTunnelForwarderWait(void);
+extern CTunnelForwarderCloseCb cbTunnelForwarderClose(void);
 
 #endif // BOXLITE_GO_BRIDGE_H

--- a/sdks/go/bridge_callback.go
+++ b/sdks/go/bridge_callback.go
@@ -515,6 +515,16 @@ func goBoxliteOnExecutionResize(errPtr *C.CBoxliteError, userData unsafe.Pointer
 	deliverUnitResult(userData, errPtr)
 }
 
+//export goBoxliteOnTunnelForwarderWait
+func goBoxliteOnTunnelForwarderWait(errPtr *C.CBoxliteError, userData unsafe.Pointer) {
+	deliverUnitResult(userData, errPtr)
+}
+
+//export goBoxliteOnTunnelForwarderClose
+func goBoxliteOnTunnelForwarderClose(errPtr *C.CBoxliteError, userData unsafe.Pointer) {
+	deliverUnitResult(userData, errPtr)
+}
+
 // ─── Generic delivery helpers ──────────────────────────────────────────────
 
 // deliverUnitResult sends an error-only result to the channel referenced by

--- a/sdks/go/runtime.go
+++ b/sdks/go/runtime.go
@@ -28,6 +28,7 @@ const drainTimeoutMs = 100
 type Runtime struct {
 	handle *C.CBoxliteRuntime
 
+	drainMu   sync.Mutex
 	drainOnce sync.Once
 	drainStop chan struct{}
 	drainDone chan struct{}
@@ -333,6 +334,19 @@ func (r *Runtime) removeBox(ctx context.Context, idOrName string, force bool) er
 // M). Because the M is already a Go thread, callbacks like pipe writes or
 // channel sends do not need to hijack a new thread.
 func (r *Runtime) ensureDrainRunning() {
+	if r == nil {
+		return
+	}
+	r.drainMu.Lock()
+	defer r.drainMu.Unlock()
+	select {
+	case <-r.closing:
+		return
+	default:
+	}
+	if r.handle == nil {
+		return
+	}
 	r.drainOnce.Do(func() {
 		r.drainStop = make(chan struct{})
 		r.drainDone = make(chan struct{})
@@ -361,17 +375,22 @@ func (r *Runtime) drainLoop() {
 }
 
 func (r *Runtime) stopDrain() {
+	r.drainMu.Lock()
 	if r.drainStop == nil {
+		r.drainMu.Unlock()
 		return
 	}
 	select {
 	case <-r.drainStop:
+		r.drainMu.Unlock()
 		return
 	default:
 	}
 	close(r.drainStop)
-	if r.drainDone != nil {
-		<-r.drainDone
+	done := r.drainDone
+	r.drainMu.Unlock()
+	if done != nil {
+		<-done
 	}
 }
 

--- a/sdks/go/tunnel.go
+++ b/sdks/go/tunnel.go
@@ -4,6 +4,8 @@ package boxlite
 
 /*
 #include "bridge.h"
+#include <stdlib.h>
+#include <unistd.h>
 */
 import "C"
 import (
@@ -11,16 +13,101 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/cgo"
+	"strings"
+	"sync"
+	"unsafe"
 )
 
 // Network is a box-scoped handle for network operations.
 type Network struct {
-	handle *C.CBoxNetworkHandle
+	handle  *C.CBoxNetworkHandle
+	runtime *Runtime
 }
 
-// BoxTunnel is a one-shot connection target for a service inside a box.
+type socketAddress struct {
+	kind C.BoxliteSocketAddressKind
+	host string
+	port uint16
+	path string
+}
+
+func TCPListenAddress(host string, port uint16) (net.Addr, error) {
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return nil, fmt.Errorf("tunnel listener host must be a numeric IP: %q", host)
+	}
+	return &net.TCPAddr{IP: append(net.IP(nil), ip...), Port: int(port)}, nil
+}
+
+func UnixListenAddress(path string) (net.Addr, error) {
+	if err := validateUnixListenPath(path); err != nil {
+		return nil, err
+	}
+	return &net.UnixAddr{Name: path, Net: "unix"}, nil
+}
+
+func validateUnixListenPath(path string) error {
+	if !filepath.IsAbs(path) {
+		return fmt.Errorf("tunnel Unix socket path must be absolute: %q", path)
+	}
+	if strings.ContainsRune(path, '\x00') {
+		return fmt.Errorf("tunnel Unix socket path must not contain NUL")
+	}
+	return nil
+}
+
+func parseListenAddress(listen net.Addr) (socketAddress, error) {
+	switch address := listen.(type) {
+	case *net.TCPAddr:
+		if address == nil || address.Port < 0 || address.Port > 65535 {
+			return socketAddress{}, fmt.Errorf("invalid TCP tunnel listener address")
+		}
+		if address.Zone != "" {
+			return socketAddress{}, fmt.Errorf("TCP tunnel listener zones are not supported")
+		}
+		ip := address.IP
+		if len(ip) == 0 {
+			ip = net.IPv4(127, 0, 0, 1)
+		}
+		if ip.To4() == nil && ip.To16() == nil {
+			return socketAddress{}, fmt.Errorf("TCP tunnel listener must use a numeric IP")
+		}
+		return socketAddress{
+			kind: C.BoxliteSocketTcp,
+			host: ip.String(),
+			port: uint16(address.Port),
+		}, nil
+	case *net.UnixAddr:
+		if address == nil || address.Net != "unix" {
+			return socketAddress{}, fmt.Errorf("tunnel Unix listener must be an absolute filesystem stream socket")
+		}
+		if err := validateUnixListenPath(address.Name); err != nil {
+			return socketAddress{}, err
+		}
+		return socketAddress{kind: C.BoxliteSocketUnix, path: address.Name}, nil
+	default:
+		return socketAddress{}, fmt.Errorf("tunnel listener must be *net.TCPAddr or *net.UnixAddr")
+	}
+}
+
+type TunnelForwarder struct {
+	mu      sync.Mutex
+	handle  *C.CTunnelForwarderHandle
+	runtime *Runtime
+	address net.Addr
+}
+
+// BoxTunnel is a prepared one-shot tunnel to a service inside a box.
 type BoxTunnel struct {
-	handle *C.CBoxTunnelHandle
+	mu      sync.Mutex
+	handle  *C.CBoxTunnelHandle
+	runtime *Runtime
 }
 
 // Network returns the box-scoped handle for network operations.
@@ -36,7 +123,109 @@ func (b *Box) Network() (*Network, error) {
 		return nil, freeError(&cerr)
 	}
 
-	return &Network{handle: cNetwork}, nil
+	return &Network{handle: cNetwork, runtime: b.runtime}, nil
+}
+
+func (f *TunnelForwarder) Addr() net.Addr {
+	if f == nil {
+		return nil
+	}
+	defer runtime.KeepAlive(f)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.handle == nil {
+		return nil
+	}
+	return cloneAddr(f.address)
+}
+
+func (f *TunnelForwarder) Wait(ctx context.Context) error {
+	if f == nil {
+		return ErrRuntimeClosed
+	}
+	defer runtime.KeepAlive(f)
+	f.mu.Lock()
+	if f.handle == nil || f.runtime == nil {
+		f.mu.Unlock()
+		return ErrRuntimeClosed
+	}
+	runtimeHandle := f.runtime
+	select {
+	case <-runtimeHandle.closing:
+		f.mu.Unlock()
+		return ErrRuntimeClosed
+	default:
+	}
+	runtimeHandle.ensureDrainRunning()
+	ch := make(chan error, 1)
+	h := registerHandleForDispatch(cgo.NewHandle(ch))
+	var cerr C.CBoxliteError
+	code := C.boxlite_tunnel_forwarder_wait(f.handle, C.cbTunnelForwarderWait(), handleToPtr(h), &cerr)
+	f.mu.Unlock()
+	if code != C.Ok {
+		deleteHandleForDispatch(h)
+		return freeError(&cerr)
+	}
+	select {
+	case err := <-ch:
+		return err
+	case <-ctx.Done():
+		abandonAsyncErr(ch, h, runtimeHandle.closing)
+		return ctx.Err()
+	case <-runtimeHandle.closing:
+		abandonAsyncErr(ch, h, runtimeHandle.closing)
+		return ErrRuntimeClosed
+	}
+}
+
+func (f *TunnelForwarder) Close() error {
+	if f == nil {
+		return nil
+	}
+	defer runtime.KeepAlive(f)
+	f.mu.Lock()
+	if f.handle == nil || f.runtime == nil {
+		f.mu.Unlock()
+		return nil
+	}
+	runtimeHandle := f.runtime
+	select {
+	case <-runtimeHandle.closing:
+		f.mu.Unlock()
+		return ErrRuntimeClosed
+	default:
+	}
+	runtimeHandle.ensureDrainRunning()
+	ch := make(chan error, 1)
+	h := registerHandleForDispatch(cgo.NewHandle(ch))
+	var cerr C.CBoxliteError
+	code := C.boxlite_tunnel_forwarder_close(f.handle, C.cbTunnelForwarderClose(), handleToPtr(h), &cerr)
+	f.mu.Unlock()
+	if code != C.Ok {
+		deleteHandleForDispatch(h)
+		return freeError(&cerr)
+	}
+	select {
+	case err := <-ch:
+		return err
+	case <-runtimeHandle.closing:
+		abandonAsyncErr(ch, h, runtimeHandle.closing)
+		return ErrRuntimeClosed
+	}
+}
+
+func (f *TunnelForwarder) free() {
+	if f == nil {
+		return
+	}
+	runtime.SetFinalizer(f, nil)
+	f.mu.Lock()
+	handle := f.handle
+	f.handle = nil
+	f.mu.Unlock()
+	if handle != nil {
+		C.boxlite_tunnel_forwarder_free(handle)
+	}
 }
 
 // Close releases the network handle.
@@ -48,7 +237,7 @@ func (n *Network) Close() error {
 	return nil
 }
 
-// Tunnel prepares a one-shot connection target for a service port inside the box.
+// Tunnel prepares a one-shot tunnel to a service port inside the box.
 func (n *Network) Tunnel(ctx context.Context, port uint16) (*BoxTunnel, error) {
 	if n == nil || n.handle == nil {
 		return nil, ErrRuntimeClosed
@@ -59,37 +248,65 @@ func (n *Network) Tunnel(ctx context.Context, port uint16) (*BoxTunnel, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-
 	var cTunnel *C.CBoxTunnelHandle
 	var cerr C.CBoxliteError
 	code := C.boxlite_network_tunnel(n.handle, C.uint16_t(port), &cTunnel, &cerr)
 	if code != C.Ok {
 		return nil, freeError(&cerr)
 	}
-	return &BoxTunnel{handle: cTunnel}, nil
+	tunnel := &BoxTunnel{handle: cTunnel, runtime: n.runtime}
+	runtime.SetFinalizer(tunnel, (*BoxTunnel).Close)
+	return tunnel, nil
 }
 
-// Close releases the tunnel handle.
+func (t *BoxTunnel) take() (*C.CBoxTunnelHandle, error) {
+	if t == nil {
+		return nil, ErrRuntimeClosed
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.handle == nil {
+		return nil, ErrRuntimeClosed
+	}
+	runtime.SetFinalizer(t, nil)
+	handle := t.handle
+	t.handle = nil
+	return handle, nil
+}
+
+// Close releases an unconsumed tunnel.
 func (t *BoxTunnel) Close() error {
-	if t != nil && t.handle != nil {
-		C.boxlite_tunnel_free(t.handle)
-		t.handle = nil
+	if t == nil {
+		return nil
+	}
+	runtime.SetFinalizer(t, nil)
+	t.mu.Lock()
+	if t.handle == nil {
+		t.mu.Unlock()
+		return nil
+	}
+	handle := t.handle
+	t.handle = nil
+	t.mu.Unlock()
+	if handle != nil {
+		C.boxlite_tunnel_free(handle)
 	}
 	return nil
 }
 
-// URI returns the public URL of a remotely served tunnel. It is empty for a
-// local tunnel, whose descriptor is already a live connection rather than an
-// address — use Connect for those.
+// URI returns the prepared tunnel's public URL. An empty string means local.
 func (t *BoxTunnel) URI() (string, error) {
-	if t == nil || t.handle == nil {
+	if t == nil {
 		return "", ErrRuntimeClosed
 	}
-
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.handle == nil {
+		return "", ErrRuntimeClosed
+	}
 	var uri *C.char
 	var cerr C.CBoxliteError
-	code := C.boxlite_tunnel_uri(t.handle, &uri, &cerr)
-	if code != C.Ok {
+	if code := C.boxlite_tunnel_uri(t.handle, &uri, &cerr); code != C.Ok {
 		return "", freeError(&cerr)
 	}
 	if uri == nil {
@@ -101,20 +318,17 @@ func (t *BoxTunnel) URI() (string, error) {
 
 // Connect consumes the tunnel's single raw byte stream.
 func (t *BoxTunnel) Connect(ctx context.Context) (net.Conn, error) {
-	if t == nil || t.handle == nil {
-		return nil, ErrRuntimeClosed
-	}
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-
+	handle, err := t.take()
+	if err != nil {
+		return nil, err
+	}
+	defer C.boxlite_tunnel_free(handle)
 	var cerr C.CBoxliteError
 	var cFD C.int32_t
-	handle := t.handle
-	code := C.boxlite_tunnel_connect(handle, &cFD, &cerr)
-	C.boxlite_tunnel_free(handle)
-	t.handle = nil
-	if code != C.Ok {
+	if code := C.boxlite_tunnel_connect(handle, &cFD, &cerr); code != C.Ok {
 		return nil, freeError(&cerr)
 	}
 	if cFD < 0 {
@@ -122,16 +336,97 @@ func (t *BoxTunnel) Connect(ctx context.Context) (net.Conn, error) {
 	}
 	file := os.NewFile(uintptr(cFD), "boxlite-tunnel")
 	if file == nil {
+		_ = C.close(C.int(cFD))
 		return nil, fmt.Errorf("boxlite tunnel returned invalid fd")
 	}
-	defer file.Close()
-	conn, err := net.FileConn(file)
+	connection, err := net.FileConn(file)
+	_ = file.Close()
 	if err != nil {
 		return nil, err
 	}
 	if err := ctx.Err(); err != nil {
-		_ = conn.Close()
+		_ = connection.Close()
 		return nil, err
 	}
-	return conn, nil
+	return connection, nil
+}
+
+func tunnelForwarderAddress(handle *C.CTunnelForwarderHandle) (net.Addr, error) {
+	var address *C.char
+	var cerr C.CBoxliteError
+	if C.boxlite_tunnel_forwarder_address(handle, &address, &cerr) != C.Ok {
+		return nil, freeError(&cerr)
+	}
+	defer C.boxlite_free_string(address)
+	value := C.GoString(address)
+	if strings.HasPrefix(value, "unix:") {
+		return &net.UnixAddr{Name: strings.TrimPrefix(value, "unix:"), Net: "unix"}, nil
+	}
+	parsed, err := net.ResolveTCPAddr("tcp", strings.TrimPrefix(value, "tcp://"))
+	if err != nil {
+		return nil, fmt.Errorf("parse tunnel listener address %q: %w", value, err)
+	}
+	return parsed, nil
+}
+
+func cloneAddr(address net.Addr) net.Addr {
+	switch address := address.(type) {
+	case *net.TCPAddr:
+		clone := *address
+		clone.IP = append(net.IP(nil), address.IP...)
+		return &clone
+	case *net.UnixAddr:
+		clone := *address
+		return &clone
+	default:
+		return nil
+	}
+}
+
+// Forward binds a local listener and forwards each client through a fresh connection.
+func (t *BoxTunnel) Forward(ctx context.Context, listen net.Addr) (*TunnelForwarder, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	address, err := parseListenAddress(listen)
+	if err != nil {
+		return nil, err
+	}
+	handle, err := t.take()
+	if err != nil {
+		return nil, err
+	}
+	defer C.boxlite_tunnel_free(handle)
+	var host, path *C.char
+	if address.host != "" {
+		host = C.CString(address.host)
+		defer C.free(unsafe.Pointer(host))
+	}
+	if address.path != "" {
+		path = C.CString(address.path)
+		defer C.free(unsafe.Pointer(path))
+	}
+	cAddress := C.BoxliteSocketAddress{
+		kind: address.kind,
+		host: host,
+		port: C.uint16_t(address.port),
+		path: path,
+	}
+	var forwarderHandle *C.CTunnelForwarderHandle
+	var cerr C.CBoxliteError
+	if code := C.boxlite_tunnel_forward(handle, &cAddress, &forwarderHandle, &cerr); code != C.Ok {
+		return nil, freeError(&cerr)
+	}
+	canonical, err := tunnelForwarderAddress(forwarderHandle)
+	if err != nil {
+		C.boxlite_tunnel_forwarder_free(forwarderHandle)
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		C.boxlite_tunnel_forwarder_free(forwarderHandle)
+		return nil, err
+	}
+	forwarder := &TunnelForwarder{handle: forwarderHandle, runtime: t.runtime, address: canonical}
+	runtime.SetFinalizer(forwarder, (*TunnelForwarder).free)
+	return forwarder, nil
 }

--- a/sdks/go/tunnel_test.go
+++ b/sdks/go/tunnel_test.go
@@ -5,6 +5,8 @@ package boxlite
 import (
 	"context"
 	"errors"
+	"net"
+	"path/filepath"
 	"testing"
 )
 
@@ -12,6 +14,69 @@ func TestNetworkTunnelRejectsClosedHandle(t *testing.T) {
 	var network *Network
 	if _, err := network.Tunnel(context.Background(), 3000); !errors.Is(err, ErrRuntimeClosed) {
 		t.Fatalf("Tunnel() error = %v, want ErrRuntimeClosed", err)
+	}
+}
+
+func TestTunnelForwardRejectsClosedHandle(t *testing.T) {
+	var tunnel *BoxTunnel
+	listen, err := TCPListenAddress("", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tunnel.Forward(context.Background(), listen); !errors.Is(err, ErrRuntimeClosed) {
+		t.Fatalf("Forward() error = %v, want ErrRuntimeClosed", err)
+	}
+}
+
+func TestListenAddressHelpersReturnStandardAddresses(t *testing.T) {
+	tcp, err := TCPListenAddress("", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := tcp.(*net.TCPAddr); !ok {
+		t.Fatalf("TCPListenAddress() = %T, want *net.TCPAddr", tcp)
+	}
+
+	unix, err := UnixListenAddress(filepath.Join(t.TempDir(), "app.sock"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := unix.(*net.UnixAddr); !ok {
+		t.Fatalf("UnixListenAddress() = %T, want *net.UnixAddr", unix)
+	}
+}
+
+func TestListenAddressValidation(t *testing.T) {
+	if _, err := TCPListenAddress("localhost", 8080); err == nil {
+		t.Fatal("hostname must be rejected")
+	}
+	if _, err := UnixListenAddress("relative.sock"); err == nil {
+		t.Fatal("relative Unix path must be rejected")
+	}
+	if _, err := UnixListenAddress("/tmp/app\x00.sock"); err == nil {
+		t.Fatal("Unix path containing NUL must be rejected")
+	}
+	if _, err := parseListenAddress(&net.UDPAddr{}); err == nil {
+		t.Fatal("UDP address must be rejected")
+	}
+	if _, err := parseListenAddress(&net.UnixAddr{Name: "/tmp/app.sock", Net: "unixgram"}); err == nil {
+		t.Fatal("Unix datagram address must be rejected")
+	}
+	if _, err := parseListenAddress(&net.UnixAddr{Name: "/tmp/app\x00.sock", Net: "unix"}); err == nil {
+		t.Fatal("generic Unix address containing NUL must be rejected")
+	}
+}
+
+func TestTunnelForwarderMethodsHandleClosedValue(t *testing.T) {
+	var forwarder *TunnelForwarder
+	if forwarder.Addr() != nil {
+		t.Fatal("Addr() must be nil for a closed forwarder")
+	}
+	if err := forwarder.Wait(context.Background()); !errors.Is(err, ErrRuntimeClosed) {
+		t.Fatalf("Wait() error = %v, want ErrRuntimeClosed", err)
+	}
+	if err := forwarder.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
 	}
 }
 
@@ -38,5 +103,18 @@ func TestNetworkAndTunnelCloseAreIdempotent(t *testing.T) {
 	}
 	if err := (&BoxTunnel{}).Close(); err != nil {
 		t.Fatalf("Tunnel.Close() error = %v", err)
+	}
+}
+
+func TestRuntimeDoesNotStartDrainAfterClosing(t *testing.T) {
+	closing := make(chan struct{})
+	close(closing)
+	runtime := &Runtime{closing: closing}
+
+	runtime.ensureDrainRunning()
+
+	if runtime.drainStop != nil {
+		runtime.stopDrain()
+		t.Fatal("ensureDrainRunning() started a drain after runtime closure")
 	}
 }

--- a/sdks/node/lib/index.ts
+++ b/sdks/node/lib/index.ts
@@ -99,8 +99,10 @@ export { getNativeModule, getJsBoxlite };
 export {
   SimpleBox,
   BoxTunnel,
+  TunnelForwarder,
   NetworkHandle,
   type NetworkSpec,
+  type SocketAddress,
   type AdvancedBoxOptions,
   type ContainerCapabilities,
   type SimpleBoxOptions,

--- a/sdks/node/lib/native-contracts.ts
+++ b/sdks/node/lib/native-contracts.ts
@@ -362,8 +362,17 @@ export interface JsSnapshotHandle {
 }
 
 export interface JsNetworkHandle {
-  /** Establish a tunnel to a service port inside the box. */
+  /** Prepare a one-shot tunnel to a service port inside the box. */
   tunnel(port: number): Promise<NativeBoxTunnel>;
+}
+
+export type SocketAddress =
+  { type: "tcp"; host?: string; port: number } | { type: "unix"; path: string };
+
+export interface NativeTunnelForwarder {
+  localAddr(): SocketAddress;
+  wait(): Promise<void>;
+  close(): Promise<void>;
 }
 
 /** Internal contract implemented by the native N-API tunnel binding. */
@@ -372,6 +381,7 @@ export interface NativeBoxTunnel {
   uri(): string | null;
   /** Consume the tunnel and return its bidirectional byte stream. */
   connect(): Promise<NativeBoxConnection>;
+  forward(listen: SocketAddress): Promise<NativeTunnelForwarder>;
 }
 
 export interface NativeBoxConnection {

--- a/sdks/node/lib/simplebox.ts
+++ b/sdks/node/lib/simplebox.ts
@@ -18,13 +18,17 @@ import type {
   JsVolumeSpec,
   NativeBoxConnection,
   NativeBoxTunnel,
+  NativeTunnelForwarder,
+  SocketAddress,
   JsExecStderr,
   JsExecStdout,
 } from "./native-contracts.js";
 
+export type { SocketAddress } from "./native-contracts.js";
+
 type BoxLike = Omit<JsBox, "network"> & {
   readonly network: {
-    tunnel(port: number): Promise<NativeBoxTunnel | BoxTunnel>;
+    tunnel(port: number): Promise<NativeBoxTunnel>;
   };
 };
 
@@ -283,16 +287,34 @@ export class NetworkHandle {
   /** @internal */
   constructor(private readonly ensureBox: () => Promise<BoxLike>) {}
 
-  /** Establish and return a tunnel handle for a port inside this box. */
+  /** Establish and return a one-shot tunnel for a port inside this box. */
   async tunnel(port: number): Promise<BoxTunnel> {
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      throw new RangeError("port must be an integer between 1 and 65535");
+    }
     const box = await this.ensureBox();
-    const tunnel = await box.network.tunnel(port);
-    return tunnel instanceof BoxTunnel ? tunnel : new BoxTunnel(tunnel);
+    return new BoxTunnel(await box.network.tunnel(port));
+  }
+}
+
+export class TunnelForwarder {
+  constructor(private readonly forwarder: NativeTunnelForwarder) {}
+
+  localAddr(): SocketAddress {
+    return this.forwarder.localAddr();
+  }
+
+  wait(): Promise<void> {
+    return this.forwarder.wait();
+  }
+
+  close(): Promise<void> {
+    return this.forwarder.close();
   }
 }
 
 export class BoxTunnel {
-  /** Wrap the native tunnel handle for a box service port. */
+  /** Wrap a prepared native tunnel handle. */
   constructor(private readonly tunnel: NativeBoxTunnel) {}
 
   /** Public URL of a remotely served tunnel, or null for a local one. */
@@ -303,6 +325,10 @@ export class BoxTunnel {
   /** Consume the tunnel and return its bidirectional byte stream. */
   async connect(): Promise<NativeBoxConnection> {
     return this.tunnel.connect();
+  }
+
+  async forward(listen: SocketAddress): Promise<TunnelForwarder> {
+    return new TunnelForwarder(await this.tunnel.forward(listen));
   }
 }
 
@@ -742,7 +768,7 @@ export class SimpleBox {
     return box.metrics();
   }
 
-  /** Open a raw bidirectional socket to a port inside this box. */
+  /** Establish and return a one-shot tunnel to a port inside this box. */
   async tunnel(port: number): Promise<BoxTunnel> {
     return this.network.tunnel(port);
   }

--- a/sdks/node/src/lib.rs
+++ b/sdks/node/src/lib.rs
@@ -30,7 +30,9 @@ pub use info::{
     JsBoxInfo, JsBoxStateInfo, JsHealthState, JsHealthStatus, JsNetworkInfo, JsPublishedPort,
 };
 pub use metrics::{JsBoxMetrics, JsRuntimeMetrics};
-pub use network::{JsBoxConnection, JsBoxTunnel, JsNetworkHandle};
+pub use network::{
+    JsBoxConnection, JsBoxTunnel, JsNetworkHandle, JsSocketAddress, JsTunnelForwarder,
+};
 pub use options::{
     ApiKeyCredential, JsAccessToken, JsBoxOptions, JsEnvVar, JsHealthCheckOptions, JsImageRegistry,
     JsImageRegistryAuth, JsNetworkSpec, JsOptions, JsPortSpec, JsSecret, JsVolumeSpec,

--- a/sdks/node/src/network.rs
+++ b/sdks/node/src/network.rs
@@ -1,8 +1,9 @@
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use boxlite::LiteBox;
-use boxlite::litebox::BoxTunnel;
+use boxlite::litebox::{BoxTunnel, SocketAddress, TunnelForwarder};
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -18,10 +19,102 @@ pub struct JsNetworkHandle {
     pub(crate) handle: Arc<LiteBox>,
 }
 
-/// A one-shot tunnel to one service port in a box.
+/// A prepared one-shot tunnel to one service port in a box.
 #[napi]
 pub struct JsBoxTunnel {
-    handle: Arc<Mutex<Option<BoxTunnel>>>,
+    handle: Mutex<Option<BoxTunnel>>,
+}
+
+#[napi(object)]
+pub struct JsSocketAddress {
+    pub r#type: String,
+    pub host: Option<String>,
+    pub port: Option<f64>,
+    pub path: Option<String>,
+}
+
+#[napi]
+pub struct JsTunnelForwarder {
+    handle: TunnelForwarder,
+}
+
+fn parse_socket_address(address: JsSocketAddress) -> Result<SocketAddress> {
+    match address.r#type.as_str() {
+        "tcp" => {
+            if address.path.is_some() {
+                return Err(Error::from_reason("TCP listener path must be omitted"));
+            }
+            let port = address
+                .port
+                .ok_or_else(|| Error::from_reason("TCP listener port is required"))?;
+            if !port.is_finite() || port.fract() != 0.0 || !(0.0..=u16::MAX as f64).contains(&port)
+            {
+                return Err(Error::from_reason(
+                    "TCP listener port must be an integer between 0 and 65535",
+                ));
+            }
+            let host = address.host.as_deref().unwrap_or("127.0.0.1");
+            let ip = if host.is_empty() {
+                IpAddr::V4(Ipv4Addr::LOCALHOST)
+            } else {
+                host.parse::<IpAddr>()
+                    .map_err(|_| Error::from_reason("TCP listener host must be a numeric IP"))?
+            };
+            Ok(SocketAddress::Tcp(SocketAddr::new(ip, port as u16)))
+        }
+        "unix" => {
+            if address.host.is_some() || address.port.is_some() {
+                return Err(Error::from_reason(
+                    "Unix listener host and port must be omitted",
+                ));
+            }
+            let path = PathBuf::from(
+                address
+                    .path
+                    .ok_or_else(|| Error::from_reason("Unix listener path is required"))?,
+            );
+            if !path.is_absolute() {
+                return Err(Error::from_reason("Unix listener path must be absolute"));
+            }
+            Ok(SocketAddress::Unix(path))
+        }
+        _ => Err(Error::from_reason("listener type must be 'tcp' or 'unix'")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn listener_port_rejects_non_integer_numbers() {
+        for port in [f64::NAN, f64::INFINITY, -1.0, 1.5, 65_536.0] {
+            let result = parse_socket_address(JsSocketAddress {
+                r#type: "tcp".into(),
+                host: None,
+                port: Some(port),
+                path: None,
+            });
+            assert!(result.is_err(), "accepted invalid port {port}");
+        }
+    }
+}
+
+fn render_socket_address(address: &SocketAddress) -> JsSocketAddress {
+    match address {
+        SocketAddress::Tcp(address) => JsSocketAddress {
+            r#type: "tcp".to_string(),
+            host: Some(address.ip().to_string()),
+            port: Some(address.port().into()),
+            path: None,
+        },
+        SocketAddress::Unix(path) => JsSocketAddress {
+            r#type: "unix".to_string(),
+            host: None,
+            port: None,
+            path: Some(path.to_string_lossy().into_owned()),
+        },
+    }
 }
 
 #[napi]
@@ -47,8 +140,36 @@ impl JsNetworkHandle {
             .await
             .map_err(map_err)?;
         Ok(JsBoxTunnel {
-            handle: Arc::new(Mutex::new(Some(tunnel))),
+            handle: Mutex::new(Some(tunnel)),
         })
+    }
+}
+
+impl JsBoxTunnel {
+    fn take(&self) -> Result<BoxTunnel> {
+        self.handle
+            .lock()
+            .map_err(|_| Error::from_reason("tunnel lock poisoned"))?
+            .take()
+            .ok_or_else(|| Error::from_reason("tunnel connection has already been consumed"))
+    }
+}
+
+#[napi]
+impl JsTunnelForwarder {
+    #[napi]
+    pub fn local_addr(&self) -> JsSocketAddress {
+        render_socket_address(self.handle.local_addr())
+    }
+
+    #[napi]
+    pub async fn wait(&self) -> Result<()> {
+        self.handle.wait().await.map_err(map_err)
+    }
+
+    #[napi]
+    pub async fn close(&self) -> Result<()> {
+        self.handle.close().await.map_err(map_err)
     }
 }
 
@@ -57,11 +178,11 @@ impl JsBoxTunnel {
     /// Public URL of a remotely served tunnel, or `null` for a local one.
     #[napi]
     pub fn uri(&self) -> Result<Option<String>> {
-        let handle = self
+        let guard = self
             .handle
             .lock()
             .map_err(|_| Error::from_reason("tunnel lock poisoned"))?;
-        let tunnel = handle
+        let tunnel = guard
             .as_ref()
             .ok_or_else(|| Error::from_reason("tunnel connection has already been consumed"))?;
         Ok(tunnel.uri().map(str::to_owned))
@@ -69,17 +190,23 @@ impl JsBoxTunnel {
 
     #[napi]
     pub async fn connect(&self) -> Result<JsBoxConnection> {
-        let tunnel = self
-            .handle
-            .lock()
-            .map_err(|_| Error::from_reason("tunnel lock poisoned"))?
-            .take()
-            .ok_or_else(|| Error::from_reason("tunnel connection has already been consumed"))?;
+        let tunnel = self.take()?;
         let (reader, writer) = tunnel.connect().map_err(map_err)?.into_split();
         Ok(JsBoxConnection {
             reader: Arc::new(tokio::sync::Mutex::new(Some(reader))),
             writer: Arc::new(tokio::sync::Mutex::new(Some(writer))),
         })
+    }
+
+    #[napi]
+    pub async fn forward(&self, listen: JsSocketAddress) -> Result<JsTunnelForwarder> {
+        let listen = parse_socket_address(listen)?;
+        let tunnel = self.take()?;
+        tunnel
+            .forward(listen)
+            .await
+            .map(|handle| JsTunnelForwarder { handle })
+            .map_err(map_err)
     }
 }
 

--- a/sdks/node/tests/tunnel.test.ts
+++ b/sdks/node/tests/tunnel.test.ts
@@ -69,6 +69,39 @@ describe("SimpleBox", () => {
     expect(connect).toHaveBeenCalledTimes(2);
   });
 
+  test("forward delegates address and lifecycle operations", async () => {
+    const { SimpleBox } = await import("../lib/simplebox.js");
+    const listen = { type: "tcp" as const, port: 0 };
+    const nativeForwarder = {
+      localAddr: vi.fn(() => ({
+        type: "tcp" as const,
+        host: "127.0.0.1",
+        port: 49152,
+      })),
+      wait: vi.fn(async () => undefined),
+      close: vi.fn(async () => undefined),
+    };
+    const forward = vi.fn(async () => nativeForwarder);
+    const nativeTunnel = { uri: vi.fn(), connect: vi.fn(), forward };
+    const box = new SimpleBox({ image: "alpine:latest" }) as SimpleBox & {
+      _box: { network: { tunnel: () => Promise<typeof nativeTunnel> } };
+    };
+    box._box = { network: { tunnel: async () => nativeTunnel } };
+
+    const tunnel = await box.network.tunnel(3000);
+    const forwarder = await tunnel.forward(listen);
+    expect(forward).toHaveBeenCalledWith(listen);
+    expect(forwarder.localAddr()).toEqual({
+      type: "tcp",
+      host: "127.0.0.1",
+      port: 49152,
+    });
+    await forwarder.wait();
+    await forwarder.close();
+    expect(nativeForwarder.wait).toHaveBeenCalledOnce();
+    expect(nativeForwarder.close).toHaveBeenCalledOnce();
+  });
+
   test("info resolves asynchronously", async () => {
     const { SimpleBox } = await import("../lib/simplebox.js");
     const metadata = { id: "box-1" };

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -244,8 +244,8 @@ Configuration options for creating a box.
 - `network: NetworkSpec | None` - Structured network configuration
 - `ports: List[Tuple | Dict]` - Local TCP forwarding; omit `host_port` in a dict for automatic allocation
   - Protocol: `"tcp"`; UDP is rejected
-  - Portable local/remote code uses `box.network.tunnel(port)`; each tunnel
-    handle represents one connection
+  - Portable local/remote code uses `box.network.tunnel(port)`; each tunnel is
+    a prepared one-shot tunnel; call `forward()` for a listener
 - `secrets: List[Secret]` - Host-side HTTP(S) secret substitution rules
 - `advanced: AdvancedBoxOptions | None` - Expert-only container options
   - `capabilities.add: List[str]` - Capabilities added to BoxLite's baseline

--- a/sdks/python/boxlite/__init__.py
+++ b/sdks/python/boxlite/__init__.py
@@ -44,6 +44,8 @@ try:
         SnapshotHandle,
         SnapshotInfo,
         SnapshotOptions,
+        SocketAddress,
+        TunnelForwarder,
         VolumeHandle,
         VolumeInfo,
     )
@@ -61,6 +63,8 @@ try:
         "Boxlite",
         "NetworkSpec",
         "NetworkHandle",
+        "SocketAddress",
+        "TunnelForwarder",
         "NetworkInfo",
         "Box",
         "Execution",
@@ -170,6 +174,7 @@ try:
         SyncNetworkHandle,
         SyncSimpleBox,
         SyncSkillBox,
+        SyncTunnelForwarder,
     )
 
     __all__.extend(
@@ -184,6 +189,7 @@ try:
             "SyncNetworkHandle",
             "SyncSimpleBox",
             "SyncSkillBox",
+            "SyncTunnelForwarder",
         ]
     )
 except ImportError:

--- a/sdks/python/boxlite/simplebox.py
+++ b/sdks/python/boxlite/simplebox.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Optional
 from .exec import ExecResult
 
 if TYPE_CHECKING:
-    from .boxlite import Boxlite
+    from .boxlite import Boxlite, TunnelForwarder
 
 logger = logging.getLogger("boxlite.simplebox")
 
@@ -27,7 +27,7 @@ class StreamType(IntEnum):
 
 
 class BoxTunnel:
-    """Prepared async tunnel handle for a box service port."""
+    """Prepared one-shot tunnel handle for a box service port."""
 
     def __init__(self, tunnel) -> None:
         self._tunnel = tunnel
@@ -40,6 +40,9 @@ class BoxTunnel:
         """Return the public URL of a remote tunnel, or ``None`` for a local one."""
         return self._tunnel.uri()
 
+    async def forward(self, listen) -> "TunnelForwarder":
+        return await self._tunnel.forward(listen)
+
 
 class NetworkHandle:
     """Network operations for a ``SimpleBox``."""
@@ -48,7 +51,7 @@ class NetworkHandle:
         self._owner = box
 
     async def tunnel(self, port: int) -> BoxTunnel:
-        """Establish and return a tunnel handle for a port inside the box."""
+        """Establish and return a one-shot tunnel for a port inside the box."""
         if not self._owner._started:
             raise RuntimeError(
                 "Box not started. Use 'async with SimpleBox(...) as box:' "
@@ -340,7 +343,7 @@ class SimpleBox:
         )
 
     async def tunnel(self, port: int) -> BoxTunnel:
-        """Establish and return a tunnel handle for a port inside this box."""
+        """Establish and return a one-shot tunnel for a port inside this box."""
         return await self.network.tunnel(port)
 
     async def metrics(self):

--- a/sdks/python/boxlite/sync_api/__init__.py
+++ b/sdks/python/boxlite/sync_api/__init__.py
@@ -46,7 +46,7 @@ from ._boxlite import SyncBoxlite
 from ._codebox import SyncCodeBox
 from ._execution import SyncExecStderr, SyncExecStdout, SyncExecution
 from ._images import SyncImageHandle
-from ._network import SyncNetworkHandle
+from ._network import SyncNetworkHandle, SyncTunnelForwarder
 from ._simplebox import SyncSimpleBox
 from ._skillbox import SyncSkillBox
 from ._sync_base import SyncBase, SyncContextManager
@@ -61,6 +61,7 @@ __all__ = [  # noqa: RUF022 - grouped by API area, not alphabetical
     "SyncBox",
     "SyncImageHandle",
     "SyncNetworkHandle",
+    "SyncTunnelForwarder",
     "SyncExecution",
     "SyncExecStdout",
     "SyncExecStderr",

--- a/sdks/python/boxlite/sync_api/_box.py
+++ b/sdks/python/boxlite/sync_api/_box.py
@@ -137,7 +137,7 @@ class SyncBox:
         return self._network
 
     def tunnel(self, port: int):
-        """Establish and return a tunnel handle for a port inside this box."""
+        """Establish and return a one-shot tunnel for a port inside this box."""
         return self.network.tunnel(port)
 
     # Context manager support

--- a/sdks/python/boxlite/sync_api/_network.py
+++ b/sdks/python/boxlite/sync_api/_network.py
@@ -5,11 +5,26 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from ._box import SyncBox
 
-__all__ = ["SyncBoxTunnel", "SyncNetworkHandle"]
+__all__ = ["SyncBoxTunnel", "SyncNetworkHandle", "SyncTunnelForwarder"]
+
+
+class SyncTunnelForwarder:
+    def __init__(self, box: "SyncBox", forwarder) -> None:
+        self._box = box
+        self._forwarder = forwarder
+
+    def local_addr(self):
+        return self._forwarder.local_addr()
+
+    def wait(self) -> None:
+        self._box._sync(self._forwarder.wait())
+
+    def close(self) -> None:
+        self._box._sync(self._forwarder.close())
 
 
 class SyncBoxTunnel:
-    """Prepared synchronous tunnel handle for a box service port."""
+    """Prepared one-shot synchronous tunnel handle."""
 
     def __init__(self, box: "SyncBox", tunnel) -> None:
         self._box = box
@@ -23,6 +38,11 @@ class SyncBoxTunnel:
         """Return the public URL of a remote tunnel, or ``None`` for a local one."""
         return self._tunnel.uri()
 
+    def forward(self, listen) -> SyncTunnelForwarder:
+        return SyncTunnelForwarder(
+            self._box, self._box._sync(self._tunnel.forward(listen))
+        )
+
 
 class SyncNetworkHandle:
     """Synchronous wrapper for a box's network handle."""
@@ -31,7 +51,7 @@ class SyncNetworkHandle:
         self._owner = box
 
     def tunnel(self, port: int) -> SyncBoxTunnel:
-        """Establish and return a tunnel handle for a port inside the box."""
+        """Establish and return a one-shot tunnel for a port inside the box."""
         if not isinstance(port, int) or not 1 <= port <= 65535:
             raise ValueError("port must be an integer between 1 and 65535")
         tunnel = self._owner._create_tunnel(port)

--- a/sdks/python/boxlite/sync_api/_simplebox.py
+++ b/sdks/python/boxlite/sync_api/_simplebox.py
@@ -252,7 +252,7 @@ class SyncSimpleBox:
         return self._runtime._sync(_exec_and_collect())
 
     def tunnel(self, port: int):
-        """Establish a tunnel handle; call ``connect()`` to consume its socket."""
+        """Establish and return a one-shot tunnel for a port inside this box."""
         if self._box is None:
             raise RuntimeError(
                 "Box not started. Use 'with SyncSimpleBox(...) as box:' first."

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -24,7 +24,9 @@ use crate::info::{
     PyBoxInfo, PyBoxStateInfo, PyHealthState, PyHealthStatus, PyNetworkInfo, PyPublishedPort,
 };
 use crate::metrics::{PyBoxMetrics, PyRuntimeMetrics};
-use crate::network::{PyBoxConnection, PyBoxTunnel, PyNetworkHandle};
+use crate::network::{
+    PyBoxConnection, PyBoxTunnel, PyNetworkHandle, PySocketAddress, PyTunnelForwarder,
+};
 use crate::options::{
     PyAccessToken, PyApiKeyCredential, PyBoxOptions, PyBoxliteRestOptions, PyCopyOptions,
     PyImageRegistry, PyNetworkSpec, PyOptions, PySecret,
@@ -67,6 +69,8 @@ fn boxlite_python(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyNetworkHandle>()?;
     m.add_class::<PyBoxTunnel>()?;
     m.add_class::<PyBoxConnection>()?;
+    m.add_class::<PySocketAddress>()?;
+    m.add_class::<PyTunnelForwarder>()?;
     m.add_class::<PyCopyOptions>()?;
     m.add_class::<PySnapshotInfo>()?;
     m.add_class::<PySnapshotHandle>()?;

--- a/sdks/python/src/network.rs
+++ b/sdks/python/src/network.rs
@@ -1,10 +1,12 @@
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use boxlite::LiteBox;
-use boxlite::litebox::BoxTunnel;
+use boxlite::litebox::{BoxTunnel, SocketAddress, TunnelForwarder};
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
+use pyo3::types::PyType;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::util::map_err;
@@ -21,7 +23,84 @@ pub(crate) struct PyNetworkHandle {
 /// A one-shot tunnel to one service port in a box.
 #[pyclass(name = "BoxTunnel")]
 pub(crate) struct PyBoxTunnel {
-    handle: Arc<Mutex<Option<BoxTunnel>>>,
+    handle: Mutex<Option<BoxTunnel>>,
+}
+
+#[pyclass(name = "SocketAddress")]
+#[derive(Clone)]
+pub(crate) struct PySocketAddress {
+    address: SocketAddress,
+}
+
+#[pyclass(name = "TunnelForwarder")]
+pub(crate) struct PyTunnelForwarder {
+    handle: TunnelForwarder,
+}
+
+#[pymethods]
+impl PySocketAddress {
+    #[classmethod]
+    #[pyo3(signature = (host="127.0.0.1", port=0))]
+    fn tcp(_class: &Bound<'_, PyType>, host: &str, port: u16) -> PyResult<Self> {
+        let ip = if host.is_empty() {
+            IpAddr::V4(Ipv4Addr::LOCALHOST)
+        } else {
+            host.parse::<IpAddr>().map_err(|_| {
+                pyo3::exceptions::PyValueError::new_err("tunnel listener host must be a numeric IP")
+            })?
+        };
+        Ok(Self {
+            address: SocketAddress::Tcp(SocketAddr::new(ip, port)),
+        })
+    }
+
+    #[classmethod]
+    fn unix(_class: &Bound<'_, PyType>, path: PathBuf) -> PyResult<Self> {
+        if !path.is_absolute() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "tunnel Unix socket path must be absolute",
+            ));
+        }
+        Ok(Self {
+            address: SocketAddress::Unix(path),
+        })
+    }
+
+    fn __str__(&self) -> String {
+        self.address.to_string()
+    }
+
+    #[getter]
+    fn kind(&self) -> &'static str {
+        match &self.address {
+            SocketAddress::Tcp(_) => "tcp",
+            SocketAddress::Unix(_) => "unix",
+        }
+    }
+
+    #[getter]
+    fn host(&self) -> Option<String> {
+        match &self.address {
+            SocketAddress::Tcp(address) => Some(address.ip().to_string()),
+            SocketAddress::Unix(_) => None,
+        }
+    }
+
+    #[getter]
+    fn port(&self) -> Option<u16> {
+        match &self.address {
+            SocketAddress::Tcp(address) => Some(address.port()),
+            SocketAddress::Unix(_) => None,
+        }
+    }
+
+    #[getter]
+    fn path(&self) -> Option<PathBuf> {
+        match &self.address {
+            SocketAddress::Tcp(_) => None,
+            SocketAddress::Unix(path) => Some(path.clone()),
+        }
+    }
 }
 
 /// A bidirectional byte stream returned by a box tunnel.
@@ -39,15 +118,56 @@ impl PyNetworkHandle {
                 "tunnel port must be non-zero",
             ));
         }
-        let handle = Arc::clone(&self.handle);
         let target: SocketAddr = format!("{}:{port}", boxlite::net::constants::GUEST_IP)
             .parse()
             .expect("BoxLite guest IP must be a valid socket address");
+        let handle = Arc::clone(&self.handle);
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let tunnel = handle.network().tunnel(target).await.map_err(map_err)?;
             Ok(PyBoxTunnel {
-                handle: Arc::new(Mutex::new(Some(tunnel))),
+                handle: Mutex::new(Some(tunnel)),
             })
+        })
+    }
+}
+
+impl PyBoxTunnel {
+    fn take(&self) -> PyResult<BoxTunnel> {
+        self.handle
+            .lock()
+            .map_err(|_| {
+                map_err(boxlite::BoxliteError::Internal(
+                    "tunnel lock poisoned".into(),
+                ))
+            })?
+            .take()
+            .ok_or_else(|| {
+                map_err(boxlite::BoxliteError::InvalidState(
+                    "tunnel connection has already been consumed".into(),
+                ))
+            })
+    }
+}
+
+#[pymethods]
+impl PyTunnelForwarder {
+    fn local_addr(&self) -> PySocketAddress {
+        PySocketAddress {
+            address: self.handle.local_addr().clone(),
+        }
+    }
+
+    fn wait<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let handle = self.handle.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            handle.wait().await.map_err(map_err)
+        })
+    }
+
+    fn close<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let handle = self.handle.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            handle.close().await.map_err(map_err)
         })
     }
 }
@@ -56,45 +176,43 @@ impl PyNetworkHandle {
 impl PyBoxTunnel {
     /// Public URL of a remotely served tunnel, or `None` for a local one.
     fn uri(&self) -> PyResult<Option<String>> {
-        Ok(self
-            .handle
-            .lock()
-            .map_err(|_| {
-                map_err(boxlite::BoxliteError::Internal(
-                    "tunnel lock poisoned".into(),
-                ))
-            })?
-            .as_ref()
-            .ok_or_else(|| {
-                map_err(boxlite::BoxliteError::InvalidState(
-                    "tunnel connection has already been consumed".into(),
-                ))
-            })?
-            .uri()
-            .map(str::to_owned))
+        let guard = self.handle.lock().map_err(|_| {
+            map_err(boxlite::BoxliteError::Internal(
+                "tunnel lock poisoned".into(),
+            ))
+        })?;
+        let tunnel = guard.as_ref().ok_or_else(|| {
+            map_err(boxlite::BoxliteError::InvalidState(
+                "tunnel connection has already been consumed".into(),
+            ))
+        })?;
+        Ok(tunnel.uri().map(str::to_owned))
     }
 
     fn connect<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        let handle = Arc::clone(&self.handle);
+        let tunnel = self.take()?;
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let tunnel = handle
-                .lock()
-                .map_err(|_| {
-                    map_err(boxlite::BoxliteError::Internal(
-                        "tunnel lock poisoned".into(),
-                    ))
-                })?
-                .take()
-                .ok_or_else(|| {
-                    map_err(boxlite::BoxliteError::InvalidState(
-                        "tunnel connection has already been consumed".into(),
-                    ))
-                })?;
             let (reader, writer) = tunnel.connect().map_err(map_err)?.into_split();
             Ok(PyBoxConnection {
                 reader: Arc::new(tokio::sync::Mutex::new(Some(reader))),
                 writer: Arc::new(tokio::sync::Mutex::new(Some(writer))),
             })
+        })
+    }
+
+    fn forward<'py>(
+        &self,
+        py: Python<'py>,
+        listen: PyRef<'_, PySocketAddress>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let tunnel = self.take()?;
+        let listen = listen.address.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            tunnel
+                .forward(listen)
+                .await
+                .map(|handle| PyTunnelForwarder { handle })
+                .map_err(map_err)
         })
     }
 }

--- a/sdks/python/tests/test_tunnel.py
+++ b/sdks/python/tests/test_tunnel.py
@@ -31,6 +31,9 @@ class _FakeTunnel:
     async def connect(self) -> _FakeConnection:
         return self.connections.pop(0)
 
+    async def forward(self, listen):
+        return _FakeForwarder(listen)
+
 
 class _FakeNetwork:
     def __init__(self, tunnel: _FakeTunnel) -> None:
@@ -40,6 +43,22 @@ class _FakeNetwork:
     async def tunnel(self, port: int) -> _FakeTunnel:
         self.ports.append(port)
         return self.tunnel_value
+
+
+class _FakeForwarder:
+    def __init__(self, listen) -> None:
+        self.listen = listen
+        self.waited = False
+        self.closed = False
+
+    def local_addr(self):
+        return self.listen
+
+    async def wait(self) -> None:
+        self.waited = True
+
+    async def close(self) -> None:
+        self.closed = True
 
 
 class _FakeBox:
@@ -106,21 +125,21 @@ async def test_uri_is_none_for_a_local_tunnel():
 
 @pytest.mark.asyncio
 async def test_connect_consumes_tunnel_once():
-    connection = _FakeConnection()
+    first_connection = _FakeConnection()
     box = SimpleBox.__new__(SimpleBox)
     box._started = True
-    box._box = _FakeBox(_FakeTunnel([connection], "unused"))
+    box._box = _FakeBox(_FakeTunnel([first_connection], "unused"))
 
     tunnel = await box.network.tunnel(3000)
     first = await tunnel.connect()
     try:
         assert await first.write(b"one") == 3
-        assert connection.writes == [b"one"]
+        assert first_connection.writes == [b"one"]
         with pytest.raises(IndexError):
             await tunnel.connect()
     finally:
         await first.close()
-        assert connection.closed
+        assert first_connection.closed
 
 
 @pytest.mark.asyncio
@@ -130,6 +149,22 @@ async def test_tunnel_requires_a_started_box():
 
     with pytest.raises(RuntimeError, match="Box not started"):
         await box.network.tunnel(3000)
+
+
+@pytest.mark.asyncio
+async def test_forward_delegates_and_preserves_lifecycle_calls():
+    box = SimpleBox.__new__(SimpleBox)
+    box._started = True
+    box._box = _FakeBox(_FakeTunnel([], None))
+    listen = object()
+
+    tunnel = await box.network.tunnel(3000)
+    forwarder = await tunnel.forward(listen)
+    assert forwarder.local_addr() is listen
+    await forwarder.wait()
+    await forwarder.close()
+    assert forwarder.waited
+    assert forwarder.closed
 
 
 @pytest.mark.parametrize("port", [0, 65536, "3000", None])

--- a/src/boxlite/src/lib.rs
+++ b/src/boxlite/src/lib.rs
@@ -33,7 +33,9 @@ mod rest;
 mod rootfs;
 mod volumes;
 
-pub use litebox::{BoxConnection, BoxReader, BoxTunnel, BoxWriter, LiteBox};
+pub use litebox::{
+    BoxConnection, BoxReader, BoxTunnel, BoxWriter, LiteBox, SocketAddress, TunnelForwarder,
+};
 pub use portal::GuestSession;
 pub use runtime::{AuthHandle, BoxliteRuntime, ImageHandle, Principal};
 

--- a/src/boxlite/src/litebox/mod.rs
+++ b/src/boxlite/src/litebox/mod.rs
@@ -23,7 +23,9 @@ pub use copy::CopyOptions;
 pub(crate) use crash_report::CrashReport;
 pub use exec::{BoxCommand, ExecResult, ExecStderr, ExecStdin, ExecStdout, Execution, ExecutionId};
 pub(crate) use manager::BoxManager;
-pub use network::{BoxConnection, BoxReader, BoxTunnel, BoxWriter, NetworkHandle};
+pub use network::{
+    BoxConnection, BoxReader, BoxTunnel, BoxWriter, NetworkHandle, SocketAddress, TunnelForwarder,
+};
 pub use snapshot::SnapshotHandle;
 pub use state::{BoxState, BoxStatus, HealthState, HealthStatus};
 

--- a/src/boxlite/src/litebox/network.rs
+++ b/src/boxlite/src/litebox/network.rs
@@ -3,15 +3,40 @@
 use std::io::ErrorKind;
 use std::net::SocketAddr;
 use std::os::fd::OwnedFd;
+use std::os::unix::fs::{FileTypeExt, MetadataExt};
+use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, ReadBuf};
+use tokio::net::{TcpListener, TcpStream, UnixListener, UnixStream};
+use tokio::sync::{Semaphore, watch};
+use tokio::task::JoinSet;
+use tokio_util::either::Either;
+use tokio_util::sync::CancellationToken;
 
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 
 use crate::runtime::backend::BoxNetworkBackend;
+
+const MAX_FORWARD_CONNECTIONS: usize = 64;
+
+/// Local address owned by a tunnel forwarder.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SocketAddress {
+    Tcp(SocketAddr),
+    Unix(PathBuf),
+}
+
+impl std::fmt::Display for SocketAddress {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Tcp(address) => write!(formatter, "tcp://{address}"),
+            Self::Unix(path) => write!(formatter, "unix:{}", path.display()),
+        }
+    }
+}
 
 /// Combines the two byte-stream traits into something boxable.
 ///
@@ -226,12 +251,9 @@ impl AsyncWrite for BoxWriter {
     }
 }
 
-/// The transport a [`BoxTunnel`] was built over — fixed at construction,
-/// never transitions. Not a state machine.
+/// The transport a [`BoxTunnel`] was built over.
 enum TunnelTransport {
-    /// Owned descriptor for the local transport; the fd *is* the tunnel.
     Local(OwnedFd),
-    /// Live remote stream plus the public URI it was opened against.
     #[cfg(feature = "rest")]
     Remote {
         uri: String,
@@ -239,21 +261,29 @@ enum TunnelTransport {
     },
 }
 
-/// A one-shot box service tunnel target.
-///
-/// [`uri`](Self::uri) reports where a remote tunnel can be reached;
-/// [`connect`](Self::connect) consumes the tunnel, so a second connect is a
-/// move error at compile time rather than a runtime state check.
+#[derive(Clone)]
+struct TunnelOpener {
+    network_backend: Arc<dyn BoxNetworkBackend>,
+    target: SocketAddr,
+}
+
+impl TunnelOpener {
+    async fn open(&self) -> BoxliteResult<BoxTunnel> {
+        self.network_backend.tunnel(self.target).await
+    }
+}
+
+/// A prepared, one-shot tunnel to one TCP service inside a box.
 pub struct BoxTunnel {
     transport: TunnelTransport,
+    opener: Option<TunnelOpener>,
 }
 
 impl BoxTunnel {
-    /// Wrap an owned transport descriptor. The fd *is* the tunnel — no bridge
-    /// copy in between.
     pub(crate) fn local(fd: OwnedFd) -> Self {
         Self {
             transport: TunnelTransport::Local(fd),
+            opener: None,
         }
     }
 
@@ -267,13 +297,15 @@ impl BoxTunnel {
                 uri,
                 connection: BoxConnection::new(connection),
             },
+            opener: None,
         }
     }
 
-    /// Where clients can reach a remote box service.
-    ///
-    /// `None` for a local tunnel: its descriptor *is* the connection, so there
-    /// is no address to hand out — use [`connect`](Self::connect) instead.
+    fn with_opener(mut self, opener: TunnelOpener) -> Self {
+        self.opener = Some(opener);
+        self
+    }
+
     pub fn uri(&self) -> Option<&str> {
         match &self.transport {
             TunnelTransport::Local(_) => None,
@@ -282,12 +314,8 @@ impl BoxTunnel {
         }
     }
 
-    /// Consume this tunnel into its single connection.
-    ///
-    /// Must run inside a tokio runtime — the local descriptor is registered
-    /// with the reactor here.
-    pub fn connect(self) -> BoxliteResult<BoxConnection> {
-        match self.transport {
+    fn connect_transport(transport: TunnelTransport) -> BoxliteResult<BoxConnection> {
+        match transport {
             TunnelTransport::Local(fd) => {
                 let stream = std::os::unix::net::UnixStream::from(fd);
                 stream.set_nonblocking(true).map_err(|error| {
@@ -302,6 +330,44 @@ impl BoxTunnel {
             #[cfg(feature = "rest")]
             TunnelTransport::Remote { connection, .. } => Ok(connection),
         }
+    }
+
+    /// Consume this prepared tunnel into its single connection.
+    pub fn connect(self) -> BoxliteResult<BoxConnection> {
+        Self::connect_transport(self.transport)
+    }
+
+    /// Consume this prepared tunnel into a local multi-connection forwarder.
+    pub async fn forward(self, listen: SocketAddress) -> BoxliteResult<TunnelForwarder> {
+        self.forward_with_bound(listen, |_| Ok(())).await
+    }
+
+    /// Bind and synchronously report the canonical address before accepting.
+    #[doc(hidden)]
+    pub async fn forward_with_bound<F>(
+        self,
+        listen: SocketAddress,
+        on_bound: F,
+    ) -> BoxliteResult<TunnelForwarder>
+    where
+        F: FnOnce(&SocketAddress) -> BoxliteResult<()>,
+    {
+        let BoxTunnel { transport, opener } = self;
+        let opener = opener
+            .ok_or_else(|| BoxliteError::Internal("tunnel is missing its network opener".into()))?;
+        let first_connection = Self::connect_transport(transport)?;
+        let listener = BoundListener::bind(listen).await?;
+        let address = listener.address();
+        on_bound(&address)?;
+        let state = Arc::new(ForwarderState::new(address));
+        let task_state = Arc::clone(&state);
+        tokio::spawn(async move {
+            run_forwarder(listener, first_connection, opener, task_state).await;
+        });
+
+        Ok(TunnelForwarder {
+            owner: Arc::new(ForwarderOwner { state }),
+        })
     }
 }
 
@@ -318,23 +384,331 @@ impl NetworkHandle {
         Self { network_backend }
     }
 
-    /// Establish a one-shot tunnel to a service port inside the box.
+    /// Establish a prepared, one-shot tunnel to a service port inside the box.
     pub async fn tunnel(&self, target: SocketAddr) -> BoxliteResult<BoxTunnel> {
-        self.network_backend.tunnel(target).await
+        if target.port() == 0 {
+            return Err(BoxliteError::InvalidArgument(
+                "tunnel target port must be non-zero".into(),
+            ));
+        }
+        let opener = TunnelOpener {
+            network_backend: Arc::clone(&self.network_backend),
+            target,
+        };
+        self.network_backend
+            .tunnel(target)
+            .await
+            .map(|tunnel| tunnel.with_opener(opener))
+    }
+}
+
+/// A running local listener that opens one box tunnel per client.
+#[derive(Clone)]
+pub struct TunnelForwarder {
+    owner: Arc<ForwarderOwner>,
+}
+
+impl std::fmt::Debug for TunnelForwarder {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("TunnelForwarder")
+            .field("local_addr", &self.local_addr())
+            .finish_non_exhaustive()
+    }
+}
+
+impl TunnelForwarder {
+    pub fn local_addr(&self) -> &SocketAddress {
+        &self.owner.state.address
+    }
+
+    /// Wait for explicit closure or a fatal listener error.
+    pub async fn wait(&self) -> BoxliteResult<()> {
+        self.owner.state.wait().await
+    }
+
+    /// Stop accepting and cancel active relays, then wait for cleanup.
+    pub async fn close(&self) -> BoxliteResult<()> {
+        self.owner.state.cancel.cancel();
+        self.wait().await
+    }
+}
+
+struct ForwarderOwner {
+    state: Arc<ForwarderState>,
+}
+
+impl Drop for ForwarderOwner {
+    fn drop(&mut self) {
+        self.state.cancel.cancel();
+    }
+}
+
+type ForwarderOutcome = Result<(), String>;
+
+struct ForwarderState {
+    address: SocketAddress,
+    cancel: CancellationToken,
+    outcome: watch::Sender<Option<ForwarderOutcome>>,
+}
+
+impl ForwarderState {
+    fn new(address: SocketAddress) -> Self {
+        let (outcome, _) = watch::channel(None);
+        Self {
+            address,
+            cancel: CancellationToken::new(),
+            outcome,
+        }
+    }
+
+    fn finish(&self, outcome: ForwarderOutcome) {
+        self.outcome.send_if_modified(|current| {
+            if current.is_some() {
+                return false;
+            }
+            *current = Some(outcome);
+            true
+        });
+    }
+
+    async fn wait(&self) -> BoxliteResult<()> {
+        let mut outcome = self.outcome.subscribe();
+        outcome
+            .wait_for(Option::is_some)
+            .await
+            .expect("forwarder outcome sender is retained by its state")
+            .clone()
+            .expect("wait_for returned only after observing an outcome")
+            .map_err(BoxliteError::Network)
+    }
+}
+
+enum BoundListener {
+    Tcp(TcpListener),
+    Unix {
+        listener: UnixListener,
+        cleanup: UnixSocketCleanup,
+    },
+}
+
+impl BoundListener {
+    async fn bind(address: SocketAddress) -> BoxliteResult<Self> {
+        match address {
+            SocketAddress::Tcp(address) => {
+                TcpListener::bind(address)
+                    .await
+                    .map(Self::Tcp)
+                    .map_err(|error| {
+                        BoxliteError::Network(format!("bind tunnel listener {address}: {error}"))
+                    })
+            }
+            SocketAddress::Unix(path) => {
+                if !path.is_absolute() {
+                    return Err(BoxliteError::InvalidArgument(format!(
+                        "tunnel Unix socket path must be absolute: {}",
+                        path.display()
+                    )));
+                }
+                match std::fs::symlink_metadata(&path) {
+                    Ok(_) => {
+                        return Err(BoxliteError::AlreadyExists(format!(
+                            "tunnel Unix socket path {}",
+                            path.display()
+                        )));
+                    }
+                    Err(error) if error.kind() == ErrorKind::NotFound => {}
+                    Err(error) => {
+                        return Err(BoxliteError::Network(format!(
+                            "inspect tunnel Unix socket path {}: {error}",
+                            path.display()
+                        )));
+                    }
+                }
+
+                let listener = UnixListener::bind(&path).map_err(|error| {
+                    BoxliteError::Network(format!(
+                        "bind tunnel Unix socket {}: {error}",
+                        path.display()
+                    ))
+                })?;
+                let metadata = std::fs::symlink_metadata(&path).map_err(|error| {
+                    BoxliteError::Network(format!(
+                        "inspect bound tunnel Unix socket {}: {error}",
+                        path.display()
+                    ))
+                })?;
+                Ok(Self::Unix {
+                    listener,
+                    cleanup: UnixSocketCleanup {
+                        path,
+                        device: metadata.dev(),
+                        inode: metadata.ino(),
+                    },
+                })
+            }
+        }
+    }
+
+    fn address(&self) -> SocketAddress {
+        match self {
+            Self::Tcp(listener) => SocketAddress::Tcp(
+                listener
+                    .local_addr()
+                    .expect("bound TCP listener must have a local address"),
+            ),
+            Self::Unix { cleanup, .. } => SocketAddress::Unix(cleanup.path.clone()),
+        }
+    }
+
+    async fn accept(&self) -> std::io::Result<LocalForwardStream> {
+        match self {
+            Self::Tcp(listener) => listener
+                .accept()
+                .await
+                .map(|(stream, _)| Either::Left(stream)),
+            Self::Unix { listener, .. } => listener
+                .accept()
+                .await
+                .map(|(stream, _)| Either::Right(stream)),
+        }
+    }
+}
+
+struct UnixSocketCleanup {
+    path: PathBuf,
+    device: u64,
+    inode: u64,
+}
+
+impl Drop for UnixSocketCleanup {
+    fn drop(&mut self) {
+        // POSIX has no atomic compare-and-unlink operation. This immediate
+        // identity check avoids removing a visible replacement in ordinary
+        // cases, but a replacement racing between this check and unlink is an
+        // unavoidable best-effort TOCTOU limitation.
+        let Ok(metadata) = std::fs::symlink_metadata(&self.path) else {
+            return;
+        };
+        if metadata.file_type().is_socket()
+            && metadata.dev() == self.device
+            && metadata.ino() == self.inode
+            && let Err(error) = std::fs::remove_file(&self.path)
+        {
+            tracing::warn!(path = %self.path.display(), %error, "failed to remove tunnel Unix socket");
+        }
+    }
+}
+
+type LocalForwardStream = Either<TcpStream, UnixStream>;
+
+enum RelayTunnel {
+    Prepared(BoxConnection),
+    Open(TunnelOpener),
+}
+
+async fn run_forwarder(
+    listener: BoundListener,
+    first_connection: BoxConnection,
+    opener: TunnelOpener,
+    state: Arc<ForwarderState>,
+) {
+    let permits = Arc::new(Semaphore::new(MAX_FORWARD_CONNECTIONS));
+    let mut relays = JoinSet::new();
+    let mut first_connection = Some(first_connection);
+    let outcome = 'accepting: loop {
+        while let Some(result) = relays.try_join_next() {
+            if let Err(error) = result {
+                tracing::warn!(%error, "tunnel relay task failed");
+            }
+        }
+
+        let permit = tokio::select! {
+            _ = state.cancel.cancelled() => break 'accepting Ok(()),
+            permit = Arc::clone(&permits).acquire_owned() => {
+                match permit {
+                    Ok(permit) => permit,
+                    Err(_) => break 'accepting Ok(()),
+                }
+            }
+        };
+
+        let stream = loop {
+            let accepted = tokio::select! {
+                _ = state.cancel.cancelled() => break 'accepting Ok(()),
+                accepted = listener.accept() => accepted,
+            };
+            match accepted {
+                Ok(stream) => break stream,
+                Err(error) if error.kind() == ErrorKind::Interrupted => continue,
+                Err(error) => {
+                    break 'accepting Err(format!(
+                        "accept connection on {}: {error}",
+                        state.address
+                    ));
+                }
+            }
+        };
+
+        let relay_cancel = state.cancel.clone();
+        let relay_target = opener.target;
+        let relay_tunnel = first_connection
+            .take()
+            .map(RelayTunnel::Prepared)
+            .unwrap_or_else(|| RelayTunnel::Open(opener.clone()));
+        relays.spawn(async move {
+            let _permit = permit;
+            if let Err(error) = relay_client(stream, relay_tunnel, relay_cancel).await {
+                tracing::warn!(target = %relay_target, %error, "tunnel client relay failed");
+            }
+        });
+    };
+
+    state.cancel.cancel();
+    relays.abort_all();
+    while let Some(result) = relays.join_next().await {
+        if let Err(error) = result
+            && !error.is_cancelled()
+        {
+            tracing::warn!(%error, "tunnel relay task failed during cleanup");
+        }
+    }
+    drop(listener);
+    state.finish(outcome);
+}
+
+async fn relay_client(
+    mut local: LocalForwardStream,
+    tunnel: RelayTunnel,
+    cancel: CancellationToken,
+) -> BoxliteResult<()> {
+    tokio::select! {
+        _ = cancel.cancelled() => Ok(()),
+        result = async {
+            let mut remote = match tunnel {
+                RelayTunnel::Prepared(connection) => connection,
+                RelayTunnel::Open(opener) => opener.open().await?.connect()?,
+            };
+            tokio::io::copy_bidirectional(&mut local, &mut remote)
+                .await
+                .map(|_| ())
+                .map_err(|error| BoxliteError::Network(format!("relay tunnel bytes: {error}")))
+        } => result,
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
     use std::os::fd::AsRawFd;
+    use std::path::PathBuf;
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    use tokio::net::UnixStream;
+    use tokio::net::{TcpStream, UnixListener, UnixStream};
 
     use super::*;
-
-    // Double-connect and uri()-after-connect need no runtime tests: connect()
-    // takes `self`, so both are move errors at compile time.
 
     #[cfg(feature = "rest")]
     #[tokio::test]
@@ -351,6 +725,353 @@ mod tests {
         assert_eq!(&response, b"one");
     }
 
+    struct EchoNetworkBackend;
+
+    #[async_trait::async_trait]
+    impl BoxNetworkBackend for EchoNetworkBackend {
+        async fn tunnel(&self, _target: SocketAddr) -> BoxliteResult<BoxTunnel> {
+            let (sdk, mut peer) = UnixStream::pair().unwrap();
+            tokio::spawn(async move {
+                let (mut reader, mut writer) = peer.split();
+                let _ = tokio::io::copy(&mut reader, &mut writer).await;
+            });
+            let fd: OwnedFd = sdk.into_std().unwrap().into();
+            Ok(BoxTunnel::local(fd))
+        }
+    }
+
+    fn echo_network() -> NetworkHandle {
+        NetworkHandle::new(Arc::new(EchoNetworkBackend))
+    }
+
+    struct FailSecondNetworkBackend {
+        attempts: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl BoxNetworkBackend for FailSecondNetworkBackend {
+        async fn tunnel(&self, target: SocketAddr) -> BoxliteResult<BoxTunnel> {
+            if self.attempts.fetch_add(1, Ordering::SeqCst) == 1 {
+                return Err(BoxliteError::Network("intentional setup failure".into()));
+            }
+            EchoNetworkBackend.tunnel(target).await
+        }
+    }
+
+    struct HoldingNetworkBackend {
+        attempts: AtomicUsize,
+        peers: Mutex<Vec<UnixStream>>,
+    }
+
+    #[async_trait::async_trait]
+    impl BoxNetworkBackend for HoldingNetworkBackend {
+        async fn tunnel(&self, _target: SocketAddr) -> BoxliteResult<BoxTunnel> {
+            let (sdk, peer) = UnixStream::pair().unwrap();
+            self.attempts.fetch_add(1, Ordering::SeqCst);
+            self.peers.lock().unwrap().push(peer);
+            let fd: OwnedFd = sdk.into_std().unwrap().into();
+            Ok(BoxTunnel::local(fd))
+        }
+    }
+
+    #[tokio::test]
+    async fn forward_tcp_reports_allocated_address_and_accepts_repeated_clients() {
+        let network = echo_network();
+        let target = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
+        let tunnel = network.tunnel(target).await.unwrap();
+        let forwarder = tunnel
+            .forward(SocketAddress::Tcp(SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::LOCALHOST),
+                0,
+            )))
+            .await
+            .unwrap();
+        let SocketAddress::Tcp(bound) = forwarder.local_addr() else {
+            panic!("expected TCP listener");
+        };
+        assert_ne!(bound.port(), 0);
+
+        for payload in [b"first".as_slice(), b"second".as_slice()] {
+            let mut client = TcpStream::connect(bound).await.unwrap();
+            client.write_all(payload).await.unwrap();
+            let mut echoed = vec![0; payload.len()];
+            client.read_exact(&mut echoed).await.unwrap();
+            assert_eq!(echoed, payload);
+        }
+
+        forwarder.close().await.unwrap();
+        forwarder.close().await.unwrap();
+        forwarder.wait().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn forward_reports_bound_address_before_accepting() {
+        let backend = Arc::new(HoldingNetworkBackend {
+            attempts: AtomicUsize::new(0),
+            peers: Mutex::new(Vec::new()),
+        });
+        let tunnel = NetworkHandle::new(backend.clone())
+            .tunnel("127.0.0.1:8080".parse().unwrap())
+            .await
+            .unwrap();
+
+        let forwarder = tunnel
+            .forward_with_bound(
+                SocketAddress::Tcp("127.0.0.1:0".parse().unwrap()),
+                |address| {
+                    assert_ne!(address, &SocketAddress::Tcp("127.0.0.1:0".parse().unwrap()));
+                    assert_eq!(
+                        backend.attempts.load(Ordering::SeqCst),
+                        1,
+                        "no client tunnel may open before the bound-address callback"
+                    );
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap();
+
+        forwarder.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn tunnel_rejects_zero_guest_port_before_opening() {
+        let backend = Arc::new(HoldingNetworkBackend {
+            attempts: AtomicUsize::new(0),
+            peers: Mutex::new(Vec::new()),
+        });
+        let error = match NetworkHandle::new(backend.clone())
+            .tunnel("127.0.0.1:0".parse().unwrap())
+            .await
+        {
+            Ok(_) => panic!("zero guest port must be rejected"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("target port must be non-zero"));
+        assert_eq!(backend.attempts.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn forward_tcp_relays_concurrent_clients_and_half_close() {
+        let network = echo_network();
+        let target = "127.0.0.1:8080".parse().unwrap();
+        let forwarder = network
+            .tunnel(target)
+            .await
+            .unwrap()
+            .forward(SocketAddress::Tcp("127.0.0.1:0".parse().unwrap()))
+            .await
+            .unwrap();
+        let SocketAddress::Tcp(bound) = *forwarder.local_addr() else {
+            panic!("expected TCP listener");
+        };
+
+        let clients = (0..8).map(|client_id| {
+            tokio::spawn(async move {
+                let payload = format!("client-{client_id}").into_bytes();
+                let mut client = TcpStream::connect(bound).await.unwrap();
+                client.write_all(&payload).await.unwrap();
+                client.shutdown().await.unwrap();
+                let mut echoed = Vec::new();
+                client.read_to_end(&mut echoed).await.unwrap();
+                assert_eq!(echoed, payload);
+            })
+        });
+        for client in clients {
+            client.await.unwrap();
+        }
+
+        let waiter = {
+            let forwarder = forwarder.clone();
+            tokio::spawn(async move { forwarder.wait().await })
+        };
+        forwarder.close().await.unwrap();
+        waiter.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn forward_client_setup_failure_does_not_stop_later_clients() {
+        let network = NetworkHandle::new(Arc::new(FailSecondNetworkBackend {
+            attempts: AtomicUsize::new(0),
+        }));
+        let forwarder = network
+            .tunnel("127.0.0.1:8080".parse().unwrap())
+            .await
+            .unwrap()
+            .forward(SocketAddress::Tcp("127.0.0.1:0".parse().unwrap()))
+            .await
+            .unwrap();
+        let SocketAddress::Tcp(bound) = *forwarder.local_addr() else {
+            panic!("expected TCP listener");
+        };
+
+        let mut first = TcpStream::connect(bound).await.unwrap();
+        first.write_all(b"first").await.unwrap();
+        let mut echoed = [0; 5];
+        first.read_exact(&mut echoed).await.unwrap();
+        assert_eq!(&echoed, b"first");
+
+        let mut failed = TcpStream::connect(bound).await.unwrap();
+        failed.write_all(b"failed").await.unwrap();
+        let mut byte = [0; 1];
+        match failed.read(&mut byte).await {
+            Ok(0) => {}
+            Err(error) if error.kind() == ErrorKind::ConnectionReset => {}
+            other => panic!("failed client should close: {other:?}"),
+        }
+
+        let mut client = TcpStream::connect(bound).await.unwrap();
+        client.write_all(b"second").await.unwrap();
+        let mut response = [0; 6];
+        client.read_exact(&mut response).await.unwrap();
+        assert_eq!(&response, b"second");
+        forwarder.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn forward_acquires_all_64_permits_before_accepting_another_client() {
+        let backend = Arc::new(HoldingNetworkBackend {
+            attempts: AtomicUsize::new(0),
+            peers: Mutex::new(Vec::new()),
+        });
+        let network = NetworkHandle::new(backend.clone());
+        let forwarder = network
+            .tunnel("127.0.0.1:8080".parse().unwrap())
+            .await
+            .unwrap()
+            .forward(SocketAddress::Tcp("127.0.0.1:0".parse().unwrap()))
+            .await
+            .unwrap();
+        let SocketAddress::Tcp(bound) = *forwarder.local_addr() else {
+            panic!("expected TCP listener");
+        };
+
+        let mut clients = Vec::new();
+        for _ in 0..=MAX_FORWARD_CONNECTIONS {
+            clients.push(TcpStream::connect(bound).await.unwrap());
+        }
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while backend.attempts.load(Ordering::SeqCst) < MAX_FORWARD_CONNECTIONS {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("64 relays should start");
+        tokio::task::yield_now().await;
+        assert_eq!(
+            backend.attempts.load(Ordering::SeqCst),
+            MAX_FORWARD_CONNECTIONS,
+            "the 65th client must remain in the listener backlog"
+        );
+
+        forwarder.close().await.unwrap();
+        drop(clients);
+    }
+
+    #[tokio::test]
+    async fn forward_unix_refuses_existing_path_and_removes_owned_socket() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("forward.sock");
+        std::fs::write(&path, b"keep").unwrap();
+        let network = echo_network();
+        let target = "127.0.0.1:8080".parse().unwrap();
+        let tunnel = network.tunnel(target).await.unwrap();
+
+        let error = tunnel
+            .forward(SocketAddress::Unix(path.clone()))
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("already exists"));
+        assert_eq!(std::fs::read(&path).unwrap(), b"keep");
+
+        std::fs::remove_file(&path).unwrap();
+        let forwarder = network
+            .tunnel(target)
+            .await
+            .unwrap()
+            .forward(SocketAddress::Unix(PathBuf::from(&path)))
+            .await
+            .unwrap();
+        assert!(path.exists());
+        forwarder.close().await.unwrap();
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn forward_unix_preserves_a_visible_replacement() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("forward.sock");
+        let displaced = directory.path().join("displaced.sock");
+        let network = echo_network();
+        let target = "127.0.0.1:8080".parse().unwrap();
+        let forwarder = network
+            .tunnel(target)
+            .await
+            .unwrap()
+            .forward(SocketAddress::Unix(path.clone()))
+            .await
+            .unwrap();
+
+        std::fs::rename(&path, &displaced).unwrap();
+        let replacement = UnixListener::bind(&path).unwrap();
+        forwarder.close().await.unwrap();
+
+        assert!(path.exists(), "a replacement socket must be preserved");
+        drop(replacement);
+    }
+
+    #[tokio::test]
+    async fn dropping_the_final_forwarder_cancels_and_cleans_up() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("drop.sock");
+        let forwarder = echo_network()
+            .tunnel("127.0.0.1:8080".parse().unwrap())
+            .await
+            .unwrap()
+            .forward(SocketAddress::Unix(path.clone()))
+            .await
+            .unwrap();
+        assert!(path.exists());
+        drop(forwarder);
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while path.exists() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("drop should clean up the listener");
+    }
+
+    #[test]
+    fn socket_address_uses_scriptable_canonical_notation() {
+        assert_eq!(
+            SocketAddress::Tcp("[::1]:8080".parse().unwrap()).to_string(),
+            "tcp://[::1]:8080"
+        );
+        assert_eq!(
+            SocketAddress::Unix(PathBuf::from("/tmp/app.sock")).to_string(),
+            "unix:/tmp/app.sock"
+        );
+    }
+
+    #[tokio::test]
+    async fn tunnel_remains_a_one_shot_prepared_connection() {
+        let tunnel = echo_network()
+            .tunnel("127.0.0.1:8080".parse().unwrap())
+            .await
+            .unwrap();
+        assert_eq!(tunnel.uri(), None);
+
+        let payload = b"one";
+        let mut connection = tunnel.connect().unwrap();
+        connection.write_all(payload).await.unwrap();
+        let mut response = vec![0; payload.len()];
+        connection.read_exact(&mut response).await.unwrap();
+        assert_eq!(response, payload);
+    }
+
     /// The tolerance must sit on the trait impl, not only on the inherent
     /// method: a Rust caller holding the public connection can reach
     /// `poll_shutdown` through `AsyncWriteExt` or `copy_bidirectional` without
@@ -359,8 +1080,7 @@ mod tests {
     async fn async_write_shutdown_also_tolerates_a_hung_up_peer() {
         for split in [false, true] {
             let (stream, peer) = UnixStream::pair().unwrap();
-            let fd = OwnedFd::from(stream.into_std().unwrap());
-            let connection = BoxTunnel::local(fd).connect().unwrap();
+            let connection = BoxConnection::new(stream);
             drop(peer);
 
             let result = if split {
@@ -375,19 +1095,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn local_tunnel_has_no_uri_and_connects_over_its_own_fd() {
-        let (stream, mut peer) = UnixStream::pair().unwrap();
-        let fd = OwnedFd::from(stream.into_std().unwrap());
-        let tunnel = BoxTunnel::local(fd);
+    async fn local_tunnel_uri_is_none_without_connecting() {
+        let backend = Arc::new(HoldingNetworkBackend {
+            attempts: AtomicUsize::new(0),
+            peers: Mutex::new(Vec::new()),
+        });
+        let tunnel = NetworkHandle::new(backend.clone())
+            .tunnel("127.0.0.1:8080".parse().unwrap())
+            .await
+            .unwrap();
 
-        // A local descriptor is a live connection, not an address.
         assert_eq!(tunnel.uri(), None);
-
-        let mut connection = tunnel.connect().unwrap();
-        peer.write_all(b"one").await.unwrap();
-        let mut response = [0; 3];
-        connection.read_exact(&mut response).await.unwrap();
-        assert_eq!(&response, b"one");
+        assert_eq!(backend.attempts.load(Ordering::SeqCst), 1);
     }
 
     /// Zero-copy contract: the descriptor the connection surrenders IS the
@@ -518,8 +1237,7 @@ mod tests {
     #[tokio::test]
     async fn split_halves_carry_traffic_and_close_after_peer_hangs_up() {
         let (stream, mut peer) = UnixStream::pair().unwrap();
-        let fd = OwnedFd::from(stream.into_std().unwrap());
-        let (mut reader, mut writer) = BoxTunnel::local(fd).connect().unwrap().into_split();
+        let (mut reader, mut writer) = BoxConnection::new(stream).into_split();
 
         writer.write_all(b"ping").await.unwrap();
         let mut got = [0; 4];

--- a/src/cli/src/cli.rs
+++ b/src/cli/src/cli.rs
@@ -1706,6 +1706,39 @@ mod tests {
         let NetworkCommand::Tunnel(args) = args.command;
         assert_eq!(args.target, "mybox");
         assert_eq!(args.port, 3000);
+        assert!(args.listen.is_none());
+    }
+
+    #[test]
+    fn network_tunnel_accepts_listener_forms() {
+        for listen in [
+            "8080",
+            "0",
+            "127.0.0.1:8080",
+            "[::1]:8080",
+            "unix:/tmp/app.sock",
+        ] {
+            Cli::try_parse_from([
+                "boxlite", "network", "tunnel", "mybox", "3000", "--listen", listen,
+            ])
+            .unwrap_or_else(|error| panic!("{listen} should parse: {error}"));
+        }
+    }
+
+    #[test]
+    fn network_tunnel_rejects_ambiguous_listener_forms() {
+        for listen in [
+            "localhost:8080",
+            "::1:8080",
+            ":8080",
+            "unix:relative.sock",
+            "127.0.0.1",
+        ] {
+            let result = Cli::try_parse_from([
+                "boxlite", "network", "tunnel", "mybox", "3000", "--listen", listen,
+            ]);
+            assert!(result.is_err(), "{listen} must be rejected");
+        }
     }
 
     #[test]

--- a/src/cli/src/commands/network/mod.rs
+++ b/src/cli/src/commands/network/mod.rs
@@ -15,7 +15,7 @@ pub struct NetworkArgs {
 
 #[derive(Subcommand, Debug)]
 pub enum NetworkCommand {
-    /// Print the public URL for a box service port.
+    /// Print a remote URL or forward a local listener to a box service.
     Tunnel(tunnel::TunnelArgs),
 }
 

--- a/src/cli/src/commands/network/tunnel.rs
+++ b/src/cli/src/commands/network/tunnel.rs
@@ -1,8 +1,11 @@
-//! Print a public service URL without creating a local TCP listener.
+//! Print a remote URL or run a local tunnel listener.
 
-use std::net::SocketAddr;
+use std::io::Write;
+use std::net::{Ipv4Addr, SocketAddr};
+use std::path::PathBuf;
 
 use anyhow::{Context, Result, anyhow};
+use boxlite::SocketAddress;
 use clap::Args;
 
 use crate::cli::GlobalFlags;
@@ -16,6 +19,35 @@ pub struct TunnelArgs {
     /// Guest port the service listens on
     #[arg(value_name = "PORT", value_parser = clap::value_parser!(u16).range(1..))]
     pub port: u16,
+
+    /// Bind a local TCP port/address or unix:/absolute/path socket
+    #[arg(long, value_name = "ADDRESS", value_parser = parse_socket_address)]
+    pub listen: Option<SocketAddress>,
+}
+
+fn parse_socket_address(value: &str) -> std::result::Result<SocketAddress, String> {
+    if let Some(path) = value.strip_prefix("unix:") {
+        let path = PathBuf::from(path);
+        if !path.is_absolute() {
+            return Err("Unix listener path must be absolute".to_string());
+        }
+        return Ok(SocketAddress::Unix(path));
+    }
+
+    if let Ok(port) = value.parse::<u16>() {
+        return Ok(SocketAddress::Tcp(SocketAddr::new(
+            Ipv4Addr::LOCALHOST.into(),
+            port,
+        )));
+    }
+
+    value
+        .parse::<SocketAddr>()
+        .map(SocketAddress::Tcp)
+        .map_err(|_| {
+            "listener must be a port, numeric IPv4:port, [IPv6]:port, or unix:/absolute/path"
+                .to_string()
+        })
 }
 
 pub async fn execute(args: TunnelArgs, global: &GlobalFlags) -> Result<()> {
@@ -28,13 +60,32 @@ pub async fn execute(args: TunnelArgs, global: &GlobalFlags) -> Result<()> {
     let guest_ip = boxlite::net::constants::GUEST_IP
         .parse()
         .context("BoxLite guest IP constant is invalid")?;
-    let tunnel = box_handle
-        .network()
-        .tunnel(SocketAddr::new(guest_ip, args.port))
+    let network = box_handle.network();
+    let target = SocketAddr::new(guest_ip, args.port);
+    let tunnel = network.tunnel(target).await?;
+    let Some(listen) = args.listen else {
+        let url = tunnel.uri().ok_or_else(|| {
+            anyhow!("local boxes have no public URL; point boxlite at a remote service with --url or --profile")
+        })?;
+        println!("{url}");
+        return Ok(());
+    };
+
+    let forwarder = tunnel
+        .forward_with_bound(listen, |address| {
+            println!("{address}");
+            std::io::stdout().flush().map_err(|error| {
+                boxlite::BoxliteError::Internal(format!("flush tunnel listener address: {error}"))
+            })
+        })
         .await?;
-    let url = tunnel.uri().ok_or_else(|| {
-        anyhow!("local boxes have no public URL; point boxlite at a remote service with --url or --profile")
-    })?;
-    println!("{url}");
+
+    tokio::select! {
+        result = forwarder.wait() => result?,
+        signal = tokio::signal::ctrl_c() => {
+            signal.context("wait for Ctrl-C")?;
+            forwarder.close().await?;
+        }
+    }
     Ok(())
 }


### PR DESCRIPTION
## Summary

Add local TCP and Unix listener forwarding to prepared one-shot box tunnels. This keeps `network.tunnel()` and the existing tunnel wire protocol unchanged while opening a fresh tunnel for every accepted client.

## Call graph

Before

```text
execute                    (CLI · src/cli/src/commands/network/tunnel.rs:53) — prepare one tunnel and print its URI
  └─ NetworkHandle::tunnel (Core · src/boxlite/src/litebox/network.rs:388)    — return a prepared one-shot BoxTunnel
       └─ BoxTunnel::uri   (Core · src/boxlite/src/litebox/network.rs:309)    — inspect the remote public URI
```

After

```text
execute                              (CLI · src/cli/src/commands/network/tunnel.rs:53) — preserve URI mode or parse --listen
  └─ NetworkHandle::tunnel           (Core · src/boxlite/src/litebox/network.rs:388)    — prepare the first one-shot tunnel
       └─ BoxTunnel::forward_with_bound (Core · src/boxlite/src/litebox/network.rs:347) — bind and report the canonical address
            └─ run_forwarder         (Core · src/boxlite/src/litebox/network.rs:610)    — accept with 64-relay backpressure
                 └─ relay_client     (Core · src/boxlite/src/litebox/network.rs:680)    — open a fresh tunnel and relay bytes
```

## Changes

- Add `SocketAddress` and repeatable `TunnelForwarder` lifecycle APIs while keeping `BoxTunnel` one-shot.
- Support loopback TCP, numeric IPv4/IPv6, automatic TCP port allocation, and absolute Unix stream socket paths.
- Add `boxlite network tunnel ... --listen` without changing the existing no-flag URI behavior.
- Expose the listener API through Rust, Python, Node.js, Go, and C, including synchronous wrappers and C runtime-drain callbacks.
- Bound active relays to 64, isolate per-client failures, cancel active relays on close, and clean up owned Unix sockets best-effort.
- Document the cross-SDK API and add core, CLI, binding, and lifecycle regression coverage.

## How to verify

- `UV_CACHE_DIR=/tmp/boxlite-uv-cache BOXLITE_DEPS_STUB=1 make fmt:check`
- `UV_CACHE_DIR=/tmp/boxlite-uv-cache BOXLITE_DEPS_STUB=1 make lint`
- `BOXLITE_DEPS_STUB=1 FILTER=litebox::network make test:unit:rust`
- `BOXLITE_DEPS_STUB=1 cargo nextest run -p boxlite --no-default-features --features rest -E 'test(litebox::network)'`
- `SETUP_DONE=1 BOXLITE_DEPS_STUB=1 FILTER=network_tunnel make test:integration:cli`
- `UV_CACHE_DIR=/tmp/boxlite-uv-cache BOXLITE_DEPS_STUB=1 make test:unit:python`
- `BOXLITE_DEPS_STUB=1 make test:unit:node`
- `BOXLITE_DEPS_STUB=1 FILTER=network::tests make test:unit:ffi`
- `SETUP_DONE=1 BOXLITE_DEPS_STUB=1 make test:unit:go FILTER='Test(NetworkTunnel|TunnelForward|ListenAddress|BoxNetwork|TunnelMethods|NetworkAndTunnel|RuntimeDoesNotStart)'`

## Risks / rollout

This is client-side forwarding only; it does not change the server, proxy, OpenAPI schema, or tunnel wire protocol. The full local pre-push integration matrix remains unavailable in this checkout because native vendor inputs are missing or mismatched; the focused rebased suites above pass, and CI remains the canonical full-matrix verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local tunnel forwarding to TCP and Unix socket listeners across supported SDKs.
  * Added forwarder lifecycle controls, including address lookup, waiting, and closing.
  * Added CLI support for `network tunnel --listen`, including dynamic ports and Unix sockets.
  * Added socket address types and forwarding APIs for C, Go, Node.js, Python, and Rust.
* **Documentation**
  * Clarified that tunnels are one-shot resources consumed by either connecting or forwarding.
  * Documented listener formats, lifecycle behavior, cancellation, and multi-client forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->