### PR TITLE
fix(api): detect MinIO via its STS endpoint

### DIFF
--- a/apps/api/src/object-storage/services/object-storage.service.spec.ts
+++ b/apps/api/src/object-storage/services/object-storage.service.spec.ts
@@ -118,4 +118,16 @@ describe('ObjectStorageService', () => {
     await expect(service.getPushAccess('org-1')).rejects.toThrow(/S3_ACCESS_KEY and S3_SECRET_KEY/)
     expect(AssumeRoleCommand).not.toHaveBeenCalled()
   })
+
+  it('recognizes MinIO from its STS path when the data endpoint is loopback', async () => {
+    const service = buildService({
+      ...awsConfig,
+      's3.endpoint': 'http://127.0.0.1:9000',
+      's3.stsEndpoint': 'http://127.0.0.1:9000/minio/v1/assume-role',
+    })
+
+    await expect(service.getPushAccess('org-1')).rejects.toThrow(/S3_ACCESS_KEY and S3_SECRET_KEY/)
+    expect(STSClient).not.toHaveBeenCalled()
+    expect(AssumeRoleCommand).not.toHaveBeenCalled()
+  })
 })

--- a/apps/api/src/object-storage/services/object-storage.service.ts
+++ b/apps/api/src/object-storage/services/object-storage.service.ts
@@ -76,7 +76,11 @@ export class ObjectStorageService {
         },
       }
 
-      const isMinioServer = s3Config.endpoint.includes('minio')
+      // A host process commonly reaches a local MinIO through 127.0.0.1, so
+      // the S3 endpoint hostname itself need not contain "minio". MinIO's STS
+      // route is the stable discriminator in that setup.
+      const isMinioServer =
+        s3Config.endpoint.includes('minio') || new URL(s3Config.stsEndpoint).pathname.startsWith('/minio/')
 
       if (isMinioServer) {
         return this.getMinioCredentials(s3Config)


### PR DESCRIPTION
## Summary

Detect MinIO from its well-known STS path when the S3 data endpoint uses an IP address or custom hostname. Preserve the existing hostname check and add regression coverage that keeps these deployments out of the AWS STS path.

## Call graph

Before

```text
getPushAccess         (ObjectStorageService · apps/api/src/object-storage/services/object-storage.service.ts:37) — assembles the object-storage configuration
  └─ isMinioServer    (provider classifier · object-storage.service.ts:79)                                      ← BUG: checks only whether the data endpoint contains "minio"
     └─ getAwsCredentials (ObjectStorageService · object-storage.service.ts:145)                               — handles an IP/custom-hostname MinIO endpoint as AWS
```

After

```text
getPushAccess         (ObjectStorageService · apps/api/src/object-storage/services/object-storage.service.ts:37) — assembles the object-storage configuration
  └─ isMinioServer    (provider classifier · object-storage.service.ts:82)                                      — also recognizes the well-known `/minio/` STS path
     └─ getMinioCredentials (ObjectStorageService · object-storage.service.ts:96)                              — signs and sends the MinIO assume-role request
```

Fixes #1273

## Changes

- Recognize MinIO when `S3_STS_ENDPOINT` has a `/minio/` path, even if `S3_ENDPOINT` is loopback, an IP address, or a custom hostname.
- Retain the existing endpoint-name detection for current deployments.
- Cover a loopback MinIO endpoint and assert that neither the AWS STS client nor `AssumeRoleCommand` is used.

## How to verify

- `cd apps && corepack yarn nx test api --runInBand --testPathPatterns=object-storage.service.spec.ts` — 5 tests passed.

## Risks / rollout

- Standard AWS STS endpoints do not use a `/minio/` path and retain their existing behavior.
- A non-MinIO S3-compatible service that deliberately exposes an STS endpoint under `/minio/` would now use the MinIO request flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of local MinIO storage endpoints when using MinIO’s STS assume-role path.
  * Prevented unauthorized access attempts when static credentials are unavailable.
  * Added regression coverage for this configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->