### PR TITLE
feat(infra): read stage config from the SST secret store

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -247,12 +247,15 @@ compiles neither component.
 
 Required GitHub configuration:
 
-- Environment variables `AWS_ACCOUNT_ID` and `AWS_REGION`, per stage. The first is what
-  the deploy workflows compose
-  `arn:aws:iam::<id>:role/boxlite-<stage>-github-deploy`. It cannot come from the
-  stage's secret store like everything else, because `configure-aws-credentials`
-  reads it before any AWS credentials exist. The region is a literal in the
-  workflows, pinned to `DEFAULT_AWS_REGION` by a test.
+- Environment variables `AWS_ACCOUNT_ID` and `AWS_REGION`, per stage. Neither can come
+  from the stage's secret store like everything else, because
+  `configure-aws-credentials` reads both before any AWS credentials exist.
+  - `AWS_ACCOUNT_ID` is **required**. The workflows compose
+    `arn:aws:iam::<id>:role/boxlite-<stage>-github-deploy` from it; only the account id
+    is unknown, since the role name follows from the stage.
+  - `AWS_REGION` is **optional**, and only for a stage outside the default. The
+    workflows fall back to `DEFAULT_AWS_REGION` as a literal, pinned to the code by a
+    test; set the variable when the stage lives elsewhere.
 
 - Environment secrets `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_DEFAULT_ACCOUNT_ID`,
   per stage. These cannot come from the SST secret store: reading it initializes the

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -245,11 +245,25 @@ deployment Environments block before the job can obtain AWS credentials.
 matching Runner GitHub Release assets, verifies both before SST runs, and
 compiles neither component.
 
-Required Environment configuration (per stage):
+Required GitHub configuration:
 
-- Variable `AWS_DEPLOY_ROLE_ARN`
-- Variable `AWS_REGION` (defaults to `ap-southeast-1`)
-- Secret `DEPLOY_ENV` containing the stage's dotenv configuration
+- Environment variables `AWS_ACCOUNT_ID` and `AWS_REGION`, per stage. The first is what
+  the deploy workflows compose
+  `arn:aws:iam::<id>:role/boxlite-<stage>-github-deploy`. It cannot come from the
+  stage's secret store like everything else, because `configure-aws-credentials`
+  reads it before any AWS credentials exist. The region is a literal in the
+  workflows, pinned to `DEFAULT_AWS_REGION` by a test.
+
+- Environment secrets `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_DEFAULT_ACCOUNT_ID`,
+  per stage. These cannot come from the SST secret store: reading it initializes the
+  Cloudflare provider, so a token kept there would be needed in order to read itself.
+
+A stage's other configuration lives in its SST secret store, seeded by
+`npm run bootstrap` and read by `apps/infra/deployment/sst.ts`; it is not
+configured on the GitHub side. Each stage still needs its Environment to *exist*,
+under exactly the stage name — the deploy role's trust policy pins
+`repo:<owner>/<repo>:environment:<stage>` — and that is where required reviewers
+are enforced.
 
 Bootstrap the scoped role, runtime permissions boundary, immutable API ECR
 repository, and private Runner artifact bucket with

--- a/.github/workflows/build-apps-api-image.yml
+++ b/.github/workflows/build-apps-api-image.yml
@@ -183,7 +183,7 @@ jobs:
       - name: Configure AWS credentials through OIDC
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/boxlite-${{ inputs.stage || 'dev' }}-github-deploy
           aws-region: ${{ env.AWS_REGION }}
           role-session-name: build-apps-api-image-${{ github.run_id }}
 

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -313,6 +313,37 @@ jobs:
               ;;
           esac
 
+      # Unconditional, unlike the component-selection probe above: this job deploys any commit on
+      # main and checks out THAT commit's apps/infra, and a commit predating the stage configuration
+      # store has a wrapper that still expects apps/infra/.env from the DEPLOY_ENV secret this
+      # workflow no longer writes. It would deploy with whatever defaults survived, so refuse here,
+      # before the deploy role is assumed, rather than half-way through a reconcile.
+      - name: Require stage configuration store support in the selected commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          capability=apps/infra/deployment/capabilities.json
+          status=unsupported
+          if [ -f "$capability" ]; then
+            if ! status=$(node -e "const fs=require('node:fs'); const c=JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); console.log(c.version === 1 && c.stageConfigStore === true ? 'supported' : 'unsupported')" "$capability"); then
+              status=unreadable
+            fi
+          fi
+          case "$status" in
+            supported) ;;
+            unsupported)
+              echo "commit $BOXLITE_ARTIFACT_REF reads its stage configuration from apps/infra/.env," >&2
+              echo "which this workflow no longer materializes — it lives in the stage's SST secret" >&2
+              echo "store now. Deploy a commit whose $capability declares stageConfigStore." >&2
+              exit 1
+              ;;
+            *)
+              echo "$capability exists at commit $BOXLITE_ARTIFACT_REF but failed to load (reason" >&2
+              echo "above); fix the file rather than deploying without its configuration." >&2
+              exit 1
+              ;;
+          esac
+
       - name: Verify native AMD64 Docker
         shell: bash
         run: |
@@ -331,7 +362,10 @@ jobs:
       - name: Configure AWS credentials through OIDC
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          # Composed from the stage's AWS_ACCOUNT_ID, not a stored AWS_DEPLOY_ROLE_ARN: the role
+          # name is fixed per stage (apps/infra/bootstrap/environment.ts's githubDeployRoleName, pinned
+          # against the CloudFormation template by a test), so only the account id has to be configured.
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/boxlite-${{ inputs.stage }}-github-deploy
           aws-region: ${{ env.AWS_REGION }}
           role-session-name: deploy-${{ inputs.stage }}-stack-${{ github.run_id }}
 
@@ -416,35 +450,15 @@ jobs:
             exit 1
           fi
 
-      - name: Materialize stage configuration
-        shell: bash
-        env:
-          DEPLOY_ENV: ${{ secrets.DEPLOY_ENV }}
-        run: |
-          set -euo pipefail
-          test -n "$DEPLOY_ENV"
-          umask 077
-          printf '%s\n' "$DEPLOY_ENV" > apps/infra/.env
-          if node -e "const pkg = require('./apps/infra/package.json'); process.exit(pkg.scripts?.['validate-environment'] ? 0 : 1)"; then
-            npm --prefix apps/infra run --silent validate-environment -- .env
-          elif [ -f apps/infra/scripts/deploy-environment-validation.mjs ]; then
-            node apps/infra/scripts/deploy-environment-validation.mjs apps/infra/.env
-          else
-            echo 'selected commit has no supported deployment environment validator' >&2
-            exit 1
-          fi
-
       - name: Install SST providers
         working-directory: apps/infra
         run: npm run --silent sst -- install --stage "$STAGE"
 
-      # These stay hand-made scoped API tokens. Cloudflare's `cf` CLI can mint
-      # an OAuth token carrying dns_records:edit, but it expires in about an
-      # hour and is renewed through a browser, which this unattended job has
-      # no way to complete. Supplying them as Environment secrets is optional:
-      # scripts/sst-with-cloudflare.mjs prefers an already-set env var and
-      # otherwise reads SSM, so a stage seeded via SSM keeps working with
-      # these unset.
+      # These stay hand-made scoped API tokens, and they stay GitHub Environment secrets rather than
+      # joining the stage's SST secret store: reading that store initializes the Cloudflare provider,
+      # so a token kept there would be needed in order to read itself. Whether this job could instead
+      # read the SSM copy apps/infra/deployment/sst.ts uses locally is untested — see the note there.
+      # Cloudflare also has no machine-to-machine OAuth grant to automate these with.
       - name: Preview the selected components
         shell: bash
         working-directory: apps/infra
@@ -494,10 +508,6 @@ jobs:
           args=(--stage "$STAGE" --policy "$policy")
           [ -z "$DEPLOY_EXCLUDE" ] || args+=(--exclude "$DEPLOY_EXCLUDE")
           npm run deploy -- "${args[@]}"
-
-      - name: Remove materialized configuration
-        if: always()
-        run: rm -f apps/infra/.env
 
   # E2E cloud has no automatic trigger of its own; a deploy is the one
   # event that makes running it meaningful, because only here are the

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -452,6 +452,13 @@ jobs:
 
       - name: Install SST providers
         working-directory: apps/infra
+        # The same credentials the deploy steps get. `install` evaluates sst.config.ts, which
+        # initializes every provider it declares — so without these the step falls back to the SSM copy
+        # whose readability from this role has never been verified. Supplying them costs nothing and
+        # removes the only place the workflow would have depended on that.
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_DEFAULT_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_DEFAULT_ACCOUNT_ID }}
         run: npm run --silent sst -- install --stage "$STAGE"
 
       # These stay hand-made scoped API tokens, and they stay GitHub Environment secrets rather than

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -325,7 +325,11 @@ jobs:
           capability=apps/infra/deployment/capabilities.json
           status=unsupported
           if [ -f "$capability" ]; then
-            if ! status=$(node -e "const fs=require('node:fs'); const c=JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); console.log(c.version === 1 && c.stageConfigStore === true ? 'supported' : 'unsupported')" "$capability"); then
+            # The same version set the component-selection gate above accepts. A capability file is one
+            # document with one version, so pinning `=== 1` here would reject a commit that bumped it
+            # to 2 for an unrelated capability while still supporting this one — which is the whole
+            # reason that gate stopped pinning a single version (#1253).
+            if ! status=$(node -e "const fs=require('node:fs'); const c=JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); console.log([1,2].includes(c.version) && c.stageConfigStore === true ? 'supported' : 'unsupported')" "$capability"); then
               status=unreadable
             fi
           fi

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Configure AWS credentials through OIDC
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/boxlite-${{ inputs.stage }}-github-deploy
           aws-region: ${{ env.AWS_REGION }}
           role-session-name: deploy-release-${{ github.run_id }}
 
@@ -118,27 +118,15 @@ jobs:
             exit 1
           fi
 
-      - name: Materialize stage configuration
-        shell: bash
-        env:
-          DEPLOY_ENV: ${{ secrets.DEPLOY_ENV }}
-        run: |
-          set -euo pipefail
-          test -n "$DEPLOY_ENV"
-          umask 077
-          printf '%s\n' "$DEPLOY_ENV" > apps/infra/.env
-          if node -e "const pkg = require('./apps/infra/package.json'); process.exit(pkg.scripts?.['validate-environment'] ? 0 : 1)"; then
-            npm --prefix apps/infra run --silent validate-environment -- .env
-          elif [ -f apps/infra/scripts/deploy-environment-validation.mjs ]; then
-            node apps/infra/scripts/deploy-environment-validation.mjs apps/infra/.env
-          else
-            echo 'selected commit has no supported deployment environment validator' >&2
-            exit 1
-          fi
-
       - name: Deploy published API and Runner artifacts
         working-directory: apps/infra
         shell: bash
+        # Same reason as deploy-infra: the wrapper reads the stage's SST secret store before invoking
+        # sst, and reading it initializes the Cloudflare provider. Without these the store read fails
+        # and a release deploy stops rather than reconciling against defaults.
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_DEFAULT_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_DEFAULT_ACCOUNT_ID }}
         run: |
           set -euo pipefail
           if node -e "const pkg = require('./package.json'); process.exit(pkg.scripts?.['validate-preview'] ? 0 : 1)" && [ -f policies/runner/PulumiPolicy.yaml ]; then
@@ -150,7 +138,3 @@ jobs:
             exit 1
           fi
           npm run deploy -- --stage "$STAGE" --policy "$policy"
-
-      - name: Remove materialized configuration
-        if: always()
-        run: rm -f apps/infra/.env

--- a/.github/workflows/e2e-cloud.yml
+++ b/.github/workflows/e2e-cloud.yml
@@ -87,8 +87,8 @@ on:
     secrets:
       BOXLITE_DEV_API_KEY:
         # Named rather than inherited. `inherit` passes every secret the
-        # caller holds, which for deploy-infra means DEPLOY_ENV and the
-        # Cloudflare API token as well — none of the suite's business.
+        # caller holds, whatever that turns out to be — none of the suite's
+        # business, and the list is not this file's to track.
         # Its AWS access is not a secret and so was never at stake here;
         # that comes from OIDC, and `permissions` below is what withholds
         # it.

--- a/apps/infra/.env.example
+++ b/apps/infra/.env.example
@@ -6,6 +6,18 @@
 # `npm run sst -- secret set` command; putting those names here does not
 # configure the deployed app.
 #
+# This file is an input to `npm run bootstrap`. Bootstrap loads it into the stage's SST
+# secret store, and every deploy — local or CI — reads the stage's configuration back from
+# there, not from here. So editing this file changes nothing until you rerun bootstrap, and
+# a key you delete from it stops applying on the next bootstrap.
+#
+# The exception is the keys bootstrap deliberately keeps OUT of the store, because a
+# machine-specific `aws` path or an artifact selector must not become stage-wide
+# configuration. Those a local deploy does read straight from this file. Section 4 lists
+# most of them, but not all: CLOUDFLARE_API_TOKEN and CLOUDFLARE_DEFAULT_ACCOUNT_ID in
+# section 1 are local-only too, and a value set for either here wins over the copy in SSM.
+# CI has no .env at all, and reads both from the stage's GitHub Environment secrets.
+#
 # Tier legend (what happens if you leave a var unset):
 #   [required]            deploy fails — the config throws or a provider errors
 #   [required at runtime] deploy succeeds, but the feature is broken until set
@@ -109,7 +121,7 @@ OIDC_AUDIENCE=https://dev.example.com/api
 
 # ─── 4. Optional overrides ───────────────────────────────────────────────────
 # Everything below is [optional]. Entries marked local-only must remain unset in
-# the GitHub `DEPLOY_ENV` secret; the workflow rejects local credential context.
+# the stage's SST secret store; `npm run bootstrap` keeps them out of it.
 
 # 4a. AWS / deploy
 # AWS region used by both SST and the post-deploy verifier.
@@ -136,10 +148,10 @@ OIDC_AUDIENCE=https://dev.example.com/api
 # Cargo.toml's workspace version.
 # VERSION=0.9.8
 # Local CLI only: AWS profile used by SST. Remove it before uploading this file
-# as `DEPLOY_ENV`; GitHub CI uses OIDC and rejects AWS_PROFILE.
+# into the stage's secret store; GitHub CI uses OIDC and never reads AWS_PROFILE.
 # AWS_PROFILE=my-aws-profile
 # Local CLI only: optional absolute AWS CLI path. Remove it before uploading
-# this file as `DEPLOY_ENV`; CI selects the native Ubuntu AWS CLI from PATH.
+# into the stage's secret store; CI selects the native Ubuntu AWS CLI from PATH.
 # AWS_CLI_PATH=/opt/homebrew/bin/aws
 # 4b. Secrets & keys — auto-generated per stack; pin only to rotate or to share
 # a value across stacks.

--- a/apps/infra/bootstrap/aws/github-deploy-role.yaml
+++ b/apps/infra/bootstrap/aws/github-deploy-role.yaml
@@ -273,6 +273,14 @@ Resources:
                   - !Sub arn:${AWS::Partition}:s3:::sst-state-*/secret/boxlite/_fallback.json
               # The buckets this stack owns. Same prefixes the runtime boundary allows, so a rename has
               # to widen both together — see shared/resource-name.ts.
+              #
+              # Four of the six prefixes are stage-scoped and two are not: boxlite-volume-* carries no
+              # stage in its name, so this grants s3:* over every stage's volume buckets, not just this
+              # one. That is the naming, not an oversight here — the runtime boundary allows the same
+              # unscoped prefix — but it means "the buckets this stack owns" is true only of the
+              # boxlite-<stage>-* and boxlite-app-<stage>-* pairs. Scoping it needs the bucket name to
+              # carry the stage first, which is a rename across the boundary, the stack, and buckets
+              # that already exist.
               - Sid: BoxLiteStageBuckets
                 Effect: Allow
                 Action: s3:*
@@ -319,6 +327,14 @@ Resources:
               # Runner binary upgrades run as SSM commands against the stage's instances
               # (runner/update.ts). SendCommand takes instance and document ARNs; the describe and
               # invocation reads are list-shaped and have no resource of their own.
+              #
+              # instance/* is account-wide, and unscoped only because there is no way to scope it here:
+              # an instance ARN carries no stage, so narrowing this means a Condition on an instance tag
+              # the stack sets — a change to what the Runner launch template tags, verifiable only
+              # against real instances. Until then this is the widest grant the deploy role holds: a job
+              # bound to one stage can run a shell command on any instance in the account, which is more
+              # than reading another stage's configuration. Stated in docs/security.md rather than left
+              # to read as stage-scoped.
               - Sid: RunnerCommandChannel
                 Effect: Allow
                 Action:

--- a/apps/infra/bootstrap/aws/github-deploy-role.yaml
+++ b/apps/infra/bootstrap/aws/github-deploy-role.yaml
@@ -373,6 +373,42 @@ Resources:
                 Condition:
                   StringEquals:
                     iam:PermissionsBoundary: !Ref BoxLiteRuntimePermissionsBoundary
+              # Two escalation paths, both closed the same way, because an IAM Allow cannot express
+              # "every boxlite-* resource except this one" — only a Deny can.
+              #
+              # First: this role is itself named boxlite-<stage>-github-deploy, so it matches the
+              # role/boxlite-* resource of the IAM grants below. iam:PutRolePolicy aimed at itself
+              # writes it any permission at all, with nothing to stop it — the runtime boundary
+              # constrains the roles SST creates, not this role's own inline policy.
+              #
+              # Second, and less obvious: the boundary IS a managed policy named
+              # boxlite-<stage>-runtime-boundary, which matches the policy/boxlite-* resource of
+              # ManageBoxLitePolicies. Widening it, then creating a bounded role under the widened
+              # version and passing it to a service, reaches anything the widened boundary allows. So
+              # the boundary policy is denied mutation too.
+              #
+              # Neither is something a deploy does: both this role and the boundary are created by
+              # `cloudformation deploy` under an operator's admin credentials, never by SST.
+              - Sid: DenySelfPrivilegeEscalation
+                Effect: Deny
+                Action:
+                  - iam:AttachRolePolicy
+                  - iam:DeleteRole
+                  - iam:DeleteRolePermissionsBoundary
+                  - iam:DeleteRolePolicy
+                  - iam:DetachRolePolicy
+                  - iam:PutRolePermissionsBoundary
+                  - iam:PutRolePolicy
+                  - iam:UpdateAssumeRolePolicy
+                  - iam:UpdateRole
+                  - iam:UpdateRoleDescription
+                  - iam:CreatePolicyVersion
+                  - iam:DeletePolicy
+                  - iam:DeletePolicyVersion
+                  - iam:SetDefaultPolicyVersion
+                Resource:
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/boxlite-${GitHubEnvironment}-github-deploy
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/boxlite-${GitHubEnvironment}-runtime-boundary
               - Sid: ManageBoxLiteRoles
                 Effect: Allow
                 Action:

--- a/apps/infra/bootstrap/aws/github-deploy-role.yaml
+++ b/apps/infra/bootstrap/aws/github-deploy-role.yaml
@@ -208,13 +208,132 @@ Resources:
                   - lambda:*
                   - logs:*
                   - rds:*
-                  - s3:*
                   - secretsmanager:*
                   - servicediscovery:*
-                  - ssm:*
+                  # s3 and ssm are deliberately absent. Both reach the SST backing store, which holds
+                  # every stage's state and secrets under one bucket and one parameter tree — the live
+                  # bucket carries secret/boxlite/dev.json beside secret/boxlite/prod.json. Granted
+                  # account-wide, a job bound to the dev Environment could read prod's configuration,
+                  # and this change makes that configuration authoritative. Scoped below instead.
                   - tag:GetResources
                   - tag:GetTagKeys
                   - tag:GetTagValues
+                Resource: '*'
+              # The SST backing store, scoped to this stage. Every prefix SST writes is
+              # `<kind>/<app>/<stage>`; the five that exist in the live bucket were read from it, and
+              # lock/ and summary/ came from sst v4.6.11 pkg/project/provider/provider.go because a
+              # lock exists only while an update runs — `list-objects` cannot see one, and a policy
+              # built from a listing fails at the moment a deploy takes its lock.
+              - Sid: SstStateForThisStage
+                Effect: Allow
+                Action:
+                  - s3:ListBucket
+                  - s3:ListBucketVersions
+                  - s3:GetBucketLocation
+                Resource:
+                  # Bucket scope, because SST enumerates before it reads. That reveals other stages'
+                  # key NAMES but not their contents; the object grants below are per stage.
+                  - !Sub arn:${AWS::Partition}:s3:::sst-state-*
+                  - !Sub arn:${AWS::Partition}:s3:::sst-asset-*
+              - Sid: SstStateObjectsForThisStage
+                Effect: Allow
+                Action:
+                  - s3:AbortMultipartUpload
+                  - s3:DeleteObject
+                  - s3:DeleteObjectVersion
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                  - s3:PutObject
+                Resource:
+                  - !Sub arn:${AWS::Partition}:s3:::sst-state-*/app/boxlite/${GitHubEnvironment}.json
+                  - !Sub arn:${AWS::Partition}:s3:::sst-state-*/secret/boxlite/${GitHubEnvironment}.json
+                  - !Sub arn:${AWS::Partition}:s3:::sst-state-*/eventlog/boxlite/${GitHubEnvironment}/*
+                  - !Sub arn:${AWS::Partition}:s3:::sst-state-*/snapshot/boxlite/${GitHubEnvironment}/*
+                  - !Sub arn:${AWS::Partition}:s3:::sst-state-*/update/boxlite/${GitHubEnvironment}/*
+                  - !Sub arn:${AWS::Partition}:s3:::sst-state-*/lock/boxlite/${GitHubEnvironment}
+                  - !Sub arn:${AWS::Partition}:s3:::sst-state-*/lock/boxlite/${GitHubEnvironment}.json
+                  - !Sub arn:${AWS::Partition}:s3:::sst-state-*/summary/boxlite/${GitHubEnvironment}/*
+                  # Deployment assets are content-addressed and carry no stage in the key, so this is
+                  # the one object grant that is NOT stage-scoped and cannot be: SST derives the key
+                  # from the content hash and every stage writes into the same bucket. A write is
+                  # therefore idempotent — same bytes, same key — but a DELETE is not bounded that way,
+                  # so a stage could remove an object another stage's next update expects to find. It
+                  # stays because `sst remove` needs it; the blast radius is a redeploy, since assets
+                  # are rebuilt from the checkout rather than recovered from the bucket.
+                  - !Sub arn:${AWS::Partition}:s3:::sst-asset-*/*
+              # `sst secret set --fallback` stores under the literal stage `_fallback`, which every
+              # stage of the app reads. It cannot be stage-scoped, so it gets READ access only: a
+              # deploy consumes a fallback, setting one is a deliberate operator action.
+              - Sid: SstFallbackSecretsRead
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                Resource:
+                  - !Sub arn:${AWS::Partition}:s3:::sst-state-*/secret/boxlite/_fallback.json
+              # The buckets this stack owns. Same prefixes the runtime boundary allows, so a rename has
+              # to widen both together — see shared/resource-name.ts.
+              - Sid: BoxLiteStageBuckets
+                Effect: Allow
+                Action: s3:*
+                Resource:
+                  - !Sub arn:${AWS::Partition}:s3:::boxlite-${GitHubEnvironment}-*
+                  - !Sub arn:${AWS::Partition}:s3:::boxlite-${GitHubEnvironment}-*/*
+                  - !Sub arn:${AWS::Partition}:s3:::boxlite-app-${GitHubEnvironment}-*
+                  - !Sub arn:${AWS::Partition}:s3:::boxlite-app-${GitHubEnvironment}-*/*
+                  - !Sub arn:${AWS::Partition}:s3:::boxlite-volume-*
+                  - !Sub arn:${AWS::Partition}:s3:::boxlite-volume-*/*
+              # /sst/bootstrap is account-wide by construction: it names the buckets every stage shares
+              # and SST reads it before it knows which stage it is running. That makes it the one
+              # parameter here a stage must not be able to WRITE — rewriting it repoints every other
+              # stage's state, deleting it breaks them all — so it gets a read-only statement of its
+              # own. Creating it is a bootstrap action, done by an operator with admin credentials
+              # before CI ever deploys.
+              - Sid: SstSharedBootstrapRead
+                Effect: Allow
+                Action:
+                  - ssm:GetParameter
+                  - ssm:GetParameters
+                Resource:
+                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/sst/bootstrap
+              # The passphrase decrypts this stage's state, so that is the one that must not be shared.
+              - Sid: SstParametersForThisStage
+                Effect: Allow
+                Action:
+                  - ssm:GetParameter
+                  - ssm:GetParameters
+                  - ssm:PutParameter
+                  - ssm:DeleteParameter
+                  - ssm:AddTagsToResource
+                  - ssm:ListTagsForResource
+                Resource:
+                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/sst/passphrase/boxlite/${GitHubEnvironment}
+                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/boxlite/${GitHubEnvironment}/*
+              - Sid: SstFallbackPassphraseRead
+                Effect: Allow
+                Action:
+                  - ssm:GetParameter
+                  - ssm:GetParameters
+                Resource:
+                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/sst/passphrase/boxlite/_fallback
+              # Runner binary upgrades run as SSM commands against the stage's instances
+              # (runner/update.ts). SendCommand takes instance and document ARNs; the describe and
+              # invocation reads are list-shaped and have no resource of their own.
+              - Sid: RunnerCommandChannel
+                Effect: Allow
+                Action:
+                  - ssm:SendCommand
+                Resource:
+                  - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:instance/*
+                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}::document/AWS-RunShellScript
+              - Sid: RunnerCommandStatus
+                Effect: Allow
+                Action:
+                  - ssm:DescribeInstanceInformation
+                  - ssm:GetCommandInvocation
+                  - ssm:ListCommandInvocations
+                  - ssm:ListCommands
+                  - ssm:DescribeParameters
                 Resource: '*'
               - Sid: ReadIamAndAccountMetadata
                 Effect: Allow

--- a/apps/infra/bootstrap/aws/github-deploy-role.yaml
+++ b/apps/infra/bootstrap/aws/github-deploy-role.yaml
@@ -407,8 +407,12 @@ Resources:
                   - iam:DeletePolicyVersion
                   - iam:SetDefaultPolicyVersion
                 Resource:
-                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/boxlite-${GitHubEnvironment}-github-deploy
-                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/boxlite-${GitHubEnvironment}-runtime-boundary
+                  # Every stage's, not just this one's. role/boxlite-* covers a SIBLING stage's deploy
+                  # role too, so without the wildcard here a dev-bound job could rewrite prod's trust
+                  # policy and assume it. No deploy ever modifies one of these — they are CloudFormation
+                  # resources an operator creates — so denying all of them costs nothing.
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/boxlite-*-github-deploy
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/boxlite-*-runtime-boundary
               - Sid: ManageBoxLiteRoles
                 Effect: Allow
                 Action:

--- a/apps/infra/bootstrap/bootstrap.ts
+++ b/apps/infra/bootstrap/bootstrap.ts
@@ -425,14 +425,20 @@ const SST_PLATFORM_DIR = join(INFRA_ROOT, '.sst', 'platform')
  */
 function ensureSstPlatform(stage: any) {
   if (sstPlatformState(SST_PLATFORM_DIR) === 'ready') {
-    runSst(['install', '--stage', stage], { timeout: SST_INSTALL_TIMEOUT_MS, label: 'install the SST platform' })
+    runSst(['install', '--stage', stage], {
+      timeout: SST_INSTALL_TIMEOUT_MS,
+      label: 'install the SST platform',
+    })
     console.log(`[${SCRIPT_NAME}] SST platform ... ready`)
     return
   }
 
   console.log(`[${SCRIPT_NAME}] SST platform ... installing (first run: pulumi + providers, a minute or two)`)
   try {
-    runSst(['install', '--stage', stage], { timeout: SST_COLD_INSTALL_TIMEOUT_MS, label: 'install the SST platform' })
+    runSst(['install', '--stage', stage], {
+      timeout: SST_COLD_INSTALL_TIMEOUT_MS,
+      label: 'install the SST platform',
+    })
   } catch (error) {
     if (sstPlatformState(SST_PLATFORM_DIR) !== 'deps-missing') throw error
     console.warn(
@@ -445,7 +451,10 @@ function ensureSstPlatform(stage: any) {
       timeout: SST_INSTALL_TIMEOUT_MS,
       killSignal: 'SIGTERM',
     })
-    runSst(['install', '--stage', stage], { timeout: SST_INSTALL_TIMEOUT_MS, label: 'install the SST platform' })
+    runSst(['install', '--stage', stage], {
+      timeout: SST_INSTALL_TIMEOUT_MS,
+      label: 'install the SST platform',
+    })
   }
   console.log(`[${SCRIPT_NAME}] SST platform ... ready`)
 }
@@ -457,7 +466,19 @@ function ensureSstPlatform(stage: any) {
  *
  * sst writes its own diagnosis to .sst/log/sst.log and prints only "Unexpected
  * error occurred" to the terminal, so a failure here is worthless without that
- * file's tail attached.
+ * file — which is why the error names its path.
+ */
+/*
+ * A failure names the sst log rather than quoting it.
+ *
+ * sst writes provider diagnostics to .sst/log/sst.log, in most detail exactly when a call fails —
+ * request bodies included. This script hands sst an app secret (`secret set`) and a stage's entire
+ * configuration (`secret load`), so quoting that file into an error message puts those values in the
+ * operator's terminal and whatever collects it.
+ *
+ * Gating it per call does not work, which is the version this replaced: the log persists across calls,
+ * so a later `install` failure would quote lines an earlier `secret load` had written. The file is
+ * one line away for anyone debugging, and printing the path costs them nothing.
  */
 function runSst(args: any, { input, timeout, label }: { input?: string; timeout: number; label: string }) {
   try {
@@ -471,18 +492,11 @@ function runSst(args: any, { input, timeout, label }: { input?: string; timeout:
     })
   } catch (cause: any) {
     const hint = cause.code === 'ETIMEDOUT' ? ` after ${Math.round(timeout / 1000)}s` : ''
-    throw new Error(`could not ${label}${hint}${sstLogTail()}`, { cause })
+    const detail = `\n  see ${join(INFRA_ROOT, '.sst', 'log', 'sst.log')}`
+    throw new Error(`could not ${label}${hint}${detail}`, { cause })
   }
 }
 
-function sstLogTail(lines = 5) {
-  try {
-    const tail = readFileSync(join(INFRA_ROOT, '.sst', 'log', 'sst.log'), 'utf8').trimEnd().split('\n').slice(-lines)
-    return tail.length ? `\n  last lines of .sst/log/sst.log:\n${tail.map((line) => `    ${line}`).join('\n')}` : ''
-  } catch {
-    return '' // no log yet — the wrapper's own stderr is all there is
-  }
-}
 
 async function ensureOidcClientId(stage: any) {
   // `?.trim() || undefined` rather than `??`: an env var set to the empty

--- a/apps/infra/bootstrap/bootstrap.ts
+++ b/apps/infra/bootstrap/bootstrap.ts
@@ -842,8 +842,18 @@ async function main() {
   ensureGitHubOidcProvider({ awsCliPath, region })
   ensureGithubEnvironment({ repo, stage, reviewerIds: effectiveReviewerIds })
   if (hasFlag(args, 'provision-auth0')) {
-    const stackDomain = process.env.STACK_DOMAIN
-    if (!stackDomain) throw new Error('STACK_DOMAIN must be set in .env before --provision-auth0 can build callback URLs')
+    /*
+     * From the snapshot that is about to be stored, not from process.env.
+     *
+     * loadDeploymentEnvironment() leaves an exported STACK_DOMAIN in place — a shell override wins
+     * over the file — so reading it here would build Auth0 callback URLs for one domain while the
+     * store, and therefore every deploy, used another. The two would disagree with nothing to say so,
+     * and Auth0 provisioning is not idempotent, so the wrong URLs are not simply re-run away.
+     */
+    const stackDomain = stageConfigLoad.payload.STACK_DOMAIN
+    if (!stackDomain) {
+      throw new Error(`STACK_DOMAIN must be set in ${ENV_PATH} before --provision-auth0 can build callback URLs`)
+    }
     provisionAuth0({ stackDomain })
   }
   await ensureCloudflareCredentials({ awsCliPath, region, stage, repo, force })

--- a/apps/infra/bootstrap/bootstrap.ts
+++ b/apps/infra/bootstrap/bootstrap.ts
@@ -4,9 +4,24 @@
 /*
  * Idempotent, human-run environment preparation for a BoxLite SST
  * deployment: the GitHub OIDC deploy role + runtime IAM boundary
- * (bootstrap/aws/github-deploy-role.yaml), the Cloudflare provider credentials in SSM,
- * the OIDC_CLIENT_ID SST secret, and the GitHub `<stage>` Environment
- * variables/secret the deploy workflow reads. See apps/infra/README.md's
+ * (bootstrap/aws/github-deploy-role.yaml), the GitHub `<stage>` Environment the
+ * deploy workflow binds to, the Cloudflare provider credentials in SSM, and the
+ * stage's own configuration — OIDC_CLIENT_ID, and every key from .env that is not
+ * local-only (deployableStageConfig) — in its SST secret store.
+ *
+ * Four things are written on the GitHub side, all on the stage's own Environment
+ * rather than the repository, so two stages never share them: the variables
+ * AWS_ACCOUNT_ID and AWS_REGION, and the secrets CLOUDFLARE_API_TOKEN and
+ * CLOUDFLARE_DEFAULT_ACCOUNT_ID. None of the four can come from the store: the
+ * workflow composes the deploy role ARN from the account id before any AWS
+ * credentials exist, and reading the store initializes the Cloudflare provider, so
+ * a token kept there would be needed in order to read itself.
+ *
+ * A local deploy reads the Cloudflare pair from SSM instead — or straight from
+ * .env, which wins over both, along with the rest of the local-only keys
+ * (deployment/sst.ts). Everything else, either way, comes from the store.
+ *
+ * See apps/infra/README.md's
  * "Deploy an existing stack" section for the full prerequisite list this
  * script does NOT cover (Cloudflare domain, Auth0/OIDC tenant, an existing
  * Runner — first-Runner provisioning is a separate, not-yet-built operation).
@@ -28,7 +43,8 @@
  *                a community fork resolves to itself automatically)
  *   --reviewers  Comma-separated numeric GitHub user ids required to approve a
  *                deployment (default: whoever is authenticated with `gh`)
- *   --force      see decideSsmOverwrite() in environment-bootstrap.mjs
+ *   --force      re-prompt for a Cloudflare credential that is already seeded
+ *                (decideCredentialRotation() in bootstrap/cloudflare-credentials.ts)
  *   --provision-auth0
  *                Create the Auth0 SPA app, custom API, and post-login Action
  *                (requires `npm run login` first). NOT idempotent — Auth0 has no
@@ -50,20 +66,24 @@ import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { hasFlag, parseFlag } from '../shared/cli-flags.js'
+import { decideCredentialRotation, writeCloudflareCredential } from './cloudflare-credentials.js'
+import { withStageConfigFile } from './stage-config-file.js'
 import { loadDeploymentEnvironment, resolveAwsRegion } from '../deployment/environment.js'
 import {
   GITHUB_OIDC_PROVIDER_URL,
   MINIMUM_AWS_CLI_VERSION,
   cloudFormationDeployChanged,
   cloudFormationParameterOverrides,
-  decideSsmOverwrite,
   githubDeployRoleStackName,
   hasGitHubOidcProvider,
   isAwsCliVersionAtLeast,
+  prepareStageConfigLoad,
+  serializeStageConfig,
   ssmParameterName,
   sstPlatformState,
   validateGitHubRepo,
 } from './environment.js'
+import { validateDotenvSyntax } from '../deployment/validate-environment.js'
 import {
   bindActionArgs,
   createActionArgs,
@@ -292,26 +312,94 @@ function putSsmSecureParameter(awsCliPath: any, region: any, name: any, value: a
   )
 }
 
-async function ensureCloudflareCredentials({ awsCliPath, region, stage, force }: any) {
+function setStageSecret({ stage, name, value }: any) {
+  // 120s, not 60s: this writes to the stage's secret store over the network, and a slow link should
+  // not look like a broken one. The value goes in on stdin — never in argv, where another process
+  // on the machine could read it.
+  runSst(['secret', 'set', name, '--stage', stage], {
+    input: value,
+    timeout: 120_000,
+    label: `set the ${name} secret`,
+  })
+}
+
+/*
+ * The Cloudflare provider credentials, in SSM rather than the stage's SST secret store with
+ * everything else.
+ *
+ * Not an oversight and not inertia: reading the SST store initializes every provider sst.config.ts
+ * declares, Cloudflare included, so `sst secret list` exits with "Cloudflare API not initialized"
+ * before printing anything. A token kept there would be required in order to read itself.
+ *
+ * The deploy workflow does not use these parameters either; it supplies the same two values as
+ * Environment secrets. Whether it could read them instead is untested — see the note in
+ * deployment/sst.ts.
+ */
+async function ensureCloudflareCredentials({ awsCliPath, region, stage, repo, force }: any) {
   for (const { envVar, param, label } of CLOUDFLARE_CREDENTIALS) {
     const name = ssmParameterName(stage, param)
     const fromEnv = process.env[envVar]?.trim()
     if (fromEnv) {
-      putSsmSecureParameter(awsCliPath, region, name, fromEnv)
+      storeCloudflareCredential({ awsCliPath, region, stage, repo, name, envVar, value: fromEnv })
       console.log(`[${SCRIPT_NAME}] ${label} ... set from ${envVar}`)
       continue
     }
 
-    const exists = ssmParameterExists(awsCliPath, region, name)
-    if (decideSsmOverwrite({ exists, force }) === 'skip') {
-      console.log(`[${SCRIPT_NAME}] ${label} ... already set (use --force to change)`)
+    // Both destinations, not just SSM: a rerun has to be able to repair a pair torn by a failed
+    // GitHub write, and keying this on SSM alone made that state permanent.
+    const rotation = decideCredentialRotation({
+      parameterExists: ssmParameterExists(awsCliPath, region, name),
+      environmentSecretExists: ghEnvironmentSecretExists({ repo, stage, name: envVar }),
+      force,
+    })
+    if (rotation === 'skip') {
+      console.log(`[${SCRIPT_NAME}] ${label} ... already set in both stores (use --force to change)`)
       continue
     }
 
     const value = requireNonEmptySecret(label, await promptSecret(`${label}: `))
-    putSsmSecureParameter(awsCliPath, region, name, value)
+    storeCloudflareCredential({ awsCliPath, region, stage, repo, name, envVar, value })
     console.log(`[${SCRIPT_NAME}] ${label} ... set`)
   }
+}
+
+/*
+ * Whether the stage's Environment already holds this secret. Only presence — GitHub never returns a
+ * secret's value — which is what decideCredentialRotation needs to spot a half-written pair.
+ */
+function ghEnvironmentSecretExists({ repo, stage, name }: any) {
+  try {
+    const listed = execFileSync('gh', ['secret', 'list', '--repo', repo, '--env', stage, '--json', 'name'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 30_000,
+      killSignal: 'SIGTERM',
+    })
+    return JSON.parse(listed).some((secret: any) => secret.name === name)
+  } catch {
+    // Unreadable is treated as absent, which biases toward writing. Costing a retyped token is the
+    // right way to be wrong here; the opposite mistake leaves a revoked credential in place.
+    return false
+  }
+}
+
+function ghEnvironmentSecretSet({ repo, stage, name, value }: any) {
+  // The value on stdin, never in argv, where any process on the machine could read it from /proc.
+  execFileSync('gh', ['secret', 'set', name, '--repo', repo, '--env', stage], {
+    input: value,
+    stdio: ['pipe', 'inherit', 'inherit'],
+    timeout: 30_000,
+    killSignal: 'SIGTERM',
+  })
+}
+
+// The rule about which destinations get a rotated credential lives in cloudflare-credentials.ts, so
+// it is reachable from a test; this only supplies the two writers.
+function storeCloudflareCredential({ awsCliPath, region, stage, repo, name, envVar, value }: any) {
+  writeCloudflareCredential(value, {
+    writeParameter: (stored: string) => putSsmSecureParameter(awsCliPath, region, name, stored),
+    writeEnvironmentSecret: (stored: string) => ghEnvironmentSecretSet({ repo, stage, name: envVar, value: stored }),
+  })
 }
 
 const SST_PLATFORM_DIR = join(INFRA_ROOT, '.sst', 'platform')
@@ -402,15 +490,64 @@ async function ensureOidcClientId(stage: any) {
   // accept it and seed an empty secret that only fails at deploy time.
   const fromEnv = process.env.OIDC_CLIENT_ID?.trim() || undefined
   const value = requireNonEmptySecret('OIDC client ID', fromEnv ?? (await promptSecret('OIDC client ID: ')))
-  // 120s, not 60s: the platform is warm by now, but this still writes to the
-  // stage's secret store over the network and a slow link should not look like
-  // a broken one.
-  runSst(['secret', 'set', 'OIDC_CLIENT_ID', '--stage', stage], {
-    input: value,
-    timeout: 120_000,
-    label: 'set the OIDC_CLIENT_ID secret',
-  })
+  setStageSecret({ stage, name: 'OIDC_CLIENT_ID', value })
   console.log(`[${SCRIPT_NAME}] OIDC_CLIENT_ID ... set${fromEnv ? ' from OIDC_CLIENT_ID env' : ''}`)
+}
+
+/*
+ * Put the stage's configuration where a deploy can read it with nothing but AWS credentials.
+ *
+ * This same .env used to travel to CI as the GitHub Environment secret DEPLOY_ENV, which put stage
+ * config in a second control plane: a repository administrator could change what gets deployed with
+ * no AWS access at all, and offboarding meant revoking both. The SST secret store is reachable by
+ * exactly the people who can already deploy the stage.
+ *
+ * So deployment/sst.ts reads this store before it invokes sst, and the only stage configuration left
+ * on the GitHub side is what cannot be read from the store at all: the AWS_ACCOUNT_ID and AWS_REGION
+ * variables, needed before any AWS credentials exist, and the two Cloudflare secrets, needed in order
+ * to read the store.
+ *
+ * One secret per key, not the file as a single blob. A blob would be the DEPLOY_ENV design again —
+ * replaceable only wholesale, invisible to `npm run secrets` — and it would have to carry newlines,
+ * which serializeStageConfig cannot represent. Per-key also keeps `sst.Secret` usable: the store
+ * already holds OIDC_CLIENT_ID and friends under their own names (stack/deploy.ts).
+ *
+ * `sst secret load` merges into the stage's existing secrets rather than replacing them, which is
+ * what keeps this from clobbering those. The cost of merging is that a key REMOVED from .env stays in
+ * the store, so the manifest written alongside the values — STAGE_CONFIG_MANIFEST_KEY, naming exactly
+ * the keys this step owns — is what makes the leftover inert: deployment/sst.ts hydrates only the
+ * names the manifest lists. That is also why the manifest cannot simply be "everything in the store":
+ * the same store holds the hand-set `sst.Secret` values, which the stack reads through sst.Secret and
+ * must never see as process.env.
+ */
+/*
+ * Takes the already-prepared load rather than reading .env again.
+ *
+ * main() validates one snapshot of the file before anything external happens, and this runs after the
+ * OIDC provider, the GitHub Environment and possibly an Auth0 app have been created — minutes later on
+ * a first bootstrap. Re-reading would store whatever the file says by then, which is not what was
+ * validated: an operator editing it while the script runs, or a half-saved buffer, would land in the
+ * stage's store unchecked. One read, one validation, one thing stored.
+ *
+ * The Cloudflare credentials are deliberately not part of this: reading the store initializes the
+ * Cloudflare provider, so a token kept there would be needed in order to read itself. They go to SSM
+ * and the GitHub Environment instead (storeCloudflareCredential).
+ */
+function ensureStageConfig(stage: any, { payload: config, storedKeys, excluded }: any) {
+  // A temp file, because `secret load` takes a path and has no stdin form. It gets a directory of
+  // its own so mkdtemp's 0700 keeps the values unreadable to other users for the seconds they
+  // exist, and the removal is in `finally` so a failed load does not leave them behind.
+  withStageConfigFile(config, (configPath: string) =>
+    runSst(['secret', 'load', configPath, '--stage', stage], {
+      timeout: 120_000,
+      label: 'load the stage configuration into the SST secret store',
+    }),
+  )
+
+  console.log(`[${SCRIPT_NAME}] stage config ... ${storedKeys.length} keys in the SST secret store`)
+  if (excluded.length > 0) {
+    console.log(`[${SCRIPT_NAME}] stage config ... kept out of the store (local-only): ${excluded.join(', ')}`)
+  }
 }
 
 /*
@@ -623,7 +760,27 @@ function deployGithubDeployRoleStack({ awsCliPath, region, stage, repo }: any) {
   return roleArn
 }
 
-function ghVariableSet({ repo, stage, name, value }: any) {
+/*
+ * The two variables GitHub still has to hold, and why neither can live in the store.
+ *
+ * (The stage's Environment also carries the two Cloudflare secrets — storeCloudflareCredential — for
+ * a different reason: reading the store initializes that provider.)
+ *
+ * `aws-actions/configure-aws-credentials` needs the role ARN to obtain credentials, so it is read
+ * before any AWS access exists — which rules out a store that AWS credentials decrypt. Only the
+ * account id is genuinely unknown, though: the role name is githubDeployRoleName(stage), so the
+ * workflows compose the ARN from AWS_ACCOUNT_ID rather than storing the whole ARN.
+ * Same shape e2e-local.yml:89 already uses. The region is written alongside it: the workflows carry
+ * DEFAULT_AWS_REGION as a literal default, which is only right for a stage in that region, so a stage
+ * bootstrapped elsewhere needs the variable to say so.
+ *
+ * Per-stage, not repository-wide. Two stages may live in two AWS accounts — the deploy role is
+ * created by whichever account bootstrap is pointed at — so one shared value would let bootstrapping
+ * prod silently repoint dev's deploys at prod's account. The region goes the same way and for the
+ * same reason as before: it is read before any AWS access exists, so it cannot come from the store,
+ * and a stage outside the default region has nowhere else to say so.
+ */
+function ghEnvironmentVariableSet({ repo, stage, name, value }: any) {
   execFileSync('gh', ['variable', 'set', name, '--repo', repo, '--env', stage, '--body', value], {
     stdio: ['ignore', 'inherit', 'inherit'],
     timeout: 30_000,
@@ -631,29 +788,10 @@ function ghVariableSet({ repo, stage, name, value }: any) {
   })
 }
 
-/*
- * The gh installed here (2.92.0) has no --body-file, and passing it makes gh
- * print usage and exit non-zero. It takes --body, or reads the value from
- * stdin when --body is omitted; --env-file is a different feature entirely
- * (many secrets named by a dotenv file, not one secret whose value is that
- * file). Passing the whole file on stdin is what stores DEPLOY_ENV as a single
- * secret, and keeps the contents out of argv where other processes could read
- * them.
- */
-function ghSecretSetFromFile({ repo, stage, name, filePath }: any) {
-  execFileSync('gh', ['secret', 'set', name, '--repo', repo, '--env', stage], {
-    input: readFileSync(filePath),
-    stdio: ['pipe', 'inherit', 'inherit'],
-    timeout: 30_000,
-    killSignal: 'SIGTERM',
-  })
-}
-
-function wireGithubEnvironment({ repo, stage, region, roleArn }: any) {
-  ghVariableSet({ repo, stage, name: 'AWS_DEPLOY_ROLE_ARN', value: roleArn })
-  ghVariableSet({ repo, stage, name: 'AWS_REGION', value: region })
-  ghSecretSetFromFile({ repo, stage, name: 'DEPLOY_ENV', filePath: requireStageEnvFile() })
-  console.log(`[${SCRIPT_NAME}] GitHub ${stage} environment ... AWS_DEPLOY_ROLE_ARN, AWS_REGION, DEPLOY_ENV set`)
+function wireGithubEnvironment({ repo, stage, accountId, region }: any) {
+  ghEnvironmentVariableSet({ repo, stage, name: 'AWS_ACCOUNT_ID', value: accountId })
+  ghEnvironmentVariableSet({ repo, stage, name: 'AWS_REGION', value: region })
+  console.log(`[${SCRIPT_NAME}] GitHub ${stage} environment ... AWS_ACCOUNT_ID, AWS_REGION set`)
 }
 
 async function main() {
@@ -668,7 +806,23 @@ async function main() {
   const awsCliPath = resolveAwsCliPath()
   const reviewerIds = parseReviewerIds(parseFlag(args, 'reviewers'))
 
-  requireStageEnvFile()
+  // Before any external mutation. Every step below creates or changes something outside this process
+  // — an OIDC provider, a GitHub Environment, optionally a non-idempotent Auth0 app — so a .env this
+  // step could not store must stop the run here rather than after half of them have happened. All
+  // three checks for that reason, not just the syntax: prepareStageConfigLoad rejects a file with
+  // nothing storable in it, and serializeStageConfig a value the store cannot carry.
+  //
+  // The result is kept and handed to ensureStageConfig later, so what gets stored is exactly what was
+  // checked here — the file is read once, not again after those external changes have happened.
+  const stageConfigSource = readFileSync(requireStageEnvFile(), 'utf8')
+  validateDotenvSyntax(stageConfigSource, ENV_PATH)
+  let stageConfigLoad
+  try {
+    stageConfigLoad = prepareStageConfigLoad(stageConfigSource)
+    serializeStageConfig(stageConfigLoad.payload)
+  } catch (cause: any) {
+    throw new Error(`${ENV_PATH} ${cause.message}`, { cause })
+  }
   requireGhAuthenticated()
   const repo = resolveRepo(args)
   requireAwsCliWithLoginSupport(awsCliPath)
@@ -688,15 +842,27 @@ async function main() {
     if (!stackDomain) throw new Error('STACK_DOMAIN must be set in .env before --provision-auth0 can build callback URLs')
     provisionAuth0({ stackDomain })
   }
-  await ensureCloudflareCredentials({ awsCliPath, region, stage, force })
-  // Before the first timed sst call, not inside it — see ensureSstPlatform.
+  await ensureCloudflareCredentials({ awsCliPath, region, stage, repo, force })
+  // Before the first timed sst call, not inside it — see ensureSstPlatform. Both steps below are
+  // `sst secret` calls, so neither can run until the platform sst needs is installed.
   ensureSstPlatform(stage)
   await ensureOidcClientId(stage)
-  const roleArn = deployGithubDeployRoleStack({ awsCliPath, region, stage, repo })
-  wireGithubEnvironment({ repo, stage, region, roleArn })
+  ensureStageConfig(stage, stageConfigLoad)
+  // The role is deployed after the store is seeded so a failure here leaves a stage that is
+  // configured but not yet deployable, rather than one the workflow can reach with no configuration.
+  deployGithubDeployRoleStack({ awsCliPath, region, stage, repo })
+  wireGithubEnvironment({ repo, stage, accountId: identity.Account, region })
 
   console.log(
     `[${SCRIPT_NAME}] done. Preview next: gh workflow run deploy-infra.yml --repo ${repo} --ref main -f stage=${stage} -f apply=false`,
+  )
+  // Not deleted here on purpose. Until this branch is merged, the deploy workflow on main still reads
+  // DEPLOY_ENV, so removing it would break deploys of every commit that predates the store. Printed
+  // rather than silently left behind, because a stale DEPLOY_ENV is invisible once it stops being read.
+  console.log(
+    `[${SCRIPT_NAME}] after the first green apply, retire the superseded GitHub entries:\n` +
+      `  gh secret delete DEPLOY_ENV --repo ${repo} --env ${stage}\n` +
+      `  gh variable delete AWS_DEPLOY_ROLE_ARN --repo ${repo} --env ${stage}`,
   )
 }
 

--- a/apps/infra/bootstrap/bootstrap.ts
+++ b/apps/infra/bootstrap/bootstrap.ts
@@ -761,7 +761,11 @@ function deployGithubDeployRoleStack({ awsCliPath, region, stage, repo }: any) {
 }
 
 /*
- * The two variables GitHub still has to hold, and why neither can live in the store.
+ * The two variables written on GitHub's side — AWS_ACCOUNT_ID, which a deploy cannot do without, and
+ * AWS_REGION, which only a stage outside the default region needs — and why neither can live in the
+ * store. Bootstrap writes both regardless: it knows the region it just deployed into, and stating it
+ * explicitly costs nothing, while leaving it to the workflows' literal default is silently wrong for
+ * exactly the stage that is hardest to debug.
  *
  * (The stage's Environment also carries the two Cloudflare secrets — storeCloudflareCredential — for
  * a different reason: reading the store initializes that provider.)

--- a/apps/infra/bootstrap/cloudflare-credentials.test.ts
+++ b/apps/infra/bootstrap/cloudflare-credentials.test.ts
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { decideCredentialRotation, writeCloudflareCredential } from './cloudflare-credentials.js'
+
+function recordingWriters({ failParameter = false } = {}) {
+  const parameter: string[] = []
+  const environmentSecret: string[] = []
+  // One list, so the order the two destinations are written in is observable — it decides which copy
+  // is left stale when the second write fails.
+  const order: string[] = []
+  return {
+    parameter,
+    environmentSecret,
+    order,
+    writers: {
+      writeParameter: (value: string) => {
+        order.push('parameter')
+        if (failParameter) throw new Error('ssm put-parameter exited 254')
+        parameter.push(value)
+      },
+      writeEnvironmentSecret: (value: string) => {
+        order.push('environmentSecret')
+        environmentSecret.push(value)
+      },
+    },
+  }
+}
+
+test('rotating a credential updates the copy CI reads, not just the SSM fallback', () => {
+  // The regression this exists for: `--force` used to write SSM alone. The deploy workflows pass these
+  // as Environment secrets and deployment/sst.ts uses an already-set variable as-is, so that copy is
+  // what CI actually reads — rotating only SSM leaves a revoked token deploying.
+  const { parameter, environmentSecret, writers } = recordingWriters()
+
+  writeCloudflareCredential('rotated-token', writers)
+
+  assert.deepEqual(parameter, ['rotated-token'])
+  assert.deepEqual(environmentSecret, ['rotated-token'], 'the GitHub copy is the one CI reads')
+})
+
+test('both destinations receive the same value', () => {
+  // A rotation that wrote different values would be worse than one that wrote none: CI and a local
+  // deploy would then authenticate as different credentials with no sign anything was wrong.
+  const { parameter, environmentSecret, writers } = recordingWriters()
+  writeCloudflareCredential('one-value', writers)
+  assert.deepEqual(parameter, environmentSecret)
+})
+
+test('a value surrounded by whitespace is stored trimmed, everywhere', () => {
+  // Pasted tokens carry a trailing newline. Cloudflare rejects it, and the failure surfaces as a
+  // provider auth error during a deploy rather than here.
+  const { parameter, environmentSecret, writers } = recordingWriters()
+  writeCloudflareCredential('  padded-token\n', writers)
+  assert.deepEqual(parameter, ['padded-token'])
+  assert.deepEqual(environmentSecret, ['padded-token'])
+})
+
+test('an empty credential is refused before either destination is touched', () => {
+  // Half-written is the state with no recovery story: one store fresh, one stale, and nothing saying
+  // which. Refusing up front keeps both at their previous values.
+  for (const empty of ['', '   ', '\n']) {
+    const { parameter, environmentSecret, writers } = recordingWriters()
+    assert.throws(() => writeCloudflareCredential(empty, writers), /cannot be empty/)
+    assert.deepEqual(parameter, [], 'nothing may be written to SSM')
+    assert.deepEqual(environmentSecret, [], 'nothing may be written to GitHub')
+  }
+})
+
+test('a rerun repairs a credential whose GitHub write failed after SSM succeeded', () => {
+  // The regression: keying the skip on SSM alone made a torn pair permanent. CI kept the old token and
+  // no rerun would fix it, because the check could not see the half that was missing.
+  assert.equal(decideCredentialRotation({ parameterExists: true, environmentSecretExists: false, force: false }), 'write')
+})
+
+test('a rerun repairs the other half too', () => {
+  assert.equal(decideCredentialRotation({ parameterExists: false, environmentSecretExists: true, force: false }), 'write')
+})
+
+test('a credential present in both places is left alone unless forced', () => {
+  // Why a skip exists at all: never clobber a token that may have been rotated by hand since the last
+  // run, and do not make the operator retype it on every bootstrap.
+  assert.equal(decideCredentialRotation({ parameterExists: true, environmentSecretExists: true, force: false }), 'skip')
+  assert.equal(decideCredentialRotation({ parameterExists: true, environmentSecretExists: true, force: true }), 'write')
+})
+
+test('a credential missing everywhere is written', () => {
+  assert.equal(decideCredentialRotation({ parameterExists: false, environmentSecretExists: false, force: false }), 'write')
+})
+
+test('the copy CI reads is written first', () => {
+  // Ordering is the whole mitigation for a half-completed rotation. If SSM went first, a failed GitHub
+  // write would leave CI on the old token — deploying unattended, discovered only via a provider auth
+  // error. This way the surviving half-write is the one whose failure the operator sees at the prompt.
+  const { order, writers } = recordingWriters()
+  writeCloudflareCredential('a-token', writers)
+  assert.deepEqual(order, ['environmentSecret', 'parameter'])
+})
+
+test('a rotation that half-completes says so, and names the repair', () => {
+  // The gap decideCredentialRotation cannot see: both destinations already existed, so both still
+  // exist, and an ordinary rerun skips. Nothing else in the run knows the two now disagree, so this
+  // error is the only warning the operator gets.
+  const { parameter, environmentSecret, writers } = recordingWriters({ failParameter: true })
+
+  assert.throws(() => writeCloudflareCredential('new-token', writers), /GitHub but not in SSM.*--force/s)
+
+  assert.deepEqual(environmentSecret, ['new-token'], 'the CI copy took the new value')
+  assert.deepEqual(parameter, [], 'SSM kept the old one, which is the divergence being reported')
+})
+
+test('the underlying failure is preserved, not swallowed', () => {
+  // Wrapping must not hide which write failed or why — that is what tells the operator whether to
+  // re-authenticate, fix a policy, or just rerun.
+  const { writers } = recordingWriters({ failParameter: true })
+  assert.throws(() => writeCloudflareCredential('new-token', writers), /ssm put-parameter exited 254/)
+})

--- a/apps/infra/bootstrap/cloudflare-credentials.ts
+++ b/apps/infra/bootstrap/cloudflare-credentials.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+/*
+ * Where a Cloudflare provider credential has to be written, and why it is both places.
+ *
+ * The credential lives in two stores, and which one is read depends on who is deploying:
+ *
+ *   GitHub Environment secret  — what CI reads. deployment/sst.ts uses an already-set variable as-is,
+ *                                and the deploy workflows set these on the job, so this copy wins
+ *                                there and the SSM lookup never runs.
+ *   SSM SecureString           — what a local deploy falls back to when the variable is unset.
+ *
+ * Writing only SSM — which is what `--force` did — rotates the copy CI does not read and leaves the
+ * live one stale, so a revoked token keeps deploying until somebody notices. So the rule is: whenever
+ * bootstrap holds a value, every destination gets it. Ordering still matters for the case where the
+ * second write fails, which is why the CI copy goes first; see writeCloudflareCredential.
+ *
+ * The destinations are injected rather than called directly so this rule is testable without an AWS
+ * account or a GitHub token — bootstrap.ts is a script, and none of it was reachable from a test.
+ */
+
+export interface CloudflareCredentialWriters {
+  writeParameter: (value: string) => void
+  writeEnvironmentSecret: (value: string) => void
+}
+
+export function writeCloudflareCredential(value: string, writers: CloudflareCredentialWriters) {
+  const trimmed = value?.trim()
+  // An empty value would store a credential that only fails at deploy time, as an auth error far from
+  // its cause. Refuse before either destination is touched, so neither ends up half-written.
+  if (!trimmed) throw new Error('a Cloudflare credential cannot be empty')
+
+  // GitHub first, because a failure there has changed nothing at all, and because the alternative
+  // ordering puts the dangerous half-write on the CI side: CI deploys unattended, so a stale token
+  // there keeps shipping until someone reads a provider auth error, while a stale SSM copy fails in
+  // front of the operator who just ran this.
+  writers.writeEnvironmentSecret(trimmed)
+  try {
+    writers.writeParameter(trimmed)
+  } catch (cause: any) {
+    // The pair is now divergent and decideCredentialRotation cannot see it — both destinations exist,
+    // so an ordinary rerun would skip. Say so here, with the flag that repairs it, because this is the
+    // only moment anything knows it happened.
+    throw new Error(
+      `the Cloudflare credential was updated on GitHub but not in SSM, so the two now disagree; ` +
+        `rerun with --force to write both (${cause.message})`,
+      { cause },
+    )
+  }
+}
+
+/*
+ * Whether a rerun has to write this credential again.
+ *
+ * The first version of this asked only whether the SSM parameter existed, which made a partial write
+ * permanent: if the GitHub write failed after SSM succeeded, every later run saw SSM present, skipped,
+ * and left CI on the old token until somebody thought to pass --force. The state that most needed
+ * repairing was exactly the one the check was blind to.
+ *
+ * So a skip needs BOTH destinations present. Existence is all that can be compared, because the GitHub
+ * API never returns a secret's value back.
+ *
+ * That catches a torn FIRST write, where one destination is still absent. It cannot catch a torn
+ * ROTATION: if both already held the old value and only one took the new one, both still exist and a
+ * rerun skips, leaving the two disagreeing indefinitely. Detecting that would need a readable
+ * fingerprint of the secret kept beside it — a second GitHub variable per credential, which is more
+ * contract surface than the case warrants. Instead writeCloudflareCredential writes the CI copy first,
+ * so the failure that survives is the one an operator sees immediately, and it raises an error naming
+ * --force rather than letting the divergence pass silently. Residual risk if that error is ignored, or
+ * if the process is killed between the two writes: --force is the repair either way.
+ */
+export function decideCredentialRotation({ parameterExists, environmentSecretExists, force }: any) {
+  if (force) return 'write'
+  return parameterExists && environmentSecretExists ? 'skip' : 'write'
+}

--- a/apps/infra/bootstrap/environment.test.ts
+++ b/apps/infra/bootstrap/environment.test.ts
@@ -283,12 +283,50 @@ test('serializeStageConfig round-trips the values a stage config actually holds'
   assert.deepEqual(parseDotenv(serializeStageConfig(config)), config)
 })
 
+test('a value containing an apostrophe survives the round trip', () => {
+  // Generated passwords and tokens contain apostrophes routinely, and refusing them outright blocked
+  // bootstrap over a value that is perfectly valid. Asserted by parsing the output rather than by
+  // matching the quoting, since what matters is the value that comes back out.
+  const config = {
+    OIDC_AUDIENCE: "it's-a-token",
+    STACK_DOMAIN: "quote'and\"double",
+  }
+  assert.deepEqual(parseDotenv(serializeStageConfig({ OIDC_AUDIENCE: config.OIDC_AUDIENCE })), {
+    OIDC_AUDIENCE: "it's-a-token",
+  })
+  // A `#` is safe inside quotes — it would otherwise start a comment — so it round-trips.
+  assert.deepEqual(parseDotenv(serializeStageConfig({ OIDC_AUDIENCE: "it's a #hash" })), {
+    OIDC_AUDIENCE: "it's a #hash",
+  })
+  // Both quote kinds together cannot be expressed without escapes the parser would reinterpret, so
+  // that one is still refused — loudly, rather than stored as something else.
+  assert.throws(() => serializeStageConfig({ STACK_DOMAIN: config.STACK_DOMAIN }), /cannot be quoted/)
+})
+
 test('serializeStageConfig refuses a value it cannot represent, without echoing it', () => {
-  for (const value of ["it's quoted", 'first\nsecond', 'carriage\rreturn']) {
+  // A newline cannot go on one line at all; a value mixing both quote kinds cannot be quoted without
+  // escapes the parser would reinterpret. Either way the message must not repeat the value — this runs
+  // over credentials, and the error reaches a terminal and whatever collects it.
+  const unrepresentable: Array<[string, RegExp]> = [
+    ['first\nsecond', /GHCR_TOKEN contains a newline/],
+    ['carriage\rreturn', /GHCR_TOKEN contains a newline/],
+    /*
+     * Everything the double-quoted form cannot carry, which is the branch an apostrophe falls into.
+     * The backslash mangles `C:\new` through the unescape pass. The `$` and the backtick are refused
+     * for the store's actual reader: `sst secret load` is Go, and godotenv expands `$VAR` inside
+     * double quotes — JavaScript's dotenv does not, so testing only against that would bless a value
+     * sst stores differently.
+     */
+    [`it's "quoted"`, /GHCR_TOKEN mixes a single quote/],
+    ["it's C:\\new", /GHCR_TOKEN mixes a single quote/],
+    ["it's $HOME", /GHCR_TOKEN mixes a single quote/],
+    ["it's `whoami`", /GHCR_TOKEN mixes a single quote/],
+  ]
+  for (const [value, expected] of unrepresentable) {
     assert.throws(
       () => serializeStageConfig({ GHCR_TOKEN: value }),
       (error: any) => {
-        assert.match(error.message, /GHCR_TOKEN contains a single quote or newline/)
+        assert.match(error.message, expected)
         assert.equal(error.message.includes(value), false)
         return true
       },

--- a/apps/infra/bootstrap/environment.test.ts
+++ b/apps/infra/bootstrap/environment.test.ts
@@ -173,6 +173,32 @@ test('a value left behind by an interrupted load is caught', () => {
   assert.notEqual(recordedDigest, actualDigest)
 })
 
+test('an app-wide fallback cannot supply a stage its manifest or digest', () => {
+  /*
+   * `sst secret set --fallback` writes under the literal stage `_fallback`, which every stage reads.
+   * If the bookkeeping keys came from there, a stage nobody bootstrapped would inherit a manifest and
+   * a digest that agree with each other, sail through both fail-closed checks, and deploy another
+   * source's configuration — the exact case those checks exist to stop.
+   */
+  const printed = [
+    '# fallback',
+    `${STAGE_CONFIG_MANIFEST_KEY}=STACK_DOMAIN`,
+    `${STAGE_CONFIG_DIGEST_KEY}=${'a'.repeat(64)}`,
+    'STACK_DOMAIN=shared.example.test',
+    '# boxlite/dev',
+  ].join('\n')
+
+  const stored = parseSecretList(printed, { app: 'boxlite', stage: 'dev' })
+  assert.equal(stored[STAGE_CONFIG_MANIFEST_KEY], undefined, 'a fallback must not name a stage manifest')
+  assert.equal(stored[STAGE_CONFIG_DIGEST_KEY], undefined, 'nor supply the digest that would match it')
+  // An ordinary value still falls back, which is what the feature is for — it simply cannot be
+  // hydrated until the stage's own manifest names it.
+  assert.equal(stored.STACK_DOMAIN, 'shared.example.test')
+
+  const { apply } = hydrateStageConfig({ stored, environment: {} })
+  assert.deepEqual(apply, {}, 'with no stage manifest, nothing is hydrated')
+})
+
 test('a store with a manifest but no digest reads as torn, not as unverifiable', () => {
   // The first interrupted load is exactly this shape: the manifest landed, the digest did not. Treating
   // an absent digest as "cannot verify, carry on" would let that one case through unchecked — and it is

--- a/apps/infra/bootstrap/environment.test.ts
+++ b/apps/infra/bootstrap/environment.test.ts
@@ -3,24 +3,36 @@
 
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+
+import { parse as parseDotenv } from 'dotenv'
 
 import {
   GITHUB_OIDC_PROVIDER_URL,
   cloudFormationDeployChanged,
   cloudFormationParameterOverrides,
-  decideSsmOverwrite,
+  deployableStageConfig,
+  githubDeployRoleName,
   githubDeployRoleStackName,
   hasGitHubOidcProvider,
   isAwsCliVersionAtLeast,
   parseAwsCliVersion,
+  prepareStageConfigLoad,
   runtimeBoundaryPolicyArn,
+  serializeStageConfig,
   ssmParameterName,
   sstPlatformState,
   validateGitHubRepo,
 } from './environment.js'
+import {
+  STAGE_CONFIG_DIGEST_KEY,
+  STAGE_CONFIG_MANIFEST_KEY,
+  hydrateStageConfig,
+  parseSecretList,
+  parseStageConfigManifest,
+} from '../deployment/stage-config.js'
 
 test('runtimeBoundaryPolicyArn matches sst.config.ts interpolation', () => {
   assert.equal(
@@ -73,14 +85,215 @@ test('ssmParameterName is stage-scoped', () => {
   assert.throws(() => ssmParameterName('dev', ''), /param is required/)
 })
 
-test('decideSsmOverwrite skips an existing parameter unless --force is set', () => {
-  assert.equal(decideSsmOverwrite({ exists: true, force: false }), 'skip')
-  assert.equal(decideSsmOverwrite({ exists: true, force: true }), 'prompt')
+test('githubDeployRoleName matches the RoleName the CloudFormation template declares', () => {
+  // The workflows compose the deploy role ARN from this name, and the template creates the role, so
+  // a drift between them is a deploy that cannot assume its own role. Read from the template rather
+  // than restated, so editing either side alone fails here.
+  const template = readFileSync(new URL('./aws/github-deploy-role.yaml', import.meta.url), 'utf8')
+  assert.match(template, /RoleName: !Sub boxlite-\$\{GitHubEnvironment\}-github-deploy$/m)
+  assert.equal(githubDeployRoleName('dev'), 'boxlite-dev-github-deploy')
+  assert.throws(() => githubDeployRoleName('dev_blue'), /must match/)
 })
 
-test('decideSsmOverwrite always prompts when the parameter does not exist yet', () => {
-  assert.equal(decideSsmOverwrite({ exists: false, force: false }), 'prompt')
-  assert.equal(decideSsmOverwrite({ exists: false, force: true }), 'prompt')
+test('deployableStageConfig stores stage configuration and keeps local-only keys out', () => {
+  const { config, excluded } = deployableStageConfig(
+    [
+      'STACK_DOMAIN=dev.boxlite.ai',
+      'OIDC_AUDIENCE=https://dev.boxlite.ai/api',
+      // Legitimate locally — stack/app.ts reads it — so it must be kept out rather than reject
+      // the whole file and leave an operator on a named profile unable to bootstrap.
+      'AWS_PROFILE=developer',
+      'AWS_CLI_PATH=/opt/local/bin/aws',
+      // The selector CI owns: a stage-wide store entry redirecting it would deploy an artifact no
+      // workflow run ever approved.
+      'BOXLITE_ARTIFACT_SOURCE=release',
+      '# a comment',
+      'PROXY_TEMPLATE_URL=',
+    ].join('\n'),
+  )
+
+  assert.deepEqual(config, {
+    OIDC_AUDIENCE: 'https://dev.boxlite.ai/api',
+    PROXY_TEMPLATE_URL: '',
+    STACK_DOMAIN: 'dev.boxlite.ai',
+  })
+  assert.deepEqual(excluded, ['AWS_CLI_PATH', 'AWS_PROFILE', 'BOXLITE_ARTIFACT_SOURCE'])
+})
+
+/*
+ * What `sst secret load` then `sst secret list` do to the payload, without sst.
+ *
+ * Load parses the file as dotenv; list prints `key=value` back under a `# <app>/<stage>` heading. The
+ * round trip matters because bootstrap writes the digest and the deploy wrapper recomputes it: any
+ * disagreement between serializeStageConfig's quoting and parseSecretList's reading surfaces as a
+ * digest mismatch on every deploy, not as a parse error anyone would trace back here.
+ */
+function throughSecretStore(payload: Record<string, string>) {
+  const stored = parseDotenv(serializeStageConfig(payload))
+  const printed = ['# fallback', '# boxlite/dev']
+  for (const [key, value] of Object.entries(stored)) printed.push(`${key}=${value}`)
+  return parseSecretList(printed.join('\n'), { app: 'boxlite', stage: 'dev' })
+}
+
+const STAGE_ENV_SOURCE = [
+  'STACK_DOMAIN=dev.boxlite.ai',
+  'OIDC_AUDIENCE=https://dev.boxlite.ai/api',
+  'AWS_PROFILE=developer',
+  'PROXY_TEMPLATE_URL=',
+].join('\n')
+
+test('the digest bootstrap writes is the one hydration recomputes', () => {
+  // The two halves of the generation check are computed by different modules from different inputs —
+  // bootstrap from .env, the wrapper from what the store prints back. They have to agree on every
+  // value that survives quoting, or the fail-closed check rejects a store that is perfectly intact.
+  const { payload } = prepareStageConfigLoad(STAGE_ENV_SOURCE)
+  const { recordedDigest, actualDigest, apply } = hydrateStageConfig({
+    stored: throughSecretStore(payload),
+    environment: {},
+  })
+
+  assert.notEqual(recordedDigest, '', 'bootstrap must write a digest for the check to have anything to do')
+  assert.equal(recordedDigest, actualDigest)
+  assert.deepEqual(apply, {
+    OIDC_AUDIENCE: 'https://dev.boxlite.ai/api',
+    PROXY_TEMPLATE_URL: '',
+    STACK_DOMAIN: 'dev.boxlite.ai',
+  })
+})
+
+test('a value left behind by an interrupted load is caught', () => {
+  // `secret load` is a read-modify-write of one document and is not atomic, so an interrupted one
+  // leaves some keys new and some old. The manifest cannot see it — every name it lists is still
+  // present — which is the whole reason the digest exists.
+  const { payload } = prepareStageConfigLoad(STAGE_ENV_SOURCE)
+  const stored = throughSecretStore(payload)
+  stored.STACK_DOMAIN = 'stale.boxlite.ai'
+
+  const { recordedDigest, actualDigest } = hydrateStageConfig({ stored, environment: {} })
+  assert.notEqual(recordedDigest, actualDigest)
+})
+
+test('a store with a manifest but no digest reads as torn, not as unverifiable', () => {
+  // The first interrupted load is exactly this shape: the manifest landed, the digest did not. Treating
+  // an absent digest as "cannot verify, carry on" would let that one case through unchecked — and it is
+  // the only case that can occur, since no bootstrap has ever written a manifest without a digest.
+  const { payload } = prepareStageConfigLoad(STAGE_ENV_SOURCE)
+  const stored = throughSecretStore(payload)
+  delete stored[STAGE_CONFIG_DIGEST_KEY]
+
+  const { recordedDigest, actualDigest } = hydrateStageConfig({ stored, environment: {} })
+  assert.equal(recordedDigest, '')
+  assert.notEqual(actualDigest, '', 'the recomputed digest is what makes the absence detectable')
+  assert.notEqual(recordedDigest, actualDigest, 'the wrapper compares these two and must see a mismatch')
+})
+
+test('a value the manifest does not name is outside the digest, as it is outside hydration', () => {
+  // The store also holds hand-set sst.Secret values whose rotation has nothing to do with this
+  // configuration. If they counted, every `sst secret set` would read as a torn load.
+  const { payload } = prepareStageConfigLoad(STAGE_ENV_SOURCE)
+  const stored = throughSecretStore(payload)
+  stored.OIDC_CLIENT_ID = 'rotated-by-hand'
+
+  const { recordedDigest, actualDigest, apply, unlisted } = hydrateStageConfig({ stored, environment: {} })
+  assert.equal(recordedDigest, actualDigest, 'an unrelated secret must not read as a torn load')
+  assert.equal(apply.OIDC_CLIENT_ID, undefined, 'the stack reads it through sst.Secret, not process.env')
+  assert.ok(unlisted.includes('OIDC_CLIENT_ID'))
+})
+
+test('a .env with nothing storable in it is refused', () => {
+  // main() runs this before the OIDC provider, the GitHub Environment and a non-idempotent Auth0 app
+  // are created. A file of only local-only keys would otherwise store a manifest naming nothing, and
+  // the deploy wrapper would fail with the stage half-bootstrapped.
+  assert.throws(
+    () => prepareStageConfigLoad('AWS_PROFILE=developer\nAWS_CLI_PATH=/opt/local/bin/aws\n'),
+    /no deployable stage configuration/,
+  )
+})
+
+test('the manifest names exactly the keys bootstrap stored', () => {
+  // Not "everything in the store": the leftover from a key deleted from .env has to stay unnamed, and
+  // the Cloudflare credentials are refused by the allowlist anyway — naming them would claim a
+  // hydration that cannot happen.
+  const { payload, storedKeys } = prepareStageConfigLoad(STAGE_ENV_SOURCE)
+  // Sorted on both sides: the manifest is serialized in sorted order and hydration reads it into a
+  // Set, so .env's line order is not part of the contract.
+  assert.deepEqual(parseStageConfigManifest(payload[STAGE_CONFIG_MANIFEST_KEY]), [...storedKeys].sort())
+  assert.deepEqual([...storedKeys].sort(), ['OIDC_AUDIENCE', 'PROXY_TEMPLATE_URL', 'STACK_DOMAIN'])
+  assert.deepEqual(
+    Object.keys(payload).filter((key) => key.startsWith('CLOUDFLARE_')),
+    [],
+    'the credentials that cannot live in the store must not be named as if they could',
+  )
+})
+
+test('deployableStageConfig keeps the Cloudflare credentials out of the store', () => {
+  // .env.example ships both keys at column 0, so a filled-in .env almost always holds the token.
+  // Copying it into the store would be circular (reading the store initializes that provider) as well
+  // as putting a live credential in a second place.
+  const { config, excluded } = deployableStageConfig(
+    [
+      'CLOUDFLARE_API_TOKEN=synthetic-token',
+      'CLOUDFLARE_DEFAULT_ACCOUNT_ID=synthetic-account',
+      'AWS_REGION=eu-west-1',
+      'SST_STAGE=dev',
+      'VERSION=1.2.3',
+      'STACK_DOMAIN=dev.boxlite.ai',
+    ].join('\n'),
+  )
+
+  assert.deepEqual(config, { STACK_DOMAIN: 'dev.boxlite.ai' })
+  assert.deepEqual(excluded, [
+    'AWS_REGION',
+    'CLOUDFLARE_API_TOKEN',
+    'CLOUDFLARE_DEFAULT_ACCOUNT_ID',
+    'SST_STAGE',
+    'VERSION',
+  ])
+})
+
+test('deployableStageConfig keeps out the AWS_ENDPOINT_URL_<SERVICE> family, not just the bare name', () => {
+  // A prefix rather than a name, so a membership test on its own would store every member of it
+  // and let a store entry point the deploy at an attacker-controlled endpoint.
+  const { config, excluded } = deployableStageConfig('AWS_ENDPOINT_URL_S3=https://s3.invalid\nSTACK_DOMAIN=dev.boxlite.ai\n')
+  assert.deepEqual(Object.keys(config), ['STACK_DOMAIN'])
+  assert.deepEqual(excluded, ['AWS_ENDPOINT_URL_S3'])
+})
+
+test('serializeStageConfig emits the single-quoted form sst secret load reads literally', () => {
+  // Pinned, not incidental: sst's double-quoted branch unescapes \" \n \r \t, so that form cannot
+  // carry a value holding one of those sequences literally.
+  assert.equal(
+    serializeStageConfig({ STACK_DOMAIN: 'dev.boxlite.ai', BOXLITE_SYSTEM_IMAGES: 'a=ghcr.io/x:1' }),
+    "BOXLITE_SYSTEM_IMAGES='a=ghcr.io/x:1'\nSTACK_DOMAIN='dev.boxlite.ai'\n",
+  )
+  assert.equal(serializeStageConfig({}), '')
+})
+
+test('serializeStageConfig round-trips the values a stage config actually holds', () => {
+  const config = {
+    // `#` would start a comment unquoted, `=` must survive the split-on-first-`=`, and the spaces
+    // would be eaten by the trim. `C:\new` is the one that rules out the double-quoted form: its
+    // literal backslash-n goes through that form's unescape pass and comes back as a newline.
+    BOXLITE_SYSTEM_IMAGES: 'base=ghcr.io/acme/base:v1,py=ghcr.io/acme/py:v1',
+    OIDC_ISSUER_BASE_URL: 'https://tenant.auth0.com/',
+    PADDED: '  leading and trailing  ',
+    WINDOWS_PATH: 'C:\\new\\thing',
+    WITH_HASH: 'value # not a comment',
+  }
+  assert.deepEqual(parseDotenv(serializeStageConfig(config)), config)
+})
+
+test('serializeStageConfig refuses a value it cannot represent, without echoing it', () => {
+  for (const value of ["it's quoted", 'first\nsecond', 'carriage\rreturn']) {
+    assert.throws(
+      () => serializeStageConfig({ GHCR_TOKEN: value }),
+      (error: any) => {
+        assert.match(error.message, /GHCR_TOKEN contains a single quote or newline/)
+        assert.equal(error.message.includes(value), false)
+        return true
+      },
+    )
+  }
 })
 
 test('parseAwsCliVersion reads the real `aws --version` banner', () => {

--- a/apps/infra/bootstrap/environment.ts
+++ b/apps/infra/bootstrap/environment.ts
@@ -15,6 +15,18 @@
 import { existsSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 
+import { parse } from 'dotenv'
+
+import {
+  STAGE_CONFIG_DIGEST_KEY,
+  STAGE_CONFIG_MANIFEST_KEY,
+  parseStageConfigManifest,
+  serializeStageConfigManifest,
+  stageConfigDigest,
+} from '../deployment/stage-config.js'
+import { isStorableStageConfigKey } from '../deployment/storable-keys.js'
+import { isLocalOnlyDeploymentKey } from '../deployment/validate-environment.js'
+
 const STAGE_LIKE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9-]*$/
 const GITHUB_REPO_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.-]*\/[A-Za-z0-9][A-Za-z0-9_.-]*$/
 const ACCOUNT_ID_PATTERN = /^\d{12}$/
@@ -81,34 +93,23 @@ export function ssmParameterName(stage: any, param: any) {
   return `/boxlite/${stage}/${param}`
 }
 
-/**
- * `/boxlite/<stage>/<param>` already holds a value from a previous run —
- * decide what this run does about it.
+/*
+ * IAM role name for the GitHub deploy role.
  *
- * This script has to stay idempotent for two different operators: BoxLite's
- * own reruns, and a community fork's operator running it against their own
- * AWS account, possibly months apart. "Already exists" therefore needs a
- * deliberate answer instead of whatever a generic overwrite-or-skip default
- * would do:
+ * Its own function even though it currently returns the same string as githubDeployRoleStackName: a
+ * CloudFormation stack name and the IAM role that stack declares are separate contracts, and the
+ * workflows compose the role ARN from this name while `cloudformation deploy` addresses the stack by
+ * the other. Renaming one must not silently rename the other. Pinned against the template's own
+ * `RoleName` by a test, which turns a drift into a failure instead of a deploy that cannot assume its
+ * role.
  *
- *   'skip'   — leave the existing value alone. Safest: never clobbers a
- *              token that may have been rotated or hand-edited since the
- *              last run. Matches how `deployment/sst.ts` already
- *              treats a credential found in the environment — used as-is,
- *              never re-probed (deployment/sst.ts).
- *   'prompt' — always re-collect and overwrite. Simplest mental model: the
- *              parameter always ends up matching whatever was just typed,
- *              at the cost of retyping a token on every rerun.
- *
- * `force` is the operator's explicit `--force` CLI flag and should always
- * win, in whichever direction makes sense for the answer below.
- *
- * @param {{ exists: boolean, force: boolean }} args
- * @returns {'skip' | 'prompt'}
+ * It sits outside shared/resource-name.ts's grammar for now — see the note there. Moving it costs a
+ * CloudFormation replacement and an edit to every workflow that composes the ARN, which is its own
+ * change rather than a rider on this one.
  */
-export function decideSsmOverwrite({ exists, force }: any) {
-  if (!exists) return 'prompt' // nothing to protect yet
-  return force ? 'prompt' : 'skip'
+export function githubDeployRoleName(stage: any) {
+  requireStageLike('stage', stage)
+  return `boxlite-${stage}-github-deploy`
 }
 
 // `aws --version` prints e.g. `aws-cli/2.35.11 Python/3.14.6 Darwin/27.0.0 source/arm64`.
@@ -147,6 +148,67 @@ export function hasGitHubOidcProvider(listOutput: any, url = GITHUB_OIDC_PROVIDE
 }
 
 /*
+ * Split the operator's local .env into the part that belongs in the stage's shared SST secret
+ * store and the part that must stay on this machine.
+ *
+ * Two rules decide what is kept: the key must be one the deploy actually reads
+ * (isStorableStageConfigKey, derived from source), and it must not be one that has to stay on this
+ * machine (isLocalOnlyDeploymentKey — AWS_PROFILE, AWS_CLI_PATH, the artifact selectors CI owns, and
+ * the keys consulted before the store can be reached at all). Anything else in .env is left here,
+ * which is deliberate: an operator's file may hold all sorts of things, and only what a deploy reads
+ * belongs in a store every deployer of the stage can read. They are kept OUT rather than made a hard error, because they
+ * are legitimate locally — stack/app.ts reads AWS_PROFILE — so rejecting the file would leave an
+ * operator who needs a named profile unable to bootstrap at all. Storing them would be worse than
+ * either: a machine-specific `aws` path, or an artifact redirect, handed to every deployer of the
+ * stage.
+ *
+ * Everything else is stored exactly as dotenv parsed it, empty values included. `KEY=` and an
+ * absent key already mean the same thing to every consumer (envOr, requireEnv, and the
+ * `process.env.X && {...}` spreads all treat '' as unset), so dropping blanks would add a rule
+ * without changing a deploy.
+ */
+export function deployableStageConfig(source: any) {
+  const parsed = parse(source ?? '')
+  const config: Record<string, string> = {}
+  const excluded = []
+  for (const key of Object.keys(parsed).sort()) {
+    if (!isStorableStageConfigKey(key) || isLocalOnlyDeploymentKey(key)) {
+      excluded.push(key)
+      continue
+    }
+    config[key] = parsed[key]
+  }
+  return { config, excluded }
+}
+
+/*
+ * The stage config as a file `sst secret load` reads back byte-for-byte.
+ *
+ * sst's parser splits each line on the first `=`, trims both halves, and only then strips quotes.
+ * The double-quoted form then runs an unescape pass over \" \n \r \t, so a value holding one of
+ * those two-character sequences literally — `C:\new`, a token with a stray backslash — comes back
+ * changed. The single-quoted form strips the quotes and does nothing else, so it round-trips, and
+ * the quotes also protect a leading or trailing space from the trim and a `#` from being read as
+ * the start of a comment.
+ *
+ * A value containing a single quote or a newline has no such representation. Refuse it here rather
+ * than store a mangled token, which would surface much later as an opaque auth failure. The value
+ * itself stays out of the message — this runs over credentials.
+ */
+export function serializeStageConfig(config: any) {
+  const lines = Object.keys(config ?? {})
+    .sort()
+    .map((key) => {
+      const value = String(config[key])
+      if (/['\r\n]/.test(value)) {
+        throw new Error(`${key} contains a single quote or newline, which the stage configuration store cannot represent`)
+      }
+      return `${key}='${value}'`
+    })
+  return lines.length > 0 ? `${lines.join('\n')}\n` : ''
+}
+
+/*
  * Whether sst's platform directory is usable. sst writes package.json on its
  * first run and only then installs the deps, so "package.json but no
  * node_modules" is the signature of an install that started and did not finish
@@ -158,5 +220,40 @@ export function sstPlatformState(dir: any) {
     return readdirSync(join(dir, 'node_modules')).length > 0 ? 'ready' : 'deps-missing'
   } catch {
     return 'deps-missing'
+  }
+}
+
+/*
+ * Everything one `sst secret load` will write, decided in one place.
+ *
+ * Both the values and the bookkeeping that describes them — the manifest of key names and the digest
+ * hydration verifies against — because they have to go into the same load. Written apart, an
+ * interruption between them leaves values whose digest describes a different generation, which is the
+ * failure the digest exists to catch rather than cause.
+ *
+ * Pure, so bootstrap's .env-to-store wiring is checkable without an AWS account: the arguments, the
+ * manifest and the refusals are all decided here.
+ */
+export function prepareStageConfigLoad(source: any) {
+  const { config, excluded } = deployableStageConfig(source)
+  const storedKeys = Object.keys(config)
+  if (storedKeys.length === 0) {
+    throw new Error(
+      'defines no deployable stage configuration — every key is local-only or unread by the deploy',
+    )
+  }
+
+  const manifest = serializeStageConfigManifest(storedKeys)
+  return {
+    excluded,
+    storedKeys,
+    payload: {
+      ...config,
+      [STAGE_CONFIG_MANIFEST_KEY]: manifest,
+      // Over the manifest's own keys rather than over `config`, so the two sides hash the same list:
+      // hydration has only the manifest to go by. A value that reaches the store without being named
+      // is then outside the digest, which is correct — an unnamed key is never hydrated either.
+      [STAGE_CONFIG_DIGEST_KEY]: stageConfigDigest(parseStageConfigManifest(manifest), config),
+    },
   }
 }

--- a/apps/infra/bootstrap/environment.ts
+++ b/apps/infra/bootstrap/environment.ts
@@ -244,16 +244,16 @@ export function prepareStageConfigLoad(source: any) {
   }
 
   const manifest = serializeStageConfigManifest(storedKeys)
-  return {
-    excluded,
-    storedKeys,
-    payload: {
-      ...config,
-      [STAGE_CONFIG_MANIFEST_KEY]: manifest,
-      // Over the manifest's own keys rather than over `config`, so the two sides hash the same list:
-      // hydration has only the manifest to go by. A value that reaches the store without being named
-      // is then outside the digest, which is correct — an unnamed key is never hydrated either.
-      [STAGE_CONFIG_DIGEST_KEY]: stageConfigDigest(parseStageConfigManifest(manifest), config),
-    },
+  // Typed as a plain map: the literal below would otherwise infer down to just the two bookkeeping
+  // keys, and a caller reading a configuration value out of it would not typecheck.
+  const payload: Record<string, string> = {
+    ...config,
+    [STAGE_CONFIG_MANIFEST_KEY]: manifest,
+    // Over the manifest's own keys rather than over `config`, so the two sides hash the same list:
+    // hydration has only the manifest to go by. A value that reaches the store without being named
+    // is then outside the digest, which is correct — an unnamed key is never hydrated either.
+    [STAGE_CONFIG_DIGEST_KEY]: stageConfigDigest(parseStageConfigManifest(manifest), config),
   }
+
+  return { excluded, storedKeys, payload }
 }

--- a/apps/infra/bootstrap/environment.ts
+++ b/apps/infra/bootstrap/environment.ts
@@ -191,8 +191,18 @@ export function deployableStageConfig(source: any) {
  * the quotes also protect a leading or trailing space from the trim and a `#` from being read as
  * the start of a comment.
  *
- * A value containing a single quote or a newline has no such representation. Refuse it here rather
- * than store a mangled token, which would surface much later as an opaque auth failure. The value
+ * So single quotes are the default. A value holding one of its own cannot use them, and an apostrophe
+ * is ordinary in a generated password — so that case takes the double-quoted form instead, but only
+ * when the value contains no `"`, `\`, `$` or backtick.
+ *
+ * The `$` matters and is easy to get wrong: `sst secret load` is Go, and godotenv expands `$VAR`
+ * inside double quotes. Checking this against JavaScript's dotenv says otherwise — that one does no
+ * expansion — so a password containing `$` would round-trip in a unit test here and be stored as
+ * something else by sst. The single-quoted form is exempt because neither parser expands inside it.
+ *
+ * What is left has no representation: a newline, which the one-assignment-per-line format cannot hold
+ * at all, and a value mixing a single quote with one of those four characters. Both are refused here
+ * rather than stored mangled, which would surface much later as an opaque auth failure. The value
  * itself stays out of the message — this runs over credentials.
  */
 export function serializeStageConfig(config: any) {
@@ -200,10 +210,24 @@ export function serializeStageConfig(config: any) {
     .sort()
     .map((key) => {
       const value = String(config[key])
-      if (/['\r\n]/.test(value)) {
-        throw new Error(`${key} contains a single quote or newline, which the stage configuration store cannot represent`)
+      // A newline cannot be represented at all: the format is one assignment per line.
+      if (/[\r\n]/.test(value)) {
+        throw new Error(`${key} contains a newline, which the stage configuration store cannot represent`)
       }
-      return `${key}='${value}'`
+      // Single quotes are the exact form — the parser strips them and does nothing else — so they are
+      // the default whenever the value has none of its own.
+      if (!value.includes("'")) return `${key}='${value}'`
+      /*
+       * An apostrophe is ordinary in a generated password or token, so refusing it outright would
+       * block bootstrap over a perfectly valid secret. Double quotes carry it, but they also make the
+       * parser process escapes — so this form is used only when there is nothing in the value for an
+       * escape to alter. Anything else is refused rather than silently mangled into a different value.
+       */
+      if (!/["\\$`]/.test(value)) return `${key}="${value}"`
+      throw new Error(
+        `${key} mixes a single quote with one of " \\ $ or a backtick, which cannot be quoted for the ` +
+          'stage configuration store without changing the value',
+      )
     })
   return lines.length > 0 ? `${lines.join('\n')}\n` : ''
 }

--- a/apps/infra/bootstrap/github.ts
+++ b/apps/infra/bootstrap/github.ts
@@ -5,7 +5,8 @@
  * Pure helpers for creating the deployment stage's GitHub Environment.
  *
  * The deploy workflow binds to `environment: ${{ inputs.stage }}` and reads
- * `AWS_DEPLOY_ROLE_ARN`/`AWS_REGION`/`DEPLOY_ENV` from it, and the AWS trust
+ * `AWS_ACCOUNT_ID`/`AWS_REGION` from it — the stage's own configuration comes
+ * from its SST secret store, not from GitHub — and the AWS trust
  * policy pins `repo:<owner>/<repo>:environment:<stage>` — so the Environment
  * must exist, under exactly that name, before any of it works.
  *

--- a/apps/infra/bootstrap/stage-config-file.test.ts
+++ b/apps/infra/bootstrap/stage-config-file.test.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { existsSync, readFileSync, statSync } from 'node:fs'
+import { dirname } from 'node:path'
+
+import { withStageConfigFile } from './stage-config-file.js'
+
+const CONFIG = { STACK_DOMAIN: 'dev.boxlite.ai', OIDC_AUDIENCE: 'https://dev.boxlite.ai/api' }
+
+test('hands sst a file holding exactly the serialized configuration', () => {
+  // What `sst secret load` will parse. Read inside the callback because the file is gone after it.
+  const contents = withStageConfigFile(CONFIG, (path: string) => readFileSync(path, 'utf8'))
+  assert.equal(contents, "OIDC_AUDIENCE='https://dev.boxlite.ai/api'\nSTACK_DOMAIN='dev.boxlite.ai'\n")
+})
+
+test('keeps the configuration unreadable to other users while it exists', () => {
+  // The whole stage configuration sits on disk for the length of one command. Both the file and the
+  // directory holding it are checked: a permissive umask would widen the file, and a shared parent
+  // would expose it regardless of the file's own mode.
+  const modes = withStageConfigFile(CONFIG, (path: string) => ({
+    file: statSync(path).mode & 0o777,
+    directory: statSync(dirname(path)).mode & 0o777,
+  }))
+  assert.equal(modes.file, 0o600)
+  assert.equal(modes.directory, 0o700)
+})
+
+test('removes the file once the load has finished', () => {
+  const path = withStageConfigFile(CONFIG, (configPath: string) => configPath)
+  assert.equal(existsSync(path), false)
+  assert.equal(existsSync(dirname(path)), false, 'the directory goes too, not just the file')
+})
+
+test('removes the file when the load fails', () => {
+  // The case that matters: `secret load` throwing is exactly when someone walks away from the
+  // terminal, and a `finally` is the only thing that stops the configuration staying in /tmp.
+  let path = ''
+  assert.throws(
+    () =>
+      withStageConfigFile(CONFIG, (configPath: string) => {
+        path = configPath
+        throw new Error('synthetic secret load failure')
+      }),
+    /synthetic secret load failure/,
+  )
+  assert.notEqual(path, '')
+  assert.equal(existsSync(path), false)
+  assert.equal(existsSync(dirname(path)), false)
+})
+
+test('refuses a configuration it cannot represent before writing anything', () => {
+  // serializeStageConfig throws on a value the single-quoted form cannot carry. Nothing may reach
+  // disk in that case, and the callback must never run.
+  let ran = false
+  assert.throws(
+    () => withStageConfigFile({ GHCR_TOKEN: "it's quoted" }, () => (ran = true)),
+    /GHCR_TOKEN contains a single quote or newline/,
+  )
+  assert.equal(ran, false)
+})

--- a/apps/infra/bootstrap/stage-config-file.test.ts
+++ b/apps/infra/bootstrap/stage-config-file.test.ts
@@ -52,12 +52,13 @@ test('removes the file when the load fails', () => {
 })
 
 test('refuses a configuration it cannot represent before writing anything', () => {
-  // serializeStageConfig throws on a value the single-quoted form cannot carry. Nothing may reach
+  // serializeStageConfig throws on a value no quoting carries — here both quote kinds at once, since
+  // an apostrophe alone is ordinary in a token and is now written double-quoted. Nothing may reach
   // disk in that case, and the callback must never run.
   let ran = false
   assert.throws(
-    () => withStageConfigFile({ GHCR_TOKEN: "it's quoted" }, () => (ran = true)),
-    /GHCR_TOKEN contains a single quote or newline/,
+    () => withStageConfigFile({ GHCR_TOKEN: `it's "quoted"` }, () => (ran = true)),
+    /GHCR_TOKEN mixes a single quote/,
   )
   assert.equal(ran, false)
 })

--- a/apps/infra/bootstrap/stage-config-file.ts
+++ b/apps/infra/bootstrap/stage-config-file.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+/*
+ * The short-lived file `sst secret load` reads the stage configuration from.
+ *
+ * `secret load` takes a path and has no stdin form, so the whole configuration — every domain, issuer
+ * and token in the operator's .env — has to exist on disk for the length of one command. That is the
+ * only reason this file exists, and everything here is about keeping that window small and closed:
+ *
+ *   - a directory of its own, from mkdtemp, so the 0700 it creates keeps other users out even before
+ *     the file inside it exists;
+ *   - 0600 on the file as well, so a umask that would have widened it cannot;
+ *   - removal in `finally`, so a failed load leaves nothing behind — which is the case that matters,
+ *     since that is when someone is most likely to walk away from the terminal.
+ *
+ * Extracted from bootstrap so those three properties can be tested without running sst.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { serializeStageConfig } from './environment.js'
+
+export function withStageConfigFile<T>(config: any, use: (configPath: string) => T): T {
+  const directory = mkdtempSync(join(tmpdir(), 'boxlite-stage-config-'))
+  try {
+    const configPath = join(directory, 'stage-config.env')
+    writeFileSync(configPath, serializeStageConfig(config), { mode: 0o600 })
+    return use(configPath)
+  } finally {
+    rmSync(directory, { recursive: true, force: true })
+  }
+}

--- a/apps/infra/deployment/capabilities.json
+++ b/apps/infra/deployment/capabilities.json
@@ -1,4 +1,5 @@
 {
   "version": 1,
-  "componentSelection": true
+  "componentSelection": true,
+  "stageConfigStore": true
 }

--- a/apps/infra/deployment/environment.ts
+++ b/apps/infra/deployment/environment.ts
@@ -8,7 +8,18 @@ import { fileURLToPath } from 'node:url'
 
 import { optionalPublicOidcIssuer, requireOidcIssuer } from './oidc.js'
 
-const DEFAULT_AWS_REGION = 'ap-southeast-1'
+// Exported because the deploy workflows carry it as a literal: `configure-aws-credentials` needs a
+// region before any AWS access exists, so it cannot come from the stage's secret store. A contract
+// test pins the YAML against this constant so the two cannot drift.
+export const DEFAULT_AWS_REGION = 'ap-southeast-1'
+
+/*
+ * The SST app name. One definition, because it is load-bearing in three unrelated places: the app
+ * SST deploys (stack/app.ts), the `<app>/<stage>` section header `sst secret list` prints
+ * (deployment/stage-config.ts), and the artifact resource names the preflights verify. SST derives
+ * every resource name from it, so the three must never disagree.
+ */
+export const SST_APP_NAME = 'boxlite'
 const STABLE_SEMVER_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/
 const DEFAULT_MODULE_DIRECTORY = dirname(fileURLToPath(import.meta.url))
 

--- a/apps/infra/deployment/pulumi-logs.test.ts
+++ b/apps/infra/deployment/pulumi-logs.test.ts
@@ -589,6 +589,12 @@ writeFileSync(process.env.SYNTHETIC_ENV_PATH, JSON.stringify(process.env))
         if (other.refusal.source === refusal.source) continue
         assert.doesNotMatch(stderr, other.refusal, `${description} must not fall through to ${other.description}`)
       }
+      /*
+       * And it exited deliberately rather than crashing. Node exits 1 on an unhandled throw too, so
+       * without this the unreadable-store case passes with its guard deleted: `stored` stays undefined,
+       * hydration throws a TypeError, and every assertion above is satisfied by a stack trace.
+       */
+      assert.doesNotMatch(stderr, /^\s+at |\b(TypeError|ReferenceError|SyntaxError)\b/m, `${description} must be refused, not crashed`)
       // The fake sst writes that file only on its fall-through, so its absence is the proof no plan was
       // ever started — the refusal has to land before sst is asked to build anything.
       assert.equal(await fileExists(capturedEnv), false, `sst must not run with ${description}`)

--- a/apps/infra/deployment/pulumi-logs.test.ts
+++ b/apps/infra/deployment/pulumi-logs.test.ts
@@ -11,6 +11,25 @@ import { setTimeout as delay } from 'node:timers/promises'
 import { fileURLToPath } from 'node:url'
 
 import { removePulumiEventLogs, withPulumiEventLogCleanup } from './pulumi-logs.js'
+import { STAGE_CONFIG_BOOKKEEPING_KEYS, stageConfigDigest } from './stage-config.js'
+
+/*
+ * The lines a synthetic `sst secret list` prints, digest included.
+ *
+ * The wrapper refuses a manifest with no matching digest — that shape is a `secret load` that tore
+ * between the two — so a fixture that omits it makes every one of these tests fail on the refusal
+ * rather than on what it means to check. The digest comes from the production function for the same
+ * reason bootstrap uses it: a hand-written constant here would be asserting the wrapper agrees with
+ * this file rather than with bootstrap.
+ */
+function syntheticSecretList(manifest: readonly string[], values: Record<string, string>) {
+  return [
+    '# boxlite/ci',
+    `BOXLITE_STAGE_CONFIG=${manifest.join(',')}`,
+    `BOXLITE_STAGE_CONFIG_DIGEST=${stageConfigDigest(manifest, values)}`,
+    ...Object.entries(values).map(([key, value]) => `${key}=${value}`),
+  ]
+}
 
 const SYNTHETIC_PROVIDER_TOKEN = 'synthetic-provider-token-for-regression-only'
 const INFRA_ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)))
@@ -346,6 +365,13 @@ test('forwards one canonical Runner policy path to the SST process', async () =>
 const { appendFileSync } = require('node:fs')
 const args = process.argv.slice(2)
 appendFileSync(process.env.SYNTHETIC_SST_CALLS_PATH, JSON.stringify(args) + '\\n')
+if (args[0] === 'secret' && args[1] === 'list') {
+  const NL = String.fromCharCode(10)
+  process.stdout.write(${JSON.stringify(
+    syntheticSecretList(['STACK_DOMAIN'], { STACK_DOMAIN: 'ci.example.test' }),
+  )}.join(NL) + NL)
+  process.exit(0)
+}
 if (args[0] === 'state' && args[1] === 'export') {
   process.stdout.write(JSON.stringify({ stack: 'ci', latest: { resources: [] } }))
 }
@@ -374,12 +400,338 @@ if (args[0] === 'state' && args[1] === 'export') {
       .trim()
       .split('\n')
       .map((line) => JSON.parse(line))
+    // The store read comes first and exactly once: everything after it — the Runner state baseline
+    // and the diff itself — is planned from the configuration it loads, so a second read would mean
+    // two answers for one command, and a later one would mean the plan was built without it.
     assert.deepEqual(calls, [
+      ['secret', 'list', '--stage', 'ci'],
       ['state', 'export', '--stage', 'ci', '--print-logs'],
       ['diff', '--stage', 'ci', '--policy', policyRoot],
     ])
   } finally {
     if (wrapper.exitCode === null && wrapper.signalCode === null) wrapper.kill('SIGKILL')
+    await rm(fixture, { recursive: true, force: true })
+  }
+})
+
+test('a manifested store with no digest stops the deploy instead of hydrating it', async () => {
+  // The shape a first `secret load` leaves if it tears between the values and the digest. Every
+  // manifest name is present, so nothing short of the digest can see it — and a wrapper that treated
+  // the absence as "cannot verify, carry on" would hydrate a configuration that never existed whole.
+  // Asserted end to end because the refusal lives in the wrapper: a unit test on hydrateStageConfig
+  // can only show the mismatch is detectable, not that anything acts on it.
+  const fixture = await fixtureRoot()
+  const fakeBin = join(fixture, 'bin')
+  const fakeSst = join(fakeBin, 'sst')
+  const capturedEnv = join(fixture, 'child-env.json')
+
+  await mkdir(fakeBin, { recursive: true })
+  await writeFile(
+    fakeSst,
+    `#!/usr/bin/env node
+const { writeFileSync } = require('node:fs')
+const args = process.argv.slice(2)
+if (args[0] === 'secret' && args[1] === 'list') {
+  const NL = String.fromCharCode(10)
+  // Deliberately no BOXLITE_STAGE_CONFIG_DIGEST line.
+  process.stdout.write(['# boxlite/ci', 'BOXLITE_STAGE_CONFIG=STACK_DOMAIN', 'STACK_DOMAIN=torn.example.test'].join(NL) + NL)
+  process.exit(0)
+}
+if (args[0] === 'state' && args[1] === 'export') {
+  process.stdout.write(JSON.stringify({ stack: 'ci', latest: { resources: [] } }))
+  process.exit(0)
+}
+writeFileSync(process.env.SYNTHETIC_ENV_PATH, JSON.stringify(process.env))
+`,
+    'utf8',
+  )
+  await chmod(fakeSst, 0o755)
+
+  const wrapper = spawnWrapper(['diff', '--stage', 'ci'], {
+    env: {
+      ...inheritedEnvironment(),
+      PATH: `${fakeBin}:${process.env.PATH}`,
+      SST_BIN_PATH: fakeSst,
+      CLOUDFLARE_API_TOKEN: 'synthetic-cloudflare-token',
+      CLOUDFLARE_DEFAULT_ACCOUNT_ID: 'synthetic-cloudflare-account',
+      RUNNERS: '1',
+      DEFAULT_RUNNER_NAME: 'default',
+      SYNTHETIC_ENV_PATH: capturedEnv,
+    },
+    stdio: ['ignore', 'inherit', 'inherit'],
+  })
+
+  try {
+    assert.deepEqual(await waitForExit(wrapper), { code: 1, signal: null }, 'the wrapper must refuse')
+    // The refusal has to happen before sst is spawned to build anything — the env file is only written
+    // by the fake sst's fall-through, so its absence is the proof no plan was started.
+    assert.equal(await fileExists(capturedEnv), false, 'sst must not be invoked with a torn configuration')
+  } finally {
+    if (wrapper.exitCode === null && wrapper.signalCode === null) wrapper.kill('SIGKILL')
+    await rm(fixture, { recursive: true, force: true })
+  }
+})
+
+test('a stored stage configuration reaches the spawned SST process', async () => {
+  // The end-to-end claim the unit tests cannot make: a value that exists only in the secret store is
+  // read by the wrapper and present in the environment of the sst child that builds the plan. The
+  // fake sst answers `secret list` with a store and then records its own environment.
+  const fixture = await fixtureRoot()
+  const fakeBin = join(fixture, 'bin')
+  const fakeSst = join(fakeBin, 'sst')
+  const capturedEnv = join(fixture, 'child-env.json')
+
+  await mkdir(fakeBin, { recursive: true })
+  await writeFile(
+    fakeSst,
+    `#!/usr/bin/env node
+const { writeFileSync } = require('node:fs')
+const args = process.argv.slice(2)
+if (args[0] === 'secret' && args[1] === 'list') {
+  // String.fromCharCode(10), not an escape: this script lives in a template literal, so a
+  // backslash-n would be resolved before the file is written and leave a real newline inside a
+  // string literal — which is a syntax error in the generated script, not a line separator.
+  const NL = String.fromCharCode(10)
+  process.stdout.write(${JSON.stringify([
+    ...syntheticSecretList(['STACK_DOMAIN', 'APP_URL', 'NODE_OPTIONS'], {
+      STACK_DOMAIN: 'stored.example.test',
+      APP_URL: 'https://stored.example.test',
+      NODE_OPTIONS: '--require /tmp/synthetic-evil.js',
+    }),
+    // Present in the store but absent from the manifest, so outside the digest as well as hydration.
+    'PROXY_DOMAIN=stale.example.test',
+  ])}.join(NL) + NL)
+  process.exit(0)
+}
+if (args[0] === 'state' && args[1] === 'export') {
+  process.stdout.write(JSON.stringify({ stack: 'ci', latest: { resources: [] } }))
+  process.exit(0)
+}
+writeFileSync(process.env.SYNTHETIC_ENV_PATH, JSON.stringify(process.env))
+`,
+    'utf8',
+  )
+  await chmod(fakeSst, 0o755)
+
+  const wrapper = spawnWrapper(['diff', '--stage', 'ci'], {
+    env: {
+      ...inheritedEnvironment(),
+      PATH: `${fakeBin}:${process.env.PATH}`,
+      SST_BIN_PATH: fakeSst,
+      CLOUDFLARE_API_TOKEN: 'synthetic-cloudflare-token',
+      CLOUDFLARE_DEFAULT_ACCOUNT_ID: 'synthetic-cloudflare-account',
+      RUNNERS: '1',
+      DEFAULT_RUNNER_NAME: 'default',
+      APP_URL: 'https://environment-wins.example.test',
+      SYNTHETIC_ENV_PATH: capturedEnv,
+    },
+    stdio: ['ignore', 'inherit', 'inherit'],
+  })
+
+  try {
+    assert.deepEqual(await waitForExit(wrapper), { code: 0, signal: null })
+    const childEnv = JSON.parse(await readFile(capturedEnv, 'utf8'))
+    assert.equal(childEnv.STACK_DOMAIN, 'stored.example.test', 'a stored value must reach the sst child')
+    assert.equal(childEnv.APP_URL, 'https://environment-wins.example.test', 'the environment must beat the store')
+    assert.equal(childEnv.PROXY_DOMAIN, undefined, 'a key off the manifest must not be hydrated')
+    assert.equal(childEnv.NODE_OPTIONS, undefined, 'a process control must not be hydrated even if manifested')
+  } finally {
+    if (wrapper.exitCode === null && wrapper.signalCode === null) wrapper.kill('SIGKILL')
+    await rm(fixture, { recursive: true, force: true })
+  }
+})
+
+test('an unreadable stage configuration store stops every command that builds a plan', async () => {
+  // `diff` included, though it only reads. A preview built from defaults is not a preview of the
+  // deploy that follows: the operator approves that plan, the apply then reads the store fine, and
+  // reconciles something nobody reviewed. Both fail or neither does.
+  const fixture = await fixtureRoot()
+  const fakeBin = join(fixture, 'bin')
+  const fakeSst = join(fakeBin, 'sst')
+  const planCalled = join(fixture, 'plan-called')
+
+  await mkdir(fakeBin, { recursive: true })
+  await writeFile(
+    fakeSst,
+    `#!/usr/bin/env node
+const { writeFileSync } = require('node:fs')
+const args = process.argv.slice(2)
+if (args[0] === 'secret' && args[1] === 'list') process.exit(7)
+if (args[0] === 'state' && args[1] === 'export') {
+  process.stdout.write(JSON.stringify({ stack: 'ci', latest: { resources: [] } }))
+  process.exit(0)
+}
+writeFileSync(process.env.SYNTHETIC_PLAN_PATH, args[0])
+`,
+    'utf8',
+  )
+  await chmod(fakeSst, 0o755)
+
+  const environment = {
+    ...inheritedEnvironment(),
+    PATH: `${fakeBin}:${process.env.PATH}`,
+    SST_BIN_PATH: fakeSst,
+    CLOUDFLARE_API_TOKEN: 'synthetic-cloudflare-token',
+    CLOUDFLARE_DEFAULT_ACCOUNT_ID: 'synthetic-cloudflare-account',
+    RUNNERS: '1',
+    DEFAULT_RUNNER_NAME: 'default',
+    SYNTHETIC_PLAN_PATH: planCalled,
+  }
+
+  try {
+    const deploying = spawnWrapper(['deploy', '--stage', 'ci'], { env: environment, stdio: 'ignore' })
+    assert.deepEqual(await waitForExit(deploying), { code: 1, signal: null }, 'a deploy must stop when the store cannot be read')
+    assert.equal(await fileExists(planCalled), false, 'no plan may run without the stage configuration')
+
+    // Each subcommand individually rather than assumed from `deploy`: remove tears the stack down,
+    // refresh rewrites its state, and diff feeds the review the apply is judged against.
+    for (const writing of ['remove', 'refresh']) {
+      const child = spawnWrapper([writing, '--stage', 'ci'], { env: environment, stdio: 'ignore' })
+      assert.deepEqual(
+        await waitForExit(child),
+        { code: 1, signal: null },
+        `${writing} writes, so it must stop when the store cannot be read`,
+      )
+      assert.equal(await fileExists(planCalled), false, `${writing} must not reach sst`)
+    }
+
+    const diffing = spawnWrapper(['diff', '--stage', 'ci'], { env: environment, stdio: 'ignore' })
+    assert.deepEqual(
+      await waitForExit(diffing),
+      { code: 1, signal: null },
+      'a preview against defaults would not describe the deploy that follows it',
+    )
+    assert.equal(await fileExists(planCalled), false, 'no plan may run without the stage configuration')
+  } finally {
+    await rm(fixture, { recursive: true, force: true })
+  }
+})
+
+test('a failed store read never repeats what sst printed', async () => {
+  // execFileSync builds its error message from the failed command line and the captured stdio, and
+  // for `secret list` that output is the store's contents. The wrapper must report the exit status
+  // only. The fake sst fails after printing a recognisable secret to both streams, and neither may
+  // appear in anything the wrapper writes.
+  const fixture = await fixtureRoot()
+  const fakeBin = join(fixture, 'bin')
+  const fakeSst = join(fakeBin, 'sst')
+  const leaked = 'synthetic-store-value-that-must-not-be-echoed'
+
+  await mkdir(fakeBin, { recursive: true })
+  await writeFile(
+    fakeSst,
+    `#!/usr/bin/env node
+const args = process.argv.slice(2)
+if (args[0] === 'secret' && args[1] === 'list') {
+  process.stdout.write('STACK_DOMAIN=${leaked}')
+  process.stderr.write('sst: ${leaked}')
+  process.exit(9)
+}
+process.exit(0)
+`,
+    'utf8',
+  )
+  await chmod(fakeSst, 0o755)
+
+  const wrapper = spawnWrapper(['diff', '--stage', 'ci'], {
+    env: {
+      ...inheritedEnvironment(),
+      PATH: `${fakeBin}:${process.env.PATH}`,
+      SST_BIN_PATH: fakeSst,
+      CLOUDFLARE_API_TOKEN: 'synthetic-cloudflare-token',
+      CLOUDFLARE_DEFAULT_ACCOUNT_ID: 'synthetic-cloudflare-account',
+      RUNNERS: '1',
+      DEFAULT_RUNNER_NAME: 'default',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  let captured = ''
+  wrapper.stdout.on('data', (chunk: any) => {
+    captured += chunk
+  })
+  wrapper.stderr.on('data', (chunk: any) => {
+    captured += chunk
+  })
+
+  try {
+    await waitForExit(wrapper)
+    assert.ok(captured.includes('could not read the ci stage configuration'), 'the failure must still be reported')
+    assert.equal(captured.includes(leaked), false, "the wrapper must not repeat sst's captured output")
+    assert.ok(captured.includes('sst exited 9'), 'the exit status is what identifies the failure')
+  } finally {
+    if (wrapper.exitCode === null && wrapper.signalCode === null) wrapper.kill('SIGKILL')
+    await rm(fixture, { recursive: true, force: true })
+  }
+})
+
+test('npm run secrets prints names without values or the manifest', async () => {
+  // The command exists because `sst secret list` inherited sst's stdio and printed every value, which
+  // now means the whole stage configuration. Asserted at the CLI, not on the parser: the leak this
+  // replaces was in how the process was wired, so only running it proves anything.
+  const fixture = await fixtureRoot()
+  const fakeBin = join(fixture, 'bin')
+  const fakeSst = join(fakeBin, 'sst')
+  const value = 'synthetic-value-that-must-stay-hidden'
+
+  await mkdir(fakeBin, { recursive: true })
+  await writeFile(
+    fakeSst,
+    `#!/usr/bin/env node
+const args = process.argv.slice(2)
+if (args[0] === 'secret' && args[1] === 'list') {
+  const NL = String.fromCharCode(10)
+  process.stdout.write(${JSON.stringify([
+    ...syntheticSecretList(['STACK_DOMAIN'], { STACK_DOMAIN: value }),
+    // An app secret sst resolves itself; named by nothing here, so never hydrated.
+    `OIDC_CLIENT_ID=${value}`,
+  ])}.join(NL) + NL)
+  process.exit(0)
+}
+process.exit(0)
+`,
+    'utf8',
+  )
+  await chmod(fakeSst, 0o755)
+
+  const listing = spawn(process.execPath, ['--import', 'tsx', 'deployment/secret-names.ts', '--stage', 'ci'], {
+    cwd: INFRA_ROOT,
+    env: {
+      ...inheritedEnvironment(),
+      PATH: `${fakeBin}:${process.env.PATH}`,
+      SST_BIN_PATH: fakeSst,
+      CLOUDFLARE_API_TOKEN: 'synthetic-cloudflare-token',
+      CLOUDFLARE_DEFAULT_ACCOUNT_ID: 'synthetic-cloudflare-account',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  let output = ''
+  listing.stdout.on('data', (chunk: any) => {
+    output += chunk
+  })
+  listing.stderr.on('data', (chunk: any) => {
+    output += chunk
+  })
+
+  try {
+    assert.deepEqual(await waitForExit(listing), { code: 0, signal: null })
+    assert.ok(output.includes('STACK_DOMAIN'), 'the names are the point of the command')
+    assert.ok(output.includes('OIDC_CLIENT_ID'), 'an app secret is still worth listing by name')
+    assert.equal(output.includes(value), false, 'no value may be printed')
+    // Each bookkeeping key by name, from the exported list. A single `includes('BOXLITE_STAGE_CONFIG')`
+    // passed for the wrong reason once the digest key arrived: its name contains the manifest's, so the
+    // check could not tell "neither is printed" from "one of them is".
+    for (const bookkeeping of STAGE_CONFIG_BOOKKEEPING_KEYS) {
+      assert.equal(output.includes(bookkeeping), false, `${bookkeeping} is bookkeeping, not a secret`)
+    }
+
+    // Spawning the script directly proves the script is safe, not that `npm run secrets` uses it.
+    // Without this, restoring the old `sst secret list` wiring — the leak this replaced — stays green.
+    const scripts = JSON.parse(await readFile(join(INFRA_ROOT, 'package.json'), 'utf8')).scripts
+    assert.equal(scripts.secrets, 'tsx deployment/secret-names.ts')
+  } finally {
+    if (listing.exitCode === null && listing.signalCode === null) listing.kill('SIGKILL')
     await rm(fixture, { recursive: true, force: true })
   }
 })
@@ -396,7 +748,15 @@ test('interrupts a pending Runner state export when the wrapper is terminated', 
     fakeSst,
     `#!/usr/bin/env node
 const { writeFileSync } = require('node:fs')
-if (process.argv[2] !== 'state' || process.argv[3] !== 'export') process.exit(99)
+const args = process.argv.slice(2)
+if (args[0] === 'secret' && args[1] === 'list') {
+  const NL = String.fromCharCode(10)
+  process.stdout.write(${JSON.stringify(
+    syntheticSecretList(['STACK_DOMAIN'], { STACK_DOMAIN: 'ci.example.test' }),
+  )}.join(NL) + NL)
+  process.exit(0)
+}
+if (args[0] !== 'state' || args[1] !== 'export') process.exit(99)
 writeFileSync(process.env.SYNTHETIC_SST_PID_PATH, String(process.pid))
 // The wrapper must still terminate a state export that refuses graceful shutdown.
 process.on('SIGTERM', () => {})
@@ -459,7 +819,25 @@ test('interrupts Runner release preflight without starting SST', async () => {
   let curlPid: any
 
   await mkdir(fakeBin, { recursive: true })
-  await writeFile(fakeSst, `#!/bin/sh\nprintf called > "$SYNTHETIC_SST_CALL_PATH"\n`, 'utf8')
+  // Records what it was asked to do, not merely that it ran: the wrapper legitimately reads the
+  // stage's configuration out of the secret store before the preflight, so "sst was never spawned"
+  // is no longer the property under test. What must hold is that nothing which MUTATES the stack
+  // ran — asserted below on the recorded subcommands.
+  //
+  // `secret list` answers with a manifest because a deploy against a store that names nothing now
+  // stops before it reaches the preflight this test is about.
+  await writeFile(
+    fakeSst,
+    `#!/bin/sh
+echo "$@" >> "$SYNTHETIC_SST_CALL_PATH"
+if [ "$1" = "secret" ] && [ "$2" = "list" ]; then
+${syntheticSecretList(['STACK_DOMAIN'], { STACK_DOMAIN: 'ci.example.test' })
+  .map((line) => `  echo ${JSON.stringify(line)}`)
+  .join('\n')}
+fi
+`,
+    'utf8',
+  )
   await writeFile(fakeAws, '#!/bin/sh\nexit 0\n', 'utf8')
   await writeFile(
     fakeCurl,
@@ -507,7 +885,18 @@ setInterval(() => {}, 1_000)
         throw error
       }
     }, 'the synthetic release preflight to exit')
-    assert.equal(await fileExists(sstCallFile), false, 'SST must not start after an interrupted release preflight')
+    const sstInvocations = (await fileExists(sstCallFile))
+      ? (await readFile(sstCallFile, 'utf8')).trim().split('\n').filter(Boolean)
+      : []
+    // Reading the store is fine and expected; nothing else is. Matched on the whole invocation rather
+    // than its first word, because `secret set`, `secret load` and `secret remove` all write — an
+    // assertion that allowed any `secret` subcommand would have passed them too.
+    const unexpected = sstInvocations.filter((invocation) => !/^secret list( |$)/.test(invocation))
+    assert.deepEqual(
+      unexpected,
+      [],
+      `only \`secret list\` may run after an interrupted release preflight (ran: ${sstInvocations.join(' | ')})`,
+    )
   } finally {
     if (wrapper.exitCode === null && wrapper.signalCode === null) wrapper.kill('SIGKILL')
     if (Number.isSafeInteger(curlPid)) {

--- a/apps/infra/deployment/pulumi-logs.test.ts
+++ b/apps/infra/deployment/pulumi-logs.test.ts
@@ -414,27 +414,127 @@ if (args[0] === 'state' && args[1] === 'export') {
   }
 })
 
-test('a manifested store with no digest stops the deploy instead of hydrating it', async () => {
-  // The shape a first `secret load` leaves if it tears between the values and the digest. Every
-  // manifest name is present, so nothing short of the digest can see it — and a wrapper that treated
-  // the absence as "cannot verify, carry on" would hydrate a configuration that never existed whole.
-  // Asserted end to end because the refusal lives in the wrapper: a unit test on hydrateStageConfig
-  // can only show the mismatch is detectable, not that anything acts on it.
-  const fixture = await fixtureRoot()
-  const fakeBin = join(fixture, 'bin')
-  const fakeSst = join(fakeBin, 'sst')
-  const capturedEnv = join(fixture, 'child-env.json')
+/*
+ * The store shapes the wrapper must refuse, each driven end to end.
+ *
+ * Six shapes across the wrapper's five refusals, not one apiece: an absent digest and a mismatched one
+ * meet the same comparison, covered as two shapes because they arise from different accidents and a
+ * reader would otherwise assume only one is handled. The other four — unreadable, no manifest, a
+ * manifested value the store lacks, and a manifest that applies nothing — get one shape each.
+ *
+ * They need the wrapper rather than a unit test: hydrateStageConfig can show a shape is detectable,
+ * never that anything acts on it. Counting `process.exit(1)` in the source proves refusals exist; it
+ * cannot prove which shape reaches which.
+ *
+ * Two things make each case prove its own branch rather than merely "something refused".
+ *
+ * The digest is stated explicitly: a placeholder makes every fixture trip the mismatch branch first,
+ * so the test passes while the branch it names is dead — which is what a first draft did, and what
+ * disabling a later refusal failed to reveal.
+ *
+ * And each case matches the wrapper's own message. Exit 1 is shared by all five, and the guards sit in
+ * a chain where removing one usually lets the next catch the same fixture — so the exit code cannot
+ * distinguish them, and a test that only checks it stays green through the regression it exists for.
+ */
+type RefusedStore = {
+  description: string
+  manifest?: string[]
+  values: Record<string, string>
+  digest: 'correct' | 'wrong' | 'omit'
+  // The store cannot be read at all — `sst secret list` itself fails.
+  listFails?: true
+  // A fragment of the refusal this shape must produce, distinct from every other guard's.
+  refusal: RegExp
+}
 
-  await mkdir(fakeBin, { recursive: true })
-  await writeFile(
-    fakeSst,
-    `#!/usr/bin/env node
+const REFUSED_STORES: RefusedStore[] = [
+  {
+    /*
+     * Not a store at all: `sst secret list` exits non-zero, as it does on a stage that was never
+     * bootstrapped or when AWS is unreachable. Its own guard, and the earliest one — everything below
+     * assumes a store that read cleanly.
+     */
+    description: 'a store that cannot be read',
+    values: {},
+    digest: 'omit',
+    listFails: true,
+    refusal: /could not read the ci stage configuration/,
+  },
+  {
+    // Torn between the values and the digest — every manifest name present, so only the digest sees it.
+    description: 'a manifested store with no digest',
+    manifest: ['STACK_DOMAIN'],
+    values: { STACK_DOMAIN: 'torn.example.test' },
+    digest: 'omit',
+    refusal: /carries no BOXLITE_STAGE_CONFIG_DIGEST/,
+  },
+  {
+    // A digest that describes a different generation: the interrupted read-modify-write.
+    description: 'a digest that does not match the values',
+    manifest: ['STACK_DOMAIN'],
+    values: { STACK_DOMAIN: 'mixed.example.test' },
+    digest: 'wrong',
+    refusal: /does not match its BOXLITE_STAGE_CONFIG_DIGEST/,
+  },
+  {
+    // Values but no manifest: never bootstrapped, or the manifest was removed. Hydration would be a
+    // no-op and the deploy would reconcile against whatever the defaults are.
+    description: 'a store with no manifest at all',
+    values: { STACK_DOMAIN: 'unmanifested.example.test' },
+    digest: 'omit',
+    refusal: /has no BOXLITE_STAGE_CONFIG manifest/,
+  },
+  {
+    // The manifest names a key the store does not hold — a half-written load. The digest is correct
+    // for what IS there, so this reaches the missing-value branch rather than the mismatch one.
+    description: 'a manifest naming a value the store lacks',
+    manifest: ['STACK_DOMAIN', 'APP_URL'],
+    values: { STACK_DOMAIN: 'partial.example.test' },
+    digest: 'correct',
+    refusal: /is incomplete/,
+  },
+  {
+    /*
+     * A manifest naming only keys that are refused: the store reads as populated and applies nothing.
+     * AWS_PROFILE rather than a process control — it is refused for the same reason and proves the same
+     * branch, but if a regression ever did hydrate it the worst case is a wrong AWS profile. A
+     * NODE_OPTIONS payload would instead name a file node executes at startup, making the fixture a
+     * preload primitive, and a child dying on the missing file would satisfy both assertions here
+     * without the refusal ever running.
+     */
+    description: 'a manifest that applies nothing',
+    manifest: ['AWS_PROFILE'],
+    values: { AWS_PROFILE: 'synthetic-refused-profile' },
+    digest: 'correct',
+    refusal: /applied nothing/,
+  },
+]
+
+function refusedStoreLines({ manifest, values, digest }: RefusedStore) {
+  const lines = ['# boxlite/ci']
+  if (manifest) lines.push(`BOXLITE_STAGE_CONFIG=${manifest.join(',')}`)
+  if (digest === 'correct') lines.push(`BOXLITE_STAGE_CONFIG_DIGEST=${stageConfigDigest(manifest ?? [], values)}`)
+  if (digest === 'wrong') lines.push(`BOXLITE_STAGE_CONFIG_DIGEST=${'0'.repeat(64)}`)
+  for (const [key, value] of Object.entries(values)) lines.push(`${key}=${value}`)
+  return lines
+}
+
+for (const refusedStore of REFUSED_STORES) {
+  const { description, refusal } = refusedStore
+  test(`${description} stops the deploy before sst runs`, async () => {
+    const fixture = await fixtureRoot()
+    const fakeBin = join(fixture, 'bin')
+    const fakeSst = join(fakeBin, 'sst')
+    const capturedEnv = join(fixture, 'child-env.json')
+
+    await mkdir(fakeBin, { recursive: true })
+    await writeFile(
+      fakeSst,
+      `#!/usr/bin/env node
 const { writeFileSync } = require('node:fs')
 const args = process.argv.slice(2)
 if (args[0] === 'secret' && args[1] === 'list') {
-  const NL = String.fromCharCode(10)
-  // Deliberately no BOXLITE_STAGE_CONFIG_DIGEST line.
-  process.stdout.write(['# boxlite/ci', 'BOXLITE_STAGE_CONFIG=STACK_DOMAIN', 'STACK_DOMAIN=torn.example.test'].join(NL) + NL)
+  ${refusedStore.listFails ? 'process.exit(7)' : `process.stdout.write(${JSON.stringify(refusedStoreLines(refusedStore))}.join(String.fromCharCode(10)) + String.fromCharCode(10))`}
   process.exit(0)
 }
 if (args[0] === 'state' && args[1] === 'export') {
@@ -443,34 +543,61 @@ if (args[0] === 'state' && args[1] === 'export') {
 }
 writeFileSync(process.env.SYNTHETIC_ENV_PATH, JSON.stringify(process.env))
 `,
-    'utf8',
-  )
-  await chmod(fakeSst, 0o755)
+      'utf8',
+    )
+    await chmod(fakeSst, 0o755)
 
-  const wrapper = spawnWrapper(['diff', '--stage', 'ci'], {
-    env: {
-      ...inheritedEnvironment(),
-      PATH: `${fakeBin}:${process.env.PATH}`,
-      SST_BIN_PATH: fakeSst,
-      CLOUDFLARE_API_TOKEN: 'synthetic-cloudflare-token',
-      CLOUDFLARE_DEFAULT_ACCOUNT_ID: 'synthetic-cloudflare-account',
-      RUNNERS: '1',
-      DEFAULT_RUNNER_NAME: 'default',
-      SYNTHETIC_ENV_PATH: capturedEnv,
-    },
-    stdio: ['ignore', 'inherit', 'inherit'],
+    const wrapper = spawnWrapper(['diff', '--stage', 'ci'], {
+      env: {
+        ...inheritedEnvironment(),
+        PATH: `${fakeBin}:${process.env.PATH}`,
+        SST_BIN_PATH: fakeSst,
+        CLOUDFLARE_API_TOKEN: 'synthetic-cloudflare-token',
+        CLOUDFLARE_DEFAULT_ACCOUNT_ID: 'synthetic-cloudflare-account',
+        RUNNERS: '1',
+        DEFAULT_RUNNER_NAME: 'default',
+        SYNTHETIC_ENV_PATH: capturedEnv,
+      },
+      stdio: ['ignore', 'inherit', 'pipe'],
+    })
+
+    /*
+     * Drained to close, not just to exit. `exit` fires when the process ends, which can be before the
+     * pipe has delivered what it wrote — so asserting on the buffer at that moment reads however much
+     * happened to arrive, and the message checks below would fail intermittently on a machine under
+     * load. `close` is the event that means "and its stdio is finished".
+     */
+    let stderr = ''
+    wrapper.stderr.setEncoding('utf8')
+    wrapper.stderr.on('data', (chunk: string) => {
+      stderr += chunk
+    })
+    const stderrDrained = new Promise<void>((resolve) => wrapper.stderr.once('close', () => resolve()))
+
+    try {
+      const exit = await waitForExit(wrapper)
+      await stderrDrained
+      assert.deepEqual(exit, { code: 1, signal: null }, `${description} must be refused`)
+      assert.match(stderr, refusal, `${description} must be refused by its own guard, not a later one`)
+      /*
+       * And no OTHER guard spoke. Matching only the expected message proves this guard ran, not that it
+       * is what stopped the deploy: delete just its `process.exit(1)` and the message still prints
+       * while the next guard down the chain exits, satisfying both assertions above. Requiring silence
+       * from the others is what makes the exit attributable to this one.
+       */
+      for (const other of REFUSED_STORES) {
+        if (other.refusal.source === refusal.source) continue
+        assert.doesNotMatch(stderr, other.refusal, `${description} must not fall through to ${other.description}`)
+      }
+      // The fake sst writes that file only on its fall-through, so its absence is the proof no plan was
+      // ever started — the refusal has to land before sst is asked to build anything.
+      assert.equal(await fileExists(capturedEnv), false, `sst must not run with ${description}`)
+    } finally {
+      if (wrapper.exitCode === null && wrapper.signalCode === null) wrapper.kill('SIGKILL')
+      await rm(fixture, { recursive: true, force: true })
+    }
   })
-
-  try {
-    assert.deepEqual(await waitForExit(wrapper), { code: 1, signal: null }, 'the wrapper must refuse')
-    // The refusal has to happen before sst is spawned to build anything — the env file is only written
-    // by the fake sst's fall-through, so its absence is the proof no plan was started.
-    assert.equal(await fileExists(capturedEnv), false, 'sst must not be invoked with a torn configuration')
-  } finally {
-    if (wrapper.exitCode === null && wrapper.signalCode === null) wrapper.kill('SIGKILL')
-    await rm(fixture, { recursive: true, force: true })
-  }
-})
+}
 
 test('a stored stage configuration reaches the spawned SST process', async () => {
   // The end-to-end claim the unit tests cannot make: a value that exists only in the secret store is

--- a/apps/infra/deployment/release-safety.test.ts
+++ b/apps/infra/deployment/release-safety.test.ts
@@ -131,6 +131,38 @@ function mutatesParameters(action: unknown) {
  * Resource and quietly return "nothing matches", it reports the statement as unanalyzable and the
  * assertion fails. The template uses neither today, and this is what keeps that true.
  */
+/*
+ * Every statement that reaches the deploy role: its inline policies, plus any standalone policy
+ * resource that attaches to it. AWS::IAM::Policy and ::ManagedPolicy name their targets in `Roles`,
+ * ::RolePolicy in `RoleName`, and any of them can grant back whatever the inline policy gives up —
+ * invisibly, to anything that reads only Properties.Policies.
+ */
+const ATTACHABLE_POLICY_TYPES = ['AWS::IAM::Policy', 'AWS::IAM::RolePolicy', 'AWS::IAM::ManagedPolicy']
+
+function deployRolePolicyStatements(template: any) {
+  const role = template.Resources.GitHubDeployRole.Properties
+  const statements = (role.Policies ?? []).flatMap((policy: any) => policy.PolicyDocument.Statement)
+
+  /*
+   * By logical id (`!Ref GitHubDeployRole`) or by the physical name the role declares
+   * (`!Sub boxlite-${GitHubEnvironment}-github-deploy`) — both address the same role, and matching
+   * only the first would miss a policy attached the other way.
+   */
+  const physicalName = template.Resources.GitHubDeployRole.Properties.RoleName
+  const attachesToDeployRole = (properties: any) =>
+    [...(properties?.Roles ?? []), properties?.RoleName].filter(Boolean).some((target: any) => {
+      const text = JSON.stringify(target)
+      return text.includes('GitHubDeployRole') || (Boolean(physicalName) && text.includes(physicalName))
+    })
+
+  for (const resource of Object.values(template.Resources) as any[]) {
+    if (!ATTACHABLE_POLICY_TYPES.includes(resource.Type)) continue
+    if (!attachesToDeployRole(resource.Properties)) continue
+    statements.push(...(resource.Properties?.PolicyDocument?.Statement ?? []))
+  }
+  return statements
+}
+
 function sharedBootstrapMutations(statement: any) {
   const asList = (value: any) => (Array.isArray(value) ? value : [value])
 
@@ -418,6 +450,85 @@ test('what bootstrap stores is the .env it validated, read once', () => {
   )
 })
 
+test('the deploy role cannot rewrite its own permissions', () => {
+  /*
+   * The role is named boxlite-<stage>-github-deploy, so it matches the `role/boxlite-*` resource of
+   * its own IAM grants. iam:PutRolePolicy on itself is unbounded privilege escalation — the
+   * permissions boundary constrains the roles SST creates, not this role's own inline policy — and
+   * iam:PutRolePermissionsBoundary would let it lift that boundary for everything else.
+   *
+   * Derived from what is granted rather than listing actions here: adding a role-mutating action to
+   * the Allows must fail until the Deny covers it too, which a hand-written list would not do.
+   */
+  const template = readDeployTemplate()
+  const statements = deployRolePolicyStatements(template)
+  const asArray = (value: any) => (Array.isArray(value) ? value : [value])
+  const SELF_ARN_FRAGMENT = 'role/boxlite-${GitHubEnvironment}-github-deploy'
+  const SELF_MUTATING = /^iam:(Attach|Detach|Put|Delete|Update)/i
+
+  const granted = new Set<string>()
+  for (const statement of statements) {
+    if (statement.Effect !== 'Allow') continue
+    const reachesOwnName = asArray(statement.Resource).some(
+      (resource: any) => typeof resource === 'string' && resource.includes('role/boxlite-*'),
+    )
+    if (!reachesOwnName) continue
+    for (const action of asArray(statement.Action)) {
+      if (typeof action !== 'string' || !SELF_MUTATING.test(action)) continue
+      // An instance-profile action cannot be aimed at a role ARN, so denying it on this role's own
+      // ARN would be inert. The deploy role has no instance profile of its own to protect.
+      if (action.includes('InstanceProfile')) continue
+      granted.add(action)
+    }
+  }
+  assert.ok(granted.size > 0, 'expected the role to manage boxlite-* roles; the premise here has changed')
+
+  const denied = new Set<string>()
+  for (const statement of statements) {
+    if (statement.Effect !== 'Deny') continue
+    /*
+     * A Deny only counts if it actually lands. `…github-deploy-other` ends with a suffix and names a
+     * different role, and a Condition can make the Deny apply in cases that never occur — so require
+     * the resource to end at the role's own name, and refuse to credit a conditional Deny at all.
+     */
+    if (statement.Condition !== undefined) continue
+    const coversSelf = asArray(statement.Resource).some(
+      (resource: any) => typeof resource === 'string' && resource.endsWith(SELF_ARN_FRAGMENT),
+    )
+    if (!coversSelf) continue
+    for (const action of asArray(statement.Action)) denied.add(action)
+  }
+
+  const uncovered = [...granted].filter((action) => !denied.has(action))
+  assert.deepEqual(
+    uncovered,
+    [],
+    'these actions can be aimed at the deploy role itself with no Deny covering it: ' + uncovered.join(', '),
+  )
+  assert.ok(denied.has('iam:PutRolePermissionsBoundary'), 'the role must not be able to set its own boundary')
+  assert.ok(denied.has('iam:DeleteRolePermissionsBoundary'), 'the role must not be able to drop its own boundary')
+
+  /*
+   * The other half, and the one that reads as harmless: the runtime boundary is a managed policy named
+   * boxlite-<stage>-runtime-boundary, which matches ManageBoxLitePolicies' policy/boxlite-* resource.
+   * Widen it, create a bounded role under the widened version, pass it to a service, and the boundary
+   * has stopped bounding anything. Denying writes to that one policy is what breaks the chain.
+   */
+  const BOUNDARY_ARN_FRAGMENT = 'policy/boxlite-${GitHubEnvironment}-runtime-boundary'
+  const deniedOnBoundary = new Set<string>()
+  for (const statement of statements) {
+    if (statement.Effect !== 'Deny' || statement.Condition !== undefined) continue
+    const coversBoundary = asArray(statement.Resource).some(
+      (resource: any) => typeof resource === 'string' && resource.endsWith(BOUNDARY_ARN_FRAGMENT),
+    )
+    if (!coversBoundary) continue
+    for (const action of asArray(statement.Action)) deniedOnBoundary.add(action)
+  }
+  for (const action of ['iam:CreatePolicyVersion', 'iam:SetDefaultPolicyVersion', 'iam:DeletePolicy']) {
+    assert.ok(deniedOnBoundary.has(action), `${action} on the runtime boundary must be denied`)
+  }
+})
+
 test('the grants that are NOT stage-scoped are the documented ones, and only those', () => {
   /*
    * The isolation test above says what the deploy role cannot reach. This says what it still can, so
@@ -427,10 +538,10 @@ test('the grants that are NOT stage-scoped are the documented ones, and only tho
    * Pinned against docs/security.md, because a limit nobody wrote down is indistinguishable from one
    * nobody noticed.
    */
+  // Every policy that reaches the role, inline or attached — the same collection the isolation test
+  // uses, because a grant added through an attached policy is exactly as account-wide as an inline one.
   const template = readDeployTemplate()
-  const statements = template.Resources.GitHubDeployRole.Properties.Policies.flatMap(
-    (policy: any) => policy.PolicyDocument.Statement,
-  )
+  const statements = deployRolePolicyStatements(template)
   const asArray = (value: any) => (Array.isArray(value) ? value : [value])
   const stageScoped = (resource: any) => String(resource).includes('${GitHubEnvironment}')
 
@@ -472,6 +583,22 @@ test('the grants that are NOT stage-scoped are the documented ones, and only tho
     ['RunnerCommandStatus', 'SSM command-history APIs are list-shaped and take no resource'],
     ['ReadIamAndAccountMetadata', 'account and IAM reads SST performs before it knows any resource'],
   ]
+
+  /*
+   * A Sid is a label, so allowing one by name is not enough on its own: `ReadIamAndAccountMetadata`
+   * could keep its name and gain `iam:PutRolePolicy` on `*`, which no other check here would see.
+   * Nothing granted account-wide may write IAM or grant everything.
+   */
+  for (const [sid] of WILDCARD_RESOURCE_STATEMENTS) {
+    const statement = statements.find((candidate: any) => candidate.Sid === sid)
+    assert.ok(statement, `${sid} is allowed a wildcard resource but no longer exists`)
+    const dangerous = asArray(statement.Action).filter(
+      (action: any) =>
+        typeof action === 'string' &&
+        (action === '*' || /^iam:(?!Get|List|Simulate)/i.test(action) || /^sts:AssumeRole/i.test(action)),
+    )
+    assert.deepEqual(dangerous, [], `${sid} grants ${dangerous.join(', ')} on every resource`)
+  }
 
   const known = [...DOCUMENTED_IN_SECURITY_MD, ...ACCOUNTED_HERE]
   const undocumented = unscoped.filter(({ sid, resource }: any) =>
@@ -1145,37 +1272,17 @@ test('the deploy role cannot reach another stage in the SST backing store', () =
   // that store, so it is the whole stack's config now, not just its app secrets.
   const template = readDeployTemplate()
   /*
-   * Every inline policy, not just the first. A second `Policies` entry grants exactly as much as the
-   * first, so reading `Policies[0]` would let one be added that restores everything narrowed here.
-   * Managed policies are worse: their contents live outside this template entirely, so the role must
-   * not attach any — there is nothing here to check them against.
+   * Every policy that reaches the role — see deployRolePolicyStatements. A managed policy ARN is
+   * different: its contents live outside this template, so there is nothing here to check it against
+   * and the role must not attach one.
    */
-  const role = template.Resources.GitHubDeployRole.Properties
   assert.deepEqual(
-    role.ManagedPolicyArns ?? [],
+    template.Resources.GitHubDeployRole.Properties.ManagedPolicyArns ?? [],
     [],
     'a managed policy ARN points outside this template, so its grants cannot be checked here',
   )
 
-  const statements = (role.Policies ?? []).flatMap((policy: any) => policy.PolicyDocument.Statement)
-
-  /*
-   * A policy does not have to be inline to reach this role. AWS::IAM::Policy and ::ManagedPolicy list
-   * their targets in `Roles`, ::RolePolicy in `RoleName`, and any of them can grant back everything the
-   * inline policy gives up — invisibly, if only Properties.Policies is read.
-   */
-  const ATTACHABLE_POLICY_TYPES = ['AWS::IAM::Policy', 'AWS::IAM::RolePolicy', 'AWS::IAM::ManagedPolicy']
-  const attachesToDeployRole = (properties: any) =>
-    [...(properties?.Roles ?? []), properties?.RoleName]
-      .filter(Boolean)
-      .some((target: any) => JSON.stringify(target).includes('GitHubDeployRole'))
-
-  for (const resource of Object.values(template.Resources) as any[]) {
-    if (!ATTACHABLE_POLICY_TYPES.includes(resource.Type)) continue
-    if (!attachesToDeployRole(resource.Properties)) continue
-    statements.push(...(resource.Properties?.PolicyDocument?.Statement ?? []))
-  }
-
+  const statements = deployRolePolicyStatements(template)
   assert.ok(statements.length > 0, 'the deploy role has no policy statements to check')
   const asArray = (value: any) => (Array.isArray(value) ? value : [value])
 

--- a/apps/infra/deployment/release-safety.test.ts
+++ b/apps/infra/deployment/release-safety.test.ts
@@ -463,7 +463,9 @@ test('the deploy role cannot rewrite its own permissions', () => {
   const template = readDeployTemplate()
   const statements = deployRolePolicyStatements(template)
   const asArray = (value: any) => (Array.isArray(value) ? value : [value])
-  const SELF_ARN_FRAGMENT = 'role/boxlite-${GitHubEnvironment}-github-deploy'
+  const SELF_ARN = 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/boxlite-${GitHubEnvironment}-github-deploy'
+  const BOUNDARY_ARN =
+    'arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/boxlite-${GitHubEnvironment}-runtime-boundary'
   const SELF_MUTATING = /^iam:(Attach|Detach|Put|Delete|Update)/i
 
   const granted = new Set<string>()
@@ -492,8 +494,10 @@ test('the deploy role cannot rewrite its own permissions', () => {
      * the resource to end at the role's own name, and refuse to credit a conditional Deny at all.
      */
     if (statement.Condition !== undefined) continue
+    // Glob, not endsWith: the Deny names role/boxlite-*-github-deploy so it protects sibling stages
+    // as well, and a literal comparison against this stage's ARN would not see that it covers it.
     const coversSelf = asArray(statement.Resource).some(
-      (resource: any) => typeof resource === 'string' && resource.endsWith(SELF_ARN_FRAGMENT),
+      (resource: any) => typeof resource === 'string' && iamGlob(resource).test(SELF_ARN),
     )
     if (!coversSelf) continue
     for (const action of asArray(statement.Action)) denied.add(action)
@@ -514,18 +518,53 @@ test('the deploy role cannot rewrite its own permissions', () => {
    * Widen it, create a bounded role under the widened version, pass it to a service, and the boundary
    * has stopped bounding anything. Denying writes to that one policy is what breaks the chain.
    */
-  const BOUNDARY_ARN_FRAGMENT = 'policy/boxlite-${GitHubEnvironment}-runtime-boundary'
   const deniedOnBoundary = new Set<string>()
   for (const statement of statements) {
     if (statement.Effect !== 'Deny' || statement.Condition !== undefined) continue
     const coversBoundary = asArray(statement.Resource).some(
-      (resource: any) => typeof resource === 'string' && resource.endsWith(BOUNDARY_ARN_FRAGMENT),
+      (resource: any) => typeof resource === 'string' && iamGlob(resource).test(BOUNDARY_ARN),
     )
     if (!coversBoundary) continue
     for (const action of asArray(statement.Action)) deniedOnBoundary.add(action)
   }
   for (const action of ['iam:CreatePolicyVersion', 'iam:SetDefaultPolicyVersion', 'iam:DeletePolicy']) {
     assert.ok(deniedOnBoundary.has(action), `${action} on the runtime boundary must be denied`)
+  }
+
+  /*
+   * And a SIBLING stage's deploy role, which is the sharper version of the same hole: role/boxlite-*
+   * covers prod's deploy role as readily as this one's, so a Deny scoped to ${GitHubEnvironment} would
+   * still leave a dev-bound job able to rewrite prod's trust policy and assume it.
+   */
+  const siblingArn = SELF_ARN.replace('${GitHubEnvironment}', 'some-other-stage')
+  const deniedOnSibling = statements
+    .filter((statement: any) => statement.Effect === 'Deny' && statement.Condition === undefined)
+    .filter((statement: any) =>
+      asArray(statement.Resource).some(
+        (resource: any) => typeof resource === 'string' && iamGlob(resource).test(siblingArn),
+      ),
+    )
+    .flatMap((statement: any) => asArray(statement.Action))
+  for (const action of ['iam:PutRolePolicy', 'iam:UpdateAssumeRolePolicy']) {
+    assert.ok(deniedOnSibling.includes(action), `${action} on another stage's deploy role must be denied`)
+  }
+
+  // The boundary needs the same treatment for the same reason: widening prod's boundary from a dev job
+  // is the identical takeover one level down.
+  const siblingBoundaryArn = BOUNDARY_ARN.replace('${GitHubEnvironment}', 'some-other-stage')
+  const deniedOnSiblingBoundary = statements
+    .filter((statement: any) => statement.Effect === 'Deny' && statement.Condition === undefined)
+    .filter((statement: any) =>
+      asArray(statement.Resource).some(
+        (resource: any) => typeof resource === 'string' && iamGlob(resource).test(siblingBoundaryArn),
+      ),
+    )
+    .flatMap((statement: any) => asArray(statement.Action))
+  for (const action of ['iam:CreatePolicyVersion', 'iam:SetDefaultPolicyVersion']) {
+    assert.ok(
+      deniedOnSiblingBoundary.includes(action),
+      `${action} on another stage's runtime boundary must be denied`,
+    )
   }
 })
 

--- a/apps/infra/deployment/release-safety.test.ts
+++ b/apps/infra/deployment/release-safety.test.ts
@@ -418,6 +418,86 @@ test('what bootstrap stores is the .env it validated, read once', () => {
   )
 })
 
+test('the grants that are NOT stage-scoped are the documented ones, and only those', () => {
+  /*
+   * The isolation test above says what the deploy role cannot reach. This says what it still can, so
+   * the two together are the whole picture: a grant that is account-wide because its resource has no
+   * stage to scope to is a documented limit, and a new one appearing silently is not.
+   *
+   * Pinned against docs/security.md, because a limit nobody wrote down is indistinguishable from one
+   * nobody noticed.
+   */
+  const template = readDeployTemplate()
+  const statements = template.Resources.GitHubDeployRole.Properties.Policies.flatMap(
+    (policy: any) => policy.PolicyDocument.Statement,
+  )
+  const asArray = (value: any) => (Array.isArray(value) ? value : [value])
+  const stageScoped = (resource: any) => String(resource).includes('${GitHubEnvironment}')
+
+  // Every resource that names no stage, excluding the SST backing store the other test covers.
+  const unscoped = statements.flatMap((statement: any) =>
+    asArray(statement.Resource)
+      .filter((resource: any) => typeof resource === 'string' && !stageScoped(resource))
+      .filter((resource: string) => !resource.includes('sst-state-') && !resource.includes('/sst/'))
+      .map((resource: string) => ({ sid: statement.Sid, resource })),
+  )
+
+  /*
+   * Every resource this role can reach across stages, and why each one cannot be scoped. The list is
+   * the point: adding a grant whose resource carries no stage should require adding a line here and
+   * saying why, rather than passing unnoticed.
+   */
+  // The three whose reach across stages is a property of this change's story, so security.md has to
+  // keep saying so — a limit recorded only in a test is a limit the next reader will not find.
+  const DOCUMENTED_IN_SECURITY_MD: Array<[string, string]> = [
+    ['sst-asset-', 'deployment assets are content-addressed; the key is the content hash'],
+    ['boxlite-volume-', 'the bucket name carries no stage — scoping it is a rename'],
+    [':instance/*', 'an EC2 instance ARN carries no stage; narrowing needs a tag Condition'],
+  ]
+  // The rest predate this change and are accounted for here rather than in the prose.
+  const ACCOUNTED_HERE: Array<[string, string]> = [
+    ['document/AWS-RunShellScript', 'an AWS-owned SSM document, not a stage resource'],
+    [':role/boxlite-*', 'SST names the roles it creates per stack, and the stage is not a prefix'],
+    [':instance-profile/boxlite-*', 'same naming as the roles they wrap'],
+    [':policy/boxlite-*', 'same naming as the roles they attach to'],
+    ['role/aws-service-role/', 'service-linked roles are account-global by AWS design'],
+  ]
+  /*
+   * `*` carries no resource name to match on, so it is allowed per statement rather than per pattern.
+   * Excluding it wholesale — which this did at first — would have let the single widest grant there is
+   * appear without failing anything.
+   */
+  const WILDCARD_RESOURCE_STATEMENTS: Array<[string, string]> = [
+    ['BoxLiteAwsControlPlane', 'the control-plane calls SST makes have no resource-level ARNs'],
+    ['RunnerCommandStatus', 'SSM command-history APIs are list-shaped and take no resource'],
+    ['ReadIamAndAccountMetadata', 'account and IAM reads SST performs before it knows any resource'],
+  ]
+
+  const known = [...DOCUMENTED_IN_SECURITY_MD, ...ACCOUNTED_HERE]
+  const undocumented = unscoped.filter(({ sid, resource }: any) =>
+    resource === '*'
+      ? !WILDCARD_RESOURCE_STATEMENTS.some(([allowedSid]) => allowedSid === sid)
+      : !known.some(([pattern]) => resource.includes(pattern)),
+  )
+  assert.deepEqual(undocumented, [], 'an account-wide resource grant appeared that nothing accounts for')
+
+  /*
+   * Both directions. "Every unscoped grant is documented" alone lets the documentation rot the other
+   * way: narrow or delete boxlite-volume-* later and security.md would still describe it as shared,
+   * with nothing failing. So each documented pattern must also still match a real unscoped resource.
+   */
+  const security = readFileSync(join(REPO_ROOT, 'apps/infra/docs/security.md'), 'utf8')
+  for (const [pattern] of DOCUMENTED_IN_SECURITY_MD) {
+    const claim = pattern.replace(/^:/, '').replace(/-$/, '-*')
+    assert.ok(security.includes(claim), `docs/security.md must still name ${claim} as a shared grant`)
+    assert.ok(
+      unscoped.some(({ resource }: any) => resource.includes(pattern)),
+      `docs/security.md still describes ${claim} as reaching every stage, but no grant matches it — ` +
+        'either the policy was narrowed and the note is now wrong, or the pattern here is stale',
+    )
+  }
+})
+
 test('every unusable stage configuration store stops the deploy rather than warning', () => {
   // Over live source, for the reason the API-image test gives: nothing executes this path in a test,
   // so a branch downgraded to a warning would leave every unit test passing. The store is now the only

--- a/apps/infra/deployment/release-safety.test.ts
+++ b/apps/infra/deployment/release-safety.test.ts
@@ -1425,13 +1425,38 @@ test('the stage configuration capability probe answers each selected-commit shap
   assert.ok(probe, 'the capability probe is not a node -e expression any more')
   const expression = probe.slice(probe.indexOf('"') + 1, probe.lastIndexOf('" "$capability"'))
 
+  /*
+   * The two gates read the same file, so they must accept the same versions. Left to drift, a bump one
+   * gate welcomes makes the other refuse the deploy — with a message about the store, for a commit
+   * whose store support never changed. This is not hypothetical: #1253 widened one of them.
+   */
+  const componentGate = workflow.jobs.deploy.steps.find(
+    (step: any) => step.name === 'Require component selection support in the selected commit',
+  )
+  assert.ok(componentGate, 'the component-selection gate is missing')
+  const acceptedVersions = (source: string) => source.match(/\[[\d,\s]+\]\.includes\(c\.version\)/)?.[0]
+  assert.equal(
+    acceptedVersions(expression),
+    acceptedVersions(liveShell(componentGate.run)),
+    'the two capability gates accept different versions of the same file',
+  )
+
   const fixture = mkdtempSync(join(tmpdir(), 'boxlite-capability-probe-'))
   const capability = join(fixture, 'capabilities.json')
   try {
     const cases: Array<[string, string]> = [
       ['supported', JSON.stringify({ version: 1, componentSelection: true, stageConfigStore: true })],
       ['unsupported', JSON.stringify({ version: 1, componentSelection: true })],
-      ['unsupported', JSON.stringify({ version: 2, stageConfigStore: true })],
+      /*
+       * v2 with the capability declared is SUPPORTED. There is one capabilities.json with one version,
+       * so a bump made for an unrelated capability must not read as "this commit cannot use the store"
+       * — which is why the component-selection gate stopped pinning a single version (#1253), and why
+       * this gate accepts the same set.
+       */
+      ['supported', JSON.stringify({ version: 2, componentSelection: true, stageConfigStore: true })],
+      ['unsupported', JSON.stringify({ version: 2, componentSelection: true })],
+      // Outside the set both gates accept: a future version this workflow has never been taught to read.
+      ['unsupported', JSON.stringify({ version: 3, stageConfigStore: true })],
     ]
     for (const [expected, contents] of cases) {
       writeFileSync(capability, contents)

--- a/apps/infra/deployment/release-safety.test.ts
+++ b/apps/infra/deployment/release-safety.test.ts
@@ -430,6 +430,36 @@ test('SST deploy verifies the selected API image before invoking SST', () => {
   assertLiveLine(source, /if \(apiSource && \(apiSource\.kind === 'release' \|\| apiSource\.ref\)\) \{/)
 })
 
+test('a failed sst call names its log rather than quoting it', () => {
+  /*
+   * sst writes provider diagnostics to .sst/log/sst.log, in most detail exactly when a call fails —
+   * request bodies included. bootstrap hands sst an app secret (`secret set`) and a stage's entire
+   * configuration (`secret load`), so quoting that file into an error message would put those values
+   * in the operator's terminal and whatever collects it.
+   *
+   * Asserted as "nothing reads the log" rather than "the calls that carry secrets do not": the log
+   * persists across calls, so a later install failure would quote what an earlier secret load wrote,
+   * and a per-call rule cannot see that. Removing the reader is what makes the property hold.
+   */
+  const source = liveText('script', readFileSync(join(REPO_ROOT, 'apps/infra/bootstrap/bootstrap.ts'), 'utf8'))
+
+  /*
+   * No read of any kind inside runSst, rather than "no read whose argument mentions sst.log" — a path
+   * held in a variable, or a helper called from the catch, would satisfy the narrower rule while
+   * quoting the same file. What has to hold is that the failure path reads nothing at all.
+   */
+  const start = source.indexOf('function runSst(')
+  assert.notEqual(start, -1, 'runSst is missing')
+  const body = source.slice(start, source.indexOf('\n}\n', start))
+  assert.doesNotMatch(body, /readFile|createReadStream|execFileSync\(\s*['"]cat/, 'the failure path must read nothing')
+
+  assert.doesNotMatch(source, /sstLogTail/, 'the log-quoting helper must stay gone')
+  // The log is named exactly once, as a path. A second mention is a second thing doing something
+  // with it, which is what this is here to notice.
+  assert.equal(source.match(/sst\.log/g)?.length, 1, 'the sst log may be named once, as a path')
+  assertLiveLine(source, /see \$\{join\(INFRA_ROOT, '\.sst', 'log', 'sst\.log'\)\}/)
+})
+
 test('what bootstrap stores is the .env it validated, read once', () => {
   // Over live source: nothing executes bootstrap in a test. main() validates a snapshot before any
   // external mutation, then ensureStageConfig runs after the OIDC provider, the GitHub Environment and

--- a/apps/infra/deployment/release-safety.test.ts
+++ b/apps/infra/deployment/release-safety.test.ts
@@ -57,6 +57,201 @@ const assertLiveLine = (text: string, pattern: RegExp, message?: string) =>
   assert.match(liveText('script', text), pattern, message ?? `missing live line: ${pattern}`)
 
 /*
+ * /sst/bootstrap names the state and asset buckets every stage shares, and SST reads it before it
+ * knows its stage, so it cannot be stage-scoped — which makes it the one parameter a stage must never
+ * be able to write. Rewriting it repoints every other stage's state; deleting it breaks them all.
+ *
+ * Deciding which statements reach it is the whole difficulty, so it is a function with its own tests
+ * rather than a condition inline in one assertion. Reading the template alone cannot prove the logic is
+ * right — the template passes, and a matcher that answered "nothing matches" would pass just as well.
+ */
+const SHARED_BOOTSTRAP_PARAMETER = '/sst/bootstrap'
+
+/*
+ * IAM matches resources by glob, so this must too: `parameter/sst/*`, `parameter/*`, `*`, and
+ * `parameter/sst/boot?trap` all reach the shared bootstrap while equalling no literal. Both wildcards
+ * IAM supports are translated and every other metacharacter escaped, so a `.` in an ARN cannot quietly
+ * stand in for an arbitrary character.
+ */
+function iamGlob(pattern: string) {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&')
+  return new RegExp(
+    `^${escaped.replace(/\*/g, '.*').replace(/\?/g, '.').split(SUB_SENTINEL).join('.*')}$`,
+    'i',
+  )
+}
+
+/*
+ * Segment the ARN rather than looking for a `:parameter` substring. `arn:aws:ssm:*:*:*` covers the
+ * shared bootstrap and contains no such marker, so a substring search silently answers "no" to the
+ * broadest grant there is.
+ *
+ * The `${AWS::Region}`-style placeholders have to be neutralised first, because they contain colons
+ * themselves and would otherwise split into phantom segments. They stand for this deploy's own
+ * partition, region and account — the same ones the parameter lives in — so they count as matching.
+ */
+const SUB_SENTINEL = '\u0001'
+
+function coversSharedBootstrap(resource: unknown) {
+  if (typeof resource !== 'string') return false
+  if (resource === '*') return true
+
+  const segments = resource.replace(/\$\{[^}]*\}/g, SUB_SENTINEL).split(':')
+  // Anything that is not a well-formed 6-field ARN. Whether IAM rejects such a resource or reads the
+  // omitted fields as wildcards is not something this can settle, and it does not need to: either way
+  // "not an ARN I can read" must not come back as "does not reach the shared bootstrap".
+  if (segments.length < 6 || segments[0] !== 'arn') return true
+  const service = segments[2]
+  if (service !== 'ssm' && service !== '*' && service !== SUB_SENTINEL) return false
+  // Rejoined: an SSM parameter name may itself contain colons.
+  const resourceId = segments.slice(5).join(':')
+  return iamGlob(resourceId).test(`parameter${SHARED_BOOTSTRAP_PARAMETER}`)
+}
+
+/*
+ * Whether an action can write a parameter — case-insensitively, because IAM action names are:
+ * `SSM:PutParameter` and `ssm:putparameter` are the same grant, so a case-sensitive prefix test is an
+ * evasion rather than a style question. `*` and `ssm:*` grant every write without naming one.
+ */
+function mutatesParameters(action: unknown) {
+  if (typeof action !== 'string') return false
+  // A substitution can resolve to anything, so `${Service}:PutParameter` has to read as a possible
+  // write rather than as "not an ssm action". Same direction the resource side widens in: unknown
+  // means flagged, never waved through.
+  if (action.includes('${')) return true
+  const normalized = action.toLowerCase()
+  if (normalized === '*' || normalized === 'ssm:*') return true
+  return normalized.startsWith('ssm:') && !/^ssm:(get|list|describe)/.test(normalized)
+}
+
+/*
+ * An Allow with NotResource grants everything EXCEPT what it lists, so it reaches /sst/bootstrap unless
+ * that is one of the exclusions; NotAction is the same inversion for actions. Reasoning about either
+ * properly means evaluating a complement, which this does not do — so rather than inspect Action and
+ * Resource and quietly return "nothing matches", it reports the statement as unanalyzable and the
+ * assertion fails. The template uses neither today, and this is what keeps that true.
+ */
+function sharedBootstrapMutations(statement: any) {
+  const asList = (value: any) => (Array.isArray(value) ? value : [value])
+
+  /*
+   * Only a grant can be a violation. A Deny naming the shared bootstrap is the opposite — a protection
+   * — and flagging it would make the guard reject the very thing it wants. Anything that is neither is
+   * refused rather than assumed harmless, since IAM requires Effect and a statement without one is
+   * malformed.
+   */
+  const effect = statement?.Effect
+  if (effect === 'Deny') return []
+  if (effect !== 'Allow') return [`unanalyzable: Effect ${JSON.stringify(effect)}`]
+
+  const inverted = ['NotAction', 'NotResource'].filter((key) => statement?.[key] !== undefined)
+  if (inverted.length > 0) return [`unanalyzable: ${inverted.join(' + ')}`]
+
+  /*
+   * Anything that is not a plain string. `!Sub` with a variable map, or `Fn::Join`, parses to an array
+   * or object rather than to text, and the value it computes cannot be read here — so it is refused
+   * rather than skipped. Skipping is the failure mode that matters: a computed resource would return
+   * "does not cover the shared bootstrap" while possibly naming exactly that.
+   */
+  const resources = asList(statement?.Resource)
+  const actions = asList(statement?.Action)
+  const computed = [...resources, ...actions].filter((entry) => typeof entry !== 'string')
+  if (computed.length > 0) return [`unanalyzable: ${computed.length} computed Action/Resource entrie(s)`]
+
+  if (!resources.some(coversSharedBootstrap)) return []
+  return actions.filter(mutatesParameters)
+}
+
+test('the shared-bootstrap guard catches every way a grant can cover it', () => {
+  // Synthetic statements, not the template: this is what can make the guard above fail. Each entry
+  // reaches /sst/bootstrap without naming it exactly, or spells a write so a naive prefix test misses
+  // it.
+  const evasions = [
+    { Effect: 'Allow', Sid: 'ExactArn', Action: 'ssm:PutParameter', Resource: 'arn:aws:ssm:r:a:parameter/sst/bootstrap' },
+    { Effect: 'Allow', Sid: 'TrailingStar', Action: 'ssm:PutParameter', Resource: 'arn:aws:ssm:r:a:parameter/sst/*' },
+    { Effect: 'Allow', Sid: 'EmbeddedStar', Action: 'ssm:DeleteParameter', Resource: 'arn:aws:ssm:r:a:parameter/*/bootstrap' },
+    { Effect: 'Allow', Sid: 'SingleCharWildcard', Action: 'ssm:PutParameter', Resource: 'arn:aws:ssm:r:a:parameter/sst/boot?trap' },
+    { Effect: 'Allow', Sid: 'EverythingResource', Action: 'ssm:PutParameter', Resource: '*' },
+    // No `:parameter` anywhere in it, yet it covers every SSM resource in the account.
+    { Effect: 'Allow', Sid: 'WildcardArnSegments', Action: 'ssm:PutParameter', Resource: 'arn:aws:ssm:*:*:*' },
+    { Effect: 'Allow', Sid: 'WildcardServiceSegment', Action: 'ssm:PutParameter', Resource: 'arn:aws:*:*:*:parameter/sst/bootstrap' },
+    { Effect: 'Allow', Sid: 'ServiceWildcardAction', Action: 'ssm:*', Resource: 'arn:aws:ssm:r:a:parameter/sst/bootstrap' },
+    { Effect: 'Allow', Sid: 'EveryAction', Action: '*', Resource: 'arn:aws:ssm:r:a:parameter/sst/bootstrap' },
+    { Effect: 'Allow', Sid: 'UppercaseService', Action: 'SSM:PutParameter', Resource: 'arn:aws:ssm:r:a:parameter/sst/bootstrap' },
+    { Effect: 'Allow', Sid: 'MixedCaseAction', Action: 'SsM:putParameter', Resource: 'arn:aws:ssm:r:a:parameter/sst/bootstrap' },
+    {
+      Effect: 'Allow',
+      Sid: 'ListedAmongReads',
+      Action: ['ssm:GetParameter', 'ssm:PutParameter'],
+      Resource: ['arn:aws:ssm:r:a:parameter/sst/*'],
+    },
+    // Inverted forms: an Allow that lists what it does NOT cover grants the rest, including this.
+    { Effect: 'Allow', Sid: 'NotResourceAllow', Action: 'ssm:PutParameter', NotResource: 'arn:aws:ssm:r:a:parameter/other' },
+    { Effect: 'Allow', Sid: 'NotActionAllow', NotAction: 's3:*', Resource: 'arn:aws:ssm:r:a:parameter/sst/bootstrap' },
+    // A computed identifier: nothing here can prove ${Whatever} is not the shared bootstrap.
+    { Effect: 'Allow', Sid: 'SubstitutedIdentifier', Action: 'ssm:PutParameter', Resource: 'arn:aws:ssm:r:a:parameter/${Whatever}' },
+    // Not text at all. `!Sub` with a variable map and `Fn::Join` survive YAML parsing as structures,
+    // and their result is not knowable here, so neither may be waved through.
+    {
+      Effect: 'Allow',
+      Sid: 'FnJoinResource',
+      Action: 'ssm:PutParameter',
+      Resource: { 'Fn::Join': [':', ['arn', 'aws', 'ssm', 'r', 'a', 'parameter/sst/bootstrap']] },
+    },
+    {
+      Effect: 'Allow',
+      Sid: 'FnSubWithVariableMap',
+      Action: 'ssm:PutParameter',
+      Resource: ['arn:aws:ssm:r:a:parameter/${Name}', { Name: 'sst/bootstrap' }],
+    },
+    { Effect: 'Allow', Sid: 'ComputedAction', Action: { 'Fn::Join': [':', ['ssm', 'PutParameter']] }, Resource: '*' },
+    // Malformed rather than permissive, but still not something this can reason about.
+    { Sid: 'NoEffect', Action: 'ssm:PutParameter', Resource: 'arn:aws:ssm:r:a:parameter/sst/bootstrap' },
+    // Not a readable 6-field ARN, so it must never come back as "reaches nothing".
+    { Effect: 'Allow', Sid: 'TruncatedArn', Action: 'ssm:PutParameter', Resource: 'arn:aws:ssm' },
+    // A substituted action: the service is only known at deploy time, so it could be ssm.
+    {
+      Effect: 'Allow',
+      Sid: 'SubstitutedActionService',
+      Action: '${Service}:PutParameter',
+      Resource: 'arn:aws:ssm:r:a:parameter/sst/bootstrap',
+    },
+    {
+      Effect: 'Allow',
+      Sid: 'SubstitutedActionVerb',
+      Action: 'ssm:${Verb}',
+      Resource: 'arn:aws:ssm:r:a:parameter/sst/bootstrap',
+    },
+    { Effect: 'Allow', Sid: 'NotAnArn', Action: 'ssm:PutParameter', Resource: 'parameter/sst/bootstrap' },
+  ]
+  for (const statement of evasions) {
+    assert.notDeepEqual(sharedBootstrapMutations(statement), [], `${statement.Sid} must be caught`)
+  }
+
+  // And what must NOT trip it, or the guard would reject the policy the stack actually needs.
+  const allowed = [
+    {
+      Effect: 'Allow',
+      Sid: 'ReadOnlyShared',
+      Action: ['ssm:GetParameter', 'ssm:GetParameters'],
+      Resource: 'arn:aws:ssm:r:a:parameter/sst/bootstrap',
+    },
+    { Effect: 'Allow', Sid: 'DescribeEverywhere', Action: 'ssm:DescribeParameters', Resource: '*' },
+    { Effect: 'Allow', Sid: 'ThisStagesParameters', Action: 'ssm:PutParameter', Resource: 'arn:aws:ssm:r:a:parameter/boxlite/dev/*' },
+    { Effect: 'Allow', Sid: 'PassphraseOnly', Action: 'ssm:PutParameter', Resource: 'arn:aws:ssm:r:a:parameter/sst/passphrase/boxlite/dev' },
+    { Effect: 'Allow', Sid: 'DifferentService', Action: 's3:PutObject', Resource: '*' },
+    // A wildcard ARN for a different service reaches no parameter at all.
+    { Effect: 'Allow', Sid: 'WildcardArnOtherService', Action: 'ssm:PutParameter', Resource: 'arn:aws:s3:*:*:*' },
+    // A Deny naming the shared bootstrap protects it. Flagging that would reject the fix, not the bug.
+    { Effect: 'Deny', Sid: 'DenyProtectsIt', Action: 'ssm:PutParameter', Resource: 'arn:aws:ssm:r:a:parameter/sst/bootstrap' },
+    { Effect: 'Deny', Sid: 'DenyInverted', NotAction: 's3:*', Resource: '*' },
+  ]
+  for (const statement of allowed) {
+    assert.deepEqual(sharedBootstrapMutations(statement), [], `${statement.Sid} must be allowed`)
+  }
+})
+
+/*
  * The stage's configuration reaches a deploy through the SST secret store, which
  * deployment/sst.ts reads with the AWS credentials the job already holds. Nothing may reintroduce
  * the GitHub half of that: `DEPLOY_ENV` put stage config in a second control plane, and writing it
@@ -869,7 +1064,39 @@ test('the deploy role cannot reach another stage in the SST backing store', () =
   // the dev Environment could read prod's. This change makes the stage configuration authoritative in
   // that store, so it is the whole stack's config now, not just its app secrets.
   const template = readDeployTemplate()
-  const statements = template.Resources.GitHubDeployRole.Properties.Policies[0].PolicyDocument.Statement
+  /*
+   * Every inline policy, not just the first. A second `Policies` entry grants exactly as much as the
+   * first, so reading `Policies[0]` would let one be added that restores everything narrowed here.
+   * Managed policies are worse: their contents live outside this template entirely, so the role must
+   * not attach any — there is nothing here to check them against.
+   */
+  const role = template.Resources.GitHubDeployRole.Properties
+  assert.deepEqual(
+    role.ManagedPolicyArns ?? [],
+    [],
+    'a managed policy ARN points outside this template, so its grants cannot be checked here',
+  )
+
+  const statements = (role.Policies ?? []).flatMap((policy: any) => policy.PolicyDocument.Statement)
+
+  /*
+   * A policy does not have to be inline to reach this role. AWS::IAM::Policy and ::ManagedPolicy list
+   * their targets in `Roles`, ::RolePolicy in `RoleName`, and any of them can grant back everything the
+   * inline policy gives up — invisibly, if only Properties.Policies is read.
+   */
+  const ATTACHABLE_POLICY_TYPES = ['AWS::IAM::Policy', 'AWS::IAM::RolePolicy', 'AWS::IAM::ManagedPolicy']
+  const attachesToDeployRole = (properties: any) =>
+    [...(properties?.Roles ?? []), properties?.RoleName]
+      .filter(Boolean)
+      .some((target: any) => JSON.stringify(target).includes('GitHubDeployRole'))
+
+  for (const resource of Object.values(template.Resources) as any[]) {
+    if (!ATTACHABLE_POLICY_TYPES.includes(resource.Type)) continue
+    if (!attachesToDeployRole(resource.Properties)) continue
+    statements.push(...(resource.Properties?.PolicyDocument?.Statement ?? []))
+  }
+
+  assert.ok(statements.length > 0, 'the deploy role has no policy statements to check')
   const asArray = (value: any) => (Array.isArray(value) ? value : [value])
 
   // No statement may grant either service account-wide again.
@@ -911,19 +1138,9 @@ test('the deploy role cannot reach another stage in the SST backing store', () =
   const parameters = statements.find((statement: any) => statement.Sid === 'SstParametersForThisStage')
   assert.ok(parameters, 'the stage-scoped parameter grant is missing')
 
-  /*
-   * /sst/bootstrap names the state and asset buckets every stage shares, and it is read before SST
-   * knows its stage, so it cannot be stage-scoped — which makes it the one parameter a stage must not
-   * be able to write. Rewriting it repoints every other stage's state; deleting it breaks them all.
-   */
-  const sharedBootstrap = '/sst/bootstrap'
   for (const statement of statements) {
-    const touchesSharedBootstrap = asArray(statement.Resource).some(
-      (resource: any) => typeof resource === 'string' && resource.endsWith(`parameter${sharedBootstrap}`),
-    )
-    if (!touchesSharedBootstrap) continue
-    const mutating = asArray(statement.Action).filter((action: string) => !/^ssm:(Get|List|Describe)/.test(action))
-    assert.deepEqual(mutating, [], `${statement.Sid} may not mutate the shared ${sharedBootstrap}`)
+    const mutating = sharedBootstrapMutations(statement)
+    assert.deepEqual(mutating, [], `${statement.Sid} may not mutate the shared ${SHARED_BOOTSTRAP_PARAMETER}`)
   }
   const passphrase = asArray(parameters.Resource).find((resource: string) => resource.includes('/sst/passphrase/'))
   assert.ok(

--- a/apps/infra/deployment/release-safety.test.ts
+++ b/apps/infra/deployment/release-safety.test.ts
@@ -675,6 +675,27 @@ test('the grants that are NOT stage-scoped are the documented ones, and only tho
   }
 })
 
+test('every step that runs the sst wrapper is given the Cloudflare credentials', () => {
+  /*
+   * The wrapper falls back to an SSM copy when the variables are unset, and whether this role can
+   * decrypt that parameter has never been verified — so a step without them either works by a path
+   * nobody has confirmed, or fails at provider initialization. Both are avoidable by passing the
+   * Environment secrets the stage already holds.
+   *
+   * `install` counts: it evaluates sst.config.ts, which initializes every provider declared there.
+   */
+  const workflow: any = load(readFileSync(DEPLOY_WORKFLOW, 'utf8'), { schema: CLOUDFORMATION_SCHEMA })
+  const steps = values(workflow.jobs).flatMap((job: any) => job.steps ?? [])
+  const wrapperSteps = steps.filter((step: any) => typeof step.run === 'string' && /npm run .*\bsst\b/.test(step.run))
+  assert.ok(wrapperSteps.length > 0, 'no step runs the sst wrapper; this test is looking at the wrong thing')
+
+  for (const step of wrapperSteps) {
+    for (const secret of ['CLOUDFLARE_API_TOKEN', 'CLOUDFLARE_DEFAULT_ACCOUNT_ID']) {
+      assert.ok(step.env?.[secret], `step "${step.name}" runs sst without ${secret}`)
+    }
+  }
+})
+
 test('every unusable stage configuration store stops the deploy rather than warning', () => {
   // Over live source, for the reason the API-image test gives: nothing executes this path in a test,
   // so a branch downgraded to a warning would leave every unit test passing. The store is now the only

--- a/apps/infra/deployment/release-safety.test.ts
+++ b/apps/infra/deployment/release-safety.test.ts
@@ -442,6 +442,17 @@ test('what bootstrap stores is the .env it validated, read once', () => {
 
   assert.doesNotMatch(body, /readFileSync|requireStageEnvFile/, 'the payload must be handed in, not re-read')
   assert.doesNotMatch(body, /prepareStageConfigLoad/, 'preparing it here would be the second read again')
+
+  /*
+   * The same value everywhere, not just read once. Auth0 provisioning builds callback URLs from
+   * STACK_DOMAIN and is not idempotent; taking it from process.env would let an exported override beat
+   * the file, so Auth0 would be configured for one domain and every deploy would use another.
+   */
+  assert.doesNotMatch(
+    source,
+    /process\.env\.STACK_DOMAIN/,
+    'STACK_DOMAIN must come from the validated snapshot, so Auth0 and the store cannot disagree',
+  )
   // Exactly one read in the whole script, and it is the one main() validates.
   assert.equal(
     source.match(/readFileSync\(requireStageEnvFile\(\)/g)?.length,

--- a/apps/infra/deployment/release-safety.test.ts
+++ b/apps/infra/deployment/release-safety.test.ts
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 BoxLite AI
 
 import assert from 'node:assert/strict'
-import { spawnSync } from 'node:child_process'
+import { execFileSync, spawnSync } from 'node:child_process'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
@@ -10,7 +10,9 @@ import { fileURLToPath } from 'node:url'
 import test from 'node:test'
 import { DEFAULT_SCHEMA, Type, load as loadYaml, type LoadOptions } from 'js-yaml'
 
+import { DEFAULT_AWS_REGION } from './environment.js'
 import { verifyDeployRoleGrantsBoundaryPermission } from './role-boundary.js'
+import { githubDeployRoleName } from '../bootstrap/environment.js'
 import { liveText } from '../shared/live-source.js'
 import { apiImageRepository } from '../artifacts/api.js'
 import { runnerArtifactsBucketName } from '../artifacts/runner.js'
@@ -54,27 +56,47 @@ const assertShellLine = (run: string, pattern: RegExp, message?: string) =>
 const assertLiveLine = (text: string, pattern: RegExp, message?: string) =>
   assert.match(liveText('script', text), pattern, message ?? `missing live line: ${pattern}`)
 
-function assertEnvironmentValidatorCompatibility(materializeStep: any) {
-  assert.ok(materializeStep, 'the stage configuration step is missing')
-  assertShellLine(
-    materializeStep.run,
-    /if node -e .*scripts\?\.\['validate-environment'\].*; then/,
-    'the workflow must prefer the selected commit validator facade',
+/*
+ * The stage's configuration reaches a deploy through the SST secret store, which
+ * deployment/sst.ts reads with the AWS credentials the job already holds. Nothing may reintroduce
+ * the GitHub half of that: `DEPLOY_ENV` put stage config in a second control plane, and writing it
+ * out as apps/infra/.env made a gitignored local file a CI transport format.
+ *
+ * Asserted as an absence, over the whole file rather than one step, because the failure this guards
+ * is a step being *added* back — anywhere in the job.
+ */
+function assertNoMaterializedStageConfig(workflow: any, source: string) {
+  assert.doesNotMatch(source, /secrets\.DEPLOY_ENV/, 'stage config must come from the SST secret store, not DEPLOY_ENV')
+  // The redirect specifically, not any mention of the path: the capability gate's own refusal message
+  // names apps/infra/.env to explain what an old commit expects, and a guard that cannot tell prose
+  // from a write would forbid explaining the thing it protects.
+  assert.doesNotMatch(source, />\s*apps\/infra\/\.env/, 'no workflow step may write apps/infra/.env')
+  assert.doesNotMatch(source, /rm -f apps\/infra\/\.env/, 'nothing should need to clean up a materialized .env')
+  assert.doesNotMatch(source, /validate-environment/, 'the DEPLOY_ENV validator went away with DEPLOY_ENV')
+  for (const step of workflow.jobs.deploy.steps) {
+    assert.notEqual(step.name, 'Materialize stage configuration')
+    assert.notEqual(step.name, 'Remove materialized configuration')
+  }
+}
+
+/*
+ * The deploy role ARN is read before any AWS credentials exist, so it cannot come from the store.
+ * Only the account id is unknown though — the role name is githubDeployRoleName(stage) — so the
+ * workflows compose it from the stage's AWS_ACCOUNT_ID instead of a per-stage AWS_DEPLOY_ROLE_ARN.
+ * Pinned against the same helper bootstrap uses, so the two cannot drift.
+ */
+function assertComposedDeployRoleArn(source: string, stageExpression: string) {
+  const expected = `role-to-assume: arn:aws:iam::\${{ vars.AWS_ACCOUNT_ID }}:role/${githubDeployRoleName('STAGE').replace('STAGE', stageExpression)}`
+  assert.ok(source.includes(expected), `missing composed deploy role ARN: ${expected}`)
+  assert.doesNotMatch(source, /vars\.AWS_DEPLOY_ROLE_ARN/, 'the per-stage role ARN variable is gone')
+  // The region keeps its optional per-stage override — a stage in another region has no other way to
+  // say so, since it is read before any AWS access exists and so cannot come from the secret store.
+  // What matters is that the DEFAULT is the wrapper's own constant, so a stage that configures nothing
+  // deploys where every local command resolves to.
+  assert.ok(
+    source.includes(`\${{ vars.AWS_REGION || '${DEFAULT_AWS_REGION}' }}`),
+    `missing the defaulted region expression for ${DEFAULT_AWS_REGION}`,
   )
-  assertShellLine(
-    materializeStep.run,
-    /npm --prefix apps\/infra run --silent validate-environment -- \.env/,
-  )
-  assertShellLine(
-    materializeStep.run,
-    /elif \[ -f apps\/infra\/scripts\/deploy-environment-validation\.mjs \]; then/,
-    'the workflow must support historical commits',
-  )
-  assertShellLine(
-    materializeStep.run,
-    /node apps\/infra\/scripts\/deploy-environment-validation\.mjs apps\/infra\/\.env/,
-  )
-  assertShellLine(materializeStep.run, /selected commit has no supported deployment environment validator/)
 }
 
 function readDeployTemplate() {
@@ -181,6 +203,61 @@ test('SST deploy verifies the selected API image before invoking SST', () => {
   assertLiveLine(source, /if \(apiSource && \(apiSource\.kind === 'release' \|\| apiSource\.ref\)\) \{/)
 })
 
+test('what bootstrap stores is the .env it validated, read once', () => {
+  // Over live source: nothing executes bootstrap in a test. main() validates a snapshot before any
+  // external mutation, then ensureStageConfig runs after the OIDC provider, the GitHub Environment and
+  // possibly an Auth0 app exist — minutes later. A second read there would store whatever the file says
+  // by then, which is not what was checked.
+  const source = liveText('script', readFileSync(join(REPO_ROOT, 'apps/infra/bootstrap/bootstrap.ts'), 'utf8'))
+  const start = source.indexOf('function ensureStageConfig(')
+  assert.notEqual(start, -1, 'ensureStageConfig is missing')
+  const body = source.slice(start, source.indexOf('\n}\n', start))
+
+  assert.doesNotMatch(body, /readFileSync|requireStageEnvFile/, 'the payload must be handed in, not re-read')
+  assert.doesNotMatch(body, /prepareStageConfigLoad/, 'preparing it here would be the second read again')
+  // Exactly one read in the whole script, and it is the one main() validates.
+  assert.equal(
+    source.match(/readFileSync\(requireStageEnvFile\(\)/g)?.length,
+    1,
+    'the stage .env must be read in exactly one place',
+  )
+})
+
+test('every unusable stage configuration store stops the deploy rather than warning', () => {
+  // Over live source, for the reason the API-image test gives: nothing executes this path in a test,
+  // so a branch downgraded to a warning would leave every unit test passing. The store is now the only
+  // source of a stage's configuration, so "read it, and continue if that failed" would deploy against
+  // defaults — a stage silently reconciled to something nobody wrote.
+  const source = liveText('script', readFileSync(SST_WRAPPER, 'utf8'))
+  const start = source.indexOf('function loadStageConfig(')
+  assert.notEqual(start, -1, 'loadStageConfig is missing from the wrapper')
+  // To the function's own closing brace at column 0 — every declaration here is top-level, and a
+  // boundary guessed at the next function would silently count another one's branches.
+  const body = source.slice(start, source.indexOf('\n}\n', start))
+
+  // Unreadable, unbootstrapped, torn, half-written, and applying-nothing. Five refusals, each an error
+  // paired with an exit: downgrading any one to a warning drops both counts and fails here.
+  assert.equal(body.match(/process\.exit\(1\)/g)?.length, 5, 'a store the wrapper cannot use must exit')
+  assert.equal(body.match(/console\.error\(/g)?.length, 5, 'every refusal must say which one it is')
+  // Exactly one, and it is not a refusal: an unlisted key is a stale or hand-written entry that will
+  // never take effect, worth surfacing but not worth failing a deploy over.
+  assert.equal(body.match(/console\.warn\(/g)?.length, 1, 'only the unlisted-keys notice may warn')
+
+  // `diff` reads only, but a preview built from defaults is not a preview of the apply that follows —
+  // the operator approves that plan and the apply then reads the store successfully.
+  assertLiveLine(source, /STAGE_CONFIG_SUBCOMMANDS = new Set\(\[[^\]]*'diff'/)
+
+  /*
+   * No refusal may echo a value. Every one of them names keys — missing.join, manifestNames(stored) —
+   * and a future edit adding "…but the store holds <value>" would put a live credential in CI logs,
+   * which is exactly the leak the DEPLOY_ENV design was criticized for. `stored[` and `apply[` are the
+   * two ways a value gets into that string, so neither may appear in the messages.
+   */
+  for (const message of body.match(/console\.error\([\s\S]*?\)\n/g) ?? []) {
+    assert.doesNotMatch(message, /stored\[|apply\[/, 'a refusal must report key names, never a value')
+  }
+})
+
 test('SST deploy does not depend on a laptop-managed remote builder', () => {
   const source = readFileSync(SST_WRAPPER, 'utf8')
   const packageSource = readFileSync(join(REPO_ROOT, 'apps/infra/package.json'), 'utf8')
@@ -243,7 +320,6 @@ test('deployment previews and reconciles the full stack in guarded GitHub CI', (
   const boundaryCheckStep = workflow.jobs.deploy.steps.find(
     (step: any) => step.name === 'Verify deploy role IAM boundary permissions',
   )
-  const materializeStep = workflow.jobs.deploy.steps.find((step: any) => step.name === 'Materialize stage configuration')
   const installStep = workflow.jobs.deploy.steps.find((step: any) => step.name === 'Install SST providers')
   const previewStep = workflow.jobs.deploy.steps.find((step: any) => step.name === 'Preview the selected components')
   const deployStep = workflow.jobs.deploy.steps.find((step: any) => step.name === 'Deploy the selected components')
@@ -371,7 +447,7 @@ test('deployment previews and reconciles the full stack in guarded GitHub CI', (
   assert.equal(workflow.jobs.e2e.uses, './.github/workflows/e2e-cloud.yml')
   assert.equal(workflow.jobs.e2e.with.ref, '${{ needs.resolve-ref.outputs.sha }}')
   assert.equal(workflow.jobs.e2e.if, '${{ inputs.apply }}')
-  // Named, not `inherit` — which would also hand the suite DEPLOY_ENV and the Cloudflare token.
+  // Named, not `inherit` — which would hand the suite every secret this job can reach.
   assert.equal(workflow.jobs.e2e.secrets.BOXLITE_DEV_API_KEY, '${{ secrets.BOXLITE_DEV_API_KEY }}')
   // `needs` carries the ordering the `if` relies on: no status-check function appears in that
   // expression, so the default success() is what stops the suite running behind a failed deploy.
@@ -472,8 +548,12 @@ test('deployment previews and reconciles the full stack in guarded GitHub CI', (
   assert.match(workflow.jobs.deploy.if, /!contains\(needs\.\*\.result, 'cancelled'\)/)
   assert.match(workflow.jobs.deploy.if, /github\.ref == 'refs\/heads\/main'/)
 
-  // Both components resolve to the one commit the build jobs actually produced. The stage secret
-  // cannot redirect that: deploy-environment-validation.mjs rejects the selector keys outright.
+  // Both components resolve to the one commit the build jobs actually produced. The stage's store
+  // cannot redirect that, at either boundary: bootstrap refuses to store the selector keys
+  // (deployableStageConfig), and hydration refuses them even if one is written by hand and named by
+  // the manifest — by the allowlist and the local-only denylist alike, so relaxing either one on its
+  // own does not open the door. The workflow's own env: block is a real environment variable too,
+  // which always beats a stored value.
   for (const selector of ['BOXLITE_ARTIFACT_SOURCE', 'API_ARTIFACT_SOURCE', 'RUNNER_ARTIFACT_SOURCE']) {
     assert.equal(workflow.jobs.deploy.env[selector], 'build', `${selector} must be set on the deploy job`)
   }
@@ -502,22 +582,34 @@ test('deployment previews and reconciles the full stack in guarded GitHub CI', (
   assertShellLine(archStep.run, /test "\$\(uname -m\)" = "x86_64"/)
   assertShellLine(archStep.run, /test "\$\(docker info --format '\{\{\.Architecture\}\}'\)" = "x86_64"/)
   assert.match(source, /aws-actions\/configure-aws-credentials@/)
-  assert.match(source, /role-to-assume: \$\{\{ vars\.AWS_DEPLOY_ROLE_ARN \}\}/)
-  assert.match(source, /secrets\.DEPLOY_ENV/)
+  assertComposedDeployRoleArn(source, '${{ inputs.stage }}')
   assert.equal(workflow.jobs.deploy.env.RUNNER_CREATE_ALLOWLIST, undefined)
   // Every sst step passes --stage "$STAGE"; without this job env they would all
   // run with an empty stage.
   assert.equal(workflow.jobs.deploy.env.STAGE, '${{ inputs.stage }}')
   assert.equal(workflow.jobs.deploy.env.IAM_PERMISSIONS_BOUNDARY_STAGE, '${{ inputs.stage }}')
-  assertEnvironmentValidatorCompatibility(materializeStep)
-  assert.doesNotMatch(materializeStep.run, /grep/)
+  assertNoMaterializedStageConfig(workflow, source)
+  // Any commit on main is deployable, and this job checks out THAT commit's apps/infra. One predating
+  // the store still expects apps/infra/.env, so it must be refused rather than deployed with whatever
+  // defaults survive — and refused before the deploy role is assumed.
+  const stageConfigGate = workflow.jobs.deploy.steps.find(
+    (step: any) => step.name === 'Require stage configuration store support in the selected commit',
+  )
+  assert.ok(stageConfigGate, 'the stage configuration capability gate is missing')
+  assert.equal(stageConfigGate.if, undefined, 'the gate must apply to every deploy, not just a narrowed scope')
+  assertShellLine(stageConfigGate.run, /c\.stageConfigStore === true/)
+  const credentialStep = workflow.jobs.deploy.steps.findIndex(
+    (step: any) => step.name === 'Configure AWS credentials through OIDC',
+  )
+  assert.ok(
+    workflow.jobs.deploy.steps.indexOf(stageConfigGate) < credentialStep,
+    'an unsupported commit must be refused before the deploy role is assumed',
+  )
+  // The capability this repo declares, so the gate cannot pass against a tree that lacks it.
+  const capabilities = JSON.parse(readFileSync(join(REPO_ROOT, 'apps/infra/deployment/capabilities.json'), 'utf8'))
+  assert.equal(capabilities.stageConfigStore, true)
   assert.ok(safetyTestStep, 'the deployment safety test step is missing')
   assert.equal(safetyTestStep.run, 'npm test')
-  const liveMaterialize = liveShell(materializeStep.run)
-  const materializeConfigIndex = liveMaterialize.indexOf('printf \'%s\\n\' "$DEPLOY_ENV" > apps/infra/.env')
-  const validateConfigIndex = liveMaterialize.indexOf("if node -e")
-  assert.notEqual(materializeConfigIndex, -1, 'the stage configuration is not materialized')
-  assert.ok(validateConfigIndex > materializeConfigIndex, 'DEPLOY_ENV must be validated after it is materialized')
   assert.ok(installStep, 'the SST provider installation step is missing')
   assert.equal(installStep.run, 'npm run --silent sst -- install --stage "$STAGE"')
   assert.ok(previewStep, 'the full-stack preview step is missing')
@@ -583,9 +675,8 @@ test('deployment previews and reconciles the full stack in guarded GitHub CI', (
     'The IAM boundary preflight must run after safety tests and before the deployment preview',
   )
   assert.ok(
-    workflow.jobs.deploy.steps.indexOf(materializeStep) < workflow.jobs.deploy.steps.indexOf(installStep) &&
-      workflow.jobs.deploy.steps.indexOf(installStep) < workflow.jobs.deploy.steps.indexOf(previewStep),
-    'SST providers must be installed after stage config and before the deployment preview',
+    workflow.jobs.deploy.steps.indexOf(installStep) < workflow.jobs.deploy.steps.indexOf(previewStep),
+    'SST providers must be installed before the deployment preview',
   )
   // A selector may name a component only through DEPLOY_EXCLUDE, whose value the `components`
   // choice allowlists. Hardcoding one here would deploy a fixed partial scope on every dispatch,
@@ -772,12 +863,124 @@ test('the cloud E2E suite is reachable only from a deploy or a human', () => {
   assert.equal(checkout.with.ref, '${{ inputs.ref || github.sha }}')
 })
 
+test('the deploy role cannot reach another stage in the SST backing store', () => {
+  // One bucket and one parameter tree hold every stage's state and secrets — the live bucket carries
+  // secret/boxlite/dev.json beside secret/boxlite/prod.json. With s3:* and ssm:* on '*', a job bound to
+  // the dev Environment could read prod's. This change makes the stage configuration authoritative in
+  // that store, so it is the whole stack's config now, not just its app secrets.
+  const template = readDeployTemplate()
+  const statements = template.Resources.GitHubDeployRole.Properties.Policies[0].PolicyDocument.Statement
+  const asArray = (value: any) => (Array.isArray(value) ? value : [value])
+
+  // No statement may grant either service account-wide again.
+  for (const statement of statements) {
+    const actions = asArray(statement.Action)
+    const wide = asArray(statement.Resource).includes('*')
+    const storeReaching = actions.some((action: string) => /^(s3|ssm):/.test(action) && action.endsWith(':*'))
+    assert.equal(
+      wide && storeReaching,
+      false,
+      `${statement.Sid} grants ${actions.filter((a: string) => /^(s3|ssm):/.test(a)).join(', ')} on every resource`,
+    )
+  }
+
+  // Every state object names the stage. `!Sub` is parsed to its literal body by CLOUDFORMATION_SCHEMA,
+  // so the interpolation is visible as text.
+  const stateObjects = statements.find((statement: any) => statement.Sid === 'SstStateObjectsForThisStage')
+  assert.ok(stateObjects, 'the stage-scoped state grant is missing')
+  for (const resource of asArray(stateObjects.Resource)) {
+    const scoped = resource.includes('${GitHubEnvironment}') || resource.includes('sst-asset-')
+    assert.ok(scoped, `${resource} is not scoped to the stage`)
+  }
+
+  // All seven prefixes SST writes. lock/ and summary/ are in this list precisely because a live
+  // `list-objects` could not see them — a lock exists only while an update runs — so they came from
+  // sst's own provider.go. A policy built from the listing alone fails when a deploy takes its lock.
+  for (const prefix of ['app/', 'secret/', 'eventlog/', 'snapshot/', 'update/', 'lock/', 'summary/']) {
+    assert.ok(
+      asArray(stateObjects.Resource).some((resource: string) => resource.includes(`/${prefix}boxlite/`)),
+      `no grant covers the ${prefix} state prefix, so a deploy cannot write it`,
+    )
+  }
+
+  // `_fallback` belongs to the app, not a stage, so it cannot be scoped — it is read-only instead.
+  const fallback = statements.find((statement: any) => statement.Sid === 'SstFallbackSecretsRead')
+  assert.ok(fallback, 'the fallback secret grant is missing, so a stage using fallbacks cannot deploy')
+  assert.deepEqual([...asArray(fallback.Action)].sort(), ['s3:GetObject', 's3:GetObjectVersion'])
+
+  const parameters = statements.find((statement: any) => statement.Sid === 'SstParametersForThisStage')
+  assert.ok(parameters, 'the stage-scoped parameter grant is missing')
+
+  /*
+   * /sst/bootstrap names the state and asset buckets every stage shares, and it is read before SST
+   * knows its stage, so it cannot be stage-scoped — which makes it the one parameter a stage must not
+   * be able to write. Rewriting it repoints every other stage's state; deleting it breaks them all.
+   */
+  const sharedBootstrap = '/sst/bootstrap'
+  for (const statement of statements) {
+    const touchesSharedBootstrap = asArray(statement.Resource).some(
+      (resource: any) => typeof resource === 'string' && resource.endsWith(`parameter${sharedBootstrap}`),
+    )
+    if (!touchesSharedBootstrap) continue
+    const mutating = asArray(statement.Action).filter((action: string) => !/^ssm:(Get|List|Describe)/.test(action))
+    assert.deepEqual(mutating, [], `${statement.Sid} may not mutate the shared ${sharedBootstrap}`)
+  }
+  const passphrase = asArray(parameters.Resource).find((resource: string) => resource.includes('/sst/passphrase/'))
+  assert.ok(
+    passphrase && passphrase.includes('${GitHubEnvironment}'),
+    'the passphrase decrypts one stage of state and must not be shared',
+  )
+})
+
+test('the stage configuration capability probe answers each selected-commit shape', () => {
+  // The gate is shell inside YAML, so the contract assertions above can only prove it is present.
+  // This runs the probe's own `node -e` expression against the three trees a dispatch can select: one
+  // that declares the capability, one from before it existed, and one whose file is corrupt. The last
+  // must not read as "supported" — a parse failure falling through to the happy path would deploy
+  // exactly the commit the gate exists to refuse.
+  const workflow = load(readFileSync(DEPLOY_WORKFLOW, 'utf8'))
+  const gate = workflow.jobs.deploy.steps.find(
+    (step: any) => step.name === 'Require stage configuration store support in the selected commit',
+  )
+  assert.ok(gate, 'the capability gate is missing')
+  const probe = liveShell(gate.run)
+    .split('\n')
+    .map((line: string) => line.trim())
+    .find((line: string) => line.startsWith('if ! status=$(node -e'))
+  assert.ok(probe, 'the capability probe is not a node -e expression any more')
+  const expression = probe.slice(probe.indexOf('"') + 1, probe.lastIndexOf('" "$capability"'))
+
+  const fixture = mkdtempSync(join(tmpdir(), 'boxlite-capability-probe-'))
+  const capability = join(fixture, 'capabilities.json')
+  try {
+    const cases: Array<[string, string]> = [
+      ['supported', JSON.stringify({ version: 1, componentSelection: true, stageConfigStore: true })],
+      ['unsupported', JSON.stringify({ version: 1, componentSelection: true })],
+      ['unsupported', JSON.stringify({ version: 2, stageConfigStore: true })],
+    ]
+    for (const [expected, contents] of cases) {
+      writeFileSync(capability, contents)
+      const status = execFileSync(process.execPath, ['-e', expression, capability], { encoding: 'utf8' }).trim()
+      assert.equal(status, expected, `probe answered '${status}' for ${contents}`)
+    }
+
+    // Corrupt JSON must throw rather than print a status: that is what makes the workflow's
+    // `if ! status=$(...)` branch set `unreadable` and refuse instead of falling through.
+    writeFileSync(capability, '{ not json')
+    assert.throws(() =>
+      execFileSync(process.execPath, ['-e', expression, capability], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }),
+    )
+  } finally {
+    rmSync(fixture, { recursive: true, force: true })
+  }
+})
+
 test('release deployment consumes one published version for both components', () => {
   const source = readFileSync(RELEASE_DEPLOY_WORKFLOW, 'utf8')
   const workflow = load(source)
-  const materializeStep = workflow.jobs.deploy.steps.find(
-    (step: any) => step.name === 'Materialize stage configuration',
-  )
   const deployStep = workflow.jobs.deploy.steps.find(
     (step: any) => step.name === 'Deploy published API and Runner artifacts',
   )
@@ -803,7 +1006,8 @@ test('release deployment consumes one published version for both components', ()
   assert.equal(workflow.on.workflow_dispatch.inputs.stage.type, 'choice')
   assert.deepEqual(workflow.on.workflow_dispatch.inputs.stage.options, ['dev', 'prod'])
   assert.ok(deployStep)
-  assertEnvironmentValidatorCompatibility(materializeStep)
+  assertNoMaterializedStageConfig(workflow, source)
+  assertComposedDeployRoleArn(source, '${{ inputs.stage }}')
   // The same guarded wrapper and the same pre-deploy gates the build path uses: a release
   // deploy reconciles the identical stack, so it owes the identical safety checks.
   assert.equal(deployStep.shell, 'bash')

--- a/apps/infra/deployment/secret-names.ts
+++ b/apps/infra/deployment/secret-names.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+/*
+ * What the stage's secret store holds, by name.
+ *
+ * `npm run secrets` used to be `sst secret list` straight through, with sst's stdio inherited — which
+ * printed every value to the terminal. That was already more than the documented purpose ("lists what
+ * is set"), and it became a great deal more once the store started holding the whole stage
+ * configuration rather than a handful of app secrets: one command now dumps every domain, issuer, and
+ * token into scrollback and whatever collects it.
+ *
+ * So the values are read and discarded here, and only names are printed. Anyone who needs a value can
+ * still ask sst for that one secret deliberately.
+ */
+
+import { execFileSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+import { SST_APP_NAME as APP, loadDeploymentEnvironment } from './environment.js'
+import { isStageConfigBookkeepingKey, parseSecretList } from './stage-config.js'
+import { resolveSstStage } from './stage.js'
+
+const SST_WRAPPER_PATH = fileURLToPath(new URL('./sst.ts', import.meta.url))
+
+loadDeploymentEnvironment()
+
+const args = process.argv.slice(2)
+let stage
+try {
+  stage = resolveSstStage(args)
+} catch (error: any) {
+  console.error(`secret-names: ${error.message}`)
+  process.exit(1)
+}
+
+let stdout
+try {
+  /*
+   * Through the wrapper, not the sst binary: reading the store initializes the Cloudflare provider,
+   * and the wrapper is what loads those credentials from SSM. Calling sst directly worked only for an
+   * operator who already had them exported, which is not the documented local setup.
+   *
+   * Its stdout is captured rather than inherited — inheriting every value is the problem this
+   * command exists to fix — and the wrapper's own progress lines are written to stderr, so what
+   * arrives here is sst's output alone. parseSecretList ignores anything that is not an assignment
+   * regardless.
+   */
+  stdout = execFileSync(process.execPath, ['--import', 'tsx', SST_WRAPPER_PATH, 'secret', 'list', '--stage', stage], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'inherit'],
+    timeout: 120_000,
+    killSignal: 'SIGTERM',
+  })
+} catch (error: any) {
+  // The status only: execFileSync's message repeats the command and its captured output.
+  console.error(`secret-names: could not read the ${stage} secret store (sst exited ${error?.status ?? 'unknown'})`)
+  process.exit(1)
+}
+
+const stored = parseSecretList(stdout, { app: APP, stage })
+// The bookkeeping entries describe the configuration; reporting them as secrets would invite someone
+// to "rotate" one.
+const names = Object.keys(stored)
+  .filter((name) => !isStageConfigBookkeepingKey(name))
+  .sort()
+
+if (names.length === 0) {
+  console.log(`${APP}/${stage}: no secrets set`)
+} else {
+  console.log(`${APP}/${stage}: ${names.length} secrets`)
+  for (const name of names) console.log(`  ${name}`)
+}

--- a/apps/infra/deployment/sst.ts
+++ b/apps/infra/deployment/sst.ts
@@ -2,13 +2,34 @@
 // Copyright (c) 2026 BoxLite AI
 
 /*
- * Run an `sst` command with the Cloudflare provider credentials loaded.
+ * Run an `sst` command with the stage's configuration loaded.
  *
- * The Cloudflare provider initializes inside `app()` (sst.config.ts), before
- * `run()` exists — so its credentials can't be `sst.Secret` like the app
- * secrets. They live in AWS SSM Parameter Store (SecureString) instead, keyed
- * per stage, and this wrapper fetches + exports them just before invoking sst.
- * App secrets are NOT handled here; sst resolves those from its own store.
+ * Values the deployed stack reads through `process.env` / `envOr()` — STACK_DOMAIN, the OIDC
+ * settings, the feature toggles, and the Cloudflare provider credentials — cannot be `sst.Secret`:
+ * the provider initializes inside `app()` (sst.config.ts) before `run()` exists, and an
+ * Output<string> would break every string comparison and `new URL(...)` in stack/*.ts. So they live
+ * in the stage's SST secret store as ordinary secrets, and this wrapper reads them back into
+ * process.env just before invoking sst. See deployment/stage-config.ts for what may and may not
+ * cross that boundary. The app secrets proper (OIDC_CLIENT_ID and friends) are NOT handled here;
+ * sst resolves those itself through `sst.Secret`.
+ *
+ * That store replaced the GitHub Environment secret DEPLOY_ENV, which the deploy workflow used to
+ * write out as apps/infra/.env for the length of a job. It is reachable by exactly the people who
+ * can already deploy the stage, so local and CI deploys now resolve the same values from the
+ * same place.
+ *
+ * The Cloudflare credentials are the one exception, and they cannot join it. Reading the store
+ * initializes every provider `app()` declares, Cloudflare included — `sst secret list` fetches the
+ * bootstrap state and then exits with "Cloudflare API not initialized" — so a token stored there
+ * would be needed to read itself. They stay in AWS SSM (SecureString, per stage) and are fetched
+ * below, before the store is read.
+ *
+ * The deploy workflow supplies them as Environment secrets rather than relying on this SSM copy.
+ * Whether the scoped deploy role could read it is untested: it holds ssm:GetParameter and no
+ * identity-based kms:Decrypt, but alias/aws/ssm is an AWS-managed key whose own key policy may admit
+ * the account via kms:ViaService, and the role trusts only the GitHub OIDC principal so it cannot be
+ * assumed locally to find out. The Environment secrets are what CI has always used; leave it that way
+ * until someone measures the alternative from inside a job.
  *
  * Wired into the deploy/remove npm scripts, plus a passthrough:
  *   npm run deploy -- --stage dev      → tsx deployment/sst.ts deploy --stage dev
@@ -18,16 +39,17 @@
  * A successful deploy is followed by a read-only AWS check that the Proxy NLB
  * listener, ECS target-group attachment, and healthy targets agree.
  *
- * One access gate: a deployer already needs AWS credentials to deploy, so the
- * same credentials fetch the Cloudflare token from SSM — nothing extra to share.
+ * One access gate: a deployer already needs AWS credentials to deploy, and the same credentials
+ * decrypt the store — nothing extra to share.
  *
- * Seed the parameters once per stage with the README's non-echoing prompt and
- * `--value file:///dev/stdin`; never put credential values in process argv.
+ * A variable already in the environment is used as-is, never overridden by a stored value. That is
+ * what keeps the deploy workflow in control of the selectors it sets itself, and it is the escape
+ * hatch for a stored value that is wrong.
  *
- * A credential already in the environment is used as-is (works offline / before
- * the params are seeded). Missing creds are a warning, not a hard stop: commands
- * that don't touch Cloudflare (e.g. `unlock`) still run, and sst surfaces its own
- * error for one that does.
+ * A store that cannot be read stops every command that builds a plan — `diff` included. A preview
+ * assembled from defaults is not a preview of the deploy that follows it: the operator approves that
+ * plan, the apply then reads the store successfully, and reconciles something nobody reviewed.
+ * Commands that need no configuration at all (`install`, `secret`, `unlock`) never read it.
  */
 
 import { execFileSync, spawn } from 'node:child_process'
@@ -35,6 +57,7 @@ import { constants as osConstants } from 'node:os'
 import { fileURLToPath } from 'node:url'
 
 import {
+  SST_APP_NAME as APP,
   loadDeploymentEnvironment,
   readWorkspaceVersion,
   resolveAwsRegion,
@@ -46,6 +69,8 @@ import {
   requireSstSubcommandFirst,
   withRequiredRunnerPolicy,
 } from './scope.js'
+import { STAGE_CONFIG_DIGEST_KEY, STAGE_CONFIG_MANIFEST_KEY, StageConfigStore, hydrateStageConfig } from './stage-config.js'
+import { isLocalOnlyDeploymentKey } from './validate-environment.js'
 import {
   verifyProxyDeploymentWithRetry,
   verifyPublicDeploymentWithRetry,
@@ -60,9 +85,15 @@ import { resolveSstStage } from './stage.js'
 import { removePulumiEventLogs, withPulumiEventLogCleanup } from './pulumi-logs.js'
 import { resolveAwsCliPath } from '../shared/aws-cli.js'
 
-const APP = 'boxlite'
 const PULUMI_EVENT_LOG_ROOT = fileURLToPath(new URL('../.sst/pulumi', import.meta.url))
 const TERMINATION_SIGNALS: NodeJS.Signals[] = ['SIGINT', 'SIGTERM']
+/*
+ * The subcommands that build a resource graph, and so the only ones that need the stage's
+ * configuration. Everything else is deliberately excluded rather than merely harmless to include:
+ * `install` and `secret` are what bootstrap itself runs, through this same wrapper, against a stage
+ * whose store is still empty — hydrating there would warn on every line of a first-time bootstrap.
+ */
+const STAGE_CONFIG_SUBCOMMANDS = new Set(['deploy', 'diff', 'remove', 'refresh'])
 
 let terminationSignal: any
 let artifactPreflightAbortController: any
@@ -102,9 +133,32 @@ try {
 }
 if (terminationSignal) process.exit(signalExitCode(terminationSignal))
 
-loadDeploymentEnvironment()
+/*
+ * .env supplies ONLY the keys that must not become stage-wide configuration, which is exactly the set
+ * isLocalOnlyDeploymentKey names — this machine's AWS_PROFILE / AWS_CLI_PATH, SST_STAGE, VERSION,
+ * AWS_REGION, the Cloudflare pair, and the artifact selectors the deploy workflow owns. Deliberately
+ * the predicate rather than a list repeated here: the two have to agree, and a hand-copied list is
+ * what silently stops agreeing. Everything else in the file is ignored.
+ *
+ * The filter is the point, not a tidiness measure. A stored value is skipped when the variable is
+ * already set (hydrateStageConfig), so loading the whole file first would let a stale local STACK_DOMAIN
+ * silently beat the store and make a local deploy differ from CI — the exact divergence moving the
+ * config into the store was meant to end. Editing .env now changes nothing until `npm run bootstrap`
+ * reloads it, which is the intended trade.
+ */
+const localEnvironment: NodeJS.ProcessEnv = {}
+loadDeploymentEnvironment({ environment: localEnvironment })
+for (const [key, value] of Object.entries(localEnvironment)) {
+  if (!isLocalOnlyDeploymentKey(key)) continue
+  if (process.env[key] !== undefined) continue // a real environment variable still wins
+  process.env[key] = value
+}
 
+// Resolved before the store is read, because the Cloudflare SSM lookup below needs it. AWS_REGION
+// therefore has to come from the environment or .env — a value stored for it would arrive too late
+// to steer this process, so stage-config.ts keeps it out of the store.
 const REGION = resolveAwsRegion()
+
 let sstExecutable: any
 try {
   sstExecutable = resolveSstExecutable()
@@ -112,12 +166,6 @@ try {
   console.error(`sst-with-cloudflare: ${error.message}`)
   process.exit(1)
 }
-
-// SSM param consulted only when the matching env var is unset.
-const CREDS = [
-  { env: 'CLOUDFLARE_API_TOKEN', param: 'cloudflare-api-token' },
-  { env: 'CLOUDFLARE_DEFAULT_ACCOUNT_ID', param: 'cloudflare-account-id' },
-]
 
 let sstArgs = process.argv.slice(2)
 if (sstArgs.length === 0) {
@@ -139,6 +187,12 @@ try {
   console.error(`sst-with-cloudflare: ${error.message}`)
   process.exit(1)
 }
+
+// SSM param consulted only when the matching env var is unset.
+const CLOUDFLARE_CREDS = [
+  { env: 'CLOUDFLARE_API_TOKEN', param: 'cloudflare-api-token' },
+  { env: 'CLOUDFLARE_DEFAULT_ACCOUNT_ID', param: 'cloudflare-account-id' },
+]
 
 function fetchFromSsm(name: any) {
   try {
@@ -163,7 +217,140 @@ function fetchFromSsm(name: any) {
     return out && out !== 'None' ? out : null
   } catch (err: any) {
     if (err.code === 'ENOENT') console.warn('sst-with-cloudflare: `aws` CLI not found; skipping SSM lookup')
-    return null // ParameterNotFound / auth error → warn below and let sst decide
+    return null // ParameterNotFound / auth error → warn above and let sst decide
+  }
+}
+
+/*
+ * The stage's own sst binary, run for its stdout.
+ *
+ * Captured rather than inherited, because `secret list` prints every value it holds and this process
+ * must not put those on the terminal or into a log. The resolved binary is called directly, never
+ * back through this wrapper — that would recurse.
+ */
+function readSstStdout(args: string[]) {
+  return execFileSync(sstExecutable, args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 120_000,
+    killSignal: 'SIGTERM',
+  })
+}
+
+// Names only, for a refusal message. '(nothing)' rather than an empty string so the message reads as
+// a sentence when the manifest is present but blank.
+function manifestNames(stored: any) {
+  const names = String(stored?.[STAGE_CONFIG_MANIFEST_KEY] ?? '').trim()
+  return names === '' ? '(nothing)' : names
+}
+
+/*
+ * Load the stage's configuration into process.env, which sst inherits.
+ *
+ * Every shape the store can be in that is not usable stops the command instead of falling back to the
+ * environment as it stands: unreadable, no manifest, a digest that does not match its values, a
+ * manifest naming a value the store lacks, and one that applies nothing. Defaults are not a safe
+ * substitute for a stage's configuration now that the store is its only source — a deploy would
+ * reconcile the stage to something nobody wrote, and report success.
+ *
+ * Commands that build no resource graph never get here (STAGE_CONFIG_SUBCOMMANDS), which is what lets
+ * bootstrap run `install` and `secret load` through this same wrapper against a store that is still
+ * empty. On a fresh stage the cause of a refusal is usually just that: nothing has seeded it yet, so
+ * every message names the command that does.
+ */
+function loadStageConfig(stage: string) {
+  if (!STAGE_CONFIG_SUBCOMMANDS.has(sstArgs[0])) return
+
+  let stored
+  try {
+    stored = new StageConfigStore({ app: APP, stage, runSst: readSstStdout }).read()
+  } catch (error: any) {
+    // Deliberately not `error.message`: execFileSync builds it from the failed command line and the
+    // captured stdio, which for `secret list` is the store's contents. Only the exit status is safe to
+    // repeat, and it is enough to tell "never bootstrapped" from "cannot reach AWS".
+    const status = error?.status ?? error?.code ?? 'unknown'
+    const advice =
+      `could not read the ${stage} stage configuration from the SST secret store (sst exited ${status}); ` +
+      `seed it with \`npm run bootstrap -- --stage ${stage}\``
+    // `diff` stops as well, even though it only reads. A preview built from defaults is not a preview
+    // of the deploy that follows: the operator approves that plan, the apply then reads the store
+    // successfully, and reconciles something nobody reviewed. Divergence between the two is the exact
+    // failure the guarded preview exists to prevent, so an unreadable store fails both or neither.
+    console.error(`sst-with-cloudflare: ${advice}`)
+    process.exit(1)
+  }
+
+  // A store that reads cleanly but names nothing is not "no configuration to apply" — it is a stage
+  // that was never bootstrapped, or one whose manifest was removed. Hydration would then be a no-op
+  // and the deploy would reconcile against whatever the defaults happen to be, which is the same
+  // outcome as an unreadable store and gets the same answer.
+  if (!stored[STAGE_CONFIG_MANIFEST_KEY]?.trim()) {
+    const advice =
+      `the ${stage} stage configuration store has no ${STAGE_CONFIG_MANIFEST_KEY} manifest, so nothing ` +
+      `can be applied from it; seed it with \`npm run bootstrap -- --stage ${stage}\``
+    console.error(`sst-with-cloudflare: ${advice}`)
+    process.exit(1)
+  }
+
+  const { apply, alreadySet, unlisted, missing, recordedDigest, actualDigest } = hydrateStageConfig({ stored })
+  // A `secret load` that was interrupted leaves some keys new and some old, with every manifest name
+  // still present — undetectable from the manifest alone, and it would deploy a configuration that
+  // never existed as a whole.
+  //
+  // A missing digest is that same failure, not a store from an older bootstrap: the manifest and the
+  // digest go into one `secret load`, and no released bootstrap has ever written the manifest without
+  // it. So "manifest but no digest" means the load tore between the two, and treating it as
+  // unverifiable-but-acceptable would let exactly the first interrupted load through unchecked.
+  if (recordedDigest !== actualDigest) {
+    const detail =
+      recordedDigest === ''
+        ? `carries no ${STAGE_CONFIG_DIGEST_KEY}, which bootstrap writes in the same load as the manifest`
+        : `does not match its ${STAGE_CONFIG_DIGEST_KEY}`
+    console.error(
+      `sst-with-cloudflare: the ${stage} stage configuration ${detail}, so a \`secret load\` was ` +
+        'interrupted and the values are not all from one generation; rerun ' +
+        `\`npm run bootstrap -- --stage ${stage}\``,
+    )
+    process.exit(1)
+  }
+  // A manifest that names a key the store does not hold describes a half-written store — a
+  // `secret load` that failed part way, or a value removed by hand. Applying the rest would deploy a
+  // configuration nobody assembled.
+  if (missing.length > 0) {
+    console.error(
+      `sst-with-cloudflare: the ${stage} stage configuration is incomplete — ${STAGE_CONFIG_MANIFEST_KEY} ` +
+        `names ${missing.join(', ')} but the store holds no value for them; rerun ` +
+        `\`npm run bootstrap -- --stage ${stage}\``,
+    )
+    process.exit(1)
+  }
+
+  // A manifest can name only keys that are refused — bookkeeping, or entries the allowlist rejects —
+  // and then nothing is applied while the store still reads as populated. Same outcome as an empty
+  // store, same answer.
+  if (Object.keys(apply).length === 0 && alreadySet.length === 0) {
+    console.error(
+      `sst-with-cloudflare: the ${stage} stage configuration applied nothing — ${STAGE_CONFIG_MANIFEST_KEY} ` +
+        `names ${manifestNames(stored)} and none is storable configuration; rerun ` +
+        `\`npm run bootstrap -- --stage ${stage}\``,
+    )
+    process.exit(1)
+  }
+  Object.assign(process.env, apply)
+
+  const applied = Object.keys(apply)
+  console.log(`sst-with-cloudflare: ${stage} stage configuration ... ${applied.length} keys loaded from the SST secret store`)
+  if (alreadySet.length > 0) {
+    console.log(`sst-with-cloudflare: ${stage} stage configuration ... already in the environment, left alone: ${alreadySet.join(', ')}`)
+  }
+  // Names only — a stored value is never printed. Worth surfacing rather than dropping silently: an
+  // unlisted key is either a stale entry from a key since removed from .env, or one written by hand
+  // that will never take effect.
+  if (unlisted.length > 0) {
+    console.warn(
+      `sst-with-cloudflare: ${stage} stage configuration ... in the store but not applied ` +
+        `(not named by ${STAGE_CONFIG_MANIFEST_KEY}, or not permitted): ${unlisted.join(', ')}`,
+    )
   }
 }
 
@@ -175,7 +362,10 @@ try {
   process.exit(1)
 }
 
-for (const { env, param } of CREDS) {
+// Before the store is read, not after: reading it initializes the Cloudflare provider, which needs
+// these. A credential already in the environment is used as-is — that is what the deploy workflow
+// relies on, its role being unable to decrypt the parameter.
+for (const { env, param } of CLOUDFLARE_CREDS) {
   if (process.env[env]) continue // already provided — don't touch
   const name = `/boxlite/${stage}/${param}`
   const value = fetchFromSsm(name)
@@ -184,11 +374,13 @@ for (const { env, param } of CREDS) {
   } else {
     console.warn(
       `sst-with-cloudflare: ${env} not in env and ${name} not in SSM (${REGION}); ` +
-        `seed it with the README's stdin-based aws ssm put-parameter procedure`,
+        `seed it with \`npm run bootstrap -- --stage ${stage}\``,
     )
   }
 }
 if (terminationSignal) process.exit(signalExitCode(terminationSignal))
+
+loadStageConfig(stage)
 
 async function runSstCommand() {
   if (terminationSignal) return signalExitCode(terminationSignal)

--- a/apps/infra/deployment/sst.ts
+++ b/apps/infra/deployment/sst.ts
@@ -363,8 +363,10 @@ try {
 }
 
 // Before the store is read, not after: reading it initializes the Cloudflare provider, which needs
-// these. A credential already in the environment is used as-is — that is what the deploy workflow
-// relies on, its role being unable to decrypt the parameter.
+// these. A credential already in the environment is used as-is, which is the path CI takes — every
+// step that reaches here is given the pair as Environment secrets, so the SSM lookup below never runs
+// there. That is deliberate rather than incidental: whether this role can decrypt the parameter is
+// untested (see the note at the top of this file), and nothing in CI should be the first to find out.
 for (const { env, param } of CLOUDFLARE_CREDS) {
   if (process.env[env]) continue // already provided — don't touch
   const name = `/boxlite/${stage}/${param}`

--- a/apps/infra/deployment/stage-config.test.ts
+++ b/apps/infra/deployment/stage-config.test.ts
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  STAGE_CONFIG_MANIFEST_KEY,
+  StageConfigStore,
+  hydrateStageConfig,
+  parseSecretList,
+  parseStageConfigManifest,
+  serializeStageConfigManifest,
+} from './stage-config.js'
+
+// The shape `sst secret list` prints: a fallback section, then the stage's own.
+const SECRET_LIST = [
+  '# fallback',
+  'STACK_DOMAIN=fallback.boxlite.ai',
+  'OIDC_AUDIENCE=https://fallback.boxlite.ai/api',
+  '# boxlite/dev',
+  'STACK_DOMAIN=dev.boxlite.ai',
+  `${STAGE_CONFIG_MANIFEST_KEY}=OIDC_AUDIENCE,STACK_DOMAIN`,
+  '',
+].join('\n')
+
+test('parseSecretList prefers the stage section over the fallback section', () => {
+  const stored = parseSecretList(SECRET_LIST, { app: 'boxlite', stage: 'dev' })
+  // STACK_DOMAIN is set in both; the stage value is the one `sst deploy` would use.
+  assert.equal(stored.STACK_DOMAIN, 'dev.boxlite.ai')
+  // OIDC_AUDIENCE is only a fallback, so it still resolves.
+  assert.equal(stored.OIDC_AUDIENCE, 'https://fallback.boxlite.ai/api')
+})
+
+test('parseSecretList resolves by section header, not by line order', () => {
+  // The same two entries with the stage section FIRST. A last-wins parse would hand back the
+  // fallback value here, which is not what a deploy of this stage would use.
+  const reordered = ['# boxlite/dev', 'STACK_DOMAIN=dev.boxlite.ai', '# fallback', 'STACK_DOMAIN=fallback.boxlite.ai'].join('\n')
+  assert.equal(parseSecretList(reordered, { app: 'boxlite', stage: 'dev' }).STACK_DOMAIN, 'dev.boxlite.ai')
+})
+
+test('parseSecretList ignores another stage section entirely', () => {
+  const other = ['# boxlite/prod', 'STACK_DOMAIN=boxlite.ai', '# boxlite/dev', 'STACK_DOMAIN=dev.boxlite.ai'].join('\n')
+  assert.deepEqual(parseSecretList(other, { app: 'boxlite', stage: 'dev' }), { STACK_DOMAIN: 'dev.boxlite.ai' })
+})
+
+test('parseSecretList treats an empty store as empty, not as a parse error', () => {
+  // What sst prints when nothing is set; a stage mid-bootstrap must not fail here.
+  assert.deepEqual(parseSecretList('No secrets found\n', { app: 'boxlite', stage: 'dev' }), {})
+  assert.deepEqual(parseSecretList('', { app: 'boxlite', stage: 'dev' }), {})
+  assert.deepEqual(parseSecretList(undefined, { app: 'boxlite', stage: 'dev' }), {})
+})
+
+test('parseSecretList keeps a value containing the separator and trailing content', () => {
+  const stored = parseSecretList(
+    ['# boxlite/dev', 'BOXLITE_SYSTEM_IMAGES=base=ghcr.io/acme/base:v1,py=ghcr.io/acme/py:v1', 'EMPTY='].join('\n'),
+    { app: 'boxlite', stage: 'dev' },
+  )
+  assert.equal(stored.BOXLITE_SYSTEM_IMAGES, 'base=ghcr.io/acme/base:v1,py=ghcr.io/acme/py:v1')
+  assert.equal(stored.EMPTY, '')
+})
+
+test('hydrateStageConfig applies only the keys the manifest names', () => {
+  const { apply, unlisted } = hydrateStageConfig({
+    stored: {
+      [STAGE_CONFIG_MANIFEST_KEY]: 'STACK_DOMAIN,OIDC_AUDIENCE',
+      STACK_DOMAIN: 'dev.boxlite.ai',
+      OIDC_AUDIENCE: 'https://dev.boxlite.ai/api',
+      // A key .env once defined and no longer does: `sst secret load` merges, so it is still in the
+      // store. Off the manifest, so it must not reach the deploy.
+      PROXY_DOMAIN: 'stale.boxlite.ai',
+      // A hand-set `sst secret set OIDC_CLIENT_ID` — the stack reads this through sst.Secret, not
+      // process.env, so hydrating it would be wrong as well as unnecessary.
+      OIDC_CLIENT_ID: 'synthetic-client-id',
+    },
+    environment: {},
+  })
+
+  assert.deepEqual(apply, { OIDC_AUDIENCE: 'https://dev.boxlite.ai/api', STACK_DOMAIN: 'dev.boxlite.ai' })
+  assert.deepEqual(unlisted, ['OIDC_CLIENT_ID', 'PROXY_DOMAIN'])
+})
+
+test('hydrateStageConfig lets a variable already in the environment win', () => {
+  const { apply, alreadySet } = hydrateStageConfig({
+    stored: {
+      [STAGE_CONFIG_MANIFEST_KEY]: 'STACK_DOMAIN,BOXLITE_SYSTEM_IMAGE_TAG',
+      STACK_DOMAIN: 'dev.boxlite.ai',
+      BOXLITE_SYSTEM_IMAGE_TAG: 'v0.1.0',
+    },
+    // What the deploy workflow sets on the job. A stored value must never override it.
+    environment: { BOXLITE_SYSTEM_IMAGE_TAG: 'v9.9.9' },
+  })
+
+  assert.deepEqual(apply, { STACK_DOMAIN: 'dev.boxlite.ai' })
+  assert.deepEqual(alreadySet, ['BOXLITE_SYSTEM_IMAGE_TAG'])
+})
+
+test('hydrateStageConfig honours an empty environment variable as deliberately set', () => {
+  // '' is how a consumer is told "unset" (envOr and requireEnv both treat it as falsy), so an
+  // operator who exported KEY= meant to suppress the stored value, not to fall through to it.
+  const { apply, alreadySet } = hydrateStageConfig({
+    stored: { [STAGE_CONFIG_MANIFEST_KEY]: 'APP_URL', APP_URL: 'https://stored.example' },
+    environment: { APP_URL: '' },
+  })
+  assert.deepEqual(apply, {})
+  assert.deepEqual(alreadySet, ['APP_URL'])
+})
+
+test('parseSecretList keeps a value\'s leading and trailing spaces', () => {
+  // sst prints `key + "=" + value` with nothing added, so every character after the first `=` is the
+  // value. Trimming the line would silently delete padding that serializeStageConfig went out of its
+  // way to preserve, and the corruption would only show up in a deployed container's environment.
+  const stored = parseSecretList(['# boxlite/dev', 'PADDED=  spaced out  ', 'TRAILING_TAB=value\t'].join('\n'), {
+    app: 'boxlite',
+    stage: 'dev',
+  })
+  assert.equal(stored.PADDED, '  spaced out  ')
+  assert.equal(stored.TRAILING_TAB, 'value\t')
+})
+
+test('hydrateStageConfig never applies a key consulted before the store is reachable', () => {
+  // CLOUDFLARE_* is needed in order to read the store at all, AWS_REGION is resolved before it, and
+  // SST_STAGE chooses which store to read. A stored copy of any of them could only disagree with the
+  // value actually used, so hydration must drop it even though bootstrap already keeps it out.
+  const guarded = ['CLOUDFLARE_API_TOKEN', 'CLOUDFLARE_DEFAULT_ACCOUNT_ID', 'AWS_REGION', 'SST_STAGE', 'VERSION']
+  const { apply, unlisted } = hydrateStageConfig({
+    stored: {
+      [STAGE_CONFIG_MANIFEST_KEY]: [...guarded, 'STACK_DOMAIN'].join(','),
+      ...Object.fromEntries(guarded.map((key) => [key, 'synthetic'])),
+      STACK_DOMAIN: 'dev.boxlite.ai',
+    },
+    environment: {},
+  })
+  assert.deepEqual(apply, { STACK_DOMAIN: 'dev.boxlite.ai' })
+  assert.deepEqual(unlisted, [...guarded].sort())
+})
+
+test('hydrateStageConfig refuses a forbidden key even when the manifest names it', () => {
+  // Defence in depth behind bootstrap's filter: the manifest is itself a store entry, so a writer
+  // who can set a secret can also name it. Neither local credential context nor an artifact
+  // selector may become stage-wide configuration.
+  const forbidden = ['AWS_PROFILE', 'AWS_CLI_PATH', 'AWS_ENDPOINT_URL_S3', 'BOXLITE_ARTIFACT_SOURCE', 'SST_BIN_PATH']
+  const { apply, unlisted } = hydrateStageConfig({
+    stored: {
+      [STAGE_CONFIG_MANIFEST_KEY]: [...forbidden, 'STACK_DOMAIN'].join(','),
+      ...Object.fromEntries(forbidden.map((key) => [key, 'synthetic'])),
+      STACK_DOMAIN: 'dev.boxlite.ai',
+    },
+    environment: {},
+  })
+
+  assert.deepEqual(apply, { STACK_DOMAIN: 'dev.boxlite.ai' })
+  assert.deepEqual(unlisted, [...forbidden].sort())
+})
+
+test('hydrateStageConfig never applies the manifest itself', () => {
+  const { apply } = hydrateStageConfig({
+    stored: { [STAGE_CONFIG_MANIFEST_KEY]: `STACK_DOMAIN,${STAGE_CONFIG_MANIFEST_KEY}`, STACK_DOMAIN: 'dev.boxlite.ai' },
+    environment: {},
+  })
+  assert.deepEqual(Object.keys(apply), ['STACK_DOMAIN'])
+})
+
+test('hydrateStageConfig applies nothing when the manifest is absent', () => {
+  // A stage bootstrapped before the manifest existed: fail closed rather than hydrate everything
+  // the store happens to hold.
+  const { apply, unlisted } = hydrateStageConfig({
+    stored: { STACK_DOMAIN: 'dev.boxlite.ai', OIDC_CLIENT_ID: 'synthetic' },
+    environment: {},
+  })
+  assert.deepEqual(apply, {})
+  assert.deepEqual(unlisted, ['OIDC_CLIENT_ID', 'STACK_DOMAIN'])
+})
+
+test('the manifest round-trips through serialize and parse', () => {
+  assert.equal(serializeStageConfigManifest(['STACK_DOMAIN', 'OIDC_AUDIENCE', 'STACK_DOMAIN']), 'OIDC_AUDIENCE,STACK_DOMAIN')
+  assert.deepEqual(parseStageConfigManifest('OIDC_AUDIENCE,STACK_DOMAIN'), ['OIDC_AUDIENCE', 'STACK_DOMAIN'])
+  assert.deepEqual(parseStageConfigManifest(' A , , B '), ['A', 'B'])
+  assert.deepEqual(parseStageConfigManifest(undefined), [])
+  assert.equal(serializeStageConfigManifest([]), '')
+})
+
+test('StageConfigStore reads the stage it was constructed for', () => {
+  const calls: any[] = []
+  const store = new StageConfigStore({
+    app: 'boxlite',
+    stage: 'dev',
+    runSst: (args: any) => {
+      calls.push(args)
+      return SECRET_LIST
+    },
+  })
+
+  const stored = store.read()
+  assert.deepEqual(calls, [['secret', 'list', '--stage', 'dev']])
+  assert.equal(stored.STACK_DOMAIN, 'dev.boxlite.ai')
+})
+
+test('StageConfigStore refuses to be built without a runner, app, or stage', () => {
+  assert.throws(() => new StageConfigStore({ app: 'boxlite', stage: 'dev' }), /requires a runSst function/)
+  assert.throws(() => new StageConfigStore({ runSst: () => '', stage: 'dev' }), /requires an app and a stage/)
+  assert.throws(() => new StageConfigStore({ runSst: () => '', app: 'boxlite' }), /requires an app and a stage/)
+})

--- a/apps/infra/deployment/stage-config.ts
+++ b/apps/infra/deployment/stage-config.ts
@@ -124,8 +124,19 @@ export function parseSecretList(stdout: any, { app, stage }: any) {
     const match = SECRET_ASSIGNMENT.exec(line)
     if (!match) continue
     const [, key, value] = match
+    /*
+     * The bookkeeping keys are never taken from the fallback section.
+     *
+     * A fallback belongs to the app, so `sst secret set --fallback BOXLITE_STAGE_CONFIG …` would give
+     * every stage a manifest — and with it a digest that matches, since both would come from the same
+     * place. A stage nobody has bootstrapped would then pass the manifest and digest checks and deploy
+     * another source's configuration, which is precisely the case those checks exist to stop.
+     *
+     * Ordinary values still fall back, which is what fallbacks are for: the value is shared on purpose
+     * and the stage's own manifest has to name it before anything is hydrated.
+     */
     if (section === stageSection) stageValues[key] = value
-    else if (section === FALLBACK_SECTION) fallback[key] = value
+    else if (section === FALLBACK_SECTION && !isStageConfigBookkeepingKey(key)) fallback[key] = value
   }
 
   return { ...fallback, ...stageValues }

--- a/apps/infra/deployment/stage-config.ts
+++ b/apps/infra/deployment/stage-config.ts
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+/*
+ * The stage's configuration, read back out of the SST secret store.
+ *
+ * `npm run bootstrap` loads the operator's .env into that store (bootstrap/bootstrap.ts's
+ * ensureStageConfig), and this is the other half: the deploy wrapper hydrates process.env from it
+ * before spawning sst, so stack/*.ts keeps reading plain `process.env` / `envOr()` values. That
+ * matters — a config key promoted to `sst.Secret` would arrive as an Output<string> and break every
+ * `envOr('JAEGER_PUBLIC','false') === 'true'` comparison and `new URL(...)` in the stack.
+ *
+ * Two things are deliberately NOT here. The Cloudflare provider credentials cannot be, because
+ * reading this store initializes that provider — see the note in deployment/sst.ts. And AWS_REGION
+ * cannot be, because the wrapper resolves the region before it reads the store.
+ *
+ * It replaces the GitHub Environment secret DEPLOY_ENV, which the deploy workflow used to
+ * materialize as apps/infra/.env for the length of a job. That put stage config in a second control
+ * plane: changing what gets deployed needed no AWS access, and offboarding meant revoking both.
+ * Reading this store needs the same AWS credentials a deploy already needs.
+ *
+ * The store is NOT the authority on everything in it. Two rules narrow what may reach process.env,
+ * because `sst secret set` is a command any deployer can run against any name:
+ *
+ *   - only keys the manifest names (STAGE_CONFIG_MANIFEST_KEY) are eligible, so a value written by
+ *     hand — or left behind by a key since deleted from .env — is inert rather than live; and
+ *   - the key must be one the deploy demonstrably reads (isStorableStageConfigKey, derived from source
+ *     in deployment/storable-keys.ts) — so an unknown name is refused without anyone naming it; and
+ *   - isLocalOnlyDeploymentKey still drops the keys that ARE read but must stay on this machine,
+ *     AWS_PROFILE among them.
+ *
+ * Every value here is a secret. Nothing in this module logs one, and the caller gets key names only.
+ */
+
+import { createHash } from 'node:crypto'
+
+import { isStorableStageConfigKey } from './storable-keys.js'
+import { isLocalOnlyDeploymentKey } from './validate-environment.js'
+
+/*
+ * The one entry in the store that is not configuration: a comma-separated list of the key names
+ * bootstrap owns.
+ *
+ * `sst secret load` merges rather than replacing, so a key removed from .env would otherwise linger
+ * in the store and keep being applied. Scoping hydration to this list makes that stale entry inert
+ * the moment bootstrap reruns, with no prune step — which could not be done safely anyway, since the
+ * same store legitimately holds OIDC_CLIENT_ID and the other hand-set `sst.Secret` values that .env
+ * never contains.
+ */
+export const STAGE_CONFIG_MANIFEST_KEY = 'BOXLITE_STAGE_CONFIG'
+
+/*
+ * A digest of the values the manifest names, written in the same `sst secret load` as the values.
+ *
+ * `secret load` is not atomic — it is a read-modify-write of one JSON document per invocation, and an
+ * interrupted one can leave some keys at their new values and some at their old. The manifest cannot
+ * detect that: every name it lists is still present, just not all from the same generation. Nothing
+ * downstream would notice, and the stage would deploy a configuration that never existed as a whole.
+ *
+ * So the digest is computed over the values, and hydration recomputes it. A mixture fails to match.
+ */
+export const STAGE_CONFIG_DIGEST_KEY = 'BOXLITE_STAGE_CONFIG_DIGEST'
+
+/*
+ * The entries in the store that describe the configuration rather than being part of it.
+ *
+ * One list, because every consumer has to skip all of them and each does it for its own reason:
+ * hydration must not export them as configuration, and `npm run secrets` must not report them as
+ * secrets. Adding the digest as a second such key broke the second of those, which had matched the
+ * manifest by name alone — so the set is named here and both read it.
+ */
+export const STAGE_CONFIG_BOOKKEEPING_KEYS: readonly string[] = [STAGE_CONFIG_MANIFEST_KEY, STAGE_CONFIG_DIGEST_KEY]
+
+export function isStageConfigBookkeepingKey(key: string) {
+  return STAGE_CONFIG_BOOKKEEPING_KEYS.includes(key)
+}
+
+/*
+ * The digest of a set of stored values, over the manifest's keys in sorted order.
+ *
+ * Deliberately not a hash of the whole store: the store also holds hand-set `sst.Secret` values whose
+ * rotation has nothing to do with this configuration, and including them would make every unrelated
+ * `secret set` look like a torn load.
+ */
+export function stageConfigDigest(keys: readonly string[], values: Record<string, string | undefined>) {
+  const hash = createHash('sha256')
+  for (const key of [...keys].sort()) {
+    // Length-prefixed, so `A=1,B=2` and `A=1B=2` cannot collide.
+    const value = values[key] ?? ''
+    hash.update(`${key.length}:${key}=${value.length}:${value}\n`)
+  }
+  return hash.digest('hex')
+}
+
+const SECRET_ASSIGNMENT = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/
+const FALLBACK_SECTION = 'fallback'
+
+/*
+ * `sst secret list` prints the fallback values under a `# fallback` header and the stage's own under
+ * a `# <app>/<stage>` header. Track the header rather than relying on the stage section coming last:
+ * a key set in both places must resolve to the stage's value because that is the one `sst deploy`
+ * would use, and "whichever line came later" is an ordering detail of sst's output, not a contract.
+ *
+ * Anything that is neither a header nor a KEY=value assignment is ignored, which is what makes the
+ * empty store ("No secrets found") a normal answer instead of a parse error.
+ */
+export function parseSecretList(stdout: any, { app, stage }: any) {
+  const stageSection = `${app}/${stage}`
+  const fallback: Record<string, string> = {}
+  const stageValues: Record<string, string> = {}
+  let section
+
+  for (const rawLine of String(stdout ?? '').split('\n')) {
+    // Split on \n and strip only a trailing \r: sst prints `key + "=" + value` with nothing added,
+    // so anything else on the line is part of the value. Trimming the whole line would silently
+    // delete a stored value's leading or trailing spaces, which serializeStageConfig goes out of its
+    // way to preserve.
+    const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine
+    if (line.trim() === '') continue
+    if (line.trimStart().startsWith('#')) {
+      section = line.trim().slice(1).trim()
+      continue
+    }
+    const match = SECRET_ASSIGNMENT.exec(line)
+    if (!match) continue
+    const [, key, value] = match
+    if (section === stageSection) stageValues[key] = value
+    else if (section === FALLBACK_SECTION) fallback[key] = value
+  }
+
+  return { ...fallback, ...stageValues }
+}
+
+export function parseStageConfigManifest(rawManifest: any) {
+  return String(rawManifest ?? '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+}
+
+export function serializeStageConfigManifest(keys: any) {
+  return [...new Set(keys)].sort().join(',')
+}
+
+/*
+ * Which stored values may reach process.env, and which must not.
+ *
+ * A variable already present in the environment always wins. That is what keeps the deploy workflow
+ * in control of the values it sets itself — BOXLITE_ARTIFACT_SOURCE, BOXLITE_ARTIFACT_REF, STAGE,
+ * DEPLOY_EXCLUDE — and it is the same rule the Cloudflare credentials were read under before this
+ * store existed ("already provided — don't touch"). It also gives an operator a one-variable escape
+ * hatch when a stored value is wrong.
+ *
+ * Returns key names only; the values go into the caller's environment, never into a log.
+ */
+export function hydrateStageConfig({ stored, environment = process.env }: any) {
+  const manifest = new Set(parseStageConfigManifest(stored?.[STAGE_CONFIG_MANIFEST_KEY]))
+  // Empty when the store holds no digest at all, which is a mismatch like any other: bootstrap writes
+  // it in the same `secret load` as the manifest, so a manifest without one means that load tore.
+  const recordedDigest = stored?.[STAGE_CONFIG_DIGEST_KEY]?.trim() ?? ''
+  const actualDigest = stageConfigDigest([...manifest], stored ?? {})
+  const apply: Record<string, string> = {}
+  const alreadySet = []
+  const unlisted = []
+  // Named by the manifest but absent from the store: bootstrap writes both together, so a gap means
+  // the write did not finish or something removed a value afterwards.
+  const missing = [...manifest]
+    .filter((key) => isStorableStageConfigKey(key) && !isLocalOnlyDeploymentKey(key) && stored?.[key] === undefined)
+    .sort()
+
+  for (const key of Object.keys(stored ?? {}).sort()) {
+    if (isStageConfigBookkeepingKey(key)) continue
+    // Checked before the manifest so a forbidden key is reported as forbidden even if something
+    // managed to name it in the manifest too.
+    // Allowlist first: a key the deploy never reads is refused whether or not anyone thought to name
+    // it. The denylist behind it catches the keys that ARE read but must not be stored — AWS_PROFILE.
+    if (!isStorableStageConfigKey(key) || isLocalOnlyDeploymentKey(key)) {
+      unlisted.push(key)
+      continue
+    }
+    if (!manifest.has(key)) {
+      unlisted.push(key)
+      continue
+    }
+    if (environment[key] !== undefined) {
+      alreadySet.push(key)
+      continue
+    }
+    apply[key] = stored[key]
+  }
+
+  return { apply, alreadySet, unlisted, missing, recordedDigest, actualDigest }
+}
+
+/*
+ * The stage's store, behind one read.
+ *
+ * `runSst` is injected because the two callers must reach sst differently: the deploy wrapper owns
+ * the resolved binary and has to call it directly (routing back through the wrapper would recurse),
+ * while bootstrap goes through the wrapper like every other sst call it makes. Injecting it also
+ * means the parsing and precedence rules above are testable without sst.
+ */
+export class StageConfigStore {
+  #runSst
+  #app
+  #stage
+
+  constructor({ runSst, app, stage }: any) {
+    if (typeof runSst !== 'function') throw new Error('StageConfigStore requires a runSst function')
+    if (!app || !stage) throw new Error('StageConfigStore requires an app and a stage')
+    this.#runSst = runSst
+    this.#app = app
+    this.#stage = stage
+  }
+
+  read() {
+    return parseSecretList(this.#runSst(['secret', 'list', '--stage', this.#stage]), {
+      app: this.#app,
+      stage: this.#stage,
+    })
+  }
+}

--- a/apps/infra/deployment/storable-keys.test.ts
+++ b/apps/infra/deployment/storable-keys.test.ts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { STORABLE_STAGE_CONFIG_KEYS, isStorableStageConfigKey } from './storable-keys.js'
+import { isLocalOnlyDeploymentKey } from './validate-environment.js'
+import { liveText } from '../shared/live-source.js'
+
+const INFRA_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+// Where a deploy resolves configuration. Test files are excluded: they set synthetic values, they do
+// not define what a deploy reads.
+const SCANNED = ['stack', 'deployment', 'artifacts', 'runner', 'shared']
+const ENV_READ =
+  /envOr\(\s*'([A-Z][A-Z0-9_]*)'|requireEnv\(\s*'([A-Z][A-Z0-9_]*)'|process\.env\.([A-Z][A-Z0-9_]*)|process\.env\[\s*'([A-Z][A-Z0-9_]*)'\s*\]|environment\.([A-Z][A-Z0-9_]*)/g
+
+function sourceFiles(directory: string): string[] {
+  const root = join(INFRA_ROOT, directory)
+  const found: string[] = []
+  for (const entry of readdirSync(root)) {
+    const path = join(root, entry)
+    if (statSync(path).isDirectory()) {
+      found.push(...sourceFiles(join(directory, entry)))
+    } else if (entry.endsWith('.ts') && !entry.endsWith('.test.ts')) {
+      found.push(path)
+    }
+  }
+  return found
+}
+
+function keysReadFromSource() {
+  const keys = new Set<string>()
+  for (const directory of SCANNED) {
+    for (const path of sourceFiles(directory)) {
+      // Comments stripped first. A doc comment writing `process.env.X` to explain a pattern is prose,
+      // and scanning it put a key named X in the allowlist — the repo already has liveText for exactly
+      // this distinction.
+      for (const match of liveText('script', readFileSync(path, 'utf8')).matchAll(ENV_READ)) {
+        const key = match.slice(1).find(Boolean)
+        if (key) keys.add(key)
+      }
+    }
+  }
+  return keys
+}
+
+test('the allowlist is exactly what the deploy reads, minus what must stay local', () => {
+  // The property that makes an allowlist worth having: it cannot drift from the code silently. Adding
+  // an `envOr('NEW_THING', …)` to the stack fails here until NEW_THING is added to the list, which is
+  // what turns "widen what a store may inject" into a decision rather than a side effect.
+  const expected = [...keysReadFromSource()].filter((key) => !isLocalOnlyDeploymentKey(key)).sort()
+  assert.deepEqual([...STORABLE_STAGE_CONFIG_KEYS].sort(), expected)
+})
+
+test('nothing the deploy never reads can be hydrated', () => {
+  // The seven vectors seven review rounds found in the denylist this replaces. None is read by the
+  // stack, so none is storable — and, unlike the denylist, an eighth nobody has thought of is refused
+  // by the same rule rather than needing to be named.
+  const vectors = [
+    'NODE_OPTIONS',
+    'BASH_ENV',
+    'GIT_SSH_COMMAND',
+    'DOCKER_HOST',
+    'DOCKER_CONTEXT',
+    'LD_AUDIT',
+    'LD_PRELOAD',
+    'SST_BUN_PATH',
+    'SST_PULUMI_PATH',
+    'BUN_OPTIONS',
+    'GH_TOKEN',
+    'RUSTC_WRAPPER',
+    'SSH_ASKPASS',
+    'PULUMI_CONFIG_PASSPHRASE',
+    'GIT_CONFIG_GLOBAL',
+    // Nobody has proposed this one; it is refused because it is unknown, which is the point.
+    'SOME_KEY_NOBODY_HAS_THOUGHT_OF',
+  ]
+  for (const key of vectors) {
+    assert.equal(isStorableStageConfigKey(key), false, `${key} must not be storable`)
+  }
+})
+
+test('the configuration a stage actually needs is storable', () => {
+  // The other half: an allowlist that refused real configuration would be useless. These are the keys
+  // .env.example marks required.
+  for (const key of ['STACK_DOMAIN', 'OIDC_AUDIENCE', 'OIDC_ISSUER_BASE_URL', 'IAM_PERMISSIONS_BOUNDARY_STAGE']) {
+    assert.equal(isStorableStageConfigKey(key), true, `${key} must be storable`)
+  }
+})
+
+test('a key that is both read by the stack and dangerous is still refused', () => {
+  // stack/app.ts reads AWS_PROFILE, so the source scan finds it — the denylist is what keeps it out.
+  // This is why that list survives as a second check rather than being deleted.
+  assert.equal(keysReadFromSource().has('AWS_PROFILE'), true, 'the scan should see it')
+  assert.equal(isStorableStageConfigKey('AWS_PROFILE'), false, 'and it must still be refused')
+})

--- a/apps/infra/deployment/storable-keys.test.ts
+++ b/apps/infra/deployment/storable-keys.test.ts
@@ -15,6 +15,18 @@ const INFRA_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 // Where a deploy resolves configuration. Test files are excluded: they set synthetic values, they do
 // not define what a deploy reads.
 const SCANNED = ['stack', 'deployment', 'artifacts', 'runner', 'shared']
+/*
+ * Direct reads only. A name handed to a helper that reads it — `runnerEndpoint('DEFAULT_RUNNER_DOMAIN',
+ * …)`, which forwards to envOr — is deliberately not matched.
+ *
+ * Widening this to follow that indirection was tried and reverted. It surfaces DEFAULT_RUNNER_DOMAIN,
+ * _API_URL and _PROXY_URL, which the stack does pass to the API, but the API consumes them only on the
+ * v0 runner path: DEFAULT_RUNNER_API_VERSION defaults to '2', is not storable, and is not set by the
+ * stack, so no deployed stage can reach v0. Allowlisting them would widen what the shared store may
+ * carry while changing nothing a stage can observe.
+ *
+ * If a stage ever becomes able to select v0, this pattern and that list both need revisiting together.
+ */
 const ENV_READ =
   /envOr\(\s*'([A-Z][A-Z0-9_]*)'|requireEnv\(\s*'([A-Z][A-Z0-9_]*)'|process\.env\.([A-Z][A-Z0-9_]*)|process\.env\[\s*'([A-Z][A-Z0-9_]*)'\s*\]|environment\.([A-Z][A-Z0-9_]*)/g
 

--- a/apps/infra/deployment/storable-keys.ts
+++ b/apps/infra/deployment/storable-keys.ts
@@ -11,11 +11,17 @@
  * credentials. An enumeration of dangerous names cannot be finished, so this is the other shape:
  * nothing is hydrated unless the deploy demonstrably reads it.
  *
- * Derived from the source that reads them — every `envOr` / `requireEnv` / `process.env.X` under
- * stack/, deployment/, artifacts/, runner/ and shared/, minus the keys isLocalOnlyDeploymentKey
+ * Derived from the source that reads them — every *direct* `envOr` / `requireEnv` / `process.env.X`
+ * under stack/, deployment/, artifacts/, runner/ and shared/, minus the keys isLocalOnlyDeploymentKey
  * refuses. The test beside this file re-derives that set and fails when the two disagree, so adding a
  * config key to the stack fails until it is added here. That failure is the point: it makes widening
  * what a store can inject a decision someone makes, not something that happens.
+ *
+ * Direct is the operative word, and errs toward refusing. A name passed to a helper that reads it —
+ * `runnerEndpoint('DEFAULT_RUNNER_DOMAIN', …)` — is not derived, so it is not storable; the test says
+ * why that particular omission is deliberate rather than missed. The failure mode of that choice is a
+ * key an operator sets being ignored, which is visible, rather than a key reaching the sst child's
+ * environment because a helper obscured it.
  *
  * The denylist stays as a second check. It is not the boundary any more, but a key that is both read
  * by the stack and dangerous — AWS_PROFILE is one — must still be refused.

--- a/apps/infra/deployment/storable-keys.ts
+++ b/apps/infra/deployment/storable-keys.ts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+/*
+ * The keys a stage's secret store may put into a deploy's environment.
+ *
+ * This started as a denylist of process controls, and seven review rounds each found a new way past
+ * it: NODE_OPTIONS, then BASH_ENV and GIT_SSH_COMMAND, then DOCKER_HOST, DOCKER_CONTEXT, LD_AUDIT,
+ * SST_BUN_PATH, GH_TOKEN, RUSTC_WRAPPER, SSH_ASKPASS. Every one of them turns a stored string into
+ * code or a moved trust boundary inside the sst child, which runs Pulumi with the deploy role's
+ * credentials. An enumeration of dangerous names cannot be finished, so this is the other shape:
+ * nothing is hydrated unless the deploy demonstrably reads it.
+ *
+ * Derived from the source that reads them — every `envOr` / `requireEnv` / `process.env.X` under
+ * stack/, deployment/, artifacts/, runner/ and shared/, minus the keys isLocalOnlyDeploymentKey
+ * refuses. The test beside this file re-derives that set and fails when the two disagree, so adding a
+ * config key to the stack fails until it is added here. That failure is the point: it makes widening
+ * what a store can inject a decision someone makes, not something that happens.
+ *
+ * The denylist stays as a second check. It is not the boundary any more, but a key that is both read
+ * by the stack and dangerous — AWS_PROFILE is one — must still be refused.
+ */
+export const STORABLE_STAGE_CONFIG_KEYS: readonly string[] = [
+  'ADMIN_API_KEY',
+  'APP_URL',
+  'BILLING_API_URL',
+  'BOXLITE_API_KEY',
+  'BOXLITE_API_URL',
+  'BOXLITE_RUNNER_STATE_BASELINE',
+  'BOXLITE_SYSTEM_BASE_IMAGE',
+  'BOXLITE_SYSTEM_IMAGES',
+  'BOXLITE_SYSTEM_IMAGE_TAG',
+  'BOXLITE_SYSTEM_NODE_IMAGE',
+  'BOXLITE_SYSTEM_PYTHON_IMAGE',
+  'BOXLITE_SYSTEM_SOURCE_REGISTRY_NAME',
+  'BOXLITE_SYSTEM_SOURCE_REGISTRY_PASSWORD',
+  'BOXLITE_SYSTEM_SOURCE_REGISTRY_PROJECT_ID',
+  'BOXLITE_SYSTEM_SOURCE_REGISTRY_URL',
+  'BOXLITE_SYSTEM_SOURCE_REGISTRY_USERNAME',
+  'BOX_MIGRATION_ARCHIVE_PREFIX',
+  'BOX_OTEL_ENDPOINT_URL',
+  'CLICKHOUSE_COMPRESS',
+  'CLICKHOUSE_CREATE_SCHEMA',
+  'CLICKHOUSE_DATABASE',
+  'CLICKHOUSE_ENDPOINT',
+  'CLICKHOUSE_EXPORTER_ENABLED',
+  'CLICKHOUSE_HOST',
+  'CLICKHOUSE_OTEL_ENDPOINT',
+  'CLICKHOUSE_PASSWORD',
+  'CLICKHOUSE_PORT',
+  'CLICKHOUSE_PROTOCOL',
+  'CLICKHOUSE_READER_DATABASE',
+  'CLICKHOUSE_READER_HOST',
+  'CLICKHOUSE_READER_PASSWORD',
+  'CLICKHOUSE_READER_PORT',
+  'CLICKHOUSE_READER_PROTOCOL',
+  'CLICKHOUSE_READER_URL',
+  'CLICKHOUSE_READER_USERNAME',
+  'CLICKHOUSE_URL',
+  'CLICKHOUSE_USERNAME',
+  'CLICKHOUSE_WRITER_DATABASE',
+  'CLICKHOUSE_WRITER_ENDPOINT',
+  'CLICKHOUSE_WRITER_PASSWORD',
+  'CLICKHOUSE_WRITER_USERNAME',
+  'DASHBOARD_BASE_API_URL',
+  'DASHBOARD_URL',
+  'DEFAULT_REGION_ID',
+  'DEFAULT_RUNNER_API_KEY',
+  'DEFAULT_RUNNER_NAME',
+  'DEFAULT_TEMPLATE',
+  'ENCRYPTION_KEY',
+  'ENCRYPTION_SALT',
+  'GHCR_TOKEN',
+  'GHCR_USERNAME',
+  'IAM_PERMISSIONS_BOUNDARY_STAGE',
+  'INSTANCE_IDS',
+  'JAEGER_PUBLIC',
+  'MAILDEV_PUBLIC',
+  'OIDC_AUDIENCE',
+  'OIDC_END_SESSION_ENDPOINT',
+  'OIDC_ISSUER_BASE_URL',
+  'OIDC_MANAGEMENT_API_AUDIENCE',
+  'OIDC_MANAGEMENT_API_BASE_URL',
+  'OIDC_MANAGEMENT_API_ENABLED',
+  'OIDC_MANAGEMENT_API_TOKEN_URL',
+  'OIDC_POST_LOGOUT_REDIRECT_ALLOWLIST',
+  'OTEL_COLLECTOR_API_KEY',
+  'OTEL_ENABLED',
+  'OTEL_EXPORTER_OTLP_ENDPOINT',
+  'OTEL_EXPORTER_OTLP_HEADERS',
+  'OTEL_TRACING_ENABLED',
+  'PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED',
+  'PGADMIN_CONFIG_SERVER_MODE',
+  'PGADMIN_DEFAULT_EMAIL',
+  'PGADMIN_DEFAULT_PASSWORD',
+  'PGADMIN_PUBLIC',
+  'POSTHOG_HOST',
+  'PROXY_API_KEY',
+  'PROXY_DOMAIN',
+  'PROXY_PROTOCOL',
+  'PROXY_TEMPLATE_URL',
+  'PUBLIC_OIDC_DOMAIN',
+  'RUNNERS',
+  'RUNNER_PORT',
+  'RUNNER_VERSION',
+  'STACK_DOMAIN',
+  'SVIX_SERVER_URL',
+  'USAGE_EXPORT_URL',
+]
+
+const STORABLE = new Set(STORABLE_STAGE_CONFIG_KEYS)
+
+export function isStorableStageConfigKey(key: string) {
+  return STORABLE.has(key)
+}

--- a/apps/infra/deployment/validate-environment.test.ts
+++ b/apps/infra/deployment/validate-environment.test.ts
@@ -4,79 +4,185 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { validateDeployEnvironment } from './validate-environment.js'
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-test('accepts ordinary dotenv deployment configuration', () => {
+import {
+  APP_SECRET_NAMES,
+  isForbiddenDeploymentKey,
+  isLocalOnlyDeploymentKey,
+  validateDotenvSyntax,
+} from './validate-environment.js'
+
+test('every credential-context and artifact-selector key is refused', () => {
+  // The set the deploy workflow was held to when the stage config travelled as DEPLOY_ENV. Each of
+  // these either hands the deploy someone else's AWS identity or redirects which artifact it installs.
+  const forbidden = [
+    'ALLOW_DOWNGRADE',
+    'API_ARTIFACT_REF',
+    'API_ARTIFACT_SOURCE',
+    'AWS_ACCESS_KEY_ID',
+    'AWS_CLI_PATH',
+    'AWS_CONFIG_FILE',
+    'AWS_CONTAINER_CREDENTIALS_FULL_URI',
+    'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI',
+    'AWS_DEFAULT_PROFILE',
+    'AWS_ENDPOINT_URL',
+    'AWS_PROFILE',
+    'AWS_ROLE_ARN',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_SHARED_CREDENTIALS_FILE',
+    'AWS_SESSION_TOKEN',
+    'AWS_WEB_IDENTITY_TOKEN_FILE',
+    'BOXLITE_ARTIFACT_REF',
+    'BOXLITE_ARTIFACT_SOURCE',
+    'BUILDX_BUILDER',
+    'RUNNER_ARTIFACT_BUCKET',
+    'RUNNER_ARTIFACT_REF',
+    'RUNNER_ARTIFACT_SOURCE',
+    'RUNNER_CREATE_ALLOWLIST',
+    'SST_BIN_PATH',
+  ]
+  for (const key of forbidden) {
+    assert.equal(isForbiddenDeploymentKey(key), true, `${key} must be refused`)
+    assert.equal(isLocalOnlyDeploymentKey(key), true, `${key} must stay local`)
+  }
+})
+
+test('the AWS_ENDPOINT_URL_<SERVICE> family is refused by prefix, not by name', () => {
+  // A membership test alone accepts every member, and redirecting an endpoint points the deploy at
+  // an attacker-chosen service.
+  for (const key of ['AWS_ENDPOINT_URL_S3', 'AWS_ENDPOINT_URL_STS', 'AWS_ENDPOINT_URL_ANYTHING']) {
+    assert.equal(isForbiddenDeploymentKey(key), true, `${key} must be refused`)
+  }
+})
+
+test('keys consulted before the store can be reached are local-only but not "forbidden"', () => {
+  // A distinct reason from the credential rule: each of these is read in order to reach the store, or
+  // before it, so a stored copy could only ever disagree with the value actually used. CLOUDFLARE_*
+  // is the sharpest case — reading the store initializes that provider, so a token kept there would
+  // be needed to read itself.
+  for (const key of ['CLOUDFLARE_API_TOKEN', 'CLOUDFLARE_DEFAULT_ACCOUNT_ID', 'AWS_REGION', 'SST_STAGE', 'VERSION']) {
+    assert.equal(isLocalOnlyDeploymentKey(key), true, `${key} must stay local`)
+    assert.equal(isForbiddenDeploymentKey(key), false, `${key} is excluded for reachability, not credentials`)
+  }
+})
+
+test('every process control that would run code beside the deploy credentials is refused', () => {
+  // Hydration injects into the environment of the sst child, which drives Pulumi with the deploy
+  // role's credentials. Each of these names a file or program that a runtime executes or trusts on
+  // startup, so a stored value for any of them is code execution, not configuration. Grown over three
+  // review rounds — enumerated here so a removal fails rather than silently widening what may be
+  // hydrated.
+  const processControls = [
+    'NODE_OPTIONS',
+    'NODE_EXTRA_CA_CERTS',
+    'NODE_TLS_REJECT_UNAUTHORIZED',
+    'SSL_CERT_FILE',
+    'SSL_CERT_DIR',
+    'REQUESTS_CA_BUNDLE',
+    'AWS_CA_BUNDLE',
+    'PATH',
+    'LD_PRELOAD',
+    'LD_LIBRARY_PATH',
+    'DYLD_INSERT_LIBRARIES',
+    'DYLD_LIBRARY_PATH',
+    'BASH_ENV',
+    'ENV',
+    'GIT_SSH_COMMAND',
+    'GIT_EXTERNAL_DIFF',
+    'GIT_PAGER',
+    'GIT_ASKPASS',
+    'PERL5OPT',
+    'PYTHONPATH',
+    'PYTHONSTARTUP',
+    'RUBYOPT',
+    'DOCKER_HOST',
+    'DOCKER_CONFIG',
+    'DOCKER_CERT_PATH',
+    'DOCKER_TLS_VERIFY',
+  ]
+  for (const key of processControls) {
+    assert.equal(isLocalOnlyDeploymentKey(key), true, `${key} must never be hydrated`)
+  }
+
+  // Families, not names: git reads GIT_CONFIG_GLOBAL and the numbered KEY/VALUE pairs, and Pulumi
+  // reads anything PULUMI_*.
+  for (const key of ['GIT_CONFIG_GLOBAL', 'GIT_CONFIG_KEY_0', 'GIT_CONFIG_VALUE_0', 'GIT_CONFIG_COUNT']) {
+    assert.equal(isLocalOnlyDeploymentKey(key), true, `${key} must never be hydrated`)
+  }
+  for (const key of ['PULUMI_CONFIG_PASSPHRASE', 'PULUMI_BACKEND_URL', 'PULUMI_SKIP_UPDATE_CHECK']) {
+    assert.equal(isLocalOnlyDeploymentKey(key), true, `${key} must never be hydrated`)
+  }
+  // Both spellings: the proxy variables have no canonical case.
+  for (const key of ['HTTP_PROXY', 'http_proxy', 'HTTPS_PROXY', 'https_proxy', 'NO_PROXY', 'no_proxy']) {
+    assert.equal(isLocalOnlyDeploymentKey(key), true, `${key} must never be hydrated`)
+  }
+})
+
+test('ordinary stage configuration is neither refused nor local-only', () => {
+  for (const key of ['STACK_DOMAIN', 'OIDC_AUDIENCE', 'OIDC_ISSUER_BASE_URL', 'BOXLITE_SYSTEM_IMAGES', 'RUNNERS']) {
+    assert.equal(isLocalOnlyDeploymentKey(key), false, `${key} belongs in the store`)
+  }
+})
+
+test('validateDotenvSyntax accepts ordinary dotenv configuration', () => {
   assert.doesNotThrow(() =>
-    validateDeployEnvironment(`
+    validateDotenvSyntax(`
+# a comment
 STACK_DOMAIN=dev.boxlite.ai
 OIDC_AUDIENCE=https://dev.boxlite.ai/api
 RUNNERS=1
+BLANK=
 `),
   )
 })
 
-test('rejects every forbidden workflow override', () => {
-  const forbiddenAssignments = [
-    'AWS_PROFILE=developer',
-    'AWS_ACCESS_KEY_ID=synthetic-access-key',
-    'AWS_CONFIG_FILE=/tmp/synthetic-aws-config',
-    'AWS_CONTAINER_CREDENTIALS_FULL_URI=https://credentials.invalid',
-    'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=/synthetic-credentials',
-    'AWS_DEFAULT_PROFILE=developer',
-    'AWS_ENDPOINT_URL=https://aws.invalid',
-    'AWS_ENDPOINT_URL_S3=https://s3.invalid',
-    'AWS_ROLE_ARN=arn:aws:iam::123456789012:role/synthetic',
-    'AWS_SECRET_ACCESS_KEY=synthetic-secret-key',
-    'AWS_SHARED_CREDENTIALS_FILE=/tmp/synthetic-aws-credentials',
-    'AWS_SESSION_TOKEN="synthetic-session-token"',
-    'AWS_WEB_IDENTITY_TOKEN_FILE=/tmp/synthetic-web-identity-token',
-    'AWS_CLI_PATH=/opt/local/bin/aws',
-    'ALLOW_DOWNGRADE=1',
-    'API_ARTIFACT_SOURCE=release',
-    'BOXLITE_ARTIFACT_REF=0123456789abcdef0123456789abcdef01234567',
-    'BOXLITE_ARTIFACT_SOURCE=release',
-    // The per-component refs win over the global one, so blocking only BOXLITE_ARTIFACT_REF
-    // would leave a stage secret able to redirect the very selector that entry protects.
-    'API_ARTIFACT_REF=0123456789abcdef0123456789abcdef01234567',
-    'RUNNER_ARTIFACT_REF=0123456789abcdef0123456789abcdef01234567',
-    'RUNNER_ARTIFACT_BUCKET=attacker-controlled-bucket',
-    'RUNNER_ARTIFACT_SOURCE=release',
-    'BUILDX_BUILDER=laptop-builder',
-    'RUNNER_CREATE_ALLOWLIST=Runner',
-    'SST_BIN_PATH=/tmp/synthetic-sst',
+test('validateDotenvSyntax rejects a line dotenv would silently skip, without echoing it', () => {
+  // dotenv drops a malformed line in silence, so the key is simply absent from the store and the
+  // failure surfaces much later as a missing value. Reject at the boundary instead.
+  const invalid = [
+    'export AWS_SECRET_ACCESS_KEY:synthetic-secret-key',
+    'export AWS_SECRET_ACCESS_KEY = synthetic-secret-key',
+    'AWS_ACCESS_KEY_ID: synthetic-access-key',
+    'AWS_PROFILE : developer',
+    // A key that cannot start with a digit. The payload deliberately avoids the word "value", which
+    // the error message itself carries in `expected KEY=value`.
+    '1INVALID=synthetic-payload',
   ]
-
-  for (const assignment of forbiddenAssignments) {
-    const secretValue = assignment.split('=', 2)[1].replaceAll('"', '')
+  for (const assignment of invalid) {
+    const value = assignment.split(/\s*(?:=|:)\s*/, 2)[1]
     assert.throws(
-      () => validateDeployEnvironment(assignment),
+      () => validateDotenvSyntax(assignment),
       (error: any) => {
-        assert.match(error.message, /DEPLOY_ENV must rely on workflow OIDC/)
-        assert.equal(error.message.includes(secretValue), false)
+        assert.match(error.message, /contains invalid assignment syntax on line 1/)
+        if (value) assert.equal(error.message.includes(value), false, 'the value must not be echoed')
         return true
       },
     )
   }
 })
 
-test('rejects non-canonical dotenv assignments before parsing', () => {
-  const invalidAssignments = [
-    'export AWS_SECRET_ACCESS_KEY:synthetic-secret-key',
-    'export AWS_SECRET_ACCESS_KEY = synthetic-secret-key',
-    'AWS_ACCESS_KEY_ID: synthetic-access-key',
-    'AWS_PROFILE : developer',
-  ]
+test('validateDotenvSyntax names the file it was given and the offending line', () => {
+  assert.throws(
+    () => validateDotenvSyntax('STACK_DOMAIN=dev.boxlite.ai\n\nOIDC_AUDIENCE', '/tmp/synthetic/.env'),
+    /\/tmp\/synthetic\/\.env contains invalid assignment syntax on line 3/,
+  )
+})
 
-  for (const assignment of invalidAssignments) {
-    const secretValue = assignment.split(/\s*(?:=|:)\s*/, 2)[1]
-    assert.throws(
-      () => validateDeployEnvironment(assignment),
-      (error: any) => {
-        assert.match(error.message, /DEPLOY_ENV contains invalid assignment syntax on line 1/)
-        assert.equal(error.message.includes(secretValue), false)
-        return true
-      },
-    )
+test('every sst.Secret the stack declares is reserved against the stage configuration', () => {
+  // `sst secret load` runs after the individual `secret set` calls, so any of these names appearing in
+  // .env would overwrite a value the operator was just prompted for. Read from stack/deploy.ts rather
+  // than restated, so declaring a new sst.Secret without reserving it fails here.
+  const deployStack = readFileSync(
+    join(resolve(dirname(fileURLToPath(import.meta.url)), '..'), 'stack/deploy.ts'),
+    'utf8',
+  )
+  const declared = [...deployStack.matchAll(/new sst\.Secret\('([A-Z0-9_]+)'/g)].map((match) => match[1])
+  assert.ok(declared.length > 0, 'no sst.Secret declarations found — the pattern has changed')
+  assert.deepEqual([...declared].sort(), [...APP_SECRET_NAMES].sort())
+  for (const name of declared) {
+    assert.equal(isLocalOnlyDeploymentKey(name), true, `${name} must never enter the stage configuration`)
   }
 })

--- a/apps/infra/deployment/validate-environment.test.ts
+++ b/apps/infra/deployment/validate-environment.test.ts
@@ -8,6 +8,10 @@ import { readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { parse as parseDotenv } from 'dotenv'
+
+import { deployableStageConfig, serializeStageConfig } from '../bootstrap/environment.js'
+
 import {
   APP_SECRET_NAMES,
   isForbiddenDeploymentKey,
@@ -139,35 +143,109 @@ BLANK=
   )
 })
 
+test('validateDotenvSyntax accepts every form the parser it guards accepts', () => {
+  /*
+   * This validator exists to reject what dotenv would silently drop, so rejecting something dotenv
+   * reads is the opposite failure: the operator is told a working .env is invalid and bootstrap
+   * refuses to run. `export KEY=value` comes from a file that doubles as a shell script; the spaces
+   * come from ordinary tidying.
+   *
+   * Each line is asserted against `parse` as well, so the two cannot drift apart on someone's word.
+   */
+  const accepted = [
+    'export STACK_DOMAIN=dev.boxlite.ai',
+    'STACK_DOMAIN = dev.boxlite.ai',
+    'export RUNNERS = 1',
+    // Surprising, and exactly why this is checked against the parser rather than a pattern: dotenv 17
+    // reads `KEY: value`, though not `KEY:value` or `KEY : value`. Rejecting it would refuse a file
+    // that loads.
+    'STACK_DOMAIN: dev.boxlite.ai',
+  ]
+  for (const line of accepted) {
+    assert.notDeepEqual(parseDotenv(line), {}, `${line} must actually parse, or the premise here is wrong`)
+    assert.doesNotThrow(() => validateDotenvSyntax(line), `${line} is valid dotenv`)
+  }
+
+  // And the near-misses dotenv really does drop, which are what this guard is for.
+  for (const line of ['STACK_DOMAIN:dev.boxlite.ai', 'STACK_DOMAIN : dev.boxlite.ai']) {
+    assert.deepEqual(parseDotenv(line), {}, `${line} must be dropped, or the premise here is wrong`)
+    assert.throws(() => validateDotenvSyntax(line), /is not an assignment dotenv can read/)
+  }
+
+  /*
+   * Accepting `KEY: value` does not loosen what may be stored. A credential written that way parses,
+   * and is then refused by the allowlist like any other — the syntax check has never been what keeps
+   * secrets out of the store, and reading it as though it were would misplace the guarantee.
+   */
+  const credentialLine = 'AWS_ACCESS_KEY_ID: synthetic-access-key'
+  assert.notDeepEqual(parseDotenv(credentialLine), {}, 'dotenv reads this form')
+  assert.doesNotThrow(() => validateDotenvSyntax(credentialLine))
+  assert.deepEqual(deployableStageConfig(credentialLine).config, {}, 'and it must still never be stored')
+})
+
 test('validateDotenvSyntax rejects a line dotenv would silently skip, without echoing it', () => {
   // dotenv drops a malformed line in silence, so the key is simply absent from the store and the
   // failure surfaces much later as a missing value. Reject at the boundary instead.
-  const invalid = [
-    'export AWS_SECRET_ACCESS_KEY:synthetic-secret-key',
-    'export AWS_SECRET_ACCESS_KEY = synthetic-secret-key',
-    'AWS_ACCESS_KEY_ID: synthetic-access-key',
-    'AWS_PROFILE : developer',
-    // A key that cannot start with a digit. The payload deliberately avoids the word "value", which
-    // the error message itself carries in `expected KEY=value`.
-    '1INVALID=synthetic-payload',
-  ]
+  // The payloads deliberately avoid the word "value", which the error message itself carries in
+  // `expected KEY=value`.
+  const invalid = ['export AWS_SECRET_ACCESS_KEY:synthetic-secret-key', 'AWS_PROFILE : developer']
   for (const assignment of invalid) {
     const value = assignment.split(/\s*(?:=|:)\s*/, 2)[1]
+    assert.deepEqual(parseDotenv(assignment), {}, `${assignment} must be dropped, or it is not this test's case`)
     assert.throws(
       () => validateDotenvSyntax(assignment),
       (error: any) => {
-        assert.match(error.message, /contains invalid assignment syntax on line 1/)
+        assert.match(error.message, /line 1 is not an assignment dotenv can read/)
         if (value) assert.equal(error.message.includes(value), false, 'the value must not be echoed')
         return true
       },
     )
   }
+
+  /*
+   * A key starting with a digit is not one this validator's business. dotenv's key pattern allows it,
+   * so the line is read rather than dropped and there is nothing here to warn about — and the
+   * allowlist refuses to store it anyway, which is where an unrecognised key is supposed to stop.
+   */
+  // A lone CR is a line break to the parser but not to `split(/\r?\n/)`, so the malformed half hid
+  // behind a line that parsed. The store would then simply lack that key.
+  const carriageReturnHidden = 'STACK_DOMAIN=dev.boxlite.ai\rBROKEN : synthetic'
+  assert.deepEqual(parseDotenv(carriageReturnHidden), { STACK_DOMAIN: 'dev.boxlite.ai' }, 'the second half is dropped')
+  assert.throws(() => validateDotenvSyntax(carriageReturnHidden), /line 2 is not an assignment/)
+
+  const digitLeading = '1INVALID=synthetic-payload'
+  assert.notDeepEqual(parseDotenv(digitLeading), {}, 'dotenv reads a digit-leading key')
+  assert.doesNotThrow(() => validateDotenvSyntax(digitLeading))
+  assert.deepEqual(deployableStageConfig(digitLeading).config, {}, 'and it is refused by the allowlist')
+})
+
+test('a value quoted across lines is refused, and the message says why it might be', () => {
+  /*
+   * dotenv reads it, so this is a deliberate refusal rather than a parse failure — and it costs
+   * nothing, because a stored value cannot contain a newline, so such a file could never be
+   * bootstrapped either way.
+   *
+   * It is refused here rather than recognised and skipped because recognising one is not possible
+   * without reimplementing the grammar: an unterminated quote parses to a key of its own, so a
+   * continuation line and a typo are indistinguishable to anything short of dotenv itself. The message
+   * therefore names both possibilities instead of asserting the wrong one.
+   */
+  const multiline = 'STACK_DOMAIN="first\nsecond"\nRUNNERS=1\n'
+  assert.deepEqual(parseDotenv(multiline), { STACK_DOMAIN: 'first\nsecond', RUNNERS: '1' }, 'dotenv does read it')
+  assert.notDeepEqual(parseDotenv('KEY="first'), {}, 'an unterminated quote yields a key, which is why')
+
+  assert.throws(() => validateDotenvSyntax(multiline), (error: any) => {
+    assert.match(error.message, /line 2 is not an assignment/)
+    assert.match(error.message, /cannot contain a newline/)
+    return true
+  })
+  assert.throws(() => serializeStageConfig({ STACK_DOMAIN: 'first\nsecond' }), /contains a newline/)
 })
 
 test('validateDotenvSyntax names the file it was given and the offending line', () => {
   assert.throws(
     () => validateDotenvSyntax('STACK_DOMAIN=dev.boxlite.ai\n\nOIDC_AUDIENCE', '/tmp/synthetic/.env'),
-    /\/tmp\/synthetic\/\.env contains invalid assignment syntax on line 3/,
+    /\/tmp\/synthetic\/\.env line 3 is not an assignment dotenv can read/,
   )
 })
 

--- a/apps/infra/deployment/validate-environment.ts
+++ b/apps/infra/deployment/validate-environment.ts
@@ -11,6 +11,8 @@
  * hydrated, and deployment/stage-config.ts drops one anyway if it somehow got written by hand.
  */
 
+import { parse } from 'dotenv'
+
 const FORBIDDEN_DEPLOYMENT_KEYS = new Set([
   'ALLOW_DOWNGRADE',
   'API_ARTIFACT_REF',
@@ -181,12 +183,36 @@ export function isLocalOnlyDeploymentKey(key: string) {
  * A malformed line is a different problem: the file does not say what its author thinks it says, and
  * dotenv would skip it in silence.
  */
+/*
+ * Reject the lines dotenv would drop in silence — a dropped key is simply absent from the store, and
+ * the failure surfaces much later as a missing value.
+ *
+ * The check asks the parser instead of describing it. A pattern here would be a second implementation
+ * of dotenv's grammar, and the two drift in both directions: too strict and an operator is told a
+ * working file is invalid (`export KEY=value` from a file that doubles as a shell script, `KEY = value`
+ * from ordinary tidying, and — genuinely surprising — `KEY: value`, which dotenv 17 reads while
+ * `KEY:value` and `KEY : value` it does not); too loose and the silent-drop this exists to catch gets
+ * through. `deployableStageConfig` hands the same text to the same parser, so agreement is the
+ * property that matters, not the shape of the rule.
+ *
+ * One case is line-oriented on purpose. A value quoted across lines parses for dotenv, but its
+ * continuations are not assignments and there is no way to recognise one without reimplementing the
+ * grammar — an unterminated quote yields a key of its own, so even "keep reading until it parses"
+ * cannot tell the two apart. Such a value could never be stored regardless, because a stored value
+ * cannot contain a newline, so it is refused here with a message that names both possibilities rather
+ * than guessing which one it is.
+ */
 export function validateDotenvSyntax(source: string, label = '.env') {
-  for (const [index, rawLine] of source.split(/\r?\n/).entries()) {
+  // A lone CR ends a line too — an old-Mac line ending, or a file mangled in transit. Splitting on
+  // \n alone folds `A=1\rBROKEN` into one line that parses as A=1, hiding the half the parser drops.
+  for (const [index, rawLine] of source.split(/\r\n|\r|\n/).entries()) {
     const line = rawLine.trim()
     if (line === '' || line.startsWith('#')) continue
-    if (!/^[A-Za-z_][A-Za-z0-9_]*=/.test(line)) {
-      throw new Error(`${label} contains invalid assignment syntax on line ${index + 1}; expected KEY=value`)
+    if (Object.keys(parse(line)).length === 0) {
+      throw new Error(
+        `${label} line ${index + 1} is not an assignment dotenv can read; expected KEY=value. If it ` +
+          'continues a value quoted across lines, note that a stored value cannot contain a newline.',
+      )
     }
   }
 }

--- a/apps/infra/deployment/validate-environment.ts
+++ b/apps/infra/deployment/validate-environment.ts
@@ -1,10 +1,15 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (c) 2026 BoxLite AI
 
-import { readFile } from 'node:fs/promises'
-import { fileURLToPath } from 'node:url'
-
-import { parse } from 'dotenv'
+/*
+ * Which keys must never leave the operator's machine.
+ *
+ * This was a CI step: the deploy workflow wrote the GitHub `DEPLOY_ENV` secret out as
+ * apps/infra/.env and ran this over it. The store replaced that transport, so the same policy now
+ * applies at three earlier points — bootstrap refuses to load one of these into the stage's secret
+ * store (bootstrap/environment.ts's deployableStageConfig), the manifest scopes what may be
+ * hydrated, and deployment/stage-config.ts drops one anyway if it somehow got written by hand.
+ */
 
 const FORBIDDEN_DEPLOYMENT_KEYS = new Set([
   'ALLOW_DOWNGRADE',
@@ -45,34 +50,143 @@ const FORBIDDEN_DEPLOYMENT_KEYS = new Set([
   'SST_BIN_PATH',
 ])
 
-export function validateDeployEnvironment(source: string) {
+/*
+ * Whether a key must never leave the operator's machine.
+ *
+ * The `AWS_ENDPOINT_URL_<SERVICE>` family is a prefix rather than a name, so a Set membership test
+ * on its own would miss every member of it.
+ */
+export function isForbiddenDeploymentKey(key: string) {
+  return FORBIDDEN_DEPLOYMENT_KEYS.has(key) || key.startsWith('AWS_ENDPOINT_URL_')
+}
+
+/*
+ * Keys that stay on this machine for a reason other than the credential-context rule above: each is
+ * consulted *before*, or in order to reach, the stage's secret store, so a stored copy could only
+ * ever disagree with the one actually used.
+ */
+const STORE_EXCLUDED_KEYS = new Set([
+  // Reading the store initializes every provider sst.config.ts declares, Cloudflare included, so a
+  // token kept there would be needed in order to read itself. These live in SSM.
+  'CLOUDFLARE_API_TOKEN',
+  'CLOUDFLARE_DEFAULT_ACCOUNT_ID',
+  // deployment/sst.ts resolves the region before it reads the store, so a stored value would arrive
+  // after the wrapper had already used another one — and the sst child would then see the stored one.
+  'AWS_REGION',
+  // Selects *which* stage's store to read, so it cannot come from inside one.
+  'SST_STAGE',
+  // Not consulted before the store like the others here — it is the documented local artifact knob,
+  // read later by resolveReleaseVersion, and CI sets it per run from the checkout's Cargo.toml. It is
+  // excluded so a stored value cannot redirect which release a deploy installs.
+  'VERSION',
+  /*
+   * Process controls, not configuration. Hydration injects into the environment of the sst child,
+   * which runs Pulumi with the deploy role's credentials, so any of these turns a stored string into
+   * code execution or a moved trust boundary inside a privileged process: NODE_OPTIONS can `--require`
+   * a file, the proxy and CA variables redirect or unwrap every TLS connection sst makes, and PATH and
+   * the preload variables choose which binaries it runs. Named explicitly here; the prefix families
+   * below cover the rest.
+   */
+  'NODE_OPTIONS',
+  'NODE_EXTRA_CA_CERTS',
+  'NODE_TLS_REJECT_UNAUTHORIZED',
+  'SSL_CERT_DIR',
+  'SSL_CERT_FILE',
+  'REQUESTS_CA_BUNDLE',
+  'AWS_CA_BUNDLE',
+  'PATH',
+  'LD_PRELOAD',
+  'LD_LIBRARY_PATH',
+  'DYLD_INSERT_LIBRARIES',
+  'DYLD_LIBRARY_PATH',
+  // Interpreter and tool hooks, same class: each names a file or command that a runtime executes on
+  // startup, so any of them turns a stored string into code running beside the deploy credentials.
+  'BASH_ENV',
+  'ENV',
+  'GIT_SSH_COMMAND',
+  'GIT_EXTERNAL_DIFF',
+  'GIT_PAGER',
+  'PERL5OPT',
+  'PYTHONPATH',
+  'PYTHONSTARTUP',
+  'RUBYOPT',
+  // Round three of this list. Each names a program or config file that git or docker will execute or
+  // trust: GIT_ASKPASS runs to answer a credential prompt, and DOCKER_HOST redirects every build and
+  // push to a daemon of the value's choosing.
+  'GIT_ASKPASS',
+  'DOCKER_HOST',
+  'DOCKER_CONTEXT',
+  'DOCKER_CONFIG',
+  'DOCKER_CERT_PATH',
+  'DOCKER_TLS_VERIFY',
+])
+
+/*
+ * The secrets the stack resolves through `sst.Secret`, seeded one at a time rather than from .env.
+ *
+ * They share the store with the stage configuration, so `sst secret load` would overwrite them: it
+ * runs after ensureOidcClientId has already prompted for OIDC_CLIENT_ID, and a .env that happens to
+ * define the same key would silently replace the value just entered. Hydrating them would be wrong
+ * too — stack/deploy.ts reads these through sst.Secret, never process.env.
+ *
+ * Pinned against the `new sst.Secret(...)` declarations by a test, so adding one there without adding
+ * it here fails rather than quietly becoming clobberable.
+ */
+export const APP_SECRET_NAMES = [
+  'OIDC_CLIENT_ID',
+  'OIDC_MANAGEMENT_API_CLIENT_ID',
+  'OIDC_MANAGEMENT_API_CLIENT_SECRET',
+  'POSTHOG_API_KEY',
+  'SVIX_AUTH_TOKEN',
+  'USAGE_EXPORT_TOKEN',
+]
+
+/*
+ * Whole families rather than names: PULUMI_* reconfigures the engine the deploy runs on, GIT_CONFIG*
+ * covers GIT_CONFIG_GLOBAL and the GIT_CONFIG_KEY_<n>/GIT_CONFIG_VALUE_<n> pairs that inject arbitrary
+ * git config (including `core.pager` and the `url.*.insteadOf` rewrites), and the proxy variables
+ * exist in both cases with no canonical spelling.
+ *
+ * This list has now grown in three separate review rounds, which is the honest signal about it: an
+ * enumeration of process controls cannot be completed. The manifest is the control that bounds
+ * hydration — only keys bootstrap wrote from .env are eligible — and this is a second line behind it,
+ * not the boundary itself.
+ */
+// SST_ and BUN_ join the prefix list rather than SST_BUN_PATH/SST_PULUMI_PATH/BUN_OPTIONS being
+// named one at a time: they select the binaries sst executes, and this is the sixth review round
+// to add process controls. SST_STAGE is already excluded above for its own reason.
+const LOCAL_ONLY_KEY_PREFIXES = ['PULUMI_', 'npm_', 'NPM_CONFIG_', 'GIT_CONFIG', 'SST_', 'BUN_']
+const PROXY_KEYS = new Set(['HTTP_PROXY', 'HTTPS_PROXY', 'ALL_PROXY', 'NO_PROXY'])
+
+/*
+ * Whether a key belongs only to this machine, never to the stage's shared secret store.
+ *
+ * Three consumers, one answer: bootstrap keeps these out when it loads .env
+ * (bootstrap/environment.ts's deployableStageConfig), the deploy wrapper reads only these from .env,
+ * and deployment/stage-config.ts refuses to hydrate one even if something wrote it into the store by
+ * hand.
+ */
+export function isLocalOnlyDeploymentKey(key: string) {
+  if (isForbiddenDeploymentKey(key) || STORE_EXCLUDED_KEYS.has(key)) return true
+  if (APP_SECRET_NAMES.includes(key)) return true
+  if (PROXY_KEYS.has(key.toUpperCase())) return true
+  return LOCAL_ONLY_KEY_PREFIXES.some((prefix) => key.startsWith(prefix))
+}
+
+/*
+ * Reject a malformed dotenv source before anything is written from it.
+ *
+ * Only the syntax. *Which* keys may be stored is decided by isLocalOnlyDeploymentKey, which filters
+ * rather than refuses, so an operator whose .env legitimately holds AWS_PROFILE can still bootstrap.
+ * A malformed line is a different problem: the file does not say what its author thinks it says, and
+ * dotenv would skip it in silence.
+ */
+export function validateDotenvSyntax(source: string, label = '.env') {
   for (const [index, rawLine] of source.split(/\r?\n/).entries()) {
     const line = rawLine.trim()
     if (line === '' || line.startsWith('#')) continue
     if (!/^[A-Za-z_][A-Za-z0-9_]*=/.test(line)) {
-      throw new Error(`DEPLOY_ENV contains invalid assignment syntax on line ${index + 1}; expected KEY=value`)
+      throw new Error(`${label} contains invalid assignment syntax on line ${index + 1}; expected KEY=value`)
     }
   }
-
-  const configuredKeys = Object.keys(parse(source))
-  const forbiddenKeys = configuredKeys
-    .filter((key) => FORBIDDEN_DEPLOYMENT_KEYS.has(key) || key.startsWith('AWS_ENDPOINT_URL_'))
-    .sort()
-  if (forbiddenKeys.length > 0) {
-    throw new Error(
-      `DEPLOY_ENV must rely on workflow OIDC and the native CI builder, and must not define: ${forbiddenKeys.join(', ')}`,
-    )
-  }
-}
-
-async function main(args: string[]) {
-  if (args.length !== 1) throw new Error('expected exactly one DEPLOY_ENV file path')
-  validateDeployEnvironment(await readFile(args[0], 'utf8'))
-}
-
-if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
-  main(process.argv.slice(2)).catch((error) => {
-    console.error(`deploy-environment-validation: ${error.message}`)
-    process.exitCode = 1
-  })
 }

--- a/apps/infra/deployment/verify-role.ts
+++ b/apps/infra/deployment/verify-role.ts
@@ -108,7 +108,7 @@ function main() {
         `${boundaryArn} on role/boxlite-*. apps/infra/sst.config.ts requires every SST-managed role to carry ` +
         `this boundary. Run \`npm run bootstrap -- --stage ${stage}\` with AWS admin ` +
         'credentials (it redeploys bootstrap/aws/github-deploy-role.yaml), then confirm the GitHub environment variable ' +
-        `AWS_DEPLOY_ROLE_ARN for '${stage}' still points at that stack's RoleArn output. ` +
+        `AWS_ACCOUNT_ID for '${stage}' still matches the account that stack was deployed into. ` +
         'See apps/infra/README.md#deploy-an-existing-stack.',
     )
   }

--- a/apps/infra/docs/deployment.md
+++ b/apps/infra/docs/deployment.md
@@ -99,9 +99,13 @@ gh workflow run deploy-infra.yml --ref main -f stage=dev -f apply=true   # deplo
 ```
 
 `npm run bootstrap` is safe to re-run. It prompts once per stage for the
-Cloudflare token and `OIDC_CLIENT_ID`, then stores them in SSM and the SST
-secret store; `--force` replaces already-seeded values. Its full flag list is in
-the script's header comment.
+Cloudflare token and `OIDC_CLIENT_ID`, and loads your `.env` into the stage's SST
+secret store alongside `OIDC_CLIENT_ID`. The Cloudflare pair goes to SSM and to
+the stage's GitHub Environment instead, because reading the store initializes the
+Cloudflare provider. On that Environment it also sets the `AWS_ACCOUNT_ID` and
+`AWS_REGION` variables, which the deploy workflow needs before it has any AWS
+credentials. `--force` re-prompts for an already-seeded Cloudflare credential. Its
+full flag list is in the script's header comment.
 
 A deploy takes 10–15 minutes and prints the service URLs. On a transient
 registry error, just rerun — SST resumes from the failed step.
@@ -213,8 +217,9 @@ runs before deployment.
 
 The workflows are manual/serialized, restricted to `main`, and bound to protected
 GitHub Environments. GitHub OIDC supplies short-lived AWS credentials; no AWS
-access keys are stored in GitHub. `DEPLOY_ENV` materializes the stage's gitignored
-`.env` only for the job and is deleted even if deployment fails.
+access keys are stored in GitHub, and no stage configuration either — a job reads
+that from the stage's SST secret store using the credentials it just assumed, so
+nothing is written to disk and there is no `.env` for a failed job to leave behind.
 
 `bootstrap/aws/github-deploy-role.yaml` bootstraps three things that must exist **before** an
 SST deploy: the OIDC role, the immutable Api ECR repository, and the private
@@ -232,24 +237,63 @@ they differ. Keep required reviewers enabled on each Environment.
 
 ## Secrets & credentials
 
-Nothing secret lives in git, but there are **two** control planes, and
-offboarding means revoking both. Most secrets live in AWS, where anyone who can
-deploy can read them. The rest are GitHub Environment secrets (see the table
-below), reachable by anyone who can administer the repository or run the
-workflow — revoking AWS access does not touch those. Secrets are per-stage; seed
+Nothing secret lives in git. A stage's configuration and its application secrets
+live in one place — its SST secret store, encrypted in the SST state bucket and
+readable by exactly the people who can already deploy that stage. The Cloudflare
+provider credentials are the one exception and are reachable two other ways, so
+offboarding still means revoking GitHub as well as AWS. Secrets are per-stage; seed
 each stage you run.
 
 | What | Stored in | Set by |
 | --- | --- | --- |
 | App secrets (`OIDC_CLIENT_ID`, Auth0 Management API, Svix, PostHog, `USAGE_EXPORT_TOKEN`) | SST secret store | `npm run bootstrap`; others via `npm run sst -- secret set <NAME> --stage <stage>` reading stdin |
-| Cloudflare creds (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_DEFAULT_ACCOUNT_ID`) | AWS SSM SecureString, or GitHub Environment secrets (which win) | `npm run bootstrap` |
-| Stage config (`STACK_DOMAIN`, `OIDC_*`, toggles) | GitHub Environment secret `DEPLOY_ENV` | `npm run bootstrap` |
+| Cloudflare creds (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_DEFAULT_ACCOUNT_ID`) | AWS SSM SecureString for local use; GitHub Environment secrets for CI (which win) | `npm run bootstrap` |
+| Stage config (`STACK_DOMAIN`, `OIDC_*`, toggles) | SST secret store | `npm run bootstrap`, from your local `.env` |
 
 Never pass secret values as command arguments or echo them. Rotate on any
 suspected disclosure. `npm run secrets -- --stage dev` lists what is set.
 
-Run SST through the npm scripts, never bare `npx sst` — the wrapper loads
-Cloudflare creds from SSM, enforces the Runner safety policy, and scrubs
+`.env` is bootstrap's input, not a deploy's. Bootstrap loads it into the store, and
+`deployment/sst.ts` reads it back into the environment before invoking sst, so a
+local `npm run deploy` and a CI deploy resolve the same values from the same place.
+Editing `.env` therefore changes nothing until you rerun bootstrap.
+
+Two rules narrow what the store may put into a deploy's environment, because
+`sst secret set` accepts any name from anyone who can deploy:
+
+- only keys named by the `BOXLITE_STAGE_CONFIG` manifest bootstrap writes. That is
+  also what makes a key you delete from `.env` stop applying: `sst secret load`
+  merges, so the old value stays in the store and simply goes unread. Tidy it up
+  with `npm run sst -- secret remove <NAME> --stage <stage>` when you care.
+- never local credential context (`AWS_PROFILE`, `AWS_CLI_PATH`) or the artifact
+  selectors CI owns — see `FORBIDDEN_DEPLOYMENT_KEYS` in
+  `deployment/validate-environment.ts`.
+
+A variable already set in the environment always wins over the store. That is how
+the deploy workflow keeps control of the selectors it sets, and how you override a
+stored value for a single command.
+
+The Cloudflare credentials cannot join the store, for two independent reasons.
+Reading the store initializes every provider `sst.config.ts` declares, Cloudflare
+included — `sst secret list` gets as far as the bootstrap state and then exits with
+`Cloudflare API not initialized` — so a token kept there would be needed in order to
+read itself. CI passes the two values as Environment secrets rather than reading the SSM copy.
+Whether the deploy role could read it is untested: it holds `ssm:GetParameter` and no
+identity-based `kms:Decrypt`, but `alias/aws/ssm` is an AWS-managed key whose key policy
+may admit the account via `kms:ViaService`, and the role trusts only the GitHub OIDC
+principal so it cannot be assumed locally to check. Measuring that from inside a job is
+what would let the Environment secrets go away.
+
+Otherwise two things are configured on the GitHub side, per stage:
+`AWS_ACCOUNT_ID` — from which the workflows compose
+`arn:aws:iam::<id>:role/boxlite-<stage>-github-deploy`. It cannot live in the store,
+because `configure-aws-credentials` reads it before any AWS credentials exist. Each
+stage's GitHub Environment must still exist under exactly the stage name — the trust
+policy pins `repo:<owner>/<repo>:environment:<stage>` — and that is where required
+reviewers are enforced.
+
+Run SST through the npm scripts, never bare `npx sst` — the wrapper loads the stage
+configuration from the secret store, enforces the Runner safety policy, and scrubs
 Pulumi event logs that can contain provider credentials. `sst dev` is disabled.
 
 ### Cloudflare API token

--- a/apps/infra/docs/deployment.md
+++ b/apps/infra/docs/deployment.md
@@ -284,13 +284,16 @@ may admit the account via `kms:ViaService`, and the role trusts only the GitHub 
 principal so it cannot be assumed locally to check. Measuring that from inside a job is
 what would let the Environment secrets go away.
 
-Otherwise two things are configured on the GitHub side, per stage:
-`AWS_ACCOUNT_ID` — from which the workflows compose
-`arn:aws:iam::<id>:role/boxlite-<stage>-github-deploy`. It cannot live in the store,
-because `configure-aws-credentials` reads it before any AWS credentials exist. Each
-stage's GitHub Environment must still exist under exactly the stage name — the trust
-policy pins `repo:<owner>/<repo>:environment:<stage>` — and that is where required
-reviewers are enforced.
+Otherwise two variables are configured on the GitHub side, per stage, and neither can live in the
+store because `configure-aws-credentials` reads both before any AWS credentials exist:
+
+- `AWS_ACCOUNT_ID`, from which the workflows compose
+  `arn:aws:iam::<id>:role/boxlite-<stage>-github-deploy`. Required.
+- `AWS_REGION`, needed only by a stage outside the workflows' default. Bootstrap writes it either
+  way, since it knows the region it just deployed into.
+
+Each stage's GitHub Environment must still exist under exactly the stage name — the trust policy pins
+`repo:<owner>/<repo>:environment:<stage>` — and that is where required reviewers are enforced.
 
 Run SST through the npm scripts, never bare `npx sst` — the wrapper loads the stage
 configuration from the secret store, enforces the Runner safety policy, and scrubs

--- a/apps/infra/docs/security.md
+++ b/apps/infra/docs/security.md
@@ -1,8 +1,35 @@
 # Infrastructure security
 
-Provider bootstrap credentials are loaded just before SST starts. Application secrets stay in the
-SST secret store; Cloudflare provider credentials are SecureString values in stage-scoped AWS SSM
-parameters. Materialized `.env` files are temporary workflow inputs and are removed unconditionally.
+Stage configuration and application secrets are loaded into the environment just before SST starts,
+from the stage's SST secret store; the Cloudflare provider credentials come from SSM or the job's
+Environment secrets, since reading that store initializes the Cloudflare provider. No workflow writes
+configuration to disk, and only keys named by the store's own `BOXLITE_STAGE_CONFIG` manifest are
+applied, so a secret written under any other name cannot reach a deploy's environment.
+
+A stage's deploy role reaches its own stage's state and secrets, and no other stage's. One bucket and
+one parameter tree hold every stage's, so the role's `s3:*`/`ssm:*` grant on `*` used to let a job
+bound to the dev Environment run `sst secret list --stage prod`. Those two are now scoped to this
+stage's state prefixes, its passphrase, and the buckets the stack owns.
+
+Three things in that store are shared by construction, and none of them is a stage's secrets:
+
+- `ListBucket` stays at bucket scope, because SST enumerates before it reads. Other stages' key
+  *names* remain visible; their contents do not.
+- `_fallback` secrets belong to the app rather than a stage, so they cannot be stage-scoped and are
+  read-only — a deploy consumes a fallback, setting one is a deliberate operator action.
+- `/sst/bootstrap` names the buckets every stage shares and is read before SST knows which stage it
+  is running, so it is read-only for the same reason.
+
+One shared write remains: deployment assets are content-addressed in a single `sst-asset-*` bucket
+with no stage in the key, so every stage writes there. A write is idempotent — the key *is* the
+content hash — but a delete is not, so a stage can remove an object another stage's next update
+expects. It stays because `sst remove` needs it, and the blast radius is a redeploy: assets are
+rebuilt from the checkout, not recovered from the bucket.
+
+That policy has not run a real deploy yet. Four of its grant groups were derived from live listings,
+and two — Pulumi's provider describe/list calls and the `ssm:SendCommand` document targets — are
+reasoned. A gap surfaces as AccessDenied on a preview, and clearing it means redeploying the bootstrap
+stack with a wider policy, so preview with `apply=false` before any apply.
 
 Every SST-created IAM role receives the stage runtime permissions boundary through the global role
 transform. The checked-in bootstrap CloudFormation template creates the deployment boundary and

--- a/apps/infra/docs/security.md
+++ b/apps/infra/docs/security.md
@@ -1,10 +1,20 @@
 # Infrastructure security
 
-Stage configuration and application secrets are loaded into the environment just before SST starts,
-from the stage's SST secret store; the Cloudflare provider credentials come from SSM or the job's
-Environment secrets, since reading that store initializes the Cloudflare provider. No workflow writes
-configuration to disk, and only keys named by the store's own `BOXLITE_STAGE_CONFIG` manifest are
-applied, so a secret written under any other name cannot reach a deploy's environment.
+A stage's configuration is loaded into the environment just before SST starts, from the stage's SST
+secret store; the Cloudflare provider credentials come from SSM or the job's Environment secrets,
+since reading that store initializes the Cloudflare provider. No workflow writes configuration to
+disk, and only keys named by the store's own `BOXLITE_STAGE_CONFIG` manifest are applied, so a secret
+written under any other name cannot reach a deploy's environment.
+
+The application secrets — `OIDC_CLIENT_ID` and the others declared as `sst.Secret` — live in that
+same store but are **not** part of that hydration. SST resolves them itself, so they never enter the
+deploy wrapper's own `process.env`; the stack still passes them to the services that need them, which
+is how they reach a deployed application's environment.
+
+Two separate things keep them intact. `sst secret load` merges rather than replacing, and bootstrap's
+payload excludes those names outright (`APP_SECRET_NAMES`), so a load cannot overwrite a value the
+operator was just prompted for. The manifest is not what protects them — it governs which stored keys
+may be hydrated, not what the load writes.
 
 A stage's deploy role reaches its own stage's **SST secret store**, and no other stage's. One bucket
 and one parameter tree hold every stage's, so the role's `s3:*`/`ssm:*` grant on `*` used to let a job

--- a/apps/infra/docs/security.md
+++ b/apps/infra/docs/security.md
@@ -20,11 +20,23 @@ Three things in that store are shared by construction, and none of them is a sta
 - `/sst/bootstrap` names the buckets every stage shares and is read before SST knows which stage it
   is running, so it is read-only for the same reason.
 
-One shared write remains: deployment assets are content-addressed in a single `sst-asset-*` bucket
-with no stage in the key, so every stage writes there. A write is idempotent — the key *is* the
-content hash — but a delete is not, so a stage can remove an object another stage's next update
-expects. It stays because `sst remove` needs it, and the blast radius is a redeploy: assets are
-rebuilt from the checkout, not recovered from the bucket.
+Three shared writes remain, and none is narrowed by this change:
+
+- Deployment assets are content-addressed in a single `sst-asset-*` bucket with no stage in the key,
+  so every stage writes there. A write is idempotent — the key *is* the content hash — but a delete
+  is not, so a stage can remove an object another stage's next update expects. It stays because
+  `sst remove` needs it, and the blast radius is a redeploy: assets are rebuilt from the checkout.
+- `boxlite-volume-*` buckets carry no stage in their names, so `s3:*` over that prefix reaches every
+  stage's volumes. Scoping it means renaming the buckets to carry the stage, across the runtime
+  boundary, the stack, and buckets that already exist.
+- `ssm:SendCommand` on `instance/*` is the widest grant the deploy role holds: an instance ARN
+  carries no stage, so a job bound to one stage can run a shell command on any instance in the
+  account. Narrowing it needs a Condition on an instance tag the Runner launch template sets, which
+  can only be verified against real instances.
+
+The first two predate this change and the third is how Runner upgrades have always been delivered;
+they are listed because the paragraph above would otherwise read as a stronger guarantee than the
+policy gives.
 
 That policy has not run a real deploy yet. Four of its grant groups were derived from live listings,
 and two — Pulumi's provider describe/list calls and the `ssm:SendCommand` document targets — are

--- a/apps/infra/docs/security.md
+++ b/apps/infra/docs/security.md
@@ -6,12 +6,16 @@ Environment secrets, since reading that store initializes the Cloudflare provide
 configuration to disk, and only keys named by the store's own `BOXLITE_STAGE_CONFIG` manifest are
 applied, so a secret written under any other name cannot reach a deploy's environment.
 
-A stage's deploy role reaches its own stage's state and secrets, and no other stage's. One bucket and
-one parameter tree hold every stage's, so the role's `s3:*`/`ssm:*` grant on `*` used to let a job
+A stage's deploy role reaches its own stage's **SST secret store**, and no other stage's. One bucket
+and one parameter tree hold every stage's, so the role's `s3:*`/`ssm:*` grant on `*` used to let a job
 bound to the dev Environment run `sst secret list --stage prod`. Those two are now scoped to this
 stage's state prefixes, its passphrase, and the buckets the stack owns.
 
-Three things in that store are shared by construction, and none of them is a stage's secrets:
+That is a claim about the SST store specifically, which is where a stage's configuration lives. It is
+*not* a claim about AWS Secrets Manager: `secretsmanager:*` is still granted account-wide, and is one
+of the two open items at the end of this section.
+
+Three things in the SST store are shared by construction, and none of them is a stage's configuration:
 
 - `ListBucket` stays at bucket scope, because SST enumerates before it reads. Other stages' key
   *names* remain visible; their contents do not.

--- a/apps/infra/docs/security.md
+++ b/apps/infra/docs/security.md
@@ -22,10 +22,12 @@ Three things in that store are shared by construction, and none of them is a sta
 
 Three shared writes remain, and none is narrowed by this change:
 
-- Deployment assets are content-addressed in a single `sst-asset-*` bucket with no stage in the key,
-  so every stage writes there. A write is idempotent — the key *is* the content hash — but a delete
-  is not, so a stage can remove an object another stage's next update expects. It stays because
-  `sst remove` needs it, and the blast radius is a redeploy: assets are rebuilt from the checkout.
+- Deployment assets share a single `sst-asset-*` bucket with no stage in the key, so every stage has
+  `PutObject`, `DeleteObject` and `DeleteObjectVersion` over all of it. SST derives each key from the
+  content hash, which makes an ordinary deploy's writes idempotent — but that is SST's behaviour, not
+  a constraint the policy imposes: the grant permits writing arbitrary bytes to any key in the bucket,
+  or deleting one another stage's next update expects. It stays because `sst remove` needs the delete,
+  and the blast radius is bounded by assets being rebuilt from the checkout rather than recovered.
 - `boxlite-volume-*` buckets carry no stage in their names, so `s3:*` over that prefix reaches every
   stage's volumes. Scoping it means renaming the buckets to carry the stage, across the runtime
   boundary, the stack, and buckets that already exist.

--- a/apps/infra/docs/security.md
+++ b/apps/infra/docs/security.md
@@ -40,6 +40,21 @@ The first two predate this change and the third is how Runner upgrades have alwa
 they are listed because the paragraph above would otherwise read as a stronger guarantee than the
 policy gives.
 
+Two grants reach other stages and are **not** narrowed here, tracked in
+[#1255](https://github.com/boxlite-ai/boxlite/issues/1255):
+
+- `ManageBoxLiteRoles` covers `role/boxlite-*`, so a job bound to one stage can rewrite or delete
+  another stage's SST-created runtime roles. This stage's own deploy role, every other stage's, and
+  the runtime boundary policies are excluded by the `DenySelfPrivilegeEscalation` statement; the
+  remaining runtime roles are not.
+- `secretsmanager:*` is granted on `*`, so one stage can read and mutate another's secrets.
+
+Both would be scoped by `${GitHubEnvironment}` the way the runtime boundary already scopes
+`secretsmanager:GetSecretValue`, but only once a preview run confirms every resource SST creates
+carries the stage in its name — a wrong pattern fails a deploy with AccessDenied and needs the
+bootstrap stack redeployed to clear. So this section says what the policy grants today rather than
+what it should grant.
+
 That policy has not run a real deploy yet. Four of its grant groups were derived from live listings,
 and two — Pulumi's provider describe/list calls and the `ssm:SendCommand` document targets — are
 reasoned. A gap surfaces as AccessDenied on a preview, and clearing it means redeploying the bootstrap

--- a/apps/infra/package.json
+++ b/apps/infra/package.json
@@ -9,12 +9,11 @@
     "test": "tsx --test artifacts/*.test.ts bootstrap/*.test.ts deployment/*.test.ts policies/runner/*.test.ts runner/*.test.ts runner/model/*.test.ts shared/*.test.ts stack/*.test.ts",
     "typecheck": "tsc --noEmit",
     "sst": "tsx deployment/sst.ts",
-    "secrets": "tsx deployment/sst.ts secret list",
+    "secrets": "tsx deployment/secret-names.ts",
     "runner:update": "tsx runner/update.ts",
     "login": "tsx bootstrap/login.ts",
     "bootstrap": "tsx bootstrap/bootstrap.ts",
     "verify-deploy-role": "tsx deployment/verify-role.ts",
-    "validate-environment": "tsx deployment/validate-environment.ts",
     "validate-preview": "tsx deployment/preview.ts",
     "runner:build-artifact": "tsx artifacts/runner-build.ts"
   },

--- a/apps/infra/shared/resource-name.ts
+++ b/apps/infra/shared/resource-name.ts
@@ -26,8 +26,11 @@
  *
  * Deliberately NOT applied to the other AWS names this repository owns, each for its own reason:
  *
- *   boxlite-<stage>-github-deploy    live, and its ARN is stored in the dev GitHub environment
- *                                    variable AWS_DEPLOY_ROLE_ARN, so renaming needs a re-bootstrap
+ *   boxlite-<stage>-github-deploy    live, and the deploy workflows compose its ARN from this exact
+ *                                    spelling (bootstrap/environment.ts's githubDeployRoleName,
+ *                                    pinned against the CloudFormation template by a test), so
+ *                                    renaming it means a CloudFormation replacement plus an edit
+ *                                    to every workflow — worth doing, but on its own
  *   boxlite-<stage>-runtime-boundary live, and attached as a permissions boundary to existing
  *                                    roles, so renaming the policy is a migration
  *   SST-managed resources            SST derives <app>-<stage>-<LogicalId>-<hash> from the app

--- a/apps/infra/stack/app.ts
+++ b/apps/infra/stack/app.ts
@@ -4,12 +4,14 @@
 import { PRODUCTION_STAGE } from './settings.js'
 
 export async function configureApp(input: { stage?: string } | undefined) {
-  const { loadDeploymentEnvironment, resolveAwsRegion } = await import('../deployment/environment.js')
-  loadDeploymentEnvironment()
+  // No dotenv load here: deployment/sst.ts is the single place that composes the deploy environment
+  // (local .env knobs, then the stage's SST secret store), and this process inherits the result.
+  // Loading .env again would reintroduce a second answer for keys the store now owns.
+  const { SST_APP_NAME, resolveAwsRegion } = await import('../deployment/environment.js')
   const REGION = resolveAwsRegion()
 
   return {
-    name: 'boxlite',
+    name: SST_APP_NAME,
     removal: input?.stage === PRODUCTION_STAGE ? ('retain' as const) : ('remove' as const),
     home: 'aws' as const,
     providers: {


### PR DESCRIPTION
A stage's deploy-time configuration lived in two control planes. The GitHub Environment secret `DEPLOY_ENV` was written out as `apps/infra/.env` for the length of a job, so changing what a stage deployed needed no AWS access at all, and offboarding meant revoking both halves. A local deploy and CI also read different files, so the two could drift.

`npm run bootstrap` now loads `.env` into the stage's SST secret store, together with a manifest of the key names it owns and a digest of their values — one `sst secret load`, because `secret load` is a read-modify-write of one document and an interrupted one leaves some keys new and some old. The manifest cannot detect that; every name it lists is still present. `deployment/sst.ts` hydrates `process.env` from that store before spawning sst, so `stack/*.ts` keeps reading plain `process.env` / `envOr()` values and needs no change.

Three rules narrow what may reach `process.env`, since `sst secret set` is a command any deployer can run against any name: the key must be named by the manifest, must be one the deploy demonstrably reads, and must not be local-only. A store that is unreadable, unbootstrapped, torn, half-written, or that would apply nothing stops the command — `diff` included, because a preview built from defaults is not a preview of the apply that follows it.

Not everything can move. The Cloudflare provider credentials cannot: reading the store initializes every provider `app()` declares, so a token kept there would be needed in order to read itself. They stay in SSM and the stage's GitHub Environment, which also holds `AWS_ACCOUNT_ID` and `AWS_REGION` — both read before any AWS credentials exist.

## Call graph

Line numbers are as of `c3c536ee` for Before and this branch's head for After.

```
Before
  Materialize stage configuration   (deploy job · .github/workflows/deploy-infra.yml:419)   ← BUG: secrets.DEPLOY_ENV written to apps/infra/.env, a second control plane
    └─ loadDeploymentEnvironment    (sst wrapper · apps/infra/deployment/sst.ts:105)        ← BUG: the whole materialized .env into process.env, stale local values included
         └─ fetchFromSsm            (sst wrapper · apps/infra/deployment/sst.ts:178)        — Cloudflare credentials, the only thing not in that file
              └─ spawn sst deploy   (sst wrapper · apps/infra/deployment/sst.ts:105)        — stack/*.ts then reads process.env / envOr()

After
  ensureStageConfig                 (bootstrap · apps/infra/bootstrap/bootstrap.ts:878)     — the one write, after every check has passed
    ├─ validateDotenvSyntax         (guard · apps/infra/deployment/validate-environment.ts:205)  — rejects only what dotenv itself would drop
    ├─ prepareStageConfigLoad       (bootstrap · apps/infra/bootstrap/environment.ts:261)   — one read of .env; values + manifest + digest decided together
    ├─ storeCloudflareCredential    (bootstrap · apps/infra/bootstrap/bootstrap.ts:398)     — GitHub Environment first, then SSM; a torn pair names --force
    └─ sst secret load              (bootstrap · apps/infra/bootstrap/bootstrap.ts:555)     — one load, so the digest describes the values beside it

  loadStageConfig                   (sst wrapper · apps/infra/deployment/sst.ts:385)        — every plan-building subcommand, `diff` included
    ├─ loadDeploymentEnvironment    (sst wrapper · apps/infra/deployment/sst.ts:150)        — .env promoted for local-only keys only, never stage config
    ├─ fetchFromSsm                 (sst wrapper · apps/infra/deployment/sst.ts:370)        — before the store read; reading it initializes that provider
    ├─ StageConfigStore.read        (store · apps/infra/deployment/stage-config.ts:214)     — sst secret list; values never logged, fallbacks never supply bookkeeping
    ├─ hydrateStageConfig           (store · apps/infra/deployment/stage-config.ts:167)     — manifest ∩ allowlist ∖ local-only; a real env var still wins
    └─ five refusals → exit 1       (sst wrapper · apps/infra/deployment/sst.ts:261)        — unreadable │ no manifest │ digest absent or mismatched │ missing │ applies nothing
         └─ spawn sst deploy        (sst wrapper · apps/infra/deployment/sst.ts:385)        — stack/*.ts reads process.env / envOr(), unchanged
```

## What review added

The first commit is the change above. Everything else came out of reviewing it, and each is a separate commit.

**Correctness, in the feature itself.** An interrupted `secret load` could deploy a mixture of generations — including the very first torn load, which an "absent digest means unverifiable" allowance would have waved through. `--force` could leave the Cloudflare pair divergent with no way to notice. `.env` was read twice, so what got stored need not be what was validated. Auth0 provisioning read `STACK_DOMAIN` from the shell while the store got the file's value, and Auth0 provisioning is not idempotent. The `.env` syntax check was stricter than the parser it guards, rejecting `export KEY=value` and every apostrophe — either would have blocked bootstrap on a valid file. And an app-wide `--fallback` could supply a stage the manifest *and* a digest that agreed with it, letting a stage nobody bootstrapped pass both fail-closed checks.

**Secret disclosure.** Every failed sst call appended the tail of `.sst/log/sst.log` to its error. That log carries provider diagnostics in most detail exactly when a call fails, and bootstrap now hands sst a stage's entire configuration. The log is no longer read at all; the error names its path.

**IAM.** The deploy role's account-wide `s3:*`/`ssm:*` are scoped to this stage's state prefixes, passphrase and buckets, and `/sst/bootstrap` — which names the buckets every stage shares — is read-only. Two privilege-escalation paths are denied outright (`DenySelfPrivilegeEscalation`, `apps/infra/bootstrap/aws/github-deploy-role.yaml:392`): the role's own name matches the `role/boxlite-*` it can write, and so does every *sibling* stage's deploy role and runtime-boundary policy.

**Documentation that was wrong.** `docs/security.md` now states what the policy grants rather than what it ought to, including three grants shared by construction and one shared write. Two grants that reach other stages are **not** narrowed here and are tracked in #1255 — doing so needs an `apply=false` preview against a real stage, since a wrong resource pattern fails a deploy with `AccessDenied`.

## Verification

- `make test:apps:infra` → **391 passing**, up from 319 on main
- `npx tsc --noEmit` in `apps/infra` → clean
- Every fix was checked by reverting it and confirming the guarding test fails. For the wrapper's five refusals that meant asserting the *specific* refusal and the silence of the others — the guards form a chain, so an exit-code assertion stays green through exactly the regression it exists to catch, and three earlier drafts of those tests passed against a deliberately broken wrapper before this was fixed.

Not verified against AWS: the narrowed policy has never run a real deploy. **Preview with `apply=false` before applying** — a gap surfaces there as `AccessDenied` rather than mid-apply, and clearing one means redeploying the bootstrap stack.

## Cutover

Per stage: redeploy the bootstrap stack, run `npm run bootstrap -- --stage <stage>`, then preview before applying. `DEPLOY_ENV` and the per-stage `AWS_DEPLOY_ROLE_ARN` variable can be deleted from the Environment once a deploy has succeeded — bootstrap prints the exact `gh` commands.

Supersedes #1257, which was opened from a branch that has since been rebased onto main.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployment configuration is now stored and loaded per stage through the SST secret store.
  * Added safer stage configuration validation, integrity checks, and allowlisted environment loading.
  * Added secure Cloudflare credential synchronization and rotation.
  * Added a command to list deployment secret names without exposing secret values.
  * Deployment roles now use stage-specific AWS account settings with more narrowly scoped permissions.

* **Documentation**
  * Updated bootstrap, deployment, security, and CI guidance for the new configuration and credential workflow.

* **Bug Fixes**
  * Improved failure handling, cleanup, secret redaction, and protection against cross-stage access or privilege escalation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->