### PR TITLE
fix(dashboard): accept nullable volume last-used timestamp

### DIFF
--- a/apps/dashboard/src/pages/Volumes.tsx
+++ b/apps/dashboard/src/pages/Volumes.tsx
@@ -47,7 +47,7 @@ const ROW_GRID = 'grid grid-cols-[1.6fr_1.2fr_1fr_0.8fr_0.85fr_104px] items-cent
 // mount" rather than "last used" (a long-running writer disproves that) and
 // rather than "last mounted", whose past tense would suggest the mount has
 // since ended — something this page has no way to know.
-function timeAgo(value?: string): string {
+function timeAgo(value?: string | null): string {
   if (!value) return 'never'
   const minutes = Math.floor((Date.now() - new Date(value).getTime()) / 60_000)
   if (minutes < 1) return 'just now'


### PR DESCRIPTION
## Summary

- Accept the nullable timestamp shape generated for `VolumeDto.lastUsedAt`.
- Restore the dashboard production build used by the apps/API image workflow.
- Preserve the existing `null`/`undefined` display behavior (`never`).

## Root cause

The generated API client declares `lastUsedAt?: string | null`, but the page-local `timeAgo` helper accepted only `string | undefined`. TypeScript therefore rejected `timeAgo(volume.lastUsedAt)` during the production dashboard build.

Failed job: https://github.com/boxlite-ai/boxlite/actions/runs/31877285700/job/94994809501

## Before

```
Volumes
  -> timeAgo(volume.lastUsedAt: string | null | undefined)
  -> timeAgo(value?: string)  ← BUG: null rejected by TypeScript
  -> dashboard:build:production
  -> TS2345
  -> apps/API image build stops
```

## After

```
Volumes
  -> timeAgo(volume.lastUsedAt: string | null | undefined)
  -> timeAgo(value?: string | null)
  -> null/undefined render as "never"
  -> dashboard:build:production
  -> apps/API image build can continue
```

## Impact

This is a type-contract correction only. Runtime rendering is unchanged because the helper already treats a missing timestamp as `never`.

## Verification

- Two-sided exact production build: unpatched source failed with `TS2345`; the one-line patch passed.
- `yarn nx build dashboard --configuration=production --skip-nx-cache --nxBail=true --output-style=stream` passed (2,653 modules; dashboard plus four dependencies).
- Mandatory pre-push changed-component matrix passed.
- `make lint:apps` passed with no errors (34 existing warnings).
- `git diff --check` passed.

`make fmt:check:apps` remains red on 156 pre-existing generated-client formatting files; the unmodified `HEAD` version of `Volumes.tsx` also fails that current Prettier gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated volume timestamp displays so missing timestamps are shown as “never” instead of causing display issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->