### PR TITLE
feat(box): start containers in the background

### DIFF
--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -300,11 +300,10 @@ func (c *Client) Create(ctx context.Context, boxDto dto.CreateBoxDTO) (string, s
 
 	// bx.Start must stay the last step of Create that can fail.
 	//
-	// A successful Start makes BoxLite publish the box's StartedAt,
-	// and BoxSync reads it as evidence this job body succeeded — it is what
-	// lets a lost job-completion callback be repaired later. A fallible step
-	// added below would publish that evidence for a Create that then returns
-	// an error, and the two would disagree with no way to tell which is right.
+	// A successful Start means BoxLite published the PID/Running boot marker and
+	// accepted the background Container.Start handoff. BoxSync uses that marker
+	// to repair a lost job-completion callback. A fallible step below would let
+	// Create return an error after publishing its completion evidence.
 	// TestCreateHasNoFallibleStepAfterStart enforces this.
 	skipStart := boxDto.SkipStart != nil && *boxDto.SkipStart
 	if !skipStart {
@@ -316,7 +315,8 @@ func (c *Client) Create(ctx context.Context, boxDto dto.CreateBoxDTO) (string, s
 	return bx.ID(), "boxlite", nil
 }
 
-// Start starts a stopped box and returns the runtime version.
+// Start boots a box, spawns its Container.Start in the background, and returns
+// the runtime version without waiting for that guest RPC.
 func (c *Client) Start(ctx context.Context, boxId string, authToken *string, metadata map[string]string) (string, error) {
 	if err := c.ensureVolumeMountsFromMetadata(ctx, boxId, metadata); err != nil {
 		c.logger.ErrorContext(ctx, "failed to ensure volume FUSE mounts", "error", err)
@@ -374,8 +374,8 @@ func (c *Client) Destroy(ctx context.Context, boxId string) error {
 //
 // Exported apart from GetBoxState because a caller that already holds a
 // BoxInfo must not fetch a second one: BoxSync pairs the state with the box's
-// StartedAt, and reading the two at different moments is what lets a stale
-// timestamp meet a fresh state.
+// boot marker, and reading the two at different moments is what lets a stale
+// marker meet a fresh state.
 func ToBoxState(state boxlite.State) enums.BoxState {
 	switch state {
 	case boxlite.StateRunning:

--- a/apps/runner/pkg/boxlite/create_invariant_test.go
+++ b/apps/runner/pkg/boxlite/create_invariant_test.go
@@ -15,9 +15,10 @@ import (
 // TestCreateHasNoFallibleStepAfterStart guards the coupling documented at the
 // bx.Start call in Create.
 //
-// A successful bx.Start makes BoxLite publish the box's StartedAt, which
-// BoxSync reads as evidence that this whole job body succeeded. That only holds
-// while Start is the last step of Create that can fail. Nothing about the
+// A successful bx.Start means BoxLite published its PID/Running boot marker
+// and accepted the background Container.Start handoff. BoxSync treats that as
+// evidence that this job body reached its last fallible operation. That only
+// holds while Start is the last step of Create that can fail. Nothing about the
 // current code enforces it — replacing the hardcoded daemon version with a real
 // probe, for instance, would silently break it — so this asserts the shape of
 // the source directly.
@@ -40,8 +41,8 @@ func TestCreateHasNoFallibleStepAfterStart(t *testing.T) {
 	for _, violation := range violations {
 		t.Errorf(
 			"Client.Create returns a non-nil error at %s, after bx.Start already "+
-				"published StartedAt. Move the fallible step above bx.Start, or "+
-				"revisit what that timestamp means.",
+				"published the boot marker and accepted Container.Start. Move the "+
+				"fallible step above bx.Start, or revisit that completion contract.",
 			violation,
 		)
 	}

--- a/apps/runner/pkg/services/box_sync.go
+++ b/apps/runner/pkg/services/box_sync.go
@@ -36,13 +36,13 @@ type BoxSyncService struct {
 	client   *apiclient.APIClient
 }
 
-// localContainerState pairs a box's local runtime state with its durable
-// Container.Start timestamp from the same BoxInfo snapshot.
+// localContainerState pairs a box's local runtime state with its durable boot
+// marker from the same BoxInfo snapshot.
 type localContainerState struct {
 	state enums.BoxState
-	// startedAt is non-nil when BoxLite recorded a successful Container.Start
-	// for the current or most recently ended lifecycle. Callers combine it with
-	// state before treating it as evidence that the box is running now.
+	// startedAt is non-nil when BoxLite recorded PID/Running publication for
+	// the current or most recently ended lifecycle. It does not prove that the
+	// asynchronous Container.Start RPC finished.
 	startedAt *time.Time
 }
 
@@ -76,14 +76,12 @@ func (s *BoxSyncService) GetLocalContainerStates(ctx context.Context) (map[strin
 	return boxStates, nil
 }
 
-// boxStartedAt reports when BoxLite confirmed a successful Container.Start for
-// the current or most recently ended lifecycle, or nil when no lifecycle has
-// such confirmation.
+// boxStartedAt returns BoxLite's PID/Running publication marker for the current
+// or most recently ended lifecycle, or nil when no boot was recorded.
 //
-// BoxLite publishes the timestamp beside the PID it belongs to and voids it in
-// the same write that publishes a new lifecycle's PID. That only buys the
-// reader anything while state and timestamp come from one snapshot, which is
-// why both are read off the same `BoxInfo`.
+// BoxLite publishes the timestamp beside its PID in the same state write. That
+// only buys the reader anything while state and timestamp come from one
+// snapshot, which is why both are read off the same `BoxInfo`.
 func boxStartedAt(box sdkboxlite.BoxInfo) *time.Time {
 	if box.StartedAt.IsZero() {
 		return nil
@@ -214,12 +212,10 @@ func (s *BoxSyncService) PerformSync(ctx context.Context) error {
 // control plane for a given remote state.
 //
 // A box the control plane still shows as coming up is the one case where the
-// local view is not self-evidently authoritative: BoxLite publishes Running
-// once the VM is up, which happens before the guest's separate Container.Start
-// runs. Reporting STARTED off that alone would call a box ready whose init was
-// never launched — so a transitional box additionally needs BoxLite's durable
-// record that Container.Start did succeed for the shim now running it. Both
-// facts come from one `BoxInfo`, so they cannot describe two lifecycles.
+// local view needs durable lifecycle evidence. A transitional box therefore
+// requires both local Running and BoxLite's boot marker from the same BoxInfo
+// snapshot. The marker confirms PID/Running publication for that lifecycle; it
+// intentionally does not confirm the asynchronous Container.Start RPC.
 //
 // Every other remote state keeps the long-standing behaviour: the local view
 // wins unconditionally.

--- a/apps/runner/pkg/services/box_sync_test.go
+++ b/apps/runner/pkg/services/box_sync_test.go
@@ -27,12 +27,12 @@ func TestBoxStartedAt(t *testing.T) {
 		want *time.Time
 	}{
 		{
-			name: "box reports a confirmed container start",
+			name: "box reports a boot marker",
 			info: sdkboxlite.BoxInfo{ID: "box-1", PID: 4242, StartedAt: startedAt},
 			want: &startedAt,
 		},
 		{
-			name: "running box whose init was never launched",
+			name: "running box without a boot marker",
 			info: sdkboxlite.BoxInfo{ID: "box-1", PID: 4242},
 			want: nil,
 		},
@@ -152,14 +152,14 @@ func newSyncServiceForTest(
 	}
 }
 
-func TestPerformSyncConfirmsTransitionalBoxOnlyWithAConfirmedStart(t *testing.T) {
+func TestPerformSyncConfirmsTransitionalBoxOnlyWithABootMarker(t *testing.T) {
 	tests := []struct {
 		name          string
 		startedAt     time.Time
 		wantStateSent bool
 	}{
-		{name: "container start confirmed", startedAt: time.Now(), wantStateSent: true},
-		{name: "running but init never launched", wantStateSent: false},
+		{name: "boot marker present", startedAt: time.Now(), wantStateSent: true},
+		{name: "boot marker missing", wantStateSent: false},
 	}
 
 	for _, tt := range tests {

--- a/docs/reference/c/README.md
+++ b/docs/reference/c/README.md
@@ -608,7 +608,9 @@ boxlite_options_free(opts);
 
 #### boxlite_start_box
 
-Start or restart a stopped box.
+Boot or restart a box, enqueue its `Container.Start` RPC, and report success
+through the callback as soon as that background action is spawned. The callback
+does not wait for the guest RPC to finish.
 
 ```c
 BoxliteErrorCode boxlite_start_box(
@@ -1207,7 +1209,7 @@ if (code != Ok) {
 | `boxlite_runtime_free()` | Free runtime |
 | `boxlite_runtime_metrics()` | Get runtime metrics |
 | `boxlite_create_box()` | Create box |
-| `boxlite_start_box()` | Start/restart box |
+| `boxlite_start_box()` | Boot/restart box and spawn asynchronous `Container.Start` |
 | `boxlite_stop_box()` | Stop box |
 | `boxlite_remove()` | Remove box |
 | `boxlite_get()` | Reattach to box |

--- a/docs/reference/cli/README.md
+++ b/docs/reference/cli/README.md
@@ -392,7 +392,10 @@ boxlite rm --all --force
 
 **Synopsis:** `boxlite start BOX [BOX...]`
 
-Start one or more stopped boxes. No options. Prints each started box's name/ID to stdout; aggregates errors and exits non-zero if any failed.
+Boot one or more boxes and enqueue each container's init start. The command returns
+after the background `Container.Start` action is spawned; it does not wait for
+that RPC to finish. No options. Prints each accepted box name/ID to stdout and
+aggregates synchronous boot or dispatch errors.
 
 ---
 
@@ -463,9 +466,10 @@ Show detailed information for one or more boxes.
 | `--format FMT` | `-f` | `json` | `json`, `yaml`, or a Go template (e.g. `'{{.State.Status}}'`) |
 
 The Go-template engine exposes a `json` function for serializing nested values.
-`State.StartedAt` is the most recent successful container start timestamp in
-RFC 3339 format, or `null` if it has not been recorded or is unavailable over
-REST.
+`State.StartedAt` is when the most recent lifecycle published its PID and
+`Running` state, in RFC 3339 format, or `null` if no boot was recorded or the
+field is unavailable over REST. It does not prove that asynchronous
+`Container.Start` finished.
 
 **Examples:**
 

--- a/docs/reference/nodejs/README.md
+++ b/docs/reference/nodejs/README.md
@@ -219,7 +219,7 @@ Metadata about a box.
 | `name` | `string \| undefined` | User-defined name |
 | `state` | `JsBoxStateInfo` | Runtime state with `status`, `running`, and optional `pid` fields |
 | `createdAt` | `string` | Creation timestamp (ISO 8601) |
-| `startedAt` | `string \| undefined` | Most recent successful container start timestamp (RFC 3339); absent if not recorded or unavailable over REST |
+| `startedAt` | `string \| undefined` | Most recent PID/Running boot-publication timestamp (RFC 3339); does not prove asynchronous `Container.Start` finished; absent if not recorded or unavailable over REST |
 | `image` | `string` | OCI image reference or rootfs path |
 | `cpus` | `number` | Allocated CPU count |
 | `memoryMib` | `number` | Allocated memory in MiB |

--- a/docs/reference/python/README.md
+++ b/docs/reference/python/README.md
@@ -246,7 +246,7 @@ Metadata about a box.
 | `name` | `str \| None` | Optional user-assigned name |
 | `state` | `BoxStateInfo` | Runtime state with `status`, `running`, and nullable `pid` fields |
 | `created_at` | `str` | ISO 8601 creation timestamp |
-| `started_at` | `str \| None` | Most recent successful container start timestamp (RFC 3339); `None` if not recorded or unavailable over REST |
+| `started_at` | `str \| None` | Most recent PID/Running boot-publication timestamp (RFC 3339); does not prove asynchronous `Container.Start` finished; `None` if not recorded or unavailable over REST |
 | `image` | `str` | OCI image used |
 | `cpus` | `int` | Allocated CPU cores |
 | `memory_mib` | `int` | Allocated memory in MiB |

--- a/docs/reference/rust/README.md
+++ b/docs/reference/rust/README.md
@@ -194,15 +194,17 @@ pub struct LiteBox {
 | `name` | `fn name(&self) -> Option<&str>` | Get optional box name |
 | `info` | `async fn info(&self) -> Result<BoxInfo>` | Get box info (no VM init) |
 | `network` | `fn network(&self) -> NetworkHandle` | Get box-scoped tunnel operations |
-| `start` | `async fn start(&self) -> BoxliteResult<()>` | Start the box |
+| `start` | `async fn start(&self) -> BoxliteResult<()>` | Boot the box, spawn `Container.Start`, and return without waiting for that RPC |
 | `run` | `async fn run(&self, command: BoxCommand) -> BoxliteResult<Execution>` | Run command |
 | `metrics` | `async fn metrics(&self) -> BoxliteResult<BoxMetrics>` | Get box metrics |
 | `stop` | `async fn stop(&self) -> BoxliteResult<()>` | Stop the box |
 
 #### Lifecycle
 
-- `start()` initializes VM for `Configured` or `Stopped` boxes
-- Idempotent: calling on `Running` box is a no-op
+- `start()` synchronously boots `Configured` or `Stopped` boxes, then spawns
+  `Container.Start` and returns before the guest RPC finishes
+- Concurrent and repeated container starts are single-flighted; after a
+  background failure, a later explicit or implicit operation may retry
 - `run()` implicitly calls `start()` if needed
 - `stop()` terminates VM; box can be restarted
 

--- a/openapi/box.openapi.yaml
+++ b/openapi/box.openapi.yaml
@@ -386,16 +386,18 @@ paths:
       - $ref: "#/components/parameters/boxId"
     post:
       operationId: startBox
-      summary: Start a box (initialize VM)
+      summary: Boot a box and enqueue its container start
       description: |
-        Initializes the VM for a box. Idempotent: if already running, returns
-        current state. Transitions: configured → running, stopped → running.
+        Initializes the VM for a box, spawns its `Container.Start` RPC in the
+        background, and returns without waiting for that RPC to finish.
+        Idempotent: if already running or starting, returns current state.
+        Transitions: configured → running, stopped → running.
       tags: [Boxes]
       parameters:
         - $ref: "#/components/parameters/idempotencyKey"
       responses:
         "200":
-          description: Box started (or already running)
+          description: Box booted and container start enqueued (or already running)
           content:
             application/json:
               schema:

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -318,11 +318,10 @@ typedef struct CBoxInfo {
   int64_t created_at;
   // Owned typed network metadata; null when network metadata is unavailable.
   struct CNetworkInfo *network;
-  // Unix milliseconds of the most recently recorded successful guest
-  // `Container.Start`; `0` when none was recorded. Preserved after stop or
-  // reboot; when [`Self::pid`] is nonzero, the timestamp describes that live
-  // PID. Milliseconds — not `created_at`'s seconds — preserve sub-second
-  // ordering against a job's timeline.
+  // Unix milliseconds when the most recent lifecycle published its PID and
+  // `Running` state; `0` when no boot was recorded. This does not prove
+  // asynchronous `Container.Start` finished. Preserved after stop; when
+  // `pid` is nonzero, the timestamp describes that live PID.
   int64_t started_at;
 } CBoxInfo;
 

--- a/sdks/c/src/info.rs
+++ b/sdks/c/src/info.rs
@@ -78,11 +78,10 @@ pub struct CBoxInfo {
     pub created_at: i64,
     /// Owned typed network metadata; null when network metadata is unavailable.
     pub network: *mut CNetworkInfo,
-    /// Unix milliseconds of the most recently recorded successful guest
-    /// `Container.Start`; `0` when none was recorded. Preserved after stop or
-    /// reboot; when [`Self::pid`] is nonzero, the timestamp describes that live
-    /// PID. Milliseconds — not `created_at`'s seconds — preserve sub-second
-    /// ordering against a job's timeline.
+    /// Unix milliseconds when the most recent lifecycle published its PID and
+    /// `Running` state; `0` when no boot was recorded. This does not prove
+    /// asynchronous `Container.Start` finished. Preserved after stop; when
+    /// `pid` is nonzero, the timestamp describes that live PID.
     pub started_at: i64,
 }
 

--- a/sdks/go/box_handle.go
+++ b/sdks/go/box_handle.go
@@ -39,7 +39,8 @@ func (b *Box) ID() string { return b.id }
 // Name returns the user-defined name of the box, if set.
 func (b *Box) Name() string { return b.name }
 
-// Start starts (or restarts) the box.
+// Start boots (or restarts) the box and returns once Container.Start has been
+// spawned in the background; it does not wait for that guest RPC to finish.
 func (b *Box) Start(ctx context.Context) error {
 	b.runtime.ensureDrainRunning()
 

--- a/sdks/go/info.go
+++ b/sdks/go/info.go
@@ -61,11 +61,10 @@ type BoxInfo struct {
 	AutoDelete uint32
 	AutoResume bool
 	CreatedAt  time.Time
-	// StartedAt is when the guest's Container.Start most recently returned
-	// success; the zero time means no successful start has been recorded. It is
-	// preserved after stop or reboot, and describes PID whenever PID is nonzero.
-	// State alone cannot answer whether the current init launched — a box reports
-	// Running from the moment its VM is up, before its init is started.
+	// StartedAt is when the most recent lifecycle published its PID and Running
+	// state. The zero time means no boot was recorded. It is preserved after stop
+	// and describes PID whenever PID is nonzero. It does not prove that the
+	// asynchronous Container.Start finished or that init ran.
 	StartedAt time.Time
 }
 

--- a/sdks/node/lib/native-contracts.ts
+++ b/sdks/node/lib/native-contracts.ts
@@ -405,6 +405,7 @@ export interface JsBox {
     name?: string | null,
   ): Promise<JsBox>;
   export(dest: string, options?: JsExportOptions | null): Promise<string>;
+  /** Boots the box and returns once background Container.Start is spawned. */
   start(): Promise<void>;
   stop(): Promise<void>;
   metrics(): Promise<JsBoxMetrics>;

--- a/sdks/node/src/box_handle.rs
+++ b/sdks/node/src/box_handle.rs
@@ -147,7 +147,8 @@ impl JsBox {
         Ok(archive.path().to_string_lossy().to_string())
     }
 
-    /// Start or restart a stopped box.
+    /// Boot or restart the box, spawn `Container.Start`, and return before
+    /// that guest RPC finishes.
     #[napi]
     pub async fn start(&self) -> Result<()> {
         self.handle.start().await.map_err(map_err)

--- a/sdks/node/src/info.rs
+++ b/sdks/node/src/info.rs
@@ -184,7 +184,8 @@ pub struct JsBoxInfo {
     /// Creation timestamp (ISO 8601 format)
     pub created_at: String,
 
-    /// Most recent successful container start timestamp (RFC 3339), when recorded
+    /// Most recent PID/Running boot-publication timestamp (RFC 3339).
+    /// This does not prove that asynchronous Container.Start finished.
     pub started_at: Option<String>,
 
     /// Image reference or rootfs path

--- a/sdks/python/boxlite/sync_api/_box.py
+++ b/sdks/python/boxlite/sync_api/_box.py
@@ -77,13 +77,12 @@ class SyncBox:
 
     def start(self) -> None:
         """
-        Start the box (initialize VM).
+        Boot the box and spawn its container-init start.
 
-        For Configured boxes: initializes VM for the first time.
-        For Stopped boxes: restarts the VM.
-
-        This is idempotent - calling start() on a Running box is a no-op.
-        Also called implicitly by exec() if the box is not running.
+        For Configured boxes this initializes the VM; for Stopped boxes it
+        restarts it. The method returns after background Container.Start is
+        spawned, without waiting for that RPC. Implicit operations such as
+        exec() still wait for the real container start.
         """
         self._sync(self._box.start())
 

--- a/sdks/python/src/box_handle.rs
+++ b/sdks/python/src/box_handle.rs
@@ -124,7 +124,7 @@ impl PyBox {
         })
     }
 
-    /// Start the box (initialize VM).
+    /// Boot the box, spawn `Container.Start`, and return before that RPC finishes.
     fn start<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
         let handle = Arc::clone(&self.handle);
 

--- a/sdks/python/src/info.rs
+++ b/sdks/python/src/info.rs
@@ -284,6 +284,8 @@ pub(crate) struct PyBoxInfo {
     pub(crate) state: PyBoxStateInfo,
     #[pyo3(get)]
     pub(crate) created_at: String,
+    /// Most recent PID/Running boot-publication timestamp (RFC 3339).
+    /// This does not prove that asynchronous Container.Start finished.
     #[pyo3(get)]
     pub(crate) started_at: Option<String>,
     #[pyo3(get)]

--- a/src/boxlite/src/event_listener/event.rs
+++ b/src/boxlite/src/event_listener/event.rs
@@ -36,7 +36,8 @@ pub enum AuditEventKind {
     /// Box created.
     BoxCreated,
 
-    /// Box VM started successfully.
+    /// An explicit `start()` owned and successfully completed guest
+    /// `Container.Start`.
     BoxStarted,
 
     /// Box VM stopped.

--- a/src/boxlite/src/event_listener/listener.rs
+++ b/src/boxlite/src/event_listener/listener.rs
@@ -38,7 +38,8 @@ pub trait EventListener: Send + Sync {
     /// Called after a box is created.
     fn on_box_created(&self, _box_id: &BoxID) {}
 
-    /// Called after a box VM starts successfully.
+    /// Called when an explicit `start()` owns and successfully completes the
+    /// guest `Container.Start`.
     fn on_box_started(&self, _box_id: &BoxID) {}
 
     /// Called after a box VM stops.

--- a/src/boxlite/src/jailer/seccomp.rs
+++ b/src/boxlite/src/jailer/seccomp.rs
@@ -362,15 +362,13 @@ mod tests {
             let filter: BpfProgram = vec![];
 
             assert_eq!(filter.len(), 0);
-
             let seccomp_level = unsafe { libc::prctl(libc::PR_GET_SECCOMP) };
-            assert_eq!(seccomp_level, 0);
+            assert_ne!(seccomp_level, -1);
 
             apply_filter(&filter).unwrap();
 
-            // Test that seccomp level remains 0 when no filter applied.
-            let seccomp_level = unsafe { libc::prctl(libc::PR_GET_SECCOMP) };
-            assert_eq!(seccomp_level, 0);
+            let current_level = unsafe { libc::prctl(libc::PR_GET_SECCOMP) };
+            assert_eq!(current_level, seccomp_level);
         })
         .join()
         .unwrap();
@@ -380,16 +378,16 @@ mod tests {
             let filter = vec![0xFF; 1];
 
             let seccomp_level = unsafe { libc::prctl(libc::PR_GET_SECCOMP) };
-            assert_eq!(seccomp_level, 0);
+            assert_ne!(seccomp_level, -1);
 
             assert!(matches!(
                 apply_filter(&filter).unwrap_err(),
                 InstallationError::Prctl(_)
             ));
 
-            // Test that seccomp level remains 0 on failure.
-            let seccomp_level = unsafe { libc::prctl(libc::PR_GET_SECCOMP) };
-            assert_eq!(seccomp_level, 0);
+            // Test that seccomp level remains unchanged on failure.
+            let current_level = unsafe { libc::prctl(libc::PR_GET_SECCOMP) };
+            assert_eq!(current_level, seccomp_level);
         })
         .join()
         .unwrap();
@@ -434,9 +432,13 @@ mod tests {
         // Empty filter should be a no-op
         thread::spawn(|| {
             let filter: BpfProgram = vec![];
-            apply_filter_all_threads(&filter).unwrap();
             let seccomp_level = unsafe { libc::prctl(libc::PR_GET_SECCOMP) };
-            assert_eq!(seccomp_level, 0);
+            assert_ne!(seccomp_level, -1);
+
+            apply_filter_all_threads(&filter).unwrap();
+
+            let current_level = unsafe { libc::prctl(libc::PR_GET_SECCOMP) };
+            assert_eq!(current_level, seccomp_level);
         })
         .join()
         .unwrap();

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -143,7 +143,12 @@ pub(crate) struct BoxImpl {
     /// client can attach first. This single-flights that step across every
     /// implicit-boot caller and an explicit `start()`, and is pre-set when we
     /// reattach to a box whose init is already running.
-    container_start: OnceCell<()>,
+    container_start: Arc<OnceCell<()>>,
+
+    #[cfg(test)]
+    background_starts_finished: Arc<std::sync::atomic::AtomicUsize>,
+    #[cfg(test)]
+    background_start_finished: Arc<tokio::sync::Notify>,
 }
 
 impl BoxImpl {
@@ -182,7 +187,11 @@ impl BoxImpl {
             event_listeners: Vec::new(), // populated from runtime options
             live: OnceCell::new(),
             watcher: std::sync::OnceLock::new(),
-            container_start: OnceCell::new(),
+            container_start: Arc::new(OnceCell::new()),
+            #[cfg(test)]
+            background_starts_finished: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            #[cfg(test)]
+            background_start_finished: Arc::new(tokio::sync::Notify::new()),
         }
     }
 
@@ -260,12 +269,11 @@ impl BoxImpl {
     // OPERATIONS (require LiveState)
     // ========================================================================
 
-    /// Start the box (initialize VM).
+    /// Boot the box, then spawn `Container.Start` without awaiting its RPC.
     ///
-    /// For Configured boxes: full pipeline (filesystem, rootfs, spawn, connect, init)
-    /// For Stopped boxes: restart pipeline (reuse rootfs, spawn, connect, init)
-    ///
-    /// This is idempotent - calling start() on a Running box is a no-op.
+    /// Configured boxes run the full boot pipeline; Stopped boxes reuse their
+    /// rootfs. Concurrent container starts are single-flighted, while a failed
+    /// background RPC leaves the cell empty so a later operation can retry.
     pub(crate) async fn start(&self) -> BoxliteResult<()> {
         let t0 = Instant::now();
 
@@ -293,26 +301,58 @@ impl BoxImpl {
         // makes `run` docker-shaped — create, attach, then start. `run` slips the
         // attach between these two calls; every other caller just wants both.
         let live = self.ensure_booted().await?;
-        let started_now = self.ensure_container_started(live).await?;
+        let guest_session = live.guest_session.clone();
+        let container_start = Arc::clone(&self.container_start);
+        let shutdown_token = self.shutdown_token.child_token();
+        let container_id = self.container_id().to_owned();
+        let box_id = self.config.id.clone();
+        let event_listeners = self.event_listeners.clone();
+        #[cfg(test)]
+        let background_starts_finished = Arc::clone(&self.background_starts_finished);
+        #[cfg(test)]
+        let background_start_finished = Arc::clone(&self.background_start_finished);
 
-        // Nothing below may fail. `ensure_container_started` has already
-        // published `started_at` (see [`Self::record_started`]), and readers of
-        // it — the cloud runner among them — take it as evidence that this
-        // whole call succeeded. A fallible step added here would publish that
-        // evidence for a start that then returned `Err`.
-        //
-        // Announce the start only when *this* call actually ran init — not on an
-        // idempotent re-`start()` or a reattach to an already-running box.
-        if started_now {
-            for listener in &self.event_listeners {
-                listener.on_box_started(&self.config.id);
+        tokio::spawn(async move {
+            match Self::ensure_container_started_owned(
+                container_start,
+                guest_session,
+                container_id,
+                shutdown_token,
+            )
+            .await
+            {
+                Ok(true) => {
+                    for listener in &event_listeners {
+                        listener.on_box_started(&box_id);
+                    }
+                    tracing::info!(
+                        box_id = %box_id,
+                        elapsed_ms = t0.elapsed().as_millis() as u64,
+                        "Box started"
+                    );
+                }
+                Ok(false) => {}
+                Err(BoxliteError::Stopped(_)) => {
+                    tracing::debug!(
+                        box_id = %box_id,
+                        "Container start cancelled because the box is stopping"
+                    );
+                }
+                Err(error) => {
+                    tracing::error!(
+                        box_id = %box_id,
+                        error = %error,
+                        "Container start failed in background"
+                    );
+                }
             }
-            tracing::info!(
-                box_id = %self.config.id,
-                elapsed_ms = t0.elapsed().as_millis() as u64,
-                "Box started"
-            );
-        }
+
+            #[cfg(test)]
+            {
+                background_starts_finished.fetch_add(1, Ordering::SeqCst);
+                background_start_finished.notify_waiters();
+            }
+        });
         Ok(())
     }
 
@@ -663,7 +703,7 @@ impl BoxImpl {
         // through the restart pipeline and spawn a new VM — exactly what
         // stop() must NOT do.
         let should_attach = self.state.read().status == BoxStatus::Running;
-        if should_attach && let Ok(live) = self.live_state().await {
+        if should_attach && let Ok(live) = self.ensure_booted().await {
             // Recovered boxes lazy-attach here via vmm_attach (now
             // ProcessIdentity-gated). Live boxes hit the cached LiveState.
             // Either way the teardown is identical:
@@ -977,66 +1017,57 @@ impl BoxImpl {
         self.live.get_or_try_init(|| self.init_live_state()).await
     }
 
-    /// Run the container's init exactly once, returning whether *this* call did
-    /// it (vs. finding it already running). Booting only creates the container;
-    /// this is the separate `Container.Start`. Single-flighted via `OnceCell`, so
-    /// the implicit-boot funnel and an explicit `start()` cannot double-run it,
+    /// Run the container's init exactly once. Booting only creates the container;
+    /// this is the separate `Container.Start`. Single-flighted via `OnceCell`,
+    /// so the implicit-boot funnel and an explicit `start()` cannot double-run it,
     /// and a box reattached with init already running pre-sets the cell.
-    async fn ensure_container_started(&self, live: &LiveState) -> BoxliteResult<bool> {
-        // `get_or_try_init` single-flights the closure but hands every concurrent
-        // caller the same `Ok`, so it cannot tell the winner from the waiters. A
-        // closure-local flag is set only inside the body that actually runs, so
-        // exactly one caller reports that it started the container (and a cell
-        // already set — e.g. a reattached, still-running box — leaves it false).
+    async fn ensure_container_started(&self, live: &LiveState) -> BoxliteResult<()> {
+        Self::ensure_container_started_owned(
+            Arc::clone(&self.container_start),
+            live.guest_session.clone(),
+            self.container_id().to_owned(),
+            self.shutdown_token.child_token(),
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Owned form used by explicit `start()` so the RPC can outlive that call.
+    ///
+    /// Returns `true` only when this call actually executes and successfully
+    /// completes the `Container.Start` initializer.
+    async fn ensure_container_started_owned(
+        container_start: Arc<OnceCell<()>>,
+        guest_session: GuestSession,
+        container_id: String,
+        shutdown_token: CancellationToken,
+    ) -> BoxliteResult<bool> {
+        // Cancellation or an RPC error leaves the cell empty, allowing a later
+        // explicit or implicit operation to retry.
         let mut started_here = false;
-        self.container_start
-            .get_or_try_init(|| async {
-                live.guest_session
+        {
+            let start = container_start.get_or_try_init(|| async {
+                guest_session
                     .container()
                     .await?
-                    .start(self.container_id())
+                    .start(&container_id)
                     .await?;
                 started_here = true;
                 Ok::<(), BoxliteError>(())
-            })
-            .await?;
-        if started_here {
-            self.record_started();
+            });
+            tokio::select! {
+                biased;
+                _ = shutdown_token.cancelled() => {
+                    return Err(BoxliteError::Stopped(format!(
+                        "Container start cancelled for box {container_id}"
+                    )));
+                }
+                result = start => {
+                    result?;
+                }
+            }
         }
         Ok(started_here)
-    }
-
-    /// Publish `started_at` for this lifecycle.
-    ///
-    /// The counterpart of the shim's `exit` file: one names how the box died,
-    /// this names that its init was launched. It rides in `BoxState` beside the
-    /// PID it belongs to, so the pair is written and read as one row and no
-    /// consumer has to re-derive which shim the timestamp describes.
-    ///
-    /// A failed persist is logged, never propagated — the guest RPC already
-    /// succeeded and the box is running, so turning a bookkeeping failure into
-    /// a start failure would be a worse answer than the missing timestamp.
-    ///
-    /// **Consumers treat this as evidence that the whole start succeeded**, so
-    /// `start()` must not grow a fallible step after `ensure_container_started`.
-    /// See the note at the tail of [`Self::start`].
-    fn record_started(&self) {
-        let (persist_result, pid) = {
-            let mut state = self.state.write();
-            state.mark_started();
-            let pid = state.pid;
-            let result = self.runtime.box_manager.save_box(&self.config.id, &state);
-            (result, pid)
-        };
-
-        if let Err(error) = persist_result {
-            tracing::error!(
-                box_id = %self.config.id,
-                pid = ?pid,
-                error = %error,
-                "Container.Start succeeded but the start could not be recorded"
-            );
-        }
     }
 
     /// The box's network control backend (gvproxy ServicesMux client), owned in
@@ -1141,20 +1172,18 @@ impl BoxImpl {
             let mut state = self.state.write();
             state.set_pid(Some(pid));
             state.set_status(BoxStatus::Running);
+            // A fresh lifecycle publishes its PID, Running state, and boot
+            // marker atomically. An adopted Running box is the same lifecycle,
+            // so its existing Some/None marker must be preserved.
+            if !adopting_running {
+                state.mark_started();
+            }
+
             // This is a fresh run of the box's main command, so the exit code
             // recorded for the previous one no longer describes it (docker
             // clears ExitCode on start too). The guest drops its matching
             // exit file in Container.Init.
             state.exit_code = None;
-            // Same reasoning for the start record, and this is the write that
-            // makes it safe: publishing the new PID and voiding the previous
-            // lifecycle's evidence happen in one `save_box`, so no reader can
-            // ever see this shim paired with the last one's start. Adopting a
-            // *running* box is not a new lifecycle — its record still names the
-            // live shim and must survive.
-            if !adopting_running {
-                state.started_at = None;
-            }
 
             // Initialize health status if health check is configured
             if self.config.options.advanced.health_check.is_some() {
@@ -1200,7 +1229,7 @@ impl BoxImpl {
 
         tracing::info!(
             box_id = %self.config.id,
-            "Box started successfully (first_start={})",
+            "Box booted successfully (first_start={})",
             is_first_start
         );
         // Lock is automatically released when _guard drops
@@ -1489,9 +1518,17 @@ mod tests {
     use crate::util::{PidFileWriter, PidRecord, ShimPidRecord, is_process_alive};
     use crate::vmm::VmmKind;
     use crate::vmm::controller::VmmMetrics;
-    use boxlite_shared::BoxTransport;
+    use boxlite_shared::{
+        BoxTransport, Container as ContainerService, ContainerInitRequest, ContainerInitResponse,
+        ContainerInitSuccess, ContainerServer, ContainerStartRequest, ContainerStartResponse,
+        ContainerStartSuccess, container_init_response, container_start_response,
+    };
     use chrono::Utc;
+    use std::sync::atomic::{AtomicBool, AtomicUsize};
     use tempfile::TempDir;
+    use tokio::sync::{Notify, Semaphore};
+    use tonic::transport::{Endpoint, Server};
+    use tonic::{Request, Response, Status};
 
     fn published_ports(info: &BoxInfo) -> Option<&[PublishedPort]> {
         info.network
@@ -1539,34 +1576,147 @@ mod tests {
         }
     }
 
-    struct RecordStartedSaveGate {
-        entered: std::sync::mpsc::Sender<()>,
-        release: std::sync::mpsc::Receiver<()>,
+    struct StartGate {
+        calls: AtomicUsize,
+        should_fail: AtomicBool,
+        entered: Semaphore,
+        release: Semaphore,
     }
 
-    static RECORD_STARTED_SAVE_GATE: std::sync::Mutex<Option<RecordStartedSaveGate>> =
-        std::sync::Mutex::new(None);
-
-    fn block_record_started_save(_: i32) -> bool {
-        let gate = RECORD_STARTED_SAVE_GATE
-            .lock()
-            .expect("record-started save gate lock poisoned")
-            .take();
-        let Some(gate) = gate else {
-            return false;
-        };
-
-        gate.entered.send(()).is_ok() && gate.release.recv().is_ok()
+    impl Default for StartGate {
+        fn default() -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                should_fail: AtomicBool::new(false),
+                entered: Semaphore::new(0),
+                release: Semaphore::new(0),
+            }
+        }
     }
 
-    #[test]
-    fn record_started_holds_state_lock_until_persist_completes() {
+    #[derive(Clone)]
+    struct StartStubGuest {
+        gate: Arc<StartGate>,
+    }
+
+    #[tonic::async_trait]
+    impl ContainerService for StartStubGuest {
+        async fn init(
+            &self,
+            request: Request<ContainerInitRequest>,
+        ) -> Result<Response<ContainerInitResponse>, Status> {
+            let container_id = request.into_inner().container_id;
+            Ok(Response::new(ContainerInitResponse {
+                result: Some(container_init_response::Result::Success(
+                    ContainerInitSuccess { container_id },
+                )),
+            }))
+        }
+
+        async fn start(
+            &self,
+            request: Request<ContainerStartRequest>,
+        ) -> Result<Response<ContainerStartResponse>, Status> {
+            let container_id = request.into_inner().container_id;
+            self.gate.calls.fetch_add(1, Ordering::SeqCst);
+            self.gate.entered.add_permits(1);
+            self.gate
+                .release
+                .acquire()
+                .await
+                .expect("start release semaphore closed")
+                .forget();
+
+            if self.gate.should_fail.load(Ordering::SeqCst) {
+                return Err(Status::internal("injected Container.Start failure"));
+            }
+
+            Ok(Response::new(ContainerStartResponse {
+                result: Some(container_start_response::Result::Success(
+                    ContainerStartSuccess { container_id },
+                )),
+            }))
+        }
+    }
+
+    #[derive(Default)]
+    struct StartedCounter {
+        count: AtomicUsize,
+        changed: Notify,
+    }
+
+    impl StartedCounter {
+        async fn wait_for(&self, expected: usize) {
+            loop {
+                let notified = self.changed.notified();
+                tokio::pin!(notified);
+                notified.as_mut().enable();
+                if self.count.load(Ordering::SeqCst) >= expected {
+                    return;
+                }
+                notified.await;
+            }
+        }
+    }
+
+    impl EventListener for StartedCounter {
+        fn on_box_started(&self, _: &BoxID) {
+            self.count.fetch_add(1, Ordering::SeqCst);
+            self.changed.notify_waiters();
+        }
+    }
+
+    async fn start_stub_guest(gate: Arc<StartGate>) -> (GuestSession, JoinHandle<()>) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind stub guest");
+        let address = listener.local_addr().expect("read stub guest address");
+        drop(listener);
+
+        let server = tokio::spawn(async move {
+            Server::builder()
+                .add_service(ContainerServer::new(StartStubGuest { gate }))
+                .serve(address)
+                .await
+                .expect("serve stub guest");
+        });
+
+        let endpoint =
+            Endpoint::from_shared(format!("http://{address}")).expect("build stub guest endpoint");
+        let mut attempts = 0;
+        loop {
+            match endpoint.connect().await {
+                Ok(_) => break,
+                Err(error) => {
+                    attempts += 1;
+                    assert!(attempts < 100, "stub guest did not start: {error}");
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+            }
+        }
+
+        (GuestSession::new(BoxTransport::tcp(address.port())), server)
+    }
+
+    struct StartFixture {
+        box_impl: Arc<BoxImpl>,
+        listener: Arc<StartedCounter>,
+        _temp_dir: TempDir,
+        server: JoinHandle<()>,
+    }
+
+    impl Drop for StartFixture {
+        fn drop(&mut self) {
+            self.server.abort();
+        }
+    }
+
+    async fn running_box_for_start_test(gate: Arc<StartGate>) -> StartFixture {
         let temp_dir = TempDir::new_in("/tmp").expect("create temp dir");
         let runtime = RuntimeImpl::new_for_test(BoxliteOptions {
             home_dir: temp_dir.path().to_path_buf(),
             image_registries: vec![],
         })
         .expect("create runtime");
+        let (guest_session, server) = start_stub_guest(gate).await;
 
         let id = BoxIDMint::mint();
         let config = BoxConfig {
@@ -1587,77 +1737,208 @@ mod tests {
         };
         let mut state = BoxState::new();
         state.status = BoxStatus::Running;
-        state.pid = Some(4242);
+        state.mark_started();
         state.set_lock_id(runtime.lock_manager.allocate().expect("allocate lock"));
         runtime
             .box_manager
             .add_box(&config, &state)
-            .expect("add box to manager");
+            .expect("persist test box");
 
-        let box_impl = Arc::new(BoxImpl::new(
+        let listener = Arc::new(StartedCounter::default());
+        let mut box_impl = BoxImpl::new(
             config,
             state,
             runtime.clone(),
             runtime.shutdown_token.child_token(),
-        ));
-        let (entered_tx, entered_rx) = std::sync::mpsc::channel();
-        let (release_tx, release_rx) = std::sync::mpsc::channel();
-        *RECORD_STARTED_SAVE_GATE
-            .lock()
-            .expect("record-started save gate lock poisoned") = Some(RecordStartedSaveGate {
-            entered: entered_tx,
-            release: release_rx,
-        });
-
-        // Hold SQLite's writer lock so its busy handler marks the exact point
-        // where record_started has entered the real persistence operation.
-        let database = runtime.box_manager.db();
-        let db_path = {
-            let conn = database.conn();
-            conn.busy_handler(Some(block_record_started_save))
-                .expect("install busy handler");
-            conn.path().expect("database has a path").to_owned()
-        };
-        let blocker = rusqlite::Connection::open(db_path).expect("open blocking connection");
-        blocker
-            .execute_batch("BEGIN IMMEDIATE")
-            .expect("acquire SQLite write lock");
-
-        let worker_box = Arc::clone(&box_impl);
-        let worker = std::thread::spawn(move || worker_box.record_started());
-        let reached_persist = entered_rx.recv_timeout(Duration::from_secs(5)).is_ok();
-        let state_lock_held = reached_persist && box_impl.state.try_write().is_none();
-
-        blocker
-            .execute_batch("ROLLBACK")
-            .expect("release SQLite write lock");
-        let _ = release_tx.send(());
-        worker.join().expect("record-started worker panicked");
-        database
-            .conn()
-            .busy_handler(None)
-            .expect("remove database busy handler");
-        *RECORD_STARTED_SAVE_GATE
-            .lock()
-            .expect("record-started save gate lock poisoned") = None;
-
-        assert!(
-            reached_persist,
-            "record_started did not reach the real SQLite update"
         );
-        assert!(
-            state_lock_held,
-            "record_started must hold the state write lock until persistence completes"
+        box_impl
+            .event_listeners
+            .push(listener.clone() as Arc<dyn EventListener>);
+
+        let live = LiveState::new(
+            Box::new(InfoTestHandler(0)),
+            guest_session,
+            None,
+            None,
+            BoxMetricsStorage::new(),
+            Disk::new(
+                temp_dir.path().join("container.qcow2"),
+                DiskFormat::Qcow2,
+                true,
+            ),
+            None,
+            #[cfg(target_os = "linux")]
+            None,
         );
-        assert!(
-            runtime
-                .box_manager
-                .update_box(&id)
-                .expect("load persisted state")
-                .started_at
-                .is_some(),
-            "record_started must persist the start timestamp"
+        assert!(box_impl.live.set(live).is_ok(), "install live state");
+
+        StartFixture {
+            box_impl: Arc::new(box_impl),
+            listener,
+            _temp_dir: temp_dir,
+            server,
+        }
+    }
+
+    async fn wait_for_background_starts(box_impl: &BoxImpl, expected: usize) {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let notified = box_impl.background_start_finished.notified();
+                tokio::pin!(notified);
+                notified.as_mut().enable();
+                if box_impl.background_starts_finished.load(Ordering::SeqCst) >= expected {
+                    return;
+                }
+                notified.await;
+            }
+        })
+        .await
+        .expect("background Container.Start task did not finish");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn explicit_start_returns_before_container_start_rpc_finishes() {
+        let gate = Arc::new(StartGate::default());
+        let fixture = running_box_for_start_test(Arc::clone(&gate)).await;
+
+        tokio::time::timeout(Duration::from_millis(250), fixture.box_impl.start())
+            .await
+            .expect("start() waited for Container.Start")
+            .expect("start() failed before spawning Container.Start");
+        gate.entered
+            .acquire()
+            .await
+            .expect("entered semaphore closed")
+            .forget();
+        assert_eq!(fixture.listener.count.load(Ordering::SeqCst), 0);
+
+        let implicit_box = Arc::clone(&fixture.box_impl);
+        let implicit = tokio::spawn(async move { implicit_box.live_state().await.map(|_| ()) });
+        fixture
+            .box_impl
+            .start()
+            .await
+            .expect("concurrent explicit start failed");
+
+        gate.release.add_permits(1);
+        implicit
+            .await
+            .expect("implicit start task panicked")
+            .expect("implicit start failed");
+        tokio::time::timeout(Duration::from_secs(5), fixture.listener.wait_for(1))
+            .await
+            .expect("successful Container.Start did not emit started event");
+        wait_for_background_starts(&fixture.box_impl, 2).await;
+
+        fixture
+            .box_impl
+            .start()
+            .await
+            .expect("idempotent explicit start failed");
+        wait_for_background_starts(&fixture.box_impl, 3).await;
+        assert_eq!(gate.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(fixture.listener.count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn explicit_start_does_not_announce_when_implicit_start_wins_single_flight() {
+        let gate = Arc::new(StartGate::default());
+        let fixture = running_box_for_start_test(Arc::clone(&gate)).await;
+
+        let implicit_box = Arc::clone(&fixture.box_impl);
+        let implicit = tokio::spawn(async move { implicit_box.live_state().await.map(|_| ()) });
+        gate.entered
+            .acquire()
+            .await
+            .expect("entered semaphore closed")
+            .forget();
+
+        fixture
+            .box_impl
+            .start()
+            .await
+            .expect("concurrent explicit start failed");
+        gate.release.add_permits(1);
+
+        implicit
+            .await
+            .expect("implicit start task panicked")
+            .expect("implicit start failed");
+        wait_for_background_starts(&fixture.box_impl, 1).await;
+
+        assert_eq!(gate.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            fixture.listener.count.load(Ordering::SeqCst),
+            0,
+            "explicit waiter must not claim implicit start success"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn background_start_failure_preserves_state_and_can_retry() {
+        let gate = Arc::new(StartGate::default());
+        gate.should_fail.store(true, Ordering::SeqCst);
+        let fixture = running_box_for_start_test(Arc::clone(&gate)).await;
+        let started_at = fixture.box_impl.state.read().started_at;
+
+        fixture.box_impl.start().await.expect("spawn failed start");
+        gate.entered
+            .acquire()
+            .await
+            .expect("entered semaphore closed")
+            .forget();
+        gate.release.add_permits(1);
+        wait_for_background_starts(&fixture.box_impl, 1).await;
+
+        assert_eq!(fixture.box_impl.state.read().status, BoxStatus::Running);
+        assert_eq!(fixture.box_impl.state.read().started_at, started_at);
+        assert_eq!(fixture.listener.count.load(Ordering::SeqCst), 0);
+
+        gate.should_fail.store(false, Ordering::SeqCst);
+        fixture.box_impl.start().await.expect("spawn retry");
+        gate.entered
+            .acquire()
+            .await
+            .expect("retry entered semaphore closed")
+            .forget();
+        gate.release.add_permits(1);
+        tokio::time::timeout(Duration::from_secs(5), fixture.listener.wait_for(1))
+            .await
+            .expect("successful retry did not emit started event");
+        wait_for_background_starts(&fixture.box_impl, 2).await;
+        assert_eq!(gate.calls.load(Ordering::SeqCst), 2);
+        assert_eq!(fixture.listener.count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stop_cancels_in_flight_background_container_start() {
+        let gate = Arc::new(StartGate::default());
+        let fixture = running_box_for_start_test(Arc::clone(&gate)).await;
+
+        fixture.box_impl.start().await.expect("spawn start");
+        gate.entered
+            .acquire()
+            .await
+            .expect("entered semaphore closed")
+            .forget();
+        fixture.box_impl.stop().await.expect("stop booted box");
+        wait_for_background_starts(&fixture.box_impl, 1).await;
+        gate.release.add_permits(1);
+
+        assert_eq!(fixture.listener.count.load(Ordering::SeqCst), 0);
+        assert_eq!(gate.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(fixture.box_impl.state.read().status, BoxStatus::Stopped);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stopping_booted_box_does_not_start_container() {
+        let gate = Arc::new(StartGate::default());
+        let fixture = running_box_for_start_test(Arc::clone(&gate)).await;
+
+        fixture.box_impl.stop().await.expect("stop booted box");
+
+        assert_eq!(gate.calls.load(Ordering::SeqCst), 0);
+        assert_eq!(fixture.listener.count.load(Ordering::SeqCst), 0);
     }
 
     // Regression test for the silent-orphan bug in stop().

--- a/src/boxlite/src/litebox/mod.rs
+++ b/src/boxlite/src/litebox/mod.rs
@@ -91,13 +91,13 @@ impl LiteBox {
         self.box_backend.info().await
     }
 
-    /// Start the box (initialize VM).
+    /// Boot the box and spawn its container-init start.
     ///
-    /// For Configured boxes: initializes VM for the first time.
-    /// For Stopped boxes: restarts the VM.
-    ///
-    /// This is idempotent - calling start() on a Running box is a no-op.
-    /// Also called implicitly by exec() if the box is not running.
+    /// For Configured boxes this initializes the VM; for Stopped boxes it
+    /// restarts it. Once booted, `Container.Start` runs in the background and
+    /// this method returns without waiting for the guest RPC. Concurrent starts
+    /// are single-flighted; implicit operations such as `exec()` still wait for
+    /// the real container start.
     pub async fn start(&self) -> BoxliteResult<()> {
         self.box_backend.start().await
     }

--- a/src/boxlite/src/litebox/state.rs
+++ b/src/boxlite/src/litebox/state.rs
@@ -232,20 +232,19 @@ pub struct BoxState {
     /// keeps existing DB rows readable without migration.
     #[serde(default)]
     pub exit_code: Option<i32>,
-    /// When the guest's `Container.Start` returned success for the lifecycle
-    /// that published [`Self::pid`] (docker's `State.StartedAt`).
+    /// When a fresh lifecycle published its PID and `Running` state.
     ///
-    /// Deliberately not derivable from [`Self::status`]: booting only *creates*
-    /// the container, and `attach()` leaves a box `Running` with its init not
-    /// yet launched, so `Running` alone cannot answer "did this box's init
-    /// ever start". Survives a stop the way docker keeps `StartedAt` on an
-    /// exited container.
+    /// This is boot-publication evidence, not proof that the asynchronous
+    /// `Container.Start` RPC finished or that the container's init ran.
+    /// `attach(None)` therefore publishes this timestamp while deliberately
+    /// leaving init unstarted. The value survives stop as lifecycle history.
     ///
     /// **Invariant — a live PID in this row is always the one this timestamp
-    /// describes.** Exactly two writes can put a different shim's PID here, and
-    /// both void the timestamp: the one that publishes a new lifecycle's PID
-    /// (`BoxImpl::init_live_state`) and the one recovery branch that can adopt
-    /// a PID this row never published ([`Self::adopt_recovered_shim`]). The
+    /// describes.** Exactly two writes can put a different shim's PID here. A
+    /// fresh boot publishes that PID with a replacement timestamp in
+    /// `BoxImpl::init_live_state`; the recovery branch that adopts a PID this
+    /// row never published clears a timestamp that belonged to the old PID
+    /// ([`Self::adopt_recovered_shim`]). The
     /// lifecycle-ending writes ([`Self::mark_stop`], [`Self::mark_failed`],
     /// [`Self::reset_for_reboot`]) instead clear only the PID and preserve
     /// `Some(t)` — read that as "the run that just ended began at t", never as
@@ -358,7 +357,7 @@ impl BoxState {
         }
     }
 
-    /// Record that this lifecycle's `Container.Start` returned success.
+    /// Record that this lifecycle published its PID and `Running` state.
     pub fn mark_started(&mut self) {
         let now = Utc::now();
         self.started_at = Some(now);
@@ -1062,12 +1061,12 @@ mod tests {
         assert!(state.health_status.last_check.is_none());
         assert!(
             state.started_at.is_none(),
-            "a row written before this field existed cannot claim a launched init"
+            "a row written before this field existed cannot claim a published boot"
         );
     }
 
     #[test]
-    fn adopting_the_recorded_shim_keeps_its_container_start() {
+    fn adopting_the_recorded_shim_keeps_its_boot_marker() {
         let mut state = BoxState::new();
         state.set_pid(Some(4242));
         state.mark_started();
@@ -1077,13 +1076,13 @@ mod tests {
 
         assert_eq!(
             state.started_at, recorded,
-            "recovery re-attaching the same shim must not void the start it recorded"
+            "recovery re-attaching the same shim must not void its boot marker"
         );
         assert_eq!(state.status, BoxStatus::Running);
     }
 
     #[test]
-    fn adopting_a_different_shim_voids_the_container_start() {
+    fn adopting_a_different_shim_voids_the_boot_marker() {
         // A crash between the shim writing its PID file and this row being
         // saved leaves recovery adopting a PID the row never published. The
         // timestamp describes the PID it was written with, so it cannot
@@ -1097,16 +1096,15 @@ mod tests {
         assert_eq!(state.pid, Some(4243));
         assert!(
             state.started_at.is_none(),
-            "a start recorded for pid 4242 must not be read as evidence about pid 4243"
+            "a boot recorded for pid 4242 must not be read as evidence about pid 4243"
         );
     }
 
-    /// The three ways a lifecycle ends all keep the timestamp — docker's
-    /// `StartedAt` on an exited container. What makes that safe is that each
+    /// The three ways a lifecycle ends all keep its boot timestamp. Each
     /// one drops the PID: `Some(started_at)` beside `pid: None` describes the
-    /// run that ended, and cannot be read as a live box.
+    /// lifecycle that ended, and cannot be read as a live box.
     #[test]
-    fn ending_a_lifecycle_keeps_the_start_and_drops_the_pid() {
+    fn ending_a_lifecycle_keeps_the_boot_marker_and_drops_the_pid() {
         let ended = |end: fn(&mut BoxState)| {
             let mut state = BoxState::new();
             state.set_pid(Some(4242));
@@ -1123,11 +1121,11 @@ mod tests {
         ] {
             assert!(
                 state.started_at.is_some(),
-                "{name} must keep the start of the run that just ended"
+                "{name} must keep the boot marker of the lifecycle that just ended"
             );
             assert_eq!(
                 state.pid, None,
-                "{name} must drop the PID, or the kept start would read as a live box"
+                "{name} must drop the PID, or the kept boot would read as a live box"
             );
             assert!(
                 !state.status.is_active(),

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -352,7 +352,7 @@ impl BoxResponse {
             exit_code: self.exit_code,
             // Like `network`, this is local-lifecycle detail the remote REST
             // surface does not publish; `None` says "not known here" rather
-            // than "init was never launched".
+            // than "no boot marker was recorded".
             started_at: None,
         })
     }

--- a/src/boxlite/src/runtime/types.rs
+++ b/src/boxlite/src/runtime/types.rs
@@ -401,17 +401,15 @@ pub struct BoxInfo {
     /// because its main command exited (docker semantics).
     pub exit_code: Option<i32>,
 
-    /// When the guest's `Container.Start` most recently returned success
-    /// (docker's `State.StartedAt`); `None` when no successful start has been
-    /// recorded. The value survives stop and reboot as lifecycle history. When
-    /// [`Self::pid`] is present, the timestamp describes that live PID.
+    /// When the most recent lifecycle published its PID and `Running` state;
+    /// `None` when no boot publication was recorded. The value survives stop
+    /// as lifecycle history. When [`Self::pid`] is present, the timestamp
+    /// describes that live PID.
     ///
-    /// Answers what [`Self::status`] cannot: `Running` is published once the
-    /// VM is up, which is before the separate `Container.Start` runs — and
-    /// `attach()` leaves a box `Running` with its init deliberately unstarted.
-    /// The cloud runner reads this to confirm a startup whose job-completion
-    /// callback was lost. Serde default keeps metadata from an older producer
-    /// readable.
+    /// This is intentionally boot evidence, not Docker `State.StartedAt`:
+    /// the separate asynchronous `Container.Start` may still be in flight or
+    /// may fail. `attach(None)` publishes this timestamp without starting init.
+    /// Serde default keeps metadata from an older producer readable.
     #[serde(default)]
     pub started_at: Option<DateTime<Utc>>,
 }

--- a/src/boxlite/tests/started_at.rs
+++ b/src/boxlite/tests/started_at.rs
@@ -1,10 +1,7 @@
 //! Integration tests for `BoxInfo::started_at`.
 //!
-//! The timestamp is deliberately distinct from `BoxStatus::Running`: booting
-//! publishes Running before the guest's separate `Container.Start` RPC runs, so
-//! Running alone cannot say whether a box's init was ever launched. The cloud
-//! runner reads this to repair a startup whose job completion was lost, which
-//! only works while the value describes the lifecycle running right now.
+//! The timestamp records when a fresh box lifecycle publishes `Running`. It is
+//! boot evidence, not proof that asynchronous `Container.Start` has finished.
 
 mod common;
 
@@ -12,7 +9,7 @@ use boxlite::BoxliteRuntime;
 use boxlite::runtime::options::BoxliteOptions;
 
 #[tokio::test]
-async fn started_at_tracks_the_shim_that_launched_init() {
+async fn started_at_tracks_the_booted_shim() {
     let home = boxlite_test_utils::home::PerTestBoxHome::new();
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
@@ -33,39 +30,38 @@ async fn started_at_tracks_the_shim_that_launched_init() {
             .expect("inspect created box")
             .started_at
             .is_none(),
-        "creating a container must not claim its init was launched"
+        "creating a container must not claim that a lifecycle was booted"
     );
 
-    // Booting is not starting: `attach` brings the VM up and stops short of
-    // running init, which is the state `BoxStatus::Running` cannot tell apart
-    // from a box whose init is live — and the whole reason this field exists.
+    // `attach` brings the VM up and stops short of running init. Publishing the
+    // new shim and its boot timestamp must be one persisted state transition.
+    let before_boot = chrono::Utc::now();
     let attached = handle.attach(None).await.expect("attach to booted box");
     let booted = handle.info().await.expect("inspect booted box");
     assert!(
         booted.status.is_running(),
         "attach must leave the box Running, or this test is not observing the window"
     );
-    assert_eq!(
-        booted.started_at, None,
-        "a booted box whose init was never launched must not report a container start"
+    assert!(
+        booted.pid.is_some(),
+        "a box that published Running must name its booted shim"
+    );
+    let booted_at = booted
+        .started_at
+        .expect("booting a box must publish started_at");
+    assert!(
+        booted_at >= before_boot,
+        "boot timestamp {booted_at} predates the boot that produced it ({before_boot})"
     );
 
-    let before_start = chrono::Utc::now();
     handle.start().await.expect("start box");
     drop(attached);
 
     let info = handle.info().await.expect("inspect running box");
-    let started_at = info
-        .started_at
-        .expect("a successful Container.Start must be recorded");
-
-    assert!(
-        info.pid.is_some(),
-        "a box that recorded a start must name the shim running it"
-    );
-    assert!(
-        started_at >= before_start,
-        "record timestamp {started_at} predates the start that produced it ({before_start})"
+    assert_eq!(
+        info.started_at,
+        Some(booted_at),
+        "starting the container must not rewrite the lifecycle's boot timestamp"
     );
 
     let _ = handle.stop().await;
@@ -74,7 +70,7 @@ async fn started_at_tracks_the_shim_that_launched_init() {
 }
 
 #[tokio::test]
-async fn a_fresh_lifecycle_replaces_the_previous_record() {
+async fn started_at_changes_for_a_fresh_lifecycle() {
     let home = boxlite_test_utils::home::PerTestBoxHome::new();
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
@@ -97,15 +93,14 @@ async fn a_fresh_lifecycle_replaces_the_previous_record() {
         .await
         .expect("inspect first lifecycle")
         .started_at
-        .expect("first start must be recorded");
+        .expect("first boot must be recorded");
 
     handle.stop().await.expect("stop first lifecycle");
 
     assert_eq!(
         handle.info().await.expect("inspect stopped box").started_at,
         Some(first),
-        "a stop must leave the record of the run that just ended, the way docker keeps \
-         StartedAt on an exited container"
+        "a stop must preserve the boot record of the lifecycle that just ended"
     );
 
     // A spent handle cannot boot another VM, so the restart goes through a
@@ -117,20 +112,35 @@ async fn a_fresh_lifecycle_replaces_the_previous_record() {
         .expect("get a fresh handle")
         .expect("box still exists");
 
-    restarted.start().await.expect("start second lifecycle");
-
-    let second_info = restarted.info().await.expect("inspect restarted box");
-    let second = second_info
+    restarted
+        .start()
+        .await
+        .expect("boot second lifecycle and enqueue Container.Start");
+    let booted_again = restarted
+        .info()
+        .await
+        .expect("inspect second booted lifecycle");
+    let second = booted_again
         .started_at
-        .expect("second start must be recorded");
+        .expect("second boot must be recorded");
 
     assert!(
-        second_info.pid.is_some(),
-        "a restarted box that recorded a start must name the shim running it"
+        booted_again.pid.is_some(),
+        "a restarted box that recorded a boot must name the shim running it"
     );
     assert!(
         second > first,
         "second record timestamp {second} does not follow the first ({first})"
+    );
+
+    assert_eq!(
+        restarted
+            .info()
+            .await
+            .expect("inspect second lifecycle again")
+            .started_at,
+        Some(second),
+        "background Container.Start must not rewrite the second lifecycle's boot timestamp"
     );
 
     let _ = restarted.stop().await;
@@ -139,7 +149,7 @@ async fn a_fresh_lifecycle_replaces_the_previous_record() {
 }
 
 #[tokio::test]
-async fn adopting_the_same_running_shim_preserves_its_record() {
+async fn started_at_is_preserved_when_adopting_the_same_running_shim() {
     let home = boxlite_test_utils::home::PerTestBoxHome::new();
     let options = || BoxliteOptions {
         home_dir: home.path.clone(),
@@ -158,13 +168,13 @@ async fn adopting_the_same_running_shim_preserves_its_record() {
         let info = handle.info().await.expect("inspect detached box");
         (
             handle.id().clone(),
-            info.started_at.expect("detached start must be recorded"),
+            info.started_at.expect("detached boot must be recorded"),
             info.pid.expect("a running box has a shim pid"),
         )
     };
 
-    // Reattaching to a still-running shim is not a new lifecycle: its init is
-    // already running, so the record that describes it must survive.
+    // Reattaching to a still-running shim is not a new lifecycle, so the boot
+    // record that describes it must survive.
     let second = BoxliteRuntime::new(options()).expect("create second runtime");
     let adopted = second
         .get(box_id.as_str())
@@ -176,7 +186,7 @@ async fn adopting_the_same_running_shim_preserves_its_record() {
     assert_eq!(
         adopted_info.started_at,
         Some(recorded),
-        "adopting a live shim must not clear or rewrite its start record"
+        "adopting a live shim must not clear or rewrite its boot record"
     );
     assert_eq!(
         adopted_info.pid,

--- a/src/cli/src/commands/serve/README.md
+++ b/src/cli/src/commands/serve/README.md
@@ -124,7 +124,7 @@ permissive (accepts any/no bearer) — the zero-config local-dev default.
 | GET    | `/v1/boxes/{box_id}`          | `boxes::get_box`     | Get box info                  |
 | HEAD   | `/v1/boxes/{box_id}`          | `boxes::head_box`    | Check box exists (204 / 404)  |
 | DELETE | `/v1/boxes/{box_id}`          | `boxes::remove_box`  | Remove box (`?force=true`)    |
-| POST   | `/v1/boxes/{box_id}/start`    | `boxes::start_box`   | Start a stopped box           |
+| POST   | `/v1/boxes/{box_id}/start`    | `boxes::start_box`   | Boot box; enqueue container start |
 | POST   | `/v1/boxes/{box_id}/stop`     | `boxes::stop_box`    | Stop a running box            |
 
 ### Command Execution


### PR DESCRIPTION
## Summary

Return from BoxLite `start()` after the VM has booted and the guest `Container.Start` work has been handed to a background task. Publish `started_at` with the PID/Running boot marker and keep live operations behind the same single-flight readiness gate.

## Call graph

Before

```text
Client.Create                 (Go · apps/runner/pkg/boxlite/client.go:219)
  └─ BoxImpl::start           (Rust · src/boxlite/src/litebox/box_impl.rs:269) — waits for the complete start path
       └─ ensure_container_started
                              (Rust · src/boxlite/src/litebox/box_impl.rs:985) — awaits the guest RPC
            └─ ContainerInterface::start
                              (Rust · src/boxlite/src/portal/interfaces/container.rs:218)
                 └─ record_started
                              (Rust · src/boxlite/src/litebox/box_impl.rs:1023) — publishes started_at after the RPC

BoxSyncService.canReport      (Go · apps/runner/pkg/services/box_sync.go:226) — repairs transitional state from the post-RPC marker
```

After

```text
Client.Create                 (Go · apps/runner/pkg/boxlite/client.go:219)
  └─ BoxImpl::start           (Rust · src/boxlite/src/litebox/box_impl.rs:277) — awaits boot, spawns the handoff, then returns
       ├─ init_live_state     (Rust · src/boxlite/src/litebox/box_impl.rs:1096)
       │    └─ BoxState::mark_started
       │                      (Rust · src/boxlite/src/litebox/state.rs:361) — publishes PID/Running/started_at together
       └─ ensure_container_started_owned
                              (Rust · src/boxlite/src/litebox/box_impl.rs:1039) — single-flight background guest RPC
            └─ ContainerInterface::start
                              (Rust · src/boxlite/src/portal/interfaces/container.rs:218)

BoxImpl::exec                 (Rust · src/boxlite/src/litebox/box_impl.rs:443)
  └─ live_state              (Rust · src/boxlite/src/litebox/box_impl.rs:987)
       └─ ensure_container_started
                              (Rust · src/boxlite/src/litebox/box_impl.rs:1024) — joins or retries the same readiness gate

BoxSyncService.canReport      (Go · apps/runner/pkg/services/box_sync.go:222) — repairs transitional state from the boot marker
```

## Changes

- Move guest `Container.Start` behind a detached, cancellable single-flight task after boot.
- Keep `exec` and other live operations blocked on the same readiness gate, with retry after a failed initializer.
- Publish and persist `started_at` atomically with the fresh lifecycle's PID and Running state.
- Align Runner reconciliation, REST/SDK contracts, and reference documentation with the boot-marker semantics.

## How to verify

- `make test:unit:rust`
- `make test:integration:rust SETUP_DONE=1 FILTER=started_at`
- `make fmt:check:rust`
- `make clippy UV_OFFLINE=1`

## Risks / rollout

- A successful `start()` now confirms VM boot and background handoff, not completion of the guest `Container.Start` RPC.
- Background start failures are logged; the next live operation joins or retries startup and surfaces its own failure.
- `started_at` now denotes PID/Running boot publication for the current lifecycle. No public method signatures change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Box startup now returns after background container initialization is queued, improving responsiveness.
  * Concurrent and repeated starts are safely coordinated; failed starts can be retried.
  * Operations requiring a running container wait for initialization to complete.

* **Bug Fixes**
  * Improved lifecycle synchronization and state reporting during startup, stopping, recovery, and adoption.

* **Documentation**
  * Updated SDK, CLI, REST API, and event documentation to clarify asynchronous startup and `started_at` semantics.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->