### PR TITLE
docs(apps): add missing interfaces to service API catalog

### DIFF
--- a/apps/API.md
+++ b/apps/API.md
@@ -1,14 +1,16 @@
 # BoxLite application API catalog
 
 This catalog lists the interfaces registered by the applications in this
-directory. It covers HTTP, WebSocket, CONNECT, OTLP, and health interfaces;
-each entry names the owning service and what the interface does. Route tables
-are collapsed by default — expand a summary line to see its routes.
+directory. It covers HTTP, WebSocket, CONNECT, OTLP, health, static-asset, and
+outbound event interfaces; each entry names the owning service and what the
+interface does. Route tables are collapsed by default — expand a summary line
+to see its routes.
 
 The inventory is implementation-grounded:
 
-- Control-plane product routes come from the generated
-  [`openapi.yaml`](./libs/api-client-go/api/openapi.yaml) and use the `/api`
+- Control-plane product routes come from the controllers under
+  [`api/src`](./api/src/), match the generated
+  [`openapi.yaml`](./libs/api-client-go/api/openapi.yaml), and use the `/api`
   prefix applied in [`main.ts`](./api/src/main.ts).
 - Hosted BoxLite-compatible routes come from the controllers in
   [`boxlite-rest`](./api/src/boxlite-rest/). They are excluded from the product
@@ -18,6 +20,17 @@ The inventory is implementation-grounded:
   [`server.go`](./runner/pkg/api/server.go),
   [`proxy.go`](./proxy/pkg/proxy/proxy.go), and
   [`config.yaml`](./otel-collector/config.yaml).
+- Static asset trees come from the `ServeStaticModule` registrations in
+  [`app.module.ts`](./api/src/app.module.ts).
+- Outbound and asynchronous interfaces come from
+  [`notification.gateway.ts`](./api/src/notification/gateways/notification.gateway.ts),
+  [`webhook-events.constants.ts`](./api/src/webhook/constants/webhook-events.constants.ts),
+  and [`kafka-exception.filter.ts`](./api/src/filters/kafka-exception.filter.ts).
+- Local-stack listeners come from the service specs in
+  [`services.py`](./infra-local/compose/services.py) and
+  [`native.py`](./infra-local/compose/native.py); the container-based
+  environment's come from
+  [`local-dex-env.mjs`](./scripts/local-dex-env.mjs).
 
 `openapi/box.openapi.yaml` also describes portable capabilities that the hosted
 service does not currently register, including snapshots, clone, export,
@@ -26,14 +39,17 @@ import, images, and runtime-wide metrics. They are intentionally absent below;
 
 ## Services at a glance
 
-| API                                                                       | Service               | Base path or host                               | Deployed port            |
-| ------------------------------------------------------------------------- | --------------------- | ----------------------------------------------- | ------------------------ |
-| [Control-plane API](#control-plane-api)                                   | `apps/api`            | `/api`                                          | `3000`                   |
-| [Hosted BoxLite-compatible API](#hosted-boxlite-compatible-api)           | `apps/api`            | `/api/v1`                                       | `3000`                   |
-| [Runner API](#runner-api)                                                 | `apps/runner`         | `/`                                             | `3003`                   |
-| [Preview proxy API](#preview-proxy-api)                                   | `apps/proxy`          | `proxy.<domain>`, `<port>-<box>.proxy.<domain>` | `4000`                   |
-| [Telemetry collector API](#telemetry-collector-api)                       | `apps/otel-collector` | OTLP/HTTP and health listeners                  | `4318`, `13133`, `13132` |
-| [Services without a first-party API](#services-without-a-first-party-api) | remaining apps        | —                                               | —                        |
+| API                                                                       | Service                      | Base path or host                                                                    | Deployed port            |
+| ------------------------------------------------------------------------- | ---------------------------- | ------------------------------------------------------------------------------------ | ------------------------ |
+| [Control-plane API](#control-plane-api)                                   | `apps/api`                   | `/api`                                                                               | `3000`                   |
+| [Hosted BoxLite-compatible API](#hosted-boxlite-compatible-api)           | `apps/api`                   | `/api/v1`                                                                            | `3000`                   |
+| [Runner API](#runner-api)                                                 | `apps/runner`                | `/`                                                                                  | `3003`                   |
+| [Preview proxy API](#preview-proxy-api)                                   | `apps/proxy`                 | `proxy.<domain>`, `<port>-<box>.proxy.<domain>`                                      | `4000`                   |
+| [Telemetry collector API](#telemetry-collector-api)                       | `apps/otel-collector`        | OTLP/HTTP and health listeners                                                       | `4318`, `13133`, `13132` |
+| [Local development stack](#local-development-stack)                       | `apps/infra-local`           | `http://localhost:28080`                                                             | local host ports only    |
+| [Container-based local environment](#container-based-local-environment)   | `apps/scripts`               | containers on `5556`, `5432`, `6379`, `5001`; apps on `3000`, `3001`, `4000`, `8080` | local host ports only    |
+| [Externally served APIs](#externally-served-apis)                         | `apps/dashboard`, `apps/api` | discovered via `GET /api/config`                                                     | —                        |
+| [Services without a first-party API](#services-without-a-first-party-api) | remaining apps               | —                                                                                    | —                        |
 
 Ports are the values used in deployments. Service ports and the collector's
 OTLP and HTTP health ports come from
@@ -49,9 +65,8 @@ deployments (`PORT` environment variable; no in-code default)
 This is the hosted product API used by the dashboard, SDKs, CLI, runners, and
 internal services. Authentication and authorization vary by route; the health
 and configuration discovery routes are public, while resource routes enforce
-user, organization, runner, or admin credentials. Besides the routes below,
-the same process statically serves the dashboard single-page app at `/` and
-runner binaries under `/runner-amd64`; both exclude `/api` paths.
+user, organization, runner, or admin credentials. The static trees this process
+serves and the events it emits are catalogued below alongside its routes.
 
 <details>
 <summary><b>Discovery and API keys</b> · 7 routes</summary>
@@ -256,7 +271,33 @@ runner binaries under `/runner-amd64`; both exclude `/api` paths.
 </details>
 
 <details>
-<summary><b>Realtime and asynchronous interfaces</b> · Socket.IO, 9 events, 1 Kafka topic</summary>
+<summary><b>Static asset trees</b> · 2 trees</summary>
+
+| Method | Path            | What it does                                                             |
+| ------ | --------------- | ------------------------------------------------------------------------ |
+| `GET`  | `/runner-amd64` | Serves `runner-amd64` from the deployment root, when that file is there. |
+| `GET`  | `/`             | Serves the dashboard single-page app and its hashed `/assets/*` bundles. |
+
+Both trees are registered by `ServeStaticModule` in
+[`app.module.ts`](./api/src/app.module.ts) and exclude `/api/{*path}`, so they
+never shadow the routes above. The dashboard tree applies a content-addressed
+cache policy from [`serve-static-cache.ts`](./api/src/serve-static-cache.ts):
+hashed `/assets/*` files are `immutable` for a year, HTML is `no-cache`, and
+everything else must revalidate.
+
+The file that route resolves to is the runner binary
+[`project.json`](./runner/project.json) builds at `dist/apps/runner-amd64`, so
+the path serves something only in a full local build: the deployed image stages
+just `dist/apps/api` and `dist/apps/dashboard`
+([`Dockerfile`](./api/Dockerfile)). No in-repo client fetches it either — runners
+take their binary from the artifact source resolved in
+[`source.ts`](./infra/artifacts/source.ts), which defaults to a published
+release fetched over HTTPS.
+
+</details>
+
+<details>
+<summary><b>Realtime and asynchronous interfaces</b> · Socket.IO, 9 events, 4 webhook events, 2 Kafka topics</summary>
 
 | Protocol                 | Path, topic, or event          | What it does                                                                                                                           |
 | ------------------------ | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
@@ -270,7 +311,22 @@ runner binaries under `/runner-amd64`; both exclude `/api` paths.
 | Socket.IO event          | `runner.created`               | Notifies an organization that a runner was registered.                                                                                 |
 | Socket.IO event          | `runner.state.updated`         | Notifies an organization that a runner's state changed.                                                                                |
 | Socket.IO event          | `runner.unschedulable.updated` | Notifies an organization that runner scheduling availability changed.                                                                  |
+| Webhook event (Svix)     | `box.created`                  | Delivers a signed box-created event to the organization's subscribed endpoints.                                                        |
+| Webhook event (Svix)     | `box.state.updated`            | Delivers a box observed-state change to the organization's subscribed endpoints.                                                       |
+| Webhook event (Svix)     | `volume.created`               | Delivers a volume-created event to the organization's subscribed endpoints.                                                            |
+| Webhook event (Svix)     | `volume.state.updated`         | Delivers a volume state change to the organization's subscribed endpoints.                                                             |
 | Kafka event              | `audit-logs` topic             | When the API worker and Kafka are enabled, consumes audit-log events and persists them, with bounded retries and dead-letter handling. |
+| Kafka event              | `audit-logs.dlq` topic         | Receives audit-log events that exhausted their retries, with the failure reason and retry count attached.                              |
+
+Socket.IO and webhook events share four names but not their delivery: Socket.IO
+broadcasts to the organization's room over the authenticated WebSocket, while
+webhook events are delivered as signed HTTP requests through Svix to endpoints
+the organization manages in its consumer portal. Payload schemas are published
+in a `webhooks` block that
+[`openapi-webhooks.ts`](./api/src/openapi-webhooks.ts) adds to the generated
+`openapi.3.1.0.json` only — not to the checked-in `openapi.yaml` named above.
+The `template.*` values remain in the `WebhookEvent` enum but nothing emits
+them.
 
 </details>
 
@@ -452,27 +508,186 @@ Only the OTLP/HTTP receiver is enabled; OTLP gRPC is not configured.
 
 </details>
 
+## Local development stack
+
+**Service:** `apps/infra-local` · **Unified entry:** `http://localhost:28080` ·
+**Ports:** fixed host ports, local only
+
+`make up` in [`infra-local`](./infra-local/) starts the dependency services as
+BoxLite boxes and the application processes on the host. Every listener below is
+bound on the developer's machine; the host ports are fixed literals in
+[`services.py`](./infra-local/compose/services.py) and
+[`native.py`](./infra-local/compose/native.py), not deployment values. From
+inside a box the same listeners are reachable as `host.boxlite.internal:<port>`.
+
+<details>
+<summary><b>Unified entry point</b> · 9 routes</summary>
+
+| Method | Host and path                                | What it does                                                       |
+| ------ | -------------------------------------------- | ------------------------------------------------------------------ |
+| `ANY`  | `<digits>-<token>.localhost:28080/{path...}` | Forwards signed port-preview hosts to the preview proxy on `4000`. |
+| `ANY`  | `localhost:28080/pgadmin/*`                  | Reverse-proxies the pgAdmin UI.                                    |
+| `ANY`  | `localhost:28080/jaeger/*`                   | Reverse-proxies the Jaeger UI.                                     |
+| `ANY`  | `localhost:28080/dex/*`                      | Reverse-proxies the Dex OIDC provider.                             |
+| `ANY`  | `localhost:28080/minio/*`                    | Reverse-proxies the MinIO S3 API.                                  |
+| `ANY`  | `localhost:28080/minio-console/*`            | Reverse-proxies the MinIO console UI.                              |
+| `ANY`  | `localhost:28080/registry/*`                 | Reverse-proxies the Docker registry v2 API.                        |
+| `ANY`  | `localhost:28080/registry-ui/*`              | Reverse-proxies the registry browser UI.                           |
+| `ANY`  | `localhost:28080/`                           | Responds with a plain-text index of the routes above.              |
+
+Caddy serves these over plain HTTP with `auto_https off`; host `28443` is
+reserved for a future `tls internal` block. Its admin API is on host `12019`
+(container `2019`), and `GET :12019/config/` is Caddy's own readiness probe —
+each of the other services below carries one of its own.
+
+</details>
+
+<details>
+<summary><b>Dependency services</b> · 10 services</summary>
+
+| Service       | Host port to container port                           | Interface                                                                         |
+| ------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `postgres`    | `25432` → `5432`                                      | PostgreSQL wire protocol; `postgresql://boxlite:boxlite@127.0.0.1:25432/boxlite`. |
+| `redis`       | `26379` → `6379`                                      | Redis protocol, backing caches, the Socket.IO adapter, and proxy lookups.         |
+| `minio`       | `29000` → `9000`, `29001` → `9001`                    | S3-compatible object storage API and console UI; probed at `/minio/health/live`.  |
+| `minio-init`  | none                                                  | One-shot `minio/mc` job that creates the `boxlite` bucket; no listener.           |
+| `registry`    | `25000` → `5000`                                      | Docker registry v2 API; probed at `/v2/`.                                         |
+| `registry-ui` | `25052` → `80`                                        | Registry browser UI.                                                              |
+| `dex`         | `25556` → `5556`                                      | OIDC provider served under the `/dex` issuer path.                                |
+| `jaeger`      | `26686` → `16686`, `26687` → `4317`                   | Trace UI, plus an OTLP/gRPC receiver fed by the local collector.                  |
+| `pgadmin`     | `25051` → `80`                                        | Postgres administration UI; probed at `/misc/ping`.                               |
+| `otel`        | `24317` → `4317`, `24318` → `4318`, `23133` → `13133` | OTLP gRPC and HTTP receivers, plus a `health_check` extension at `/`.             |
+
+The local collector is the upstream `otel/opentelemetry-collector` image with an
+inline config, not the first-party build described in
+[Telemetry collector API](#telemetry-collector-api): it enables OTLP gRPC as
+well as HTTP, exports traces to the Jaeger box, and answers health at `/`
+instead of `/health/status`.
+
+This Dex box serves the inline `_DEX_CONFIG` from
+[`services.py`](./infra-local/compose/services.py), written to
+`/tmp/dex-config.yaml` at boot: one public static client, `boxlite`, whose
+redirect URIs cover the dashboard, the Vite dev server, and the CLI loopback
+callback at `http://127.0.0.1:5555/callback`, plus a password database holding
+two static users. [`dex/config.yaml`](./dex/config.yaml) is a separate file for
+a separate environment — see
+[Container-based local environment](#container-based-local-environment).
+`apps/infra` deploys no Dex service; deployed stacks point
+`OIDC_ISSUER_BASE_URL` at a hosted provider and reach it through the same
+`/.well-known/openid-configuration` discovery document.
+
+</details>
+
+<details>
+<summary><b>Application processes</b> · 4 processes</summary>
+
+| Process     | Host port | Interface                                                                  |
+| ----------- | --------- | -------------------------------------------------------------------------- |
+| `api`       | `3001`    | Control-plane and hosted BoxLite-compatible APIs; probed at `/api/health`. |
+| `dashboard` | `3000`    | Vite dev server for the dashboard app.                                     |
+| `proxy`     | `4000`    | Preview proxy API (`PROXY_PORT`).                                          |
+| `runner`    | `3003`    | Runner API (`API_PORT`).                                                   |
+
+The local API listens on `3001` rather than the deployed `3000`, which the
+dashboard dev server uses; `BOXLITE_LOCAL_API_PORT` overrides it. This stack
+starts no mail service and sets no `SMTP_HOST`.
+
+</details>
+
+## Container-based local environment
+
+**Service:** `apps/scripts` · **Entry points:** `yarn dev:dex`, `yarn e2e:local`
+
+A second local environment: [`local-dex-env.mjs`](./scripts/local-dex-env.mjs)
+starts four Docker containers, then runs the same four application processes on
+the host through the `serve-slim` target. It is the only environment here that
+runs [`dex/config.yaml`](./dex/config.yaml), which it renders to
+`.boxlite-home/dex/config.local.yaml` and mounts read-only into the Dex
+container.
+
+<details>
+<summary><b>Containers</b> · 4 services</summary>
+
+| Service    | Host port       | Interface                                                                                        |
+| ---------- | --------------- | ------------------------------------------------------------------------------------------------ |
+| `dex`      | `5556`          | OIDC provider: `ghcr.io/dexidp/dex:v2.41.1` serving the rendered `dex/config.yaml`.              |
+| `postgres` | `5432`          | PostgreSQL wire protocol: `postgres:16-alpine`, database `boxlite`.                              |
+| `redis`    | `6379`          | Redis protocol: `redis:7-alpine`.                                                                |
+| `registry` | `5001` → `5000` | Docker registry v2 API: `registry:2`, probed at `/v2/boxlite/{name}/manifests/{tag}` for images. |
+
+</details>
+
+<details>
+<summary><b>Application processes</b> · 4 processes</summary>
+
+| Process     | Host port | Interface                                                   |
+| ----------- | --------- | ----------------------------------------------------------- |
+| `api`       | `3001`    | Control-plane and hosted BoxLite-compatible APIs.           |
+| `dashboard` | `3000`    | Vite dev server, kept on its own `/api` proxy path.         |
+| `proxy`     | `4000`    | Preview proxy API.                                          |
+| `runner`    | `8080`    | Runner API, left on the in-code default rather than `3003`. |
+
+These are the same four projects the boxed stack serves, on the same `3000`,
+`3001`, and `4000` host ports, so the two local environments cannot run at the
+same time.
+
+</details>
+
+## Externally served APIs
+
+These interfaces are called from this directory but served by systems outside
+it, so no route table above owns them. The analytics and billing clients take
+their base URL from `GET /api/config` and disable the corresponding UI when it
+is unset; the same document carries PostHog's key and host to the browser.
+
+<details>
+<summary><b>External interfaces</b> · 2 APIs, 2 SaaS integrations</summary>
+
+| Interface     | Client                                                                                 | Base URL source                  | What it covers                                                                                                                                               |
+| ------------- | -------------------------------------------------------------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Analytics API | [`libs/analytics-api-client`](./libs/analytics-api-client/), generated                 | `analyticsApiUrl`                | 8 routes: per-box and organization usage, aggregates, and charts, plus box logs, metrics, and traces.                                                        |
+| Billing API   | [`billingApiClient.ts`](./dashboard/src/billing-api/billingApiClient.ts), hand-written | `billingApiUrl`                  | 20 routes: usage, wallet and top-ups, tiers, invoices, coupons, billing emails, portal and checkout URLs.                                                    |
+| PostHog       | `posthog-js` in the dashboard; `posthog-node` in the API                               | `posthog.apiKey`, `posthog.host` | Browser product analytics; server-side `api_*` operation events from the global metrics interceptor, two `groupIdentify` calls, and feature-flag evaluation. |
+| Pylon         | [`App.tsx`](./dashboard/src/App.tsx) widget, production builds only                    | `pylonAppId`                     | Outbound support-chat widget; it registers no route here.                                                                                                    |
+
+The analytics client is generated from
+[`swagger.json`](./libs/analytics-api-client/swagger.json). Its four telemetry
+routes duplicate the control plane's own [box telemetry](#control-plane-api)
+routes, and the dashboard's box telemetry views call the analytics client only —
+they disable themselves when `analyticsApiUrl` is unset rather than falling back.
+Nothing in this directory registers the analytics or billing paths.
+
+</details>
+
 ## Services without a first-party API
 
 <details>
 <summary><b>Non-API services and bundled tools</b> · 10 entries</summary>
 
-| Service                     | Role                                                                                                                                                                                                  |
-| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `apps/dashboard`            | Static browser application; it consumes the control-plane API and does not register a server API.                                                                                                     |
-| `apps/dex`                  | Development configuration for the third-party Dex OIDC provider; Dex serves standard OIDC discovery, authorization, token, device-flow, and user-interface endpoints rather than a BoxLite-owned API. |
-| `apps/infra`                | Infrastructure-as-code and deployment tooling; it does not run an application API.                                                                                                                    |
-| `apps/infra-local`          | Local BoxLite-based service orchestration; it starts dependencies and application services but does not expose its own API.                                                                           |
-| `apps/e2e`                  | End-to-end test client; it calls deployed APIs but does not expose one.                                                                                                                               |
-| `apps/box-images`           | Image build inputs; they produce box images and do not run a service.                                                                                                                                 |
-| `apps/hack`, `apps/scripts` | Development and code-generation utilities; they do not run application APIs.                                                                                                                          |
-| Jaeger                      | Bundled third-party trace ingestion and UI, not a BoxLite-owned API.                                                                                                                                  |
-| PgAdmin                     | Bundled third-party database administration UI, internal only.                                                                                                                                        |
-| MailDev                     | Bundled third-party SMTP test service and UI in deployed environments; not part of the local stack.                                                                                                   |
+| Service                     | Role                                                                                                                                                                                                                                                                                                                                                                                     |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `apps/dashboard`            | Static browser application; it consumes the control-plane API and the [externally served APIs](#externally-served-apis), and registers no server API.                                                                                                                                                                                                                                    |
+| `apps/dex`                  | Development-only configuration for the third-party Dex OIDC provider, plus a Dockerfile that bakes it into a `dex:v2.42.0` image nothing in this repository builds. The endpoints Dex serves are its own, not a BoxLite-owned API; the listener that does run this config is catalogued under [Container-based local environment](#container-based-local-environment), on `dex:v2.41.1`. |
+| `apps/infra`                | Infrastructure-as-code and deployment tooling; it does not run an application API.                                                                                                                                                                                                                                                                                                       |
+| `apps/infra-local`          | Local service orchestration; it registers no API of its own, but every listener it starts is catalogued under the [local development stack](#local-development-stack).                                                                                                                                                                                                                   |
+| `apps/e2e`                  | End-to-end test client; it calls deployed APIs but does not expose one.                                                                                                                                                                                                                                                                                                                  |
+| `apps/box-images`           | Image build inputs; they produce box images and do not run a service.                                                                                                                                                                                                                                                                                                                    |
+| `apps/hack`, `apps/scripts` | Development and code-generation utilities; they register no API of their own, though `apps/scripts` starts the [container-based local environment](#container-based-local-environment).                                                                                                                                                                                                  |
+| Jaeger                      | Bundled third-party trace ingestion and UI, not a BoxLite-owned API; deployed behind an internal load balancer on `80` for the UI (`16686`) and `4318` for OTLP/HTTP.                                                                                                                                                                                                                    |
+| PgAdmin                     | Bundled third-party database administration UI; deployed behind an internal load balancer on `80`, reachable only from inside the VPC.                                                                                                                                                                                                                                                   |
+| MailDev                     | Bundled third-party SMTP test service and UI in deployed environments, behind an internal load balancer on `80` (UI `1080`); not part of the local stack.                                                                                                                                                                                                                                |
+
+MinIO, the registry UI, and Caddy are bundled only in the local development
+stack, and a Docker registry appears in both local environments, so all of their
+interfaces are listed under
+[Local development stack](#local-development-stack) and
+[Container-based local environment](#container-based-local-environment) rather
+than here.
 
 Libraries under `apps/libs` — generated API clients and shared Go packages —
 are consumed by the services above; they are not services. A generated client
 specification alone is therefore not treated as a live endpoint unless a
-runtime application registers the route.
+runtime application registers the route. Where a client has no in-repo server,
+it is listed under [Externally served APIs](#externally-served-apis).
 
 </details>

--- a/apps/README.md
+++ b/apps/README.md
@@ -97,8 +97,11 @@ The deployment runbook and operational constraints live in
 
 ## API catalog
 
-See [`API.md`](./API.md) for the categorized inventory of every registered
-application API, including its method, path, owning service, and purpose.
+See [`API.md`](./API.md) for the categorized inventory of every application
+interface, including its method, path, owning service, and purpose. Alongside
+the registered routes it covers outbound events, static asset trees, the local
+development stack, and the APIs whose clients live here but whose routes are
+served elsewhere.
 
 ## Data model
 


### PR DESCRIPTION
## Summary

The apps API catalog listed every registered HTTP route but no other kind of
interface. Outbound events, static asset trees, both local environments, and the
APIs whose clients live here but whose routes are served elsewhere were absent.
This adds them, and records the source each inventory is grounded in.

## Call graph

Before

```text
API.md · Control-plane API
  Realtime and asynchronous interfaces
    ├─ NotificationGateway         (Api · apps/api/src/notification/gateways/notification.gateway.ts:29)   — 9 Socket.IO events, catalogued
    ├─ AuditKafkaConsumer          (Api · apps/api/src/audit/publishers/kafka/audit-kafka-consumer.controller.ts:22) — audit-logs topic, catalogued
    ├─ WebhookEventHandlerService  (Api · apps/api/src/webhook/services/webhook-event-handler.service.ts:37) — 4 Svix events, ABSENT
    └─ KafkaExceptionFilter        (Api · apps/api/src/filters/kafka-exception.filter.ts:97)               — audit-logs.dlq topic, ABSENT
  ServeStaticModule                (Api · apps/api/src/app.module.ts:108)                                  — 2 static asset trees, ABSENT
API.md · (no section)
  ├─ ServiceSpec[]                (infra-local · apps/infra-local/compose/services.py:51)                  — 10 services + Caddy entry, ABSENT
  ├─ runLocalDexEnvironment       (scripts · apps/scripts/local-dex-env.mjs:46)                            — 4 containers + 4 processes, ABSENT
  ├─ AnalyticsApi                 (libs · apps/libs/analytics-api-client/swagger.json)                     — 8 external routes, ABSENT
  ├─ BillingApiClient             (dashboard · apps/dashboard/src/billing-api/billingApiClient.ts:25)      — 20 external routes, ABSENT
  └─ MetricsInterceptor           (Api · apps/api/src/interceptors/metrics.interceptor.ts:72)              — PostHog capture stream, ABSENT
```

After

```text
API.md · Control-plane API
  Realtime and asynchronous interfaces · 16 rows
    ├─ NotificationGateway         (Api · apps/api/src/notification/gateways/notification.gateway.ts:29)   — 9 Socket.IO events
    ├─ AuditKafkaConsumer          (Api · apps/api/src/audit/publishers/kafka/audit-kafka-consumer.controller.ts:22) — audit-logs topic
    ├─ WebhookEventHandlerService  (Api · apps/api/src/webhook/services/webhook-event-handler.service.ts:37) — 4 Svix events, delivery contrasted with Socket.IO
    └─ KafkaExceptionFilter        (Api · apps/api/src/filters/kafka-exception.filter.ts:97)               — audit-logs.dlq topic
  Static asset trees · 2 trees
    └─ ServeStaticModule           (Api · apps/api/src/app.module.ts:108)                                  — /runner-amd64 and the dashboard SPA, with cache policy
API.md · Local development stack
  └─ ServiceSpec[]                 (infra-local · apps/infra-local/compose/services.py:51)                  — Caddy entry (9 routes), 10 services, 4 host processes
API.md · Container-based local environment
  └─ runLocalDexEnvironment        (scripts · apps/scripts/local-dex-env.mjs:46)                            — 4 containers, 4 host processes, the only runner of dex/config.yaml
API.md · Externally served APIs
  ├─ AnalyticsApi                  (libs · apps/libs/analytics-api-client/swagger.json)                     — 8 routes, base URL from GET /api/config
  ├─ BillingApiClient              (dashboard · apps/dashboard/src/billing-api/billingApiClient.ts:25)      — 20 routes, base URL from GET /api/config
  └─ MetricsInterceptor            (Api · apps/api/src/interceptors/metrics.interceptor.ts:72)              — server api_* events, two groupIdentify calls, feature flags
```

## Changes

- Add 4 outbound Svix webhook events and the `audit-logs.dlq` topic to the
  realtime section, noting that the four names shared with Socket.IO differ in
  delivery and that the `template.*` enum values have no emitter.
- Add the two static asset trees, their cache policy, and the provenance of the
  file `/runner-amd64` resolves to — only a full local build stages one, and no
  in-repo client fetches it.
- Add a Local development stack section: Caddy's entry point and admin API, ten
  dependency services with host-to-container ports, and four host processes.
- Add a Container-based local environment section for `dev:dex` / `e2e:local`:
  four containers and the four host processes served alongside them. It is the
  only environment here that runs `dex/config.yaml`; the boxed stack serves its
  own inline Dex config.
- Add an Externally served APIs section for the analytics and billing APIs plus
  PostHog and Pylon, whose clients live in this directory but whose routes are
  served elsewhere.
- Record the source each inventory is grounded in, note the deployed ports of
  the bundled third-party tools, and widen `apps/README.md`'s description of the
  catalog to match its new scope.

## How to verify

- Route tables are unchanged from `HEAD`: `git diff HEAD -- apps/API.md | grep '^[-+]| \`'`
  shows no removed or renamed method/path cell.
- Every added claim resolves: each row cites a file that exists at the stated
  path, and the anchors added to the glance table match the new `##` headings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded the API catalog to include static assets, realtime and webhook interfaces, Kafka dead-letter handling, local development APIs, externally served APIs, and supporting services.
  - Updated service overviews, control-plane descriptions, implementation references, and route counts.
  - Clarified the catalog overview to cover routes, outbound events, static assets, local APIs, and externally served APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->