### PR TITLE
feat(box): start containers in the background

### DIFF
--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -300,7 +300,7 @@ func (c *Client) Create(ctx context.Context, boxDto dto.CreateBoxDTO) (string, s
 
 	// bx.Start must stay the last step of Create that can fail.
 	//
-	// A successful Start makes BoxLite publish the box's StartedAt,
+	// A successful Start publishes StartedAt when BoxLite moves the box to Running,
 	// and BoxSync reads it as evidence this job body succeeded — it is what
 	// lets a lost job-completion callback be repaired later. A fallible step
 	// added below would publish that evidence for a Create that then returns

--- a/apps/runner/pkg/boxlite/create_invariant_test.go
+++ b/apps/runner/pkg/boxlite/create_invariant_test.go
@@ -15,7 +15,7 @@ import (
 // TestCreateHasNoFallibleStepAfterStart guards the coupling documented at the
 // bx.Start call in Create.
 //
-// A successful bx.Start makes BoxLite publish the box's StartedAt, which
+// A successful bx.Start publishes StartedAt when BoxLite moves the box to Running, which
 // BoxSync reads as evidence that this whole job body succeeded. That only holds
 // while Start is the last step of Create that can fail. Nothing about the
 // current code enforces it — replacing the hardcoded daemon version with a real

--- a/apps/runner/pkg/services/box_sync.go
+++ b/apps/runner/pkg/services/box_sync.go
@@ -37,12 +37,12 @@ type BoxSyncService struct {
 }
 
 // localContainerState pairs a box's local runtime state with its durable
-// Container.Start timestamp from the same BoxInfo snapshot.
+// service-level start timestamp from the same BoxInfo snapshot.
 type localContainerState struct {
 	state enums.BoxState
-	// startedAt is non-nil when BoxLite recorded a successful Container.Start
-	// for the current or most recently ended lifecycle. Callers combine it with
-	// state before treating it as evidence that the box is running now.
+	// startedAt is non-nil when BoxLite recorded the box entering Running for
+	// the current or most recently ended lifecycle. Callers combine it with state
+	// before treating it as evidence that the box is running now.
 	startedAt *time.Time
 }
 
@@ -76,14 +76,14 @@ func (s *BoxSyncService) GetLocalContainerStates(ctx context.Context) (map[strin
 	return boxStates, nil
 }
 
-// boxStartedAt reports when BoxLite confirmed a successful Container.Start for
-// the current or most recently ended lifecycle, or nil when no lifecycle has
-// such confirmation.
+// boxStartedAt reports when BoxLite most recently transitioned the box into
+// Running for the current or most recently ended lifecycle, or nil when no
+// service-level start time was recorded.
 //
-// BoxLite publishes the timestamp beside the PID it belongs to and voids it in
-// the same write that publishes a new lifecycle's PID. That only buys the
-// reader anything while state and timestamp come from one snapshot, which is
-// why both are read off the same `BoxInfo`.
+// BoxLite publishes the timestamp beside the PID and Running state. Recovery
+// clears it if it adopts a different PID whose start time is unknown. State
+// and timestamp must come from the same `BoxInfo` snapshot so they cannot
+// describe two lifecycles.
 func boxStartedAt(box sdkboxlite.BoxInfo) *time.Time {
 	if box.StartedAt.IsZero() {
 		return nil
@@ -213,13 +213,13 @@ func (s *BoxSyncService) PerformSync(ctx context.Context) error {
 // canReport decides whether this runner may state its local view to the
 // control plane for a given remote state.
 //
-// A box the control plane still shows as coming up is the one case where the
-// local view is not self-evidently authoritative: BoxLite publishes Running
-// once the VM is up, which happens before the guest's separate Container.Start
-// runs. Reporting STARTED off that alone would call a box ready whose init was
-// never launched — so a transitional box additionally needs BoxLite's durable
-// record that Container.Start did succeed for the shim now running it. Both
-// facts come from one `BoxInfo`, so they cannot describe two lifecycles.
+// A box the control plane still shows as coming up is reconciled only after
+// BoxLite has durably published the service-level start: PID, Running, and
+// StartedAt from one BoxInfo snapshot. The timestamp records the transition
+// into Running, not readiness or completion of the configured user task.
+// Requiring it distinguishes a recorded box start from an incomplete or legacy
+// local snapshot while keeping state and timestamp tied to the same lifecycle.
+// Every fact comes from one `BoxInfo`, so they cannot describe two lifecycles.
 //
 // Every other remote state keeps the long-standing behaviour: the local view
 // wins unconditionally.

--- a/apps/runner/pkg/services/box_sync_test.go
+++ b/apps/runner/pkg/services/box_sync_test.go
@@ -27,12 +27,12 @@ func TestBoxStartedAt(t *testing.T) {
 		want *time.Time
 	}{
 		{
-			name: "box reports a confirmed container start",
+			name: "box reports a recorded Running transition",
 			info: sdkboxlite.BoxInfo{ID: "box-1", PID: 4242, StartedAt: startedAt},
 			want: &startedAt,
 		},
 		{
-			name: "running box whose init was never launched",
+			name: "box has no recorded Running transition",
 			info: sdkboxlite.BoxInfo{ID: "box-1", PID: 4242},
 			want: nil,
 		},
@@ -152,14 +152,14 @@ func newSyncServiceForTest(
 	}
 }
 
-func TestPerformSyncConfirmsTransitionalBoxOnlyWithAConfirmedStart(t *testing.T) {
+func TestPerformSyncConfirmsTransitionalBoxOnlyWithARecordedStart(t *testing.T) {
 	tests := []struct {
 		name          string
 		startedAt     time.Time
 		wantStateSent bool
 	}{
-		{name: "container start confirmed", startedAt: time.Now(), wantStateSent: true},
-		{name: "running but init never launched", wantStateSent: false},
+		{name: "box start recorded", startedAt: time.Now(), wantStateSent: true},
+		{name: "Running without a recorded start", wantStateSent: false},
 	}
 
 	for _, tt := range tests {

--- a/docs/reference/cli/README.md
+++ b/docs/reference/cli/README.md
@@ -463,9 +463,9 @@ Show detailed information for one or more boxes.
 | `--format FMT` | `-f` | `json` | `json`, `yaml`, or a Go template (e.g. `'{{.State.Status}}'`) |
 
 The Go-template engine exposes a `json` function for serializing nested values.
-`State.StartedAt` is the most recent successful container start timestamp in
-RFC 3339 format, or `null` if it has not been recorded or is unavailable over
-REST.
+`State.StartedAt` is when the box most recently entered `Running`, in RFC 3339
+format, or `null` if the start time has not been recorded or is unavailable
+over REST.
 
 **Examples:**
 

--- a/docs/reference/nodejs/README.md
+++ b/docs/reference/nodejs/README.md
@@ -219,7 +219,7 @@ Metadata about a box.
 | `name` | `string \| undefined` | User-defined name |
 | `state` | `JsBoxStateInfo` | Runtime state with `status`, `running`, and optional `pid` fields |
 | `createdAt` | `string` | Creation timestamp (ISO 8601) |
-| `startedAt` | `string \| undefined` | Most recent successful container start timestamp (RFC 3339); absent if not recorded or unavailable over REST |
+| `startedAt` | `string \| undefined` | Time when the box most recently entered `Running` (RFC 3339); absent if not recorded or unavailable over REST |
 | `image` | `string` | OCI image reference or rootfs path |
 | `cpus` | `number` | Allocated CPU count |
 | `memoryMib` | `number` | Allocated memory in MiB |

--- a/docs/reference/python/README.md
+++ b/docs/reference/python/README.md
@@ -246,7 +246,7 @@ Metadata about a box.
 | `name` | `str \| None` | Optional user-assigned name |
 | `state` | `BoxStateInfo` | Runtime state with `status`, `running`, and nullable `pid` fields |
 | `created_at` | `str` | ISO 8601 creation timestamp |
-| `started_at` | `str \| None` | Most recent successful container start timestamp (RFC 3339); `None` if not recorded or unavailable over REST |
+| `started_at` | `str \| None` | Time when the box most recently entered `Running` (RFC 3339); `None` if not recorded or unavailable over REST |
 | `image` | `str` | OCI image used |
 | `cpus` | `int` | Allocated CPU cores |
 | `memory_mib` | `int` | Allocated memory in MiB |

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -318,11 +318,11 @@ typedef struct CBoxInfo {
   int64_t created_at;
   // Owned typed network metadata; null when network metadata is unavailable.
   struct CNetworkInfo *network;
-  // Unix milliseconds of the most recently recorded successful guest
-  // `Container.Start`; `0` when none was recorded. Preserved after stop or
-  // reboot; when [`Self::pid`] is nonzero, the timestamp describes that live
-  // PID. Milliseconds — not `created_at`'s seconds — preserve sub-second
-  // ordering against a job's timeline.
+  // Unix milliseconds when the box most recently entered `Running`; `0`
+  // when no start time was recorded. Preserved after stop or reboot; when
+  // [`Self::pid`] is nonzero, the timestamp describes that live PID.
+  // Milliseconds — not `created_at`'s seconds — preserve sub-second ordering
+  // against a job's timeline.
   int64_t started_at;
 } CBoxInfo;
 

--- a/sdks/c/src/info.rs
+++ b/sdks/c/src/info.rs
@@ -78,11 +78,11 @@ pub struct CBoxInfo {
     pub created_at: i64,
     /// Owned typed network metadata; null when network metadata is unavailable.
     pub network: *mut CNetworkInfo,
-    /// Unix milliseconds of the most recently recorded successful guest
-    /// `Container.Start`; `0` when none was recorded. Preserved after stop or
-    /// reboot; when [`Self::pid`] is nonzero, the timestamp describes that live
-    /// PID. Milliseconds — not `created_at`'s seconds — preserve sub-second
-    /// ordering against a job's timeline.
+    /// Unix milliseconds when the box most recently entered `Running`; `0`
+    /// when no start time was recorded. Preserved after stop or reboot; when
+    /// [`Self::pid`] is nonzero, the timestamp describes that live PID.
+    /// Milliseconds — not `created_at`'s seconds — preserve sub-second ordering
+    /// against a job's timeline.
     pub started_at: i64,
 }
 

--- a/sdks/go/info.go
+++ b/sdks/go/info.go
@@ -61,11 +61,11 @@ type BoxInfo struct {
 	AutoDelete uint32
 	AutoResume bool
 	CreatedAt  time.Time
-	// StartedAt is when the guest's Container.Start most recently returned
-	// success; the zero time means no successful start has been recorded. It is
-	// preserved after stop or reboot, and describes PID whenever PID is nonzero.
-	// State alone cannot answer whether the current init launched — a box reports
-	// Running from the moment its VM is up, before its init is started.
+	// StartedAt is when the box most recently entered Running; the zero time
+	// means no such start time has been recorded. It is preserved after stop or
+	// reboot and describes PID whenever PID is nonzero. It does not report when
+	// the configured user task becomes ready, exits, or completes; those are
+	// workload lifecycle outcomes.
 	StartedAt time.Time
 }
 

--- a/sdks/node/src/info.rs
+++ b/sdks/node/src/info.rs
@@ -184,7 +184,7 @@ pub struct JsBoxInfo {
     /// Creation timestamp (ISO 8601 format)
     pub created_at: String,
 
-    /// Most recent successful container start timestamp (RFC 3339), when recorded
+    /// When the box most recently entered `Running` (RFC 3339), when recorded
     pub started_at: Option<String>,
 
     /// Image reference or rootfs path

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -143,7 +143,12 @@ pub(crate) struct BoxImpl {
     /// client can attach first. This single-flights that step across every
     /// implicit-boot caller and an explicit `start()`, and is pre-set when we
     /// reattach to a box whose init is already running.
-    container_start: OnceCell<()>,
+    container_start: Arc<OnceCell<()>>,
+
+    #[cfg(test)]
+    background_starts_finished: Arc<std::sync::atomic::AtomicUsize>,
+    #[cfg(test)]
+    background_start_finished: Arc<tokio::sync::Notify>,
 }
 
 impl BoxImpl {
@@ -182,7 +187,11 @@ impl BoxImpl {
             event_listeners: Vec::new(), // populated from runtime options
             live: OnceCell::new(),
             watcher: std::sync::OnceLock::new(),
-            container_start: OnceCell::new(),
+            container_start: Arc::new(OnceCell::new()),
+            #[cfg(test)]
+            background_starts_finished: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            #[cfg(test)]
+            background_start_finished: Arc::new(tokio::sync::Notify::new()),
         }
     }
 
@@ -293,26 +302,58 @@ impl BoxImpl {
         // makes `run` docker-shaped — create, attach, then start. `run` slips the
         // attach between these two calls; every other caller just wants both.
         let live = self.ensure_booted().await?;
-        let started_now = self.ensure_container_started(live).await?;
+        let guest_session = live.guest_session.clone();
+        let container_start = Arc::clone(&self.container_start);
+        let shutdown_token = self.shutdown_token.child_token();
+        let container_id = self.container_id().to_owned();
+        let box_id = self.config.id.clone();
+        let event_listeners = self.event_listeners.clone();
+        #[cfg(test)]
+        let background_starts_finished = Arc::clone(&self.background_starts_finished);
+        #[cfg(test)]
+        let background_start_finished = Arc::clone(&self.background_start_finished);
 
-        // Nothing below may fail. `ensure_container_started` has already
-        // published `started_at` (see [`Self::record_started`]), and readers of
-        // it — the cloud runner among them — take it as evidence that this
-        // whole call succeeded. A fallible step added here would publish that
-        // evidence for a start that then returned `Err`.
-        //
-        // Announce the start only when *this* call actually ran init — not on an
-        // idempotent re-`start()` or a reattach to an already-running box.
-        if started_now {
-            for listener in &self.event_listeners {
-                listener.on_box_started(&self.config.id);
+        tokio::spawn(async move {
+            match Self::ensure_container_started_owned(
+                container_start,
+                guest_session,
+                container_id,
+                shutdown_token,
+            )
+            .await
+            {
+                Ok(true) => {
+                    for listener in &event_listeners {
+                        listener.on_box_started(&box_id);
+                    }
+                    tracing::info!(
+                        box_id = %box_id,
+                        elapsed_ms = t0.elapsed().as_millis() as u64,
+                        "Box started"
+                    );
+                }
+                Ok(false) => {}
+                Err(BoxliteError::Stopped(_)) => {
+                    tracing::debug!(
+                        box_id = %box_id,
+                        "Container start cancelled because the box is stopping"
+                    );
+                }
+                Err(error) => {
+                    tracing::error!(
+                        box_id = %box_id,
+                        error = %error,
+                        "Container start failed in background"
+                    );
+                }
             }
-            tracing::info!(
-                box_id = %self.config.id,
-                elapsed_ms = t0.elapsed().as_millis() as u64,
-                "Box started"
-            );
-        }
+
+            #[cfg(test)]
+            {
+                background_starts_finished.fetch_add(1, Ordering::SeqCst);
+                background_start_finished.notify_waiters();
+            }
+        });
         Ok(())
     }
 
@@ -663,7 +704,7 @@ impl BoxImpl {
         // through the restart pipeline and spawn a new VM — exactly what
         // stop() must NOT do.
         let should_attach = self.state.read().status == BoxStatus::Running;
-        if should_attach && let Ok(live) = self.live_state().await {
+        if should_attach && let Ok(live) = self.ensure_booted().await {
             // Recovered boxes lazy-attach here via vmm_attach (now
             // ProcessIdentity-gated). Live boxes hit the cached LiveState.
             // Either way the teardown is identical:
@@ -977,66 +1018,57 @@ impl BoxImpl {
         self.live.get_or_try_init(|| self.init_live_state()).await
     }
 
-    /// Run the container's init exactly once, returning whether *this* call did
-    /// it (vs. finding it already running). Booting only creates the container;
-    /// this is the separate `Container.Start`. Single-flighted via `OnceCell`, so
-    /// the implicit-boot funnel and an explicit `start()` cannot double-run it,
+    /// Run the container's init exactly once. Booting only creates the container;
+    /// this is the separate `Container.Start`. Single-flighted via `OnceCell`,
+    /// so the implicit-boot funnel and an explicit `start()` cannot double-run it,
     /// and a box reattached with init already running pre-sets the cell.
-    async fn ensure_container_started(&self, live: &LiveState) -> BoxliteResult<bool> {
-        // `get_or_try_init` single-flights the closure but hands every concurrent
-        // caller the same `Ok`, so it cannot tell the winner from the waiters. A
-        // closure-local flag is set only inside the body that actually runs, so
-        // exactly one caller reports that it started the container (and a cell
-        // already set — e.g. a reattached, still-running box — leaves it false).
+    async fn ensure_container_started(&self, live: &LiveState) -> BoxliteResult<()> {
+        Self::ensure_container_started_owned(
+            Arc::clone(&self.container_start),
+            live.guest_session.clone(),
+            self.container_id().to_owned(),
+            self.shutdown_token.child_token(),
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Owned form used by explicit `start()` so the RPC can outlive that call.
+    ///
+    /// Returns `true` only when this call actually executes and successfully
+    /// completes the `Container.Start` initializer.
+    async fn ensure_container_started_owned(
+        container_start: Arc<OnceCell<()>>,
+        guest_session: GuestSession,
+        container_id: String,
+        shutdown_token: CancellationToken,
+    ) -> BoxliteResult<bool> {
+        // Cancellation or an RPC error leaves the cell empty, allowing a later
+        // explicit or implicit operation to retry.
         let mut started_here = false;
-        self.container_start
-            .get_or_try_init(|| async {
-                live.guest_session
+        {
+            let start = container_start.get_or_try_init(|| async {
+                guest_session
                     .container()
                     .await?
-                    .start(self.container_id())
+                    .start(&container_id)
                     .await?;
                 started_here = true;
                 Ok::<(), BoxliteError>(())
-            })
-            .await?;
-        if started_here {
-            self.record_started();
+            });
+            tokio::select! {
+                biased;
+                _ = shutdown_token.cancelled() => {
+                    return Err(BoxliteError::Stopped(format!(
+                        "Container start cancelled for container {container_id}"
+                    )));
+                }
+                result = start => {
+                    result?;
+                }
+            }
         }
         Ok(started_here)
-    }
-
-    /// Publish `started_at` for this lifecycle.
-    ///
-    /// The counterpart of the shim's `exit` file: one names how the box died,
-    /// this names that its init was launched. It rides in `BoxState` beside the
-    /// PID it belongs to, so the pair is written and read as one row and no
-    /// consumer has to re-derive which shim the timestamp describes.
-    ///
-    /// A failed persist is logged, never propagated — the guest RPC already
-    /// succeeded and the box is running, so turning a bookkeeping failure into
-    /// a start failure would be a worse answer than the missing timestamp.
-    ///
-    /// **Consumers treat this as evidence that the whole start succeeded**, so
-    /// `start()` must not grow a fallible step after `ensure_container_started`.
-    /// See the note at the tail of [`Self::start`].
-    fn record_started(&self) {
-        let (persist_result, pid) = {
-            let mut state = self.state.write();
-            state.mark_started();
-            let pid = state.pid;
-            let result = self.runtime.box_manager.save_box(&self.config.id, &state);
-            (result, pid)
-        };
-
-        if let Err(error) = persist_result {
-            tracing::error!(
-                box_id = %self.config.id,
-                pid = ?pid,
-                error = %error,
-                "Container.Start succeeded but the start could not be recorded"
-            );
-        }
     }
 
     /// The box's network control backend (gvproxy ServicesMux client), owned in
@@ -1141,20 +1173,18 @@ impl BoxImpl {
             let mut state = self.state.write();
             state.set_pid(Some(pid));
             state.set_status(BoxStatus::Running);
+            // A box entering Running publishes its PID, status, and `started_at`
+            // timestamp atomically. An adopted Running box is the same lifecycle,
+            // so its existing Some/None value must be preserved.
+            if !adopting_running {
+                state.mark_started();
+            }
+
             // This is a fresh run of the box's main command, so the exit code
             // recorded for the previous one no longer describes it (docker
             // clears ExitCode on start too). The guest drops its matching
             // exit file in Container.Init.
             state.exit_code = None;
-            // Same reasoning for the start record, and this is the write that
-            // makes it safe: publishing the new PID and voiding the previous
-            // lifecycle's evidence happen in one `save_box`, so no reader can
-            // ever see this shim paired with the last one's start. Adopting a
-            // *running* box is not a new lifecycle — its record still names the
-            // live shim and must survive.
-            if !adopting_running {
-                state.started_at = None;
-            }
 
             // Initialize health status if health check is configured
             if self.config.options.advanced.health_check.is_some() {
@@ -1200,7 +1230,7 @@ impl BoxImpl {
 
         tracing::info!(
             box_id = %self.config.id,
-            "Box started successfully (first_start={})",
+            "Box booted successfully (first_start={})",
             is_first_start
         );
         // Lock is automatically released when _guard drops
@@ -1489,9 +1519,17 @@ mod tests {
     use crate::util::{PidFileWriter, PidRecord, ShimPidRecord, is_process_alive};
     use crate::vmm::VmmKind;
     use crate::vmm::controller::VmmMetrics;
-    use boxlite_shared::BoxTransport;
+    use boxlite_shared::{
+        BoxTransport, Container as ContainerService, ContainerInitRequest, ContainerInitResponse,
+        ContainerInitSuccess, ContainerServer, ContainerStartRequest, ContainerStartResponse,
+        ContainerStartSuccess, container_init_response, container_start_response,
+    };
     use chrono::Utc;
+    use std::sync::atomic::{AtomicBool, AtomicUsize};
     use tempfile::TempDir;
+    use tokio::sync::{Notify, Semaphore};
+    use tonic::transport::{Endpoint, Server};
+    use tonic::{Request, Response, Status};
 
     fn published_ports(info: &BoxInfo) -> Option<&[PublishedPort]> {
         info.network
@@ -1539,34 +1577,150 @@ mod tests {
         }
     }
 
-    struct RecordStartedSaveGate {
-        entered: std::sync::mpsc::Sender<()>,
-        release: std::sync::mpsc::Receiver<()>,
+    struct StartGate {
+        calls: AtomicUsize,
+        should_fail: AtomicBool,
+        entered: Semaphore,
+        release: Semaphore,
     }
 
-    static RECORD_STARTED_SAVE_GATE: std::sync::Mutex<Option<RecordStartedSaveGate>> =
-        std::sync::Mutex::new(None);
-
-    fn block_record_started_save(_: i32) -> bool {
-        let gate = RECORD_STARTED_SAVE_GATE
-            .lock()
-            .expect("record-started save gate lock poisoned")
-            .take();
-        let Some(gate) = gate else {
-            return false;
-        };
-
-        gate.entered.send(()).is_ok() && gate.release.recv().is_ok()
+    impl Default for StartGate {
+        fn default() -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                should_fail: AtomicBool::new(false),
+                entered: Semaphore::new(0),
+                release: Semaphore::new(0),
+            }
+        }
     }
 
-    #[test]
-    fn record_started_holds_state_lock_until_persist_completes() {
+    #[derive(Clone)]
+    struct StartStubGuest {
+        gate: Arc<StartGate>,
+    }
+
+    #[tonic::async_trait]
+    impl ContainerService for StartStubGuest {
+        async fn init(
+            &self,
+            request: Request<ContainerInitRequest>,
+        ) -> Result<Response<ContainerInitResponse>, Status> {
+            let container_id = request.into_inner().container_id;
+            Ok(Response::new(ContainerInitResponse {
+                result: Some(container_init_response::Result::Success(
+                    ContainerInitSuccess { container_id },
+                )),
+            }))
+        }
+
+        async fn start(
+            &self,
+            request: Request<ContainerStartRequest>,
+        ) -> Result<Response<ContainerStartResponse>, Status> {
+            let container_id = request.into_inner().container_id;
+            self.gate.calls.fetch_add(1, Ordering::SeqCst);
+            self.gate.entered.add_permits(1);
+            self.gate
+                .release
+                .acquire()
+                .await
+                .expect("start release semaphore closed")
+                .forget();
+
+            if self.gate.should_fail.load(Ordering::SeqCst) {
+                return Err(Status::internal("injected Container.Start failure"));
+            }
+
+            Ok(Response::new(ContainerStartResponse {
+                result: Some(container_start_response::Result::Success(
+                    ContainerStartSuccess { container_id },
+                )),
+            }))
+        }
+    }
+
+    #[derive(Default)]
+    struct StartedCounter {
+        count: AtomicUsize,
+        changed: Notify,
+    }
+
+    impl StartedCounter {
+        async fn wait_for(&self, expected: usize) {
+            loop {
+                let notified = self.changed.notified();
+                tokio::pin!(notified);
+                notified.as_mut().enable();
+                if self.count.load(Ordering::SeqCst) >= expected {
+                    return;
+                }
+                notified.await;
+            }
+        }
+    }
+
+    impl EventListener for StartedCounter {
+        fn on_box_started(&self, _: &BoxID) {
+            self.count.fetch_add(1, Ordering::SeqCst);
+            self.changed.notify_waiters();
+        }
+    }
+
+    async fn start_stub_guest(gate: Arc<StartGate>) -> (GuestSession, JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind stub guest");
+        let address = listener.local_addr().expect("read stub guest address");
+        let incoming = tonic::transport::server::TcpIncoming::from_listener(listener, true, None)
+            .expect("configure stub guest listener");
+
+        let server = tokio::spawn(async move {
+            Server::builder()
+                .add_service(ContainerServer::new(StartStubGuest { gate }))
+                .serve_with_incoming(incoming)
+                .await
+                .expect("serve stub guest");
+        });
+
+        let endpoint =
+            Endpoint::from_shared(format!("http://{address}")).expect("build stub guest endpoint");
+        let mut attempts = 0;
+        loop {
+            match endpoint.connect().await {
+                Ok(_) => break,
+                Err(error) => {
+                    attempts += 1;
+                    assert!(attempts < 100, "stub guest did not start: {error}");
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+            }
+        }
+
+        (GuestSession::new(BoxTransport::tcp(address.port())), server)
+    }
+
+    struct StartFixture {
+        box_impl: Arc<BoxImpl>,
+        listener: Arc<StartedCounter>,
+        _temp_dir: TempDir,
+        server: JoinHandle<()>,
+    }
+
+    impl Drop for StartFixture {
+        fn drop(&mut self) {
+            self.server.abort();
+        }
+    }
+
+    async fn running_box_for_start_test(gate: Arc<StartGate>) -> StartFixture {
         let temp_dir = TempDir::new_in("/tmp").expect("create temp dir");
         let runtime = RuntimeImpl::new_for_test(BoxliteOptions {
             home_dir: temp_dir.path().to_path_buf(),
             image_registries: vec![],
         })
         .expect("create runtime");
+        let (guest_session, server) = start_stub_guest(gate).await;
 
         let id = BoxIDMint::mint();
         let config = BoxConfig {
@@ -1587,77 +1741,208 @@ mod tests {
         };
         let mut state = BoxState::new();
         state.status = BoxStatus::Running;
-        state.pid = Some(4242);
+        state.mark_started();
         state.set_lock_id(runtime.lock_manager.allocate().expect("allocate lock"));
         runtime
             .box_manager
             .add_box(&config, &state)
-            .expect("add box to manager");
+            .expect("persist test box");
 
-        let box_impl = Arc::new(BoxImpl::new(
+        let listener = Arc::new(StartedCounter::default());
+        let mut box_impl = BoxImpl::new(
             config,
             state,
             runtime.clone(),
             runtime.shutdown_token.child_token(),
-        ));
-        let (entered_tx, entered_rx) = std::sync::mpsc::channel();
-        let (release_tx, release_rx) = std::sync::mpsc::channel();
-        *RECORD_STARTED_SAVE_GATE
-            .lock()
-            .expect("record-started save gate lock poisoned") = Some(RecordStartedSaveGate {
-            entered: entered_tx,
-            release: release_rx,
-        });
-
-        // Hold SQLite's writer lock so its busy handler marks the exact point
-        // where record_started has entered the real persistence operation.
-        let database = runtime.box_manager.db();
-        let db_path = {
-            let conn = database.conn();
-            conn.busy_handler(Some(block_record_started_save))
-                .expect("install busy handler");
-            conn.path().expect("database has a path").to_owned()
-        };
-        let blocker = rusqlite::Connection::open(db_path).expect("open blocking connection");
-        blocker
-            .execute_batch("BEGIN IMMEDIATE")
-            .expect("acquire SQLite write lock");
-
-        let worker_box = Arc::clone(&box_impl);
-        let worker = std::thread::spawn(move || worker_box.record_started());
-        let reached_persist = entered_rx.recv_timeout(Duration::from_secs(5)).is_ok();
-        let state_lock_held = reached_persist && box_impl.state.try_write().is_none();
-
-        blocker
-            .execute_batch("ROLLBACK")
-            .expect("release SQLite write lock");
-        let _ = release_tx.send(());
-        worker.join().expect("record-started worker panicked");
-        database
-            .conn()
-            .busy_handler(None)
-            .expect("remove database busy handler");
-        *RECORD_STARTED_SAVE_GATE
-            .lock()
-            .expect("record-started save gate lock poisoned") = None;
-
-        assert!(
-            reached_persist,
-            "record_started did not reach the real SQLite update"
         );
-        assert!(
-            state_lock_held,
-            "record_started must hold the state write lock until persistence completes"
+        box_impl
+            .event_listeners
+            .push(listener.clone() as Arc<dyn EventListener>);
+
+        let live = LiveState::new(
+            Box::new(InfoTestHandler(0)),
+            guest_session,
+            None,
+            None,
+            BoxMetricsStorage::new(),
+            Disk::new(
+                temp_dir.path().join("container.qcow2"),
+                DiskFormat::Qcow2,
+                true,
+            ),
+            None,
+            #[cfg(target_os = "linux")]
+            None,
         );
-        assert!(
-            runtime
-                .box_manager
-                .update_box(&id)
-                .expect("load persisted state")
-                .started_at
-                .is_some(),
-            "record_started must persist the start timestamp"
+        assert!(box_impl.live.set(live).is_ok(), "install live state");
+
+        StartFixture {
+            box_impl: Arc::new(box_impl),
+            listener,
+            _temp_dir: temp_dir,
+            server,
+        }
+    }
+
+    async fn wait_for_background_starts(box_impl: &BoxImpl, expected: usize) {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let notified = box_impl.background_start_finished.notified();
+                tokio::pin!(notified);
+                notified.as_mut().enable();
+                if box_impl.background_starts_finished.load(Ordering::SeqCst) >= expected {
+                    return;
+                }
+                notified.await;
+            }
+        })
+        .await
+        .expect("background Container.Start task did not finish");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn explicit_start_returns_before_container_start_rpc_finishes() {
+        let gate = Arc::new(StartGate::default());
+        let fixture = running_box_for_start_test(Arc::clone(&gate)).await;
+
+        tokio::time::timeout(Duration::from_millis(250), fixture.box_impl.start())
+            .await
+            .expect("start() waited for Container.Start")
+            .expect("start() failed before spawning Container.Start");
+        gate.entered
+            .acquire()
+            .await
+            .expect("entered semaphore closed")
+            .forget();
+        assert_eq!(fixture.listener.count.load(Ordering::SeqCst), 0);
+
+        let implicit_box = Arc::clone(&fixture.box_impl);
+        let implicit = tokio::spawn(async move { implicit_box.live_state().await.map(|_| ()) });
+        fixture
+            .box_impl
+            .start()
+            .await
+            .expect("concurrent explicit start failed");
+
+        gate.release.add_permits(1);
+        implicit
+            .await
+            .expect("implicit start task panicked")
+            .expect("implicit start failed");
+        tokio::time::timeout(Duration::from_secs(5), fixture.listener.wait_for(1))
+            .await
+            .expect("successful Container.Start did not emit started event");
+        wait_for_background_starts(&fixture.box_impl, 2).await;
+
+        fixture
+            .box_impl
+            .start()
+            .await
+            .expect("idempotent explicit start failed");
+        wait_for_background_starts(&fixture.box_impl, 3).await;
+        assert_eq!(gate.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(fixture.listener.count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn explicit_start_does_not_announce_when_implicit_start_wins_single_flight() {
+        let gate = Arc::new(StartGate::default());
+        let fixture = running_box_for_start_test(Arc::clone(&gate)).await;
+
+        let implicit_box = Arc::clone(&fixture.box_impl);
+        let implicit = tokio::spawn(async move { implicit_box.live_state().await.map(|_| ()) });
+        gate.entered
+            .acquire()
+            .await
+            .expect("entered semaphore closed")
+            .forget();
+
+        fixture
+            .box_impl
+            .start()
+            .await
+            .expect("concurrent explicit start failed");
+        gate.release.add_permits(1);
+
+        implicit
+            .await
+            .expect("implicit start task panicked")
+            .expect("implicit start failed");
+        wait_for_background_starts(&fixture.box_impl, 1).await;
+
+        assert_eq!(gate.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            fixture.listener.count.load(Ordering::SeqCst),
+            0,
+            "explicit waiter must not claim implicit start success"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn background_start_failure_preserves_state_and_can_retry() {
+        let gate = Arc::new(StartGate::default());
+        gate.should_fail.store(true, Ordering::SeqCst);
+        let fixture = running_box_for_start_test(Arc::clone(&gate)).await;
+        let started_at = fixture.box_impl.state.read().started_at;
+
+        fixture.box_impl.start().await.expect("spawn failed start");
+        gate.entered
+            .acquire()
+            .await
+            .expect("entered semaphore closed")
+            .forget();
+        gate.release.add_permits(1);
+        wait_for_background_starts(&fixture.box_impl, 1).await;
+
+        assert_eq!(fixture.box_impl.state.read().status, BoxStatus::Running);
+        assert_eq!(fixture.box_impl.state.read().started_at, started_at);
+        assert_eq!(fixture.listener.count.load(Ordering::SeqCst), 0);
+
+        gate.should_fail.store(false, Ordering::SeqCst);
+        fixture.box_impl.start().await.expect("spawn retry");
+        gate.entered
+            .acquire()
+            .await
+            .expect("retry entered semaphore closed")
+            .forget();
+        gate.release.add_permits(1);
+        tokio::time::timeout(Duration::from_secs(5), fixture.listener.wait_for(1))
+            .await
+            .expect("successful retry did not emit started event");
+        wait_for_background_starts(&fixture.box_impl, 2).await;
+        assert_eq!(gate.calls.load(Ordering::SeqCst), 2);
+        assert_eq!(fixture.listener.count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stop_cancels_in_flight_background_container_start() {
+        let gate = Arc::new(StartGate::default());
+        let fixture = running_box_for_start_test(Arc::clone(&gate)).await;
+
+        fixture.box_impl.start().await.expect("spawn start");
+        gate.entered
+            .acquire()
+            .await
+            .expect("entered semaphore closed")
+            .forget();
+        fixture.box_impl.stop().await.expect("stop booted box");
+        wait_for_background_starts(&fixture.box_impl, 1).await;
+        gate.release.add_permits(1);
+
+        assert_eq!(fixture.listener.count.load(Ordering::SeqCst), 0);
+        assert_eq!(gate.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(fixture.box_impl.state.read().status, BoxStatus::Stopped);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stopping_booted_box_does_not_start_container() {
+        let gate = Arc::new(StartGate::default());
+        let fixture = running_box_for_start_test(Arc::clone(&gate)).await;
+
+        fixture.box_impl.stop().await.expect("stop booted box");
+
+        assert_eq!(gate.calls.load(Ordering::SeqCst), 0);
+        assert_eq!(fixture.listener.count.load(Ordering::SeqCst), 0);
     }
 
     // Regression test for the silent-orphan bug in stop().

--- a/src/boxlite/src/litebox/state.rs
+++ b/src/boxlite/src/litebox/state.rs
@@ -232,25 +232,24 @@ pub struct BoxState {
     /// keeps existing DB rows readable without migration.
     #[serde(default)]
     pub exit_code: Option<i32>,
-    /// When the guest's `Container.Start` returned success for the lifecycle
-    /// that published [`Self::pid`] (docker's `State.StartedAt`).
+    /// When the box most recently entered [`BoxStatus::Running`] (docker's
+    /// `State.StartedAt`).
     ///
-    /// Deliberately not derivable from [`Self::status`]: booting only *creates*
-    /// the container, and `attach()` leaves a box `Running` with its init not
-    /// yet launched, so `Running` alone cannot answer "did this box's init
-    /// ever start". Survives a stop the way docker keeps `StartedAt` on an
-    /// exited container.
+    /// This is BoxLite's service-level start timestamp. It does not describe
+    /// when the configured user task becomes ready, exits, or completes. The
+    /// value survives stop the way docker keeps `StartedAt` on an exited
+    /// container.
     ///
     /// **Invariant — a live PID in this row is always the one this timestamp
-    /// describes.** Exactly two writes can put a different shim's PID here, and
-    /// both void the timestamp: the one that publishes a new lifecycle's PID
-    /// (`BoxImpl::init_live_state`) and the one recovery branch that can adopt
-    /// a PID this row never published ([`Self::adopt_recovered_shim`]). The
+    /// describes.** A fresh lifecycle publishes its PID, `Running` state, and
+    /// new timestamp atomically in `BoxImpl::init_live_state`. Recovery may also
+    /// adopt a PID this row never published ([`Self::adopt_recovered_shim`]);
+    /// that path clears the timestamp because its start time is unknown. The
     /// lifecycle-ending writes ([`Self::mark_stop`], [`Self::mark_failed`],
     /// [`Self::reset_for_reboot`]) instead clear only the PID and preserve
-    /// `Some(t)` — read that as "the run that just ended began at t", never as
-    /// "something is running". Readers therefore interpret the timestamp
-    /// together with the lifecycle state from the same snapshot.
+    /// `Some(t)` — read that as "the run that just ended entered Running at t",
+    /// never as "something is running". Readers therefore interpret the
+    /// timestamp together with the lifecycle state from the same snapshot.
     ///
     /// Serde default keeps existing DB rows readable without migration.
     #[serde(default)]
@@ -358,7 +357,7 @@ impl BoxState {
         }
     }
 
-    /// Record that this lifecycle's `Container.Start` returned success.
+    /// Record when this box enters [`BoxStatus::Running`].
     pub fn mark_started(&mut self) {
         let now = Utc::now();
         self.started_at = Some(now);
@@ -367,12 +366,12 @@ impl BoxState {
 
     /// Adopt a live shim that recovery found on disk.
     ///
-    /// The one place a PID can enter this row without having been published by
-    /// the boot that owns it: a crash between the shim writing its PID file and
-    /// the row being saved leaves the two naming different lifecycles. A
-    /// `started_at` written for the PID we are replacing cannot describe the
-    /// one we are adopting, so it goes with it — that is what lets every reader
-    /// take the timestamp at face value.
+    /// Recovery can find a live PID that this row did not publish with its
+    /// matching Running transition—for example, when a crash occurs between the
+    /// shim writing its PID file and this row being saved. A `started_at` written
+    /// for the PID we are replacing cannot describe the adopted one, so recovery
+    /// clears it. This keeps the PID and timestamp safe to read together as one
+    /// snapshot.
     pub fn adopt_recovered_shim(&mut self, pid: u32) {
         if self.pid != Some(pid) {
             self.started_at = None;
@@ -1062,12 +1061,12 @@ mod tests {
         assert!(state.health_status.last_check.is_none());
         assert!(
             state.started_at.is_none(),
-            "a row written before this field existed cannot claim a launched init"
+            "a row written before this field existed cannot claim a Running transition"
         );
     }
 
     #[test]
-    fn adopting_the_recorded_shim_keeps_its_container_start() {
+    fn adopting_the_recorded_shim_keeps_started_at() {
         let mut state = BoxState::new();
         state.set_pid(Some(4242));
         state.mark_started();
@@ -1077,13 +1076,13 @@ mod tests {
 
         assert_eq!(
             state.started_at, recorded,
-            "recovery re-attaching the same shim must not void the start it recorded"
+            "recovery re-attaching the same shim must preserve its Running timestamp"
         );
         assert_eq!(state.status, BoxStatus::Running);
     }
 
     #[test]
-    fn adopting_a_different_shim_voids_the_container_start() {
+    fn adopting_a_different_shim_voids_started_at() {
         // A crash between the shim writing its PID file and this row being
         // saved leaves recovery adopting a PID the row never published. The
         // timestamp describes the PID it was written with, so it cannot
@@ -1097,16 +1096,16 @@ mod tests {
         assert_eq!(state.pid, Some(4243));
         assert!(
             state.started_at.is_none(),
-            "a start recorded for pid 4242 must not be read as evidence about pid 4243"
+            "started_at for pid 4242 must not be read as evidence about pid 4243"
         );
     }
 
-    /// The three ways a lifecycle ends all keep the timestamp — docker's
-    /// `StartedAt` on an exited container. What makes that safe is that each
-    /// one drops the PID: `Some(started_at)` beside `pid: None` describes the
-    /// run that ended, and cannot be read as a live box.
+    /// The three ways a lifecycle ends all keep the timestamp, like docker's
+    /// `StartedAt` on an exited container. With the PID cleared,
+    /// `Some(started_at)` describes when the run that ended entered `Running`;
+    /// it cannot be read as a live box.
     #[test]
-    fn ending_a_lifecycle_keeps_the_start_and_drops_the_pid() {
+    fn ending_a_lifecycle_keeps_started_at_and_drops_the_pid() {
         let ended = |end: fn(&mut BoxState)| {
             let mut state = BoxState::new();
             state.set_pid(Some(4242));
@@ -1123,11 +1122,11 @@ mod tests {
         ] {
             assert!(
                 state.started_at.is_some(),
-                "{name} must keep the start of the run that just ended"
+                "{name} must keep when the run that just ended entered Running"
             );
             assert_eq!(
                 state.pid, None,
-                "{name} must drop the PID, or the kept start would read as a live box"
+                "{name} must drop the PID, or kept started_at would read as a live box"
             );
             assert!(
                 !state.status.is_active(),

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -350,9 +350,9 @@ impl BoxResponse {
             auto_resume: self.auto_resume,
             health_status: crate::litebox::HealthStatus::new(), // REST API doesn't provide health status
             exit_code: self.exit_code,
-            // Like `network`, this is local-lifecycle detail the remote REST
-            // surface does not publish; `None` says "not known here" rather
-            // than "init was never launched".
+            // Like `network`, the remote REST surface does not publish this
+            // local start timestamp; `None` means "not known here", not
+            // "the box never entered Running".
             started_at: None,
         })
     }

--- a/src/boxlite/src/runtime/types.rs
+++ b/src/boxlite/src/runtime/types.rs
@@ -401,16 +401,16 @@ pub struct BoxInfo {
     /// because its main command exited (docker semantics).
     pub exit_code: Option<i32>,
 
-    /// When the guest's `Container.Start` most recently returned success
-    /// (docker's `State.StartedAt`); `None` when no successful start has been
-    /// recorded. The value survives stop and reboot as lifecycle history. When
+    /// When the box most recently entered [`BoxStatus::Running`] (docker's
+    /// `State.StartedAt`); `None` when no service-level start was recorded.
+    /// The value survives stop and reboot as lifecycle history. When
     /// [`Self::pid`] is present, the timestamp describes that live PID.
     ///
-    /// Answers what [`Self::status`] cannot: `Running` is published once the
-    /// VM is up, which is before the separate `Container.Start` runs — and
-    /// `attach()` leaves a box `Running` with its init deliberately unstarted.
-    /// The cloud runner reads this to confirm a startup whose job-completion
-    /// callback was lost. Serde default keeps metadata from an older producer
+    /// This is BoxLite's service-level start timestamp. It does not report when
+    /// the configured user task becomes ready, exits, or completes. Those are
+    /// workload lifecycle outcomes. The cloud runner reads this timestamp to
+    /// confirm a start whose job-completion callback was lost. Serde default
+    /// keeps metadata from an older producer
     /// readable.
     #[serde(default)]
     pub started_at: Option<DateTime<Utc>>,

--- a/src/boxlite/tests/started_at.rs
+++ b/src/boxlite/tests/started_at.rs
@@ -1,10 +1,7 @@
 //! Integration tests for `BoxInfo::started_at`.
 //!
-//! The timestamp is deliberately distinct from `BoxStatus::Running`: booting
-//! publishes Running before the guest's separate `Container.Start` RPC runs, so
-//! Running alone cannot say whether a box's init was ever launched. The cloud
-//! runner reads this to repair a startup whose job completion was lost, which
-//! only works while the value describes the lifecycle running right now.
+//! The timestamp records the most recent box start: the transition into
+//! `Running`. It does not describe workload readiness, exit, or completion.
 
 mod common;
 
@@ -12,7 +9,7 @@ use boxlite::BoxliteRuntime;
 use boxlite::runtime::options::BoxliteOptions;
 
 #[tokio::test]
-async fn started_at_tracks_the_shim_that_launched_init() {
+async fn started_at_tracks_the_running_lifecycle() {
     let home = boxlite_test_utils::home::PerTestBoxHome::new();
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
@@ -33,39 +30,41 @@ async fn started_at_tracks_the_shim_that_launched_init() {
             .expect("inspect created box")
             .started_at
             .is_none(),
-        "creating a container must not claim its init was launched"
+        "creating a box must not claim that a lifecycle has started"
     );
 
-    // Booting is not starting: `attach` brings the VM up and stops short of
-    // running init, which is the state `BoxStatus::Running` cannot tell apart
-    // from a box whose init is live — and the whole reason this field exists.
-    let attached = handle.attach(None).await.expect("attach to booted box");
-    let booted = handle.info().await.expect("inspect booted box");
+    // `attach` initializes the lifecycle without launching the configured main
+    // task. Publishing the shim and lifecycle timestamp is one state transition.
+    let before_start = chrono::Utc::now();
+    let attached = handle
+        .attach(None)
+        .await
+        .expect("attach to initialized box");
+    let running = handle.info().await.expect("inspect running box");
     assert!(
-        booted.status.is_running(),
+        running.status.is_running(),
         "attach must leave the box Running, or this test is not observing the window"
     );
-    assert_eq!(
-        booted.started_at, None,
-        "a booted box whose init was never launched must not report a container start"
+    assert!(
+        running.pid.is_some(),
+        "a box that published Running must name its shim"
+    );
+    let started_at = running
+        .started_at
+        .expect("entering Running must publish started_at");
+    assert!(
+        started_at >= before_start,
+        "started_at {started_at} predates its Running publication ({before_start})"
     );
 
-    let before_start = chrono::Utc::now();
     handle.start().await.expect("start box");
     drop(attached);
 
     let info = handle.info().await.expect("inspect running box");
-    let started_at = info
-        .started_at
-        .expect("a successful Container.Start must be recorded");
-
-    assert!(
-        info.pid.is_some(),
-        "a box that recorded a start must name the shim running it"
-    );
-    assert!(
-        started_at >= before_start,
-        "record timestamp {started_at} predates the start that produced it ({before_start})"
+    assert_eq!(
+        info.started_at,
+        Some(started_at),
+        "launching the configured main task must not rewrite the Running timestamp"
     );
 
     let _ = handle.stop().await;
@@ -74,7 +73,7 @@ async fn started_at_tracks_the_shim_that_launched_init() {
 }
 
 #[tokio::test]
-async fn a_fresh_lifecycle_replaces_the_previous_record() {
+async fn started_at_changes_for_a_fresh_lifecycle() {
     let home = boxlite_test_utils::home::PerTestBoxHome::new();
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
@@ -97,15 +96,14 @@ async fn a_fresh_lifecycle_replaces_the_previous_record() {
         .await
         .expect("inspect first lifecycle")
         .started_at
-        .expect("first start must be recorded");
+        .expect("first Running transition must be recorded");
 
     handle.stop().await.expect("stop first lifecycle");
 
     assert_eq!(
         handle.info().await.expect("inspect stopped box").started_at,
         Some(first),
-        "a stop must leave the record of the run that just ended, the way docker keeps \
-         StartedAt on an exited container"
+        "a stop must preserve when the lifecycle entered Running"
     );
 
     // A spent handle cannot boot another VM, so the restart goes through a
@@ -118,19 +116,31 @@ async fn a_fresh_lifecycle_replaces_the_previous_record() {
         .expect("box still exists");
 
     restarted.start().await.expect("start second lifecycle");
-
-    let second_info = restarted.info().await.expect("inspect restarted box");
-    let second = second_info
+    let running_again = restarted
+        .info()
+        .await
+        .expect("inspect second running lifecycle");
+    let second = running_again
         .started_at
-        .expect("second start must be recorded");
+        .expect("second Running transition must be recorded");
 
     assert!(
-        second_info.pid.is_some(),
-        "a restarted box that recorded a start must name the shim running it"
+        running_again.pid.is_some(),
+        "a restarted box with started_at must name the shim running it"
     );
     assert!(
         second > first,
         "second record timestamp {second} does not follow the first ({first})"
+    );
+
+    assert_eq!(
+        restarted
+            .info()
+            .await
+            .expect("inspect second lifecycle again")
+            .started_at,
+        Some(second),
+        "the second Running timestamp must remain stable after start returns"
     );
 
     let _ = restarted.stop().await;
@@ -139,7 +149,7 @@ async fn a_fresh_lifecycle_replaces_the_previous_record() {
 }
 
 #[tokio::test]
-async fn adopting_the_same_running_shim_preserves_its_record() {
+async fn started_at_is_preserved_when_adopting_the_same_running_shim() {
     let home = boxlite_test_utils::home::PerTestBoxHome::new();
     let options = || BoxliteOptions {
         home_dir: home.path.clone(),
@@ -158,13 +168,14 @@ async fn adopting_the_same_running_shim_preserves_its_record() {
         let info = handle.info().await.expect("inspect detached box");
         (
             handle.id().clone(),
-            info.started_at.expect("detached start must be recorded"),
+            info.started_at
+                .expect("detached box's Running transition must be recorded"),
             info.pid.expect("a running box has a shim pid"),
         )
     };
 
-    // Reattaching to a still-running shim is not a new lifecycle: its init is
-    // already running, so the record that describes it must survive.
+    // Reattaching to a still-running shim is not a new lifecycle, so the
+    // timestamp for entering Running must survive.
     let second = BoxliteRuntime::new(options()).expect("create second runtime");
     let adopted = second
         .get(box_id.as_str())
@@ -176,7 +187,7 @@ async fn adopting_the_same_running_shim_preserves_its_record() {
     assert_eq!(
         adopted_info.started_at,
         Some(recorded),
-        "adopting a live shim must not clear or rewrite its start record"
+        "adopting a live shim must not clear or rewrite its Running timestamp"
     );
     assert_eq!(
         adopted_info.pid,


### PR DESCRIPTION
## Summary

Make the implementation match the existing BoxLite service-level `start()` contract while reducing caller latency. The operation initializes the VM and guest/container environment, transitions the box to `Running`, and hands off launch of the configured main task. Workload readiness, exit, and completion remain outside the service-level start operation.

## Changes

- Run the guest `Container.Start` RPC in an owned background task after the box enters `Running`.
- Keep `exec`, metrics, and copy operations behind the same single-flight container-start gate, including retry after a failed initializer.
- Publish `started_at` atomically with the PID and `Running` transition for a fresh lifecycle.
- Preserve idempotent start, reattach, stop cancellation, and owner-only start announcements.
- Align Runner reconciliation and SDK/reference field documentation with `started_at` as the time the box entered `Running`.

## Call graph

Before

```text
BoxImpl::start                       (src/boxlite/src/litebox/box_impl.rs:269)
  ├─ ensure_booted                  (src/boxlite/src/litebox/box_impl.rs:966)
  └─ ensure_container_started       (src/boxlite/src/litebox/box_impl.rs:985) — await guest startup
       ├─ ContainerInterface::start (src/boxlite/src/portal/interfaces/container.rs:218)
       └─ record_started            (src/boxlite/src/litebox/box_impl.rs:1023) — timestamp after RPC success
```

After

```text
BoxImpl::start                             (src/boxlite/src/litebox/box_impl.rs:278)
  ├─ ensure_booted                        (src/boxlite/src/litebox/box_impl.rs:1007)
  │    └─ init_live_state                 (src/boxlite/src/litebox/box_impl.rs:1097)
  │         └─ BoxState::mark_started     (src/boxlite/src/litebox/state.rs:361) — publish PID/Running/started_at
  └─ ensure_container_started_owned       (src/boxlite/src/litebox/box_impl.rs:1040) — spawned background owner
       └─ ContainerInterface::start       (src/boxlite/src/portal/interfaces/container.rs:218)

BoxImpl::exec                              (src/boxlite/src/litebox/box_impl.rs:444)
  └─ live_state                           (src/boxlite/src/litebox/box_impl.rs:988)
       └─ ensure_container_started        (src/boxlite/src/litebox/box_impl.rs:1025) — join or retry the same gate
```

## Validation

- `make test:unit:rust FILTER=explicit_start`
- `make test:unit:rust FILTER=background_start_failure`
- `make test:unit:rust FILTER=stop_cancels_in_flight_background_container_start`
- `make test:unit:rust FILTER=stopping_booted_box_does_not_start_container`
- `make test:unit:rust FILTER=started_at`
- `make fmt:check:rust`
- `make fmt:check:go`
- `make clippy`
- `git diff --check`

## Risks

- The internal guest start RPC may still be running after the service-level `start()` call returns. A subsequent live operation waits on or retries the shared gate before issuing its own guest operation.
- Background RPC failures are logged; the next live operation surfaces the result of its own retry.
- `started_at` records when the box enters `Running`; it is not a user-workload readiness, exit, or completion timestamp.
- No public API signatures change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved box startup handling with cancellable initialization, retry support after failures, and safer concurrent start behavior.
  - Preserved lifecycle timestamps across stops and reboots, while recording new timestamps for fresh running sessions.
  - Improved recovery and synchronization of running-state information when process details are unavailable.

- **Documentation**
  - Clarified that `StartedAt` represents the most recent transition to `Running`, not workload readiness or task completion.
  - Updated CLI and SDK references to explain timestamp persistence, precision, and unknown-value behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->