### PR TITLE
fix(ci): accept deployment capability v2

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -285,7 +285,7 @@ jobs:
           capability=apps/infra/deployment/capabilities.json
           legacy_module=apps/infra/scripts/deployment-scope.mjs
           if [ -f "$capability" ]; then
-            if ! status=$(node -e "const fs=require('node:fs'); const c=JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); console.log(c.version === 1 && c.componentSelection === true ? 'supported' : 'unsupported')" "$capability"); then
+            if ! status=$(node -e "const fs=require('node:fs'); const c=JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); console.log([1,2].includes(c.version) && c.componentSelection === true ? 'supported' : 'unsupported')" "$capability"); then
               status=unreadable
             fi
             source_path=$capability

--- a/apps/infra/deployment/release-safety.test.ts
+++ b/apps/infra/deployment/release-safety.test.ts
@@ -2,7 +2,9 @@
 // Copyright (c) 2026 BoxLite AI
 
 import assert from 'node:assert/strict'
-import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import test from 'node:test'
@@ -193,6 +195,43 @@ test('SST deploy does not depend on a laptop-managed remote builder', () => {
     'apps/infra/buildkit/buildkitd.toml',
   ]) {
     assert.equal(existsSync(join(REPO_ROOT, legacyPath)), false, `${legacyPath} must be removed`)
+  }
+})
+
+test('component-selection bridge accepts capability v2 for existing single exclusions', () => {
+  const workflow = load(readFileSync(DEPLOY_WORKFLOW, 'utf8'))
+  const scopeSupportStep = workflow.jobs.deploy.steps.find(
+    (step: any) => step.name === 'Require component selection support in the selected commit',
+  )
+  assert.ok(scopeSupportStep, 'the component-selection capability check is missing')
+
+  const checkout = mkdtempSync(join(tmpdir(), 'boxlite-capability-bridge-'))
+  const capability = join(checkout, 'apps/infra/deployment/capabilities.json')
+  mkdirSync(dirname(capability), { recursive: true })
+
+  const runGuard = (version: number, componentSelection: boolean, exclude: 'Api' | 'Runner') => {
+    writeFileSync(capability, `${JSON.stringify({ version, componentSelection })}\n`)
+    return spawnSync('/usr/bin/env', ['bash', '-c', scopeSupportStep.run], {
+      cwd: checkout,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        BOXLITE_ARTIFACT_REF: 'fixture-commit',
+        DEPLOY_EXCLUDE: exclude,
+      },
+    })
+  }
+
+  try {
+    for (const exclude of ['Api', 'Runner'] as const) {
+      assert.equal(runGuard(1, true, exclude).status, 0, `capability v1 must keep supporting --exclude ${exclude}`)
+      const v2 = runGuard(2, true, exclude)
+      assert.equal(v2.status, 0, `capability v2 must support --exclude ${exclude}: ${v2.stderr}`)
+    }
+    assert.notEqual(runGuard(3, true, 'Runner').status, 0, 'an unknown capability version must fail closed')
+    assert.notEqual(runGuard(2, false, 'Runner').status, 0, 'v2 without component selection must fail closed')
+  } finally {
+    rmSync(checkout, { recursive: true, force: true })
   }
 })
 
@@ -389,7 +428,7 @@ test('deployment previews and reconciles the full stack in guarded GitHub CI', (
   assertShellLine(scopeSupportStep.run, /if \[ -f "\$capability" \]; then/)
   assertShellLine(scopeSupportStep.run, /if ! status=\$\(node -e .* "\$capability"\); then/)
   assertShellLine(scopeSupportStep.run, /status=unreadable/)
-  assertShellLine(scopeSupportStep.run, /c\.version === 1 && c\.componentSelection === true/)
+  assertShellLine(scopeSupportStep.run, /\[1,2\]\.includes\(c\.version\) && c\.componentSelection === true/)
   assertShellLine(scopeSupportStep.run, /elif \[ -f "\$legacy_module" \]; then/)
   assertShellLine(scopeSupportStep.run, /typeof m\.resolveDeployScope === 'function'/)
   // Absence of both formats is its own decision, not an import failure.


### PR DESCRIPTION
## Summary

Accept deployment capability version 2 in the existing API-only and Runner-only workflow paths. This lets `main` safely validate selected PR merges that use the newer capability contract before their workflow changes land.

## Call graph

Before
  workflow_dispatch  (GitHub Actions · .github/workflows/deploy-infra.yml:253) — checks out the selected merge
    └─ capability guard  (Bash · .github/workflows/deploy-infra.yml:288) ← BUG: rejects a valid version 2 contract before preview
         └─ preview  (SST · .github/workflows/deploy-infra.yml:448) — never reached

After
  workflow_dispatch  (GitHub Actions · .github/workflows/deploy-infra.yml:253) — checks out the selected merge
    └─ capability guard  (Bash · .github/workflows/deploy-infra.yml:288) — accepts versions 1 and 2 when component selection is enabled
         └─ preview  (SST · .github/workflows/deploy-infra.yml:448) — continues with the existing single-component exclusion

Fixes #1250

## Changes

- accept capability versions 1 and 2 for existing single-component deployments
- execute the production workflow guard against supported and fail-closed capability fixtures

## How to verify

- `make test:apps:infra`
- `actionlint .github/workflows/deploy-infra.yml`

## Risks / rollout

Unknown capability versions and contracts with component selection disabled still fail closed. Infrastructure-only selection remains in the larger follow-up PR and is not enabled here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Deployment safety checks now support capability metadata versions 1 and 2.
  - Existing version 1 configurations remain compatible.
  - Validation continues to require component-selection support for single-component exclusions.
  - Unsupported metadata versions and version 2 configurations without component-selection support are rejected.
- **Tests**
  - Added coverage for supported and invalid capability configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->