### PR TITLE
fix(dashboard): restore the OpenAPI mention in REST quickstart setup

### DIFF
--- a/apps/dashboard/src/lib/quickstart/interfaces.json
+++ b/apps/dashboard/src/lib/quickstart/interfaces.json
@@ -81,7 +81,7 @@
     "run": "BOXLITE_API_KEY=$KEY BOXLITE_REST_URL={{REST_API_URL}} bash quickstart-rest.sh",
     "codeLanguage": "bash",
     "setupLabel": "Check REST tools",
-    "setupDescription": "REST does not require an SDK install. The next step uses curl and jq to create a Box and execute a command.",
+    "setupDescription": "REST does not require an SDK install. The next step uses curl and jq to create a Box and execute a command. OpenAPI is available for full endpoint reference and generated clients.",
     "executionDescription": "What it does: uses your API key from Step 1, calls the REST API to create and start a Box, executes a command, prints execution status, then removes the Box.",
     "template": "rest"
   }


### PR DESCRIPTION
`onboarding-code-examples.test.ts > keeps REST setup focused on required local tools` fails on `main` today. This restores the copy the test asserts.

## Call graph

**Before**

```
OnboardingGuideDialog.tsx   activeExample.setupDescription
  └─ getOnboardingCodeExamples()      onboarding-code-examples.ts
       └─ interfaces.json  rest.setupDescription
            "REST does not require an SDK install. …execute a command."
            ← BUG: closing sentence dropped when examples moved into JSON
  onboarding-code-examples.test.ts:97
       expect(setupDescription).toContain('OpenAPI is available')   → FAILS
```

**After**

```
OnboardingGuideDialog.tsx   activeExample.setupDescription
  └─ getOnboardingCodeExamples()      onboarding-code-examples.ts
       └─ interfaces.json  rest.setupDescription
            "…execute a command. OpenAPI is available for full endpoint
             reference and generated clients."                    ← restored
  onboarding-code-examples.test.ts:97                             → PASSES
```

## Why this side

The copy regressed; the assertion was correct. Traced through history:

| commit | date | effect |
|---|---|---|
| `11bc821b` | Jul 1 | added the copy **and** the assertion together — consistent |
| `3162ba50` | Jul 3 | dropped the closing sentence while moving examples into `interfaces.json` |
| `d1a675ec` (#894) | Jul 7 | landed on `main` carrying the **truncated copy** + the **full assertion** |
| `06b73c71` | Aug 6 | still carries the complete sentence, confirming intended wording |

So the test has never passed on `main` — #894 squashed together two different revisions of the branch.

Deleting the assertion was the tempting fix, but the same test also asserts `install` does **not** contain `box.openapi.yaml`. Those two assertions encode one decision: don't force the spec download, but do tell REST users the spec exists. Dropping the assertion would discard half of that and leave REST users with no pointer to the endpoint reference.

## Testing

- `npx vitest run dashboard/src/lib/onboarding-code-examples.test.ts --root dashboard` → 6 passed (was 5 passed / 1 failed).
- Full dashboard suite: **17 files, 78 tests, 0 failures**.
- `prettier --check` clean; JSON re-parsed to confirm all 7 interface entries intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the REST quickstart guidance to highlight OpenAPI availability for endpoint references and client generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->