### PR TITLE
test(infra): type-check infra scripts before running their suite

### DIFF
--- a/apps/infra/README.md
+++ b/apps/infra/README.md
@@ -19,8 +19,8 @@ npm command -> domain CLI -> deployment facade -> SST -> stack/deployStack()
 Use the repository make targets for validation:
 
 ```bash
-make test:apps:infra
-make test:apps:infra-config
+make test:apps:infra         # type-checks what needs no `sst install`, then runs the suite
+make test:apps:infra-config  # installs the SST platform, then type-checks the whole package
 ```
 
 Never apply a preview merely to validate configuration. All deploys require an explicit stage and

--- a/apps/infra/deployment/composite-actions.test.ts
+++ b/apps/infra/deployment/composite-actions.test.ts
@@ -373,11 +373,24 @@ test('a change under .github reaches this suite locally, not only in CI', () => 
     'the ci tag is not filtered out of FMT_COMPONENTS',
   )
 
+  const testMk = readFileSync(join(REPO_ROOT, 'make/test.mk'), 'utf8')
   assert.ok(
-    readFileSync(join(REPO_ROOT, 'make/test.mk'), 'utf8').includes(
-      'test\\:changed\\:ci:\n\t@$(MAKE) test:apps:infra',
-    ),
+    testMk.includes('test\\:changed\\:ci:\n\t@$(MAKE) test:apps:infra'),
     'the ci component tag dispatches to no test target',
+  )
+
+  // Dispatching here is only worth anything if what it reaches also type-checks. `tsx --test`
+  // strips types without checking them, so the suite alone stays green on a signature that no
+  // longer compiles — which is how a TS2559 in this very file reached CI as the only red.
+  // Order, not exact text: the echo lines around these two commands are cosmetic, and pinning
+  // them verbatim would turn a reworded message into a failure that reads like a missing gate.
+  const recipe = testMk.split('test\\:apps\\:infra: _ensure-infra-deps\n')[1]?.split('\n\n')[0]
+  assert.ok(recipe, 'make/test.mk declares no test:apps:infra recipe')
+  const typecheckAt = recipe.indexOf('npm run --silent typecheck:tooling')
+  assert.ok(typecheckAt >= 0, 'test:apps:infra never type-checks the suite it runs')
+  assert.ok(
+    typecheckAt < recipe.indexOf('npm test'),
+    'test:apps:infra runs the suite before type-checking it',
   )
 
   const hooks: any = loadYaml(readFileSync(join(REPO_ROOT, '.pre-commit-config.yaml'), 'utf8'))

--- a/apps/infra/package-lock.json
+++ b/apps/infra/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@pulumi/aws": "^7.24.0",
         "@pulumi/policy": "1.21.0",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.13.4",
         "js-yaml": "^4.1.0",
         "sst": "^4.6.11",
@@ -1461,6 +1462,13 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/keyv": {

--- a/apps/infra/package.json
+++ b/apps/infra/package.json
@@ -8,6 +8,7 @@
     "remove": "tsx deployment/sst.ts remove",
     "test": "tsx --test artifacts/*.test.ts bootstrap/*.test.ts deployment/*.test.ts policies/runner/*.test.ts runner/*.test.ts runner/model/*.test.ts shared/*.test.ts stack/*.test.ts",
     "typecheck": "tsc --noEmit",
+    "typecheck:tooling": "tsc --noEmit -p tsconfig.tooling.json",
     "sst": "tsx deployment/sst.ts",
     "secrets": "tsx deployment/secret-names.ts",
     "runner:update": "tsx runner/update.ts",

--- a/apps/infra/package.json
+++ b/apps/infra/package.json
@@ -18,9 +18,10 @@
     "runner:build-artifact": "tsx artifacts/runner-build.ts"
   },
   "devDependencies": {
-    "@types/node": "^22.13.4",
     "@pulumi/aws": "^7.24.0",
     "@pulumi/policy": "1.21.0",
+    "@types/js-yaml": "^4.0.9",
+    "@types/node": "^22.13.4",
     "js-yaml": "^4.1.0",
     "sst": "^4.6.11",
     "ts-node": "10.9.1",

--- a/apps/infra/tsconfig.tooling.json
+++ b/apps/infra/tsconfig.tooling.json
@@ -1,0 +1,30 @@
+// The subset of this package that type-checks without `sst install`.
+//
+// sst.config.ts and the stack/ modules that build resources reference ambient globals — `sst`,
+// `$app`, `$util` — declared in .sst/platform/config.d.ts, which only exists after `sst install`
+// has run. Without it tsc reports 137 errors here that say nothing about the code, so a gate that
+// ran the full project would be unusable anywhere the install has not happened.
+//
+// What makes dropping them work is the inbound direction: nothing outside that set imports them.
+// (stack/contract.test.ts asserts against them as text, via shared/live-source.ts, rather than
+// importing them.) They do import outward — into artifacts/, deployment/, runner/ — but that only
+// pulls in files this config already checks. So dropping them from the root set drops them from
+// the program, instead of tsc pulling them back in through an import.
+//
+// Listing what to check rather than what to skip keeps this fail-safe: a new stack/ module that
+// needs the SST globals is simply absent here, and `test:apps:infra-config` — which runs the full
+// tsconfig.json in CI after `sst install` — is what covers it.
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "artifacts/**/*.ts",
+    "bootstrap/**/*.ts",
+    "deployment/**/*.ts",
+    "policies/**/*.ts",
+    "runner/**/*.ts",
+    "shared/**/*.ts",
+    "stack/**/*.test.ts",
+    "stack/app.ts",
+    "stack/settings.ts"
+  ]
+}

--- a/make/test.mk
+++ b/make/test.mk
@@ -445,7 +445,12 @@ _ensure-infra-deps:
 		cd apps/infra && npm ci --no-audit --no-fund; \
 	fi
 
+# Type-check first: the suite runs under `tsx --test`, which strips types without checking them, so
+# a signature change that no longer compiles still leaves every test green. tsconfig.tooling.json
+# is the subset that checks without `sst install`; test:apps:infra-config below covers the rest.
 test\:apps\:infra: _ensure-infra-deps
+	@echo "🧪 Type-checking infrastructure scripts..."
+	@cd apps/infra && npm run --silent typecheck:tooling
 	@echo "🧪 Running infrastructure script tests..."
 	@cd apps/infra && npm test
 


### PR DESCRIPTION
## Summary

`tsx --test` executes TypeScript without type-checking it, so `apps/infra`'s suite stays green on
code that does not compile — a `TS2559` in `deployment/composite-actions.test.ts` reached CI that way
on #1265, 411/411 locally with the SST config job the only red. This adds the missing type-check to
the one target both local dispatch paths already converge on.

## Call graph

Before

```
test:changed             (make · make/test.mk:95)                    — fans out per changed tag
  ├─ test:changed:apps     (make · make/test.mk:130)                 — apps/ tag (make/changes.mk:22)
  │    └─ test:apps          (make · make/test.mk:457)
  │         └─ test:apps:infra  (make · make/test.mk:448)
  │              └─ npm test       (npm · apps/infra/package.json:9)  ← BUG: tsx --test strips types, never checks them
  └─ test:changed:ci       (make · make/test.mk:136)                 — .github/ tag (make/changes.mk:25-26)
       └─ test:apps:infra     (make · make/test.mk:448)
            └─ npm test          (npm · apps/infra/package.json:9)    ← BUG: same blind suite
```

After

```
test:changed             (make · make/test.mk:95)                    — unchanged
  ├─ test:changed:apps     (make · make/test.mk:130)                 — unchanged
  │    └─ test:apps          (make · make/test.mk:462)
  │         └─ test:apps:infra  (make · make/test.mk:451)
  │              ├─ npm run typecheck:tooling  (npm · apps/infra/package.json:11)  — tsc exits 2 here
  │              └─ npm test                   (npm · apps/infra/package.json:9)
  └─ test:changed:ci       (make · make/test.mk:136)                 — unchanged
       └─ test:apps:infra     (make · make/test.mk:451)              — same two steps, one gate for both paths
```

**Key:** both dispatch paths already converged on `test:apps:infra`, so the gate goes in once and
covers a change under `apps/` and under `.github/` alike.

## Changes

- `apps/infra/tsconfig.tooling.json` (new) — the subset that type-checks without `sst install`.
  `sst.config.ts` and the six `stack/` modules that build resources read SST's ambient globals from
  `.sst/platform/config.d.ts`, and account for **all 137** errors a bare `tsc --noEmit` reports here
  (`runners.ts` 37, `deploy.ts` 27, `api.ts` 25, `foundation.ts` 24, `edge.ts` 13,
  `observability.ts` 8, `sst.config.ts` 3). Nothing outside that set imports them —
  `stack/contract.test.ts` asserts against them as *text* via `shared/live-source.ts` — so dropping
  them from the root set drops them from the program rather than having tsc pull them back in;
  `--listFiles` reports a 68-file program containing none of them.
- The config lists what to check rather than what to skip, so it fails safe: a new `stack/` module
  needing the SST globals is simply absent from the local gate, and `test:apps:infra-config`
  (`make/test.mk:457`) still type-checks the whole package in CI after the install.
- `composite-actions.test.ts` — the existing "a change under .github reaches this suite locally"
  test gains its last link: that what it reaches also type-checks. Pins ordering, not verbatim text,
  so rewording the target's echo lines is not a failure.

## How to verify

```bash
make test:apps:infra          # type-check then 411/411

# the gate catches the real historical regression the suite alone missed:
git checkout 783ec4b1~1 -- apps/infra/deployment/composite-actions.test.ts
cd apps/infra && npm test                       # exit 0, 411/411 — blind
npx tsc --noEmit -p tsconfig.tooling.json       # exit 2, TS2559 at 400,54
git checkout HEAD -- deployment/composite-actions.test.ts
```

The new assertion was mutation-tested both ways, since it pins a property: removing the type-check
lines gives `test:apps:infra never type-checks the suite it runs`; swapping the order gives
`test:apps:infra runs the suite before type-checking it`.

## Risks / rollout

`deploy-infra.yml:401` and `deploy-release.yml:105` run `npm test` in `apps/infra` directly, so those
two deploy-time steps stay type-blind. Left alone deliberately: the scope here is the local gate, and
anything reaching those steps has already cleared `lint.yml:306`'s `make test:apps:infra` plus
`test:apps:infra-config`. The residual is unchanged, not worsened.

---

https://claude.ai/code/session_01JmHHH8kVQSovag3vGqNRJr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved infrastructure validation by checking tooling scripts for TypeScript issues before tests run.
  * Expanded CI validation to cover relevant infrastructure configuration changes and enforce the correct check order.

* **Documentation**
  * Clarified which infrastructure validation commands require SST installation and which can run independently.
  * Added clearer guidance for validating infrastructure tooling and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->