### PR TITLE
fix(infra): enable allocation snapshots with usage export

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -93,6 +93,9 @@ BILLING_API_URL=
 #   USAGE_EXPORT_TIMEOUT_MS below the window a claimed batch stays hidden for —
 #     at or above it, rows can be re-claimed while their request is in flight
 USAGE_EXPORT_ENABLED=false
+# Sends the current full set of open allocations every five minutes. It uses
+# USAGE_EXPORT_URL and USAGE_EXPORT_TOKEN and can be enabled independently.
+USAGE_ALLOCATION_SNAPSHOT_ENABLED=false
 USAGE_EXPORT_URL=
 USAGE_EXPORT_TOKEN=
 USAGE_EXPORT_BATCH_SIZE=200

--- a/apps/api/src/usage/open-allocation.spec.ts
+++ b/apps/api/src/usage/open-allocation.spec.ts
@@ -50,6 +50,7 @@ describe('toOpenAllocationDto', () => {
     ['a negative quantity', { disk: -1 }],
     ['a blank organizationId', { organizationId: '  ' }],
     ['a blank boxId', { boxId: '' }],
+    ['a region longer than Commerce accepts', { region: 'r'.repeat(201) }],
     ['an invalid startAt', { startAt: new Date('nonsense') }],
     ['a quantity past the encodable ceiling', { mem: 1e16 }],
     ['a quantity that rounds away to zero', { cpu: 1e-13 }],

--- a/apps/api/src/usage/usage-event.spec.ts
+++ b/apps/api/src/usage/usage-event.spec.ts
@@ -145,6 +145,7 @@ describe('usage period validation', () => {
     ['a negative quantity', { disk: -1 }],
     ['a blank organizationId', { organizationId: '  ' }],
     ['a blank boxId', { boxId: '' }],
+    ['a boxId longer than Commerce accepts', { boxId: 'b'.repeat(201) }],
     ['an invalid startAt', { startAt: new Date('nonsense') }],
     ['an end before the start', { endAt: new Date('2026-07-01T00:00:00.000Z') }],
     ['a quantity past the encodable ceiling', { mem: 1e16 }],
@@ -157,6 +158,10 @@ describe('usage period validation', () => {
 
   it('accepts a quantity at the ceiling', () => {
     expect(() => usageEventKey(period({ mem: 1e15 }))).not.toThrow()
+  })
+
+  it('accepts an identity at the Commerce boundary', () => {
+    expect(() => usageEventKey(period({ region: 'r'.repeat(200) }))).not.toThrow()
   })
 
   it('accepts the smallest quantity the encoding can still carry', () => {

--- a/apps/api/src/usage/usage-event.ts
+++ b/apps/api/src/usage/usage-event.ts
@@ -19,6 +19,9 @@ export const USAGE_EXPORT_SCHEMA_VERSION = 1
  */
 const MAX_QUANTITY = 1e15
 
+/** Matches Commerce's identity ceiling for usage events and snapshots. */
+const MAX_IDENTITY_LENGTH = 200
+
 /** Digits kept when encoding a quantity. Trailing zeros are stripped. */
 const QUANTITY_DECIMALS = 12
 
@@ -134,8 +137,8 @@ export function timestampString(value: Date, field: string): string {
 }
 
 export function identityString(value: string, field: string): string {
-  if (typeof value !== 'string' || !value.trim()) {
-    throw new InvalidUsagePeriodError(`${field} must be a non-empty string`)
+  if (typeof value !== 'string' || !value.trim() || value.length > MAX_IDENTITY_LENGTH) {
+    throw new InvalidUsagePeriodError(`${field} must be a non-empty string of at most ${MAX_IDENTITY_LENGTH} characters`)
   }
   return value
 }

--- a/apps/infra/.env.example
+++ b/apps/infra/.env.example
@@ -261,6 +261,8 @@ OIDC_AUDIENCE=https://dev.example.com/api
 #   USAGE_INGEST_TOKEN — for boxlite-commerce, the value its own stack keeps in
 #   Secrets Manager under boxlite-commerce/<stage>/usage-ingest-token. Use the
 #   non-echoing stdin procedure in README.md; never put the value in process argv.
+#   A non-blank token enables both finalized usage export and the five-minute
+#   full allocation snapshot used for available-credit estimates.
 
 # 4k. Observability backend — ClickHouse (trace/metric/log storage). All [optional];
 # unset = the OtelCollector targets a disabled endpoint and the API's observability

--- a/apps/infra/stack/api.ts
+++ b/apps/infra/stack/api.ts
@@ -346,6 +346,11 @@ const api = new sst.aws.Service('Api', {
       // shared secret would crash-loop on deploy instead of simply not
       // exporting yet. Setting the secret is what turns delivery on.
       USAGE_EXPORT_ENABLED: usageExportToken.value.apply((token: string) => (token.trim() ? 'true' : 'false')),
+      // The same destination and credential carry the five-minute full
+      // snapshot used by Commerce to estimate still-open usage.
+      USAGE_ALLOCATION_SNAPSHOT_ENABLED: usageExportToken.value.apply((token: string) =>
+        (token.trim() ? 'true' : 'false'),
+      ),
     }),
   },
 })

--- a/apps/infra/stack/contract.test.ts
+++ b/apps/infra/stack/contract.test.ts
@@ -531,6 +531,10 @@ test('usage is exported to the ingest origin, never to the dashboard billing URL
     liveConfig,
     /USAGE_EXPORT_ENABLED: usageExportToken\.value\.apply\(\(token(?:: string)?\) => \(token\.trim\(\) \? 'true' : 'false'\)\)/,
   )
+  assert.match(
+    liveConfig,
+    /USAGE_ALLOCATION_SNAPSHOT_ENABLED: usageExportToken\.value\.apply\(\(token(?:: string)?\) =>\s*\(token\.trim\(\) \? 'true' : 'false'\),?\s*\)/,
+  )
   assert.match(liveConfig, /const usageExportToken = new sst\.Secret\('USAGE_EXPORT_TOKEN', ''\)/)
 
   // Nothing here can discover the receiving half — it belongs to the billing service's own stack —


### PR DESCRIPTION
## Summary

- Enable five-minute open-allocation snapshot delivery whenever the Commerce usage-export token is configured.
- Keep finalized usage and allocation snapshots on the same Commerce destination and credential.
- Align BoxLite usage/snapshot identity validation with Commerce's 200-character boundary.
- Document the environment switches and extend focused API and SST configuration-contract coverage.

## Why

Finalized usage alone cannot represent resources that are still running. The companion Commerce read model needs full open-allocation snapshots to subtract estimated, unsettled usage from available credit. Validating identities at the producer boundary also prevents Commerce from rejecting oversized payloads.

Companion Commerce PR: https://github.com/boxlite-ai/boxlite-commerce/pull/15

## Before

```text
SST USAGE_EXPORT_TOKEN
  -> USAGE_EXPORT_ENABLED
  -> UsageExporter
  -> POST Commerce /internal/usage-events

AllocationSnapshotExporter
  -> USAGE_ALLOCATION_SNAPSHOT_ENABLED unset
  -> disabled

usage/snapshot identity
  -> non-empty validation only
  -> values over 200 characters can reach and be rejected by Commerce
```

## After

```text
SST USAGE_EXPORT_TOKEN
  -> USAGE_EXPORT_ENABLED
  -> USAGE_ALLOCATION_SNAPSHOT_ENABLED

Box finalization
  -> usage outbox
  -> UsageExporter
  -> POST Commerce /internal/usage-events

Active boxes every five minutes
  -> full open-allocation snapshot
  -> AllocationSnapshotExporter
  -> POST Commerce /internal/allocation-snapshot

usage/snapshot identity
  -> identityString (non-empty and <= 200 characters)
  -> Commerce-compatible payload
```

## Validation

- Focused usage-event boundary tests cover the 200-character identity limit and over-limit rejection.
- Open-allocation tests assert snapshot delivery is enabled by configuration.
- SST configuration-contract tests assert snapshots and finalized usage share the token-controlled rollout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic five-minute allocation snapshots when usage export credentials are configured.
  * Documented the required configuration for finalized usage exports and allocation snapshots.

* **Bug Fixes**
  * Improved usage event validation by enforcing a 200-character maximum for identity fields.

* **Tests**
  * Added coverage for identifier length boundaries and allocation snapshot configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->