### PR TITLE
fix(infra): keep deploy-wrapper progress off sst's stdout stream

### DIFF
--- a/apps/infra/deployment/pulumi-logs.test.ts
+++ b/apps/infra/deployment/pulumi-logs.test.ts
@@ -1098,3 +1098,102 @@ test('the infrastructure config check does not invoke SST outside the cleanup wr
   assert.doesNotMatch(makeTargets, /npm exec -- sst/)
   assert.match(makeTargets, /IAM_PERMISSIONS_BOUNDARY_STAGE=ci npm run sst -- install --stage ci/)
 })
+
+test('the wrapper keeps its own progress off the stream sst writes its plan to', async () => {
+  /*
+   * `sst diff --json` is piped straight into a JSON parser by the deploy workflow's preview step, and
+   * the wrapper spawns sst with `stdio: 'inherit'` — so stdout is one shared stream, and a progress
+   * line the wrapper prints lands in that pipe ahead of the plan. It fails the parse on its first
+   * character, reported as an invalid preview rather than as anything about the deploy: run
+   * 31880617031 died on `Unexpected token 's', "sst-with-c"...` with a plan that was fine.
+   *
+   * Driven through the wrapper because the coupling is between two processes: the messages are the
+   * wrapper's, the stream discipline is the child's, and nothing in either half alone shows that one
+   * corrupts the other.
+   */
+  const fixture = await fixtureRoot()
+  const fakeBin = join(fixture, 'bin')
+  const fakeSst = join(fakeBin, 'sst')
+  const plan = { steps: [], summary: { same: 3 } }
+
+  await mkdir(fakeBin, { recursive: true })
+  await writeFile(
+    fakeSst,
+    `#!/usr/bin/env node
+const args = process.argv.slice(2)
+if (args[0] === 'secret' && args[1] === 'list') {
+  const NL = String.fromCharCode(10)
+  process.stdout.write(${JSON.stringify(
+    syntheticSecretList(['STACK_DOMAIN', 'APP_URL'], {
+      STACK_DOMAIN: 'stored.example.test',
+      APP_URL: 'https://stored.example.test',
+    }),
+  )}.join(NL) + NL)
+  process.exit(0)
+}
+if (args[0] === 'state' && args[1] === 'export') {
+  process.stdout.write(JSON.stringify({ stack: 'ci', latest: { resources: [] } }))
+  process.exit(0)
+}
+// The plan, on the stream the preview step parses.
+process.stdout.write(JSON.stringify(${JSON.stringify(plan)}))
+`,
+    'utf8',
+  )
+  await chmod(fakeSst, 0o755)
+
+  const wrapper = spawnWrapper(['diff', '--stage', 'ci', '--json'], {
+    env: {
+      ...inheritedEnvironment(),
+      PATH: `${fakeBin}:${process.env.PATH}`,
+      SST_BIN_PATH: fakeSst,
+      CLOUDFLARE_API_TOKEN: 'synthetic-cloudflare-token',
+      CLOUDFLARE_DEFAULT_ACCOUNT_ID: 'synthetic-cloudflare-account',
+      RUNNERS: '1',
+      DEFAULT_RUNNER_NAME: 'default',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  /*
+   * Drained to close, not just to exit, for the reason spelled out at the refusal fixtures above —
+   * `exit` can fire before the pipe has delivered what was written. It matters more here than there:
+   * a short read makes `JSON.parse` throw the same SyntaxError a genuine stdout leak produces, so a
+   * flake on a loaded machine would be indistinguishable from the bug this test exists to catch.
+   */
+  let stdout = ''
+  let stderr = ''
+  wrapper.stdout.setEncoding('utf8')
+  wrapper.stderr.setEncoding('utf8')
+  wrapper.stdout.on('data', (chunk: string) => {
+    stdout += chunk
+  })
+  wrapper.stderr.on('data', (chunk: string) => {
+    stderr += chunk
+  })
+  const streamsDrained = Promise.all([
+    new Promise<void>((resolve) => wrapper.stdout.once('close', () => resolve())),
+    new Promise<void>((resolve) => wrapper.stderr.once('close', () => resolve())),
+  ])
+
+  try {
+    const exit = await waitForExit(wrapper)
+    await streamsDrained
+    assert.deepEqual(exit, { code: 0, signal: null })
+    // The whole stream, parsed the way the preview step parses it — not a substring search, which
+    // would pass with a progress line sitting in front of the plan.
+    assert.deepEqual(
+      JSON.parse(stdout),
+      plan,
+      `stdout must carry sst's plan and nothing else, but the preview step would parse: ${stdout.slice(0, 120)}`,
+    )
+    /*
+     * And the messages still exist. Without this the wrapper could pass by having gone silent, which
+     * is a different regression — the deploy log is where an operator sees which keys were loaded.
+     */
+    assert.match(stderr, /sst-with-cloudflare: ci stage configuration \.\.\. 2 keys loaded/)
+  } finally {
+    if (wrapper.exitCode === null && wrapper.signalCode === null) wrapper.kill('SIGKILL')
+    await rm(fixture, { recursive: true, force: true })
+  }
+})

--- a/apps/infra/deployment/sst.ts
+++ b/apps/infra/deployment/sst.ts
@@ -194,6 +194,21 @@ const CLOUDFLARE_CREDS = [
   { env: 'CLOUDFLARE_DEFAULT_ACCOUNT_ID', param: 'cloudflare-account-id' },
 ]
 
+/*
+ * The wrapper's own progress, on stderr.
+ *
+ * stdout belongs to the sst child, which this process spawns with `stdio: 'inherit'` — so anything
+ * written here goes into the same stream, ahead of sst's output. `sst diff --json` is piped straight
+ * into a JSON parser by the deploy workflow's preview step, and a progress line landing in that pipe
+ * fails the parse on its first character rather than on anything about the plan.
+ *
+ * Named rather than `console.error` at each site: these are not errors, and the reason they avoid
+ * stdout is not local to any one of them.
+ */
+function reportProgress(message: string) {
+  console.error(message)
+}
+
 function fetchFromSsm(name: any) {
   try {
     const awsCliPath = resolveAwsCliPath()
@@ -339,9 +354,9 @@ function loadStageConfig(stage: string) {
   Object.assign(process.env, apply)
 
   const applied = Object.keys(apply)
-  console.log(`sst-with-cloudflare: ${stage} stage configuration ... ${applied.length} keys loaded from the SST secret store`)
+  reportProgress(`sst-with-cloudflare: ${stage} stage configuration ... ${applied.length} keys loaded from the SST secret store`)
   if (alreadySet.length > 0) {
-    console.log(`sst-with-cloudflare: ${stage} stage configuration ... already in the environment, left alone: ${alreadySet.join(', ')}`)
+    reportProgress(`sst-with-cloudflare: ${stage} stage configuration ... already in the environment, left alone: ${alreadySet.join(', ')}`)
   }
   // Names only — a stored value is never printed. Worth surfacing rather than dropping silently: an
   // unlisted key is either a stale entry from a key since removed from .env, or one written by hand
@@ -453,7 +468,7 @@ if (sstArgs[0] === 'deploy') {
         },
         { awsCliPath: resolveAwsCliPath() },
       )
-      console.log(
+      reportProgress(
         `sst-with-cloudflare: Api ${apiSource.kind} image verified (${image.repository}:${image.tag}, ${image.digest})`,
       )
     }
@@ -473,12 +488,12 @@ if (sstArgs[0] === 'deploy') {
             }
           : process.env
       const runnerArtifact = await verifyRunnerArtifact(runnerSource, { environment: artifactEnvironment, signal })
-      console.log(
+      reportProgress(
         `sst-with-cloudflare: Runner ${runnerSource.kind} artifact verified (${runnerArtifact.tarballUrl}, linux-amd64)`,
       )
     }
     if (deployScope.excluded.length > 0) {
-      console.log(
+      reportProgress(
         `sst-with-cloudflare: ${deployScope.excluded.join(', ')} excluded from this deploy; artifact unverified`,
       )
     }
@@ -534,7 +549,7 @@ if (exitCode === 0 && !terminationSignal && sstArgs[0] === 'deploy') {
         },
       },
     )
-    console.log(
+    reportProgress(
       `sst-with-cloudflare: Proxy routing verified ` +
         `(${verification.healthyTargetCount}/${verification.desiredCount} healthy, ` +
         `listener → ${verification.targetGroupArn})`,
@@ -549,7 +564,7 @@ if (exitCode === 0 && !terminationSignal && sstArgs[0] === 'deploy') {
         )
       },
     })
-    console.log(
+    reportProgress(
       `sst-with-cloudflare: public deployment verified ` +
         `(Proxy ${publicVerification.proxyHealthUrl}, wildcard ${publicVerification.proxyWildcardHealthUrl}, ` +
         `API ${publicVerification.apiConfigUrl}, ` +


### PR DESCRIPTION
## Summary

The deploy wrapper printed its own progress to stdout, which it shares with the sst child it spawns
`stdio: 'inherit'`. The preview step pipes that stream into a JSON parser, so the progress line landed
ahead of the plan and failed the parse on its first character. All seven progress sites now write to
stderr.

## Call graph

Before

```
Preview the selected components   (deploy-infra.yml · .github/workflows/deploy-infra.yml:498)  — pipes sst's stdout into the validator
  └─ loadStageConfig              (sst wrapper · apps/infra/deployment/sst.ts:261)             — hydrates the stage config
     └─ console.log               (sst wrapper · apps/infra/deployment/sst.ts:342)             ← BUG: progress goes to stdout, the same stream sst writes its plan to
  └─ runSstCommand                (sst wrapper · apps/infra/deployment/sst.ts:387)
     └─ spawn(sst, --json)        (sst wrapper · apps/infra/deployment/sst.ts:394)             — stdio: 'inherit', so the plan joins the progress line already there
  └─ validateDeploymentPreview    (preview · apps/infra/deployment/preview.ts:33)              — JSON.parse trips on 'sst-with-c…'
```

After

```
Preview the selected components   (deploy-infra.yml · .github/workflows/deploy-infra.yml:498)  — unchanged
  └─ loadStageConfig              (sst wrapper · apps/infra/deployment/sst.ts:276)             — hydrates the stage config
     └─ reportProgress            (sst wrapper · apps/infra/deployment/sst.ts:208)             — console.error, so progress leaves stdout untouched
  └─ runSstCommand                (sst wrapper · apps/infra/deployment/sst.ts:402)
     └─ spawn(sst, --json)        (sst wrapper · apps/infra/deployment/sst.ts:409)             — stdio: 'inherit', and the plan is now alone on stdout
  └─ validateDeploymentPreview    (preview · apps/infra/deployment/preview.ts:33)              — parses the plan
```

Fixes #1261

## Changes

- `reportProgress` routes the wrapper's own messages to stderr. Named rather than calling
  `console.error` at each site: these are not errors, and the reason they avoid stdout is not local to
  any one of them.
- All seven `console.log` sites moved, not only the one that fired. They share the shape — the
  artifact-preflight lines run before sst on exactly the `diff --json` path, and the post-deploy
  verification lines write to the same stream.
- A regression test drives the real wrapper against a fake sst that writes a plan to stdout, then
  parses the wrapper's entire stdout the way the preview step does. A substring search would pass with
  a progress line sitting in front of the plan; whole-stream `JSON.parse` cannot. It also asserts the
  messages still appear on stderr, so the wrapper cannot satisfy it by going silent.

## How to verify

- `make test:apps:infra` — 392 tests, 392 pass, 0 fail.
- To see it catch the bug: change the seven `reportProgress` calls in `apps/infra/deployment/sst.ts`
  back to `console.log` and run
  `cd apps/infra && npx tsx --test deployment/pulumi-logs.test.ts`. It fails with
  `SyntaxError: Unexpected token 's', "sst-with-c"... is not valid JSON` — the same error CI reported.

## Risks / rollout

- The five deploy-path messages move streams. Nothing parses or greps them: the only machine-read
  stdout pipeline in the repo is the one this fixes, and no test asserts on them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed JSON output for infrastructure plan commands by keeping progress messages separate from standard output.
  * Ensured configuration, artifact, and deployment status messages no longer corrupt machine-readable results.

* **Tests**
  * Added regression coverage confirming plans remain valid JSON while progress information is sent to the error output stream.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->