### PR TITLE
fix(api): give the image build a node-gyp toolchain

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -3,7 +3,13 @@
 FROM node:24-slim AS base
 ENV CI=true
 
-RUN apt-get update && apt-get install -y --no-install-recommends bash curl && \
+# python3/make/g++ are node-gyp's toolchain. Native dependencies (sqlite3, ssh2) normally unpack
+# a prebuilt binary and never invoke gyp, so this is dead weight on a good day — but the fallback
+# `prebuild-install ... || node-gyp rebuild` runs whenever that download fails, and without a
+# toolchain the fallback cannot succeed, so one lost download fails the whole `yarn install`
+# rather than degrading into a slower build. The shipped image starts from its own node:24-slim
+# below and copies only node_modules, so none of this reaches it.
+RUN apt-get update && apt-get install -y --no-install-recommends bash curl python3 make g++ && \
   rm -rf /var/lib/apt/lists/*
 RUN npm install -g corepack && corepack enable
 


### PR DESCRIPTION
## Summary

A `dev` deploy died at `Build commit Api image` when sqlite3's prebuilt binary download hit
`ECONNRESET`. Its install script is `prebuild-install -r napi || node-gyp rebuild`, and
`node:24-slim` carries no `python3`, `make` or `g++` — so the fallback could not run and one lost
download failed the whole `yarn install --immutable`. This gives the base stage that toolchain.

Nothing regressed: the lockfile and the base-image digest (`sha256:3638d9a6…`) were identical to the
previous successful build. The `||` had simply never been reached before, so the missing toolchain
was never exercised.

## Call graph

Before

```
docker build --file apps/api/Dockerfile   (.github/workflows/build-apps-api-image.yml:248)
  base                                    (apps/api/Dockerfile:3)   — node:24-slim; apt: bash, curl only
   ├─ deps                                (apps/api/Dockerfile:12)
   │    yarn install --immutable          (Dockerfile:14 · sqlite3 @ apps/yarn.lock:36010)  ← BUG: its
   │                                        install script is `prebuild-install -r napi || node-gyp
   │                                        rebuild`, and base has no python3/make/g++, so the fallback
   │                                        cannot run — one failed download fails the whole build
   ├─ runtime-deps                        (Dockerfile:16 · same install, apps/yarn.lock:36010)  ← BUG: same gap
   └─ build                               (apps/api/Dockerfile:21)
  boxlite                                 (apps/api/Dockerfile:38)  — FROM node:24-slim; the shipped stage
```

After

```
docker build --file apps/api/Dockerfile   (.github/workflows/build-apps-api-image.yml:248)
  base                                    (apps/api/Dockerfile:3)   — apt now adds python3, make, g++ (:12)
   ├─ deps                                (apps/api/Dockerfile:18)
   │    yarn install --immutable          (apps/api/Dockerfile:20)  — the fallback can now compile from
   │                                        source, so a failed download costs time, not the build
   ├─ runtime-deps                        (apps/api/Dockerfile:22)  — same
   └─ build                               (apps/api/Dockerfile:27)
  boxlite                                 (apps/api/Dockerfile:44)  — unchanged; still FROM node:24-slim
                                            with bash, curl only (:48)
```

**Key:** the shipped stage does not derive from `base`, so the toolchain never reaches the runtime
image — it only makes the build's own fallback path viable.

Fixes #1268

## Changes

- `apps/api/Dockerfile:12` — add `python3 make g++` to the base stage's apt install.

## How to verify

```bash
docker build -f apps/api/Dockerfile --target deps .          # the stage that failed in CI
docker run --rm <image> sh -c 'python3 -V; make -v | head -1; g++ --version | head -1'
```

The fallback itself, on the real base image:

```bash
# without the toolchain — reproduces CI's failure
docker run --rm node:24-slim sh -c \
  'apt-get update >/dev/null && apt-get install -y -q curl >/dev/null && \
   npm i --build-from-source sqlite3@5.1.7'     # gyp ERR! find Python — "python3" is not in PATH
```

## Risks / rollout

**This fix is not exercised by CI.** A green build proves the image still builds with the packages
present; it cannot run `node-gyp rebuild`, because that path executes only when the prebuilt download
fails. What is checkable statically, without waiting for another failed download:

- `sqlite3@5.1.7` install script is `prebuild-install -r napi || node-gyp rebuild`
- `node-gyp` is its optional dependency (`8.x`), resolved at `apps/yarn.lock:29682` → 8.4.1 and
  materialized under `apps/node_modules/sqlite3/node_modules/node-gyp`, so its bin is on PATH
- that node-gyp's `lib/find-python.js:52` accepts `>=3.6.0` and probes `python3`; bookworm ships 3.11
- plain `node:24-slim` has none of `python3`, `make`, `g++`, `cc` — the gap being closed
- plain `node:24-slim` does have `libstdc++.so.6` and `libgcc_s.so.1`, so a from-source binary built
  in `runtime-deps` loads in the shipped stage — the fallback yields a working image, not a build
  success followed by a runtime failure

Image size is unchanged for the shipped artifact; only the discarded builder stages grow.

`apps/proxy`, `apps/runner` and `apps/otel-collector` install the same lockfile on `node:22-alpine`
and share the fragility, unevenly: `apps/proxy:11` and `apps/otel-collector:11` are
`apk add --no-cache git` with no toolchain at all, while `apps/runner:11` already has `build-base`
and needs only `python3`. None has failed, none is verified here, and each needs its own apk change —
so they are left for a follow-up rather than shipped unverified alongside this.

---

https://claude.ai/code/session_01JmHHH8kVQSovag3vGqNRJr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the API container environment to support building native dependencies when prebuilt packages are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->