### PR TITLE
feat(volumes): implement named-volume backend for LocalRuntime

### DIFF
--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -4,6 +4,7 @@
 //! to/from core types (BoxInfo, BoxOptions, etc.) at the boundary.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 use boxlite_shared::errors::BoxliteError;
 use serde::{Deserialize, Serialize};
@@ -393,6 +394,10 @@ pub(crate) struct VolumeResponse {
     pub created_at: String,
     #[serde(default)]
     pub size_bytes: Option<u64>,
+    /// Host directory backing this volume — lets a client resolve a volume id
+    /// to a mount source (e.g. for volume mounts at box creation).
+    #[serde(default)]
+    pub host_path: Option<String>,
 }
 
 impl VolumeResponse {
@@ -405,6 +410,11 @@ impl VolumeResponse {
             id: self.id.clone(),
             created_at,
             size_bytes: self.size_bytes,
+            host_path: self
+                .host_path
+                .as_deref()
+                .map(PathBuf::from)
+                .unwrap_or_default(),
         }
     }
 }

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -1822,32 +1822,45 @@ impl super::images::ImageBackend for LocalRuntime {
     }
 }
 
-// Named-volume operations (separate from RuntimeBackend). The concrete backend
-// is not yet implemented: the local filesystem store was removed in favor of a
-// future managed volume backend, so every operation returns `Unsupported`.
+// Named-volume operations (separate from RuntimeBackend). Each volume is
+// stored in a directory under `{home}/volumes/{id}` by `NamedVolumeStore`.
 #[async_trait::async_trait]
 impl super::volumes::VolumeBackend for LocalRuntime {
     async fn create_volume(&self) -> BoxliteResult<crate::volumes::VolumeInfo> {
-        Err(volumes_unsupported())
+        if self.0.shutdown_token.is_cancelled() {
+            return Err(BoxliteError::Stopped(
+                "Cannot create volume: runtime has been shut down".into(),
+            ));
+        }
+        crate::volumes::NamedVolumeStore::new(self.0.layout.home_dir()).create()
     }
 
     async fn list_volumes(&self) -> BoxliteResult<Vec<crate::volumes::VolumeInfo>> {
-        Err(volumes_unsupported())
+        if self.0.shutdown_token.is_cancelled() {
+            return Err(BoxliteError::Stopped(
+                "Cannot list volumes: runtime has been shut down".into(),
+            ));
+        }
+        crate::volumes::NamedVolumeStore::new(self.0.layout.home_dir()).list()
     }
 
     async fn get_volume(&self, _id: &str) -> BoxliteResult<crate::volumes::VolumeInfo> {
-        Err(volumes_unsupported())
+        if self.0.shutdown_token.is_cancelled() {
+            return Err(BoxliteError::Stopped(
+                "Cannot get volume: runtime has been shut down".into(),
+            ));
+        }
+        crate::volumes::NamedVolumeStore::new(self.0.layout.home_dir()).get(_id)
     }
 
     async fn remove_volume(&self, _id: &str, _force: bool) -> BoxliteResult<()> {
-        Err(volumes_unsupported())
+        if self.0.shutdown_token.is_cancelled() {
+            return Err(BoxliteError::Stopped(
+                "Cannot remove volume: runtime has been shut down".into(),
+            ));
+        }
+        crate::volumes::NamedVolumeStore::new(self.0.layout.home_dir()).remove(_id, _force)
     }
-}
-
-/// Error returned by every named-volume operation until a volume backend is
-/// wired up.
-fn volumes_unsupported() -> BoxliteError {
-    BoxliteError::Unsupported("named volumes are not supported yet".to_string())
 }
 
 // ============================================================================

--- a/src/boxlite/src/volumes/mod.rs
+++ b/src/boxlite/src/volumes/mod.rs
@@ -15,4 +15,4 @@ pub use container_volume::{ContainerMount, ContainerVolumeManager};
 pub use guest_volume::GuestVolumeManager;
 pub use share::{VolumeShare, classify_volume_share};
 pub use staging::stage_single_file;
-pub use store::VolumeInfo;
+pub use store::{NamedVolumeStore, VolumeInfo};

--- a/src/boxlite/src/volumes/store.rs
+++ b/src/boxlite/src/volumes/store.rs
@@ -1,14 +1,22 @@
-//! Named-volume metadata type.
+//! Named-volume store and metadata type.
 //!
 //! [`VolumeInfo`] is the storage-agnostic view of a volume returned by the
 //! [`VolumeBackend`](crate::runtime::volumes::VolumeBackend) trait and rendered
-//! by the CLI. Volumes are addressed by a server-assigned id (like boxes). The
-//! concrete backend that would populate it is not yet implemented — see
-//! `impl VolumeBackend for LocalRuntime`, which currently returns `Unsupported`
-//! until a managed volume backend is wired up.
+//! by the CLI. Volumes are addressed by a server-assigned id (like boxes).
+//! [`NamedVolumeStore`] is the concrete local backend wired into
+//! `impl VolumeBackend for LocalRuntime`: each volume lives in a directory
+//! under `{home}/volumes/{id}`.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+
+const ANONYMOUS_VOLUMES_DIR: &str = "anonymous";
 
 /// Public metadata about a volume.
 ///
@@ -19,9 +27,244 @@ pub struct VolumeInfo {
     /// Server-assigned volume id — the addressing key for get/remove.
     pub id: String,
 
+    pub host_path: PathBuf,
+
     /// When the volume was created.
     pub created_at: DateTime<Utc>,
 
     /// Size of the payload in bytes, if it could be computed.
     pub size_bytes: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NamedVolumeStore {
+    volumes_dir: PathBuf,
+}
+
+impl NamedVolumeStore {
+    /// Create a store rooted at '{home_dir}/volumes'.
+    pub fn new(home_dir: &Path) -> Self {
+        Self {
+            volumes_dir: home_dir.join("volumes"),
+        }
+    }
+
+    /// Create a new volume and return its metadata (including the assigned id).
+    pub fn create(&self) -> BoxliteResult<VolumeInfo> {
+        let id = crate::runtime::id::BoxIDMint::mint().to_string();
+        let dir = self.volumes_dir.join(&id);
+        fs::create_dir_all(&dir).map_err(|e| {
+            BoxliteError::Storage(format!(
+                "failed to create volume dir {}: {}",
+                dir.display(),
+                e
+            ))
+        })?;
+        Ok(VolumeInfo {
+            id,
+            host_path: dir,
+            created_at: Utc::now(),
+            size_bytes: None,
+        })
+    }
+
+    /// List all named volume.
+    pub fn list(&self) -> BoxliteResult<Vec<VolumeInfo>> {
+        let entries = match fs::read_dir(&self.volumes_dir) {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => {
+                return Err(BoxliteError::Storage(format!(
+                    "failed to read volume dir {}: {}",
+                    self.volumes_dir.display(),
+                    e
+                )));
+            }
+        };
+
+        let mut infos = Vec::new();
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if name == ANONYMOUS_VOLUMES_DIR {
+                continue;
+            }
+            infos.push(self.volume_info(name, &path));
+        }
+        Ok(infos)
+    }
+
+    /// Get metadata for a single volume by id.
+    ///
+    /// Returns `BoxliteError::NotFound` when no such volume exists.
+    pub fn get(&self, id: &str) -> BoxliteResult<VolumeInfo> {
+        let dir = self.volume_dir(id)?;
+        if !dir.is_dir() {
+            return Err(BoxliteError::NotFound(format!("volume not found: {id}")));
+        }
+        Ok(self.volume_info(id.to_string(), &dir))
+    }
+
+    /// Remove a volume by id. With `force`, a missing volume is a no-op.
+    pub fn remove(&self, id: &str, force: bool) -> BoxliteResult<()> {
+        let dir = self.volume_dir(id)?;
+        if !dir.exists() {
+            if force {
+                return Ok(());
+            }
+            return Err(BoxliteError::NotFound(format!("volume not found: {id}")));
+        }
+        if !dir.is_dir() {
+            return Err(BoxliteError::InvalidArgument(format!(
+                "volume path is not a directory: {}",
+                dir.display(),
+            )));
+        }
+        fs::remove_dir_all(&dir).map_err(|e| {
+            BoxliteError::Storage(format!(
+                "failed to remove directory {}: {}",
+                dir.display(),
+                e,
+            ))
+        })
+    }
+
+    /// Resolve `{volumes_dir}/{id}` with a path-traversal guard:
+    /// the id must be a single directory name, never a path.
+    ///
+    /// The reserved `anonymous/` subtree (the CLI's anonymous volumes) is also rejected — this store must never touch it, neither to list nor to delete.
+    pub fn volume_dir(&self, id: &str) -> BoxliteResult<PathBuf> {
+        if id.is_empty()
+            || id == "."
+            || id == ".."
+            || id.contains('/')
+            || id.contains('\\')
+            || id == ANONYMOUS_VOLUMES_DIR
+        {
+            return Err(BoxliteError::InvalidArgument(format!(
+                "invalid volume id: {id:?}"
+            )));
+        }
+        Ok(self.volumes_dir.join(id))
+    }
+
+    pub fn volume_info(&self, id: String, dir: &Path) -> VolumeInfo {
+        let created_at = fs::metadata(dir)
+            .and_then(|m| m.modified())
+            .ok()
+            .map(DateTime::<Utc>::from)
+            .unwrap_or_else(Utc::now);
+        VolumeInfo {
+            id,
+            host_path: dir.to_path_buf(),
+            created_at,
+            size_bytes: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_then_get_roundtrips() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = NamedVolumeStore::new(tmp.path());
+        let created = store.create().unwrap();
+
+        assert!(created.host_path.is_dir());
+        assert_eq!(
+            created.host_path,
+            tmp.path().join("volumes").join(&created.id)
+        );
+
+        let got = store.get(&created.id).unwrap();
+        assert_eq!(got.id, created.id);
+        assert_eq!(got.host_path, created.host_path);
+    }
+
+    #[test]
+    fn list_lists_only_named_volumes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = NamedVolumeStore::new(tmp.path());
+        let volume1 = store.create().unwrap();
+        let volume2 = store.create().unwrap();
+
+        let anon = tmp.path().join("volumes").join("anonymous").join("ulid-x");
+        fs::create_dir_all(&anon).unwrap();
+
+        let ids: Vec<String> = store.list().unwrap().into_iter().map(|v| v.id).collect();
+
+        assert!(ids.contains(&volume1.id));
+        assert!(ids.contains(&volume2.id));
+        assert_eq!(2, ids.len(), "anonymous volume must be excluded: {ids:?}");
+    }
+
+    #[test]
+    fn remove_deletes_and_force_tolerates_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = NamedVolumeStore::new(tmp.path());
+        let created = store.create().unwrap();
+
+        store.remove(&created.id, false).unwrap();
+        assert!(!created.host_path.exists());
+        assert!(!tmp.path().join("volumes").join(&created.id).exists());
+
+        let err = store.remove(&created.id, false).unwrap_err();
+        assert!(matches!(err, BoxliteError::NotFound(_)));
+
+        store.remove(&created.id, true).unwrap();
+    }
+
+    #[test]
+    fn get_missing_volume_is_not_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = NamedVolumeStore::new(tmp.path());
+        let err = store.get("foo").unwrap_err();
+
+        assert!(matches!(err, BoxliteError::NotFound(_)));
+    }
+
+    #[test]
+    fn traversal_ids_are_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = NamedVolumeStore::new(tmp.path());
+        for bad in ["..", ".", "a/b", "a\\b", "../escape"] {
+            assert!(
+                store.get(bad).is_err(),
+                "id {bad:?} must be rejected by get"
+            );
+            assert!(
+                store.remove(bad, true).is_err(),
+                "id {bad:?} must be rejected by remove"
+            );
+        }
+    }
+
+    #[test]
+    fn reserved_anonymous_id_is_protected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = NamedVolumeStore::new(tmp.path());
+        // A real CLI anonymous volume living under volumes/anonymous/.
+        let anon = tmp.path().join("volumes").join("anonymous").join("ulid-x");
+        fs::create_dir_all(&anon).unwrap();
+
+        assert!(
+            store.get("anonymous").is_err(),
+            "get must reject the reserved anonymous id"
+        );
+        assert!(
+            store.remove("anonymous", true).is_err(),
+            "remove must reject the reserved anonymous id"
+        );
+        assert!(
+            anon.is_dir(),
+            "anonymous volumes must survive a remove attempt"
+        );
+    }
 }

--- a/src/cli/src/commands/serve/handlers/boxes.rs
+++ b/src/cli/src/commands/serve/handlers/boxes.rs
@@ -7,6 +7,8 @@ use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 
+use crate::commands::serve::resolve_volume_mounts;
+
 use super::super::types::{CreateBoxRequest, ListBoxesResponse, RemoveQuery};
 use super::super::{
     AppState, box_info_to_response, build_box_options, error_from_boxlite, error_response,
@@ -18,7 +20,11 @@ pub(in crate::commands::serve) async fn create_box(
     Json(req): Json<CreateBoxRequest>,
 ) -> Response {
     let name = req.name.clone();
-    let options = match build_box_options(&req) {
+    let volumes = match resolve_volume_mounts(&state.runtime, &req.volumes).await {
+        Ok(volumes) => volumes,
+        Err(e) => return error_from_boxlite(&e),
+    };
+    let mut options = match build_box_options(&req) {
         Ok(options) => options,
         Err(e) => {
             return error_response(
@@ -29,6 +35,10 @@ pub(in crate::commands::serve) async fn create_box(
             );
         }
     };
+    // `BoxOptions.volumes` is a pub field: inject the resolved mounts here.
+    // Volume resolution is async (`resolve_volume_mounts` awaits
+    // `VolumeHandle::get`), so it cannot run inside the sync `build_box_options`.
+    options.volumes = volumes;
 
     let litebox = match state.runtime.create(options, name).await {
         Ok(b) => b,

--- a/src/cli/src/commands/serve/handlers/volumes.rs
+++ b/src/cli/src/commands/serve/handlers/volumes.rs
@@ -1,8 +1,7 @@
 //! Named-volume handlers (`/v1/volumes`).
 //!
-//! These mirror the box handlers, delegating to `runtime.volumes()`. The
-//! concrete backend returns `Unsupported` for now, so every operation currently
-//! responds `400 UnsupportedError`.
+//! These mirror the box handlers, delegating to `runtime.volumes()`, whose
+//! local backend stores each volume in a directory under `{home}/volumes/`.
 
 use std::sync::Arc;
 

--- a/src/cli/src/commands/serve/mod.rs
+++ b/src/cli/src/commands/serve/mod.rs
@@ -30,6 +30,7 @@ use boxlite::{
 };
 
 use crate::cli::GlobalFlags;
+use crate::commands::serve::types::CreateVolumeMount;
 use crate::defaults::{LOCAL_SERVE_HOST, LOCAL_SERVE_PORT};
 
 use self::types::{BoxResponse, CreateBoxRequest, ErrorBody, ErrorDetail, ExecRequest};
@@ -725,6 +726,39 @@ fn volume_info_to_response(info: &boxlite::runtime::types::VolumeInfo) -> types:
     }
 }
 
+/// A volume mount's `guest_path` must name an absolute path inside the guest.
+///
+/// Rejecting a non-absolute path here (rather than downstream) keeps a
+/// malformed mount from reaching the runtime, and makes the rule unit-testable
+/// without constructing a runtime.
+fn validate_guest_path(guest_path: &str) -> Result<(), boxlite::BoxliteError> {
+    if guest_path.trim().is_empty() || !guest_path.starts_with('/') {
+        return Err(boxlite::BoxliteError::InvalidArgument(format!(
+            "volume guest_path must be an absolute path, got {:?}",
+            guest_path
+        )));
+    }
+    Ok(())
+}
+
+async fn resolve_volume_mounts(
+    runtime: &BoxliteRuntime,
+    mounts: &[CreateVolumeMount],
+) -> Result<Vec<boxlite::runtime::options::VolumeSpec>, boxlite::BoxliteError> {
+    let volume_handle = runtime.volumes()?;
+    let mut specs = Vec::with_capacity(mounts.len());
+    for m in mounts {
+        validate_guest_path(&m.guest_path)?;
+        let info = volume_handle.get(&m.volume_id).await?;
+        specs.push(boxlite::runtime::options::VolumeSpec {
+            host_path: info.host_path.to_string_lossy().into_owned(),
+            guest_path: m.guest_path.clone(),
+            read_only: m.read_only,
+        });
+    }
+    Ok(specs)
+}
+
 fn build_box_options(req: &CreateBoxRequest) -> Result<BoxOptions, boxlite::BoxliteError> {
     let rootfs = if let Some(ref path) = req.rootfs_path {
         RootfsSpec::RootfsPath(path.clone())
@@ -766,6 +800,10 @@ fn build_box_options(req: &CreateBoxRequest) -> Result<BoxOptions, boxlite::Boxl
         cmd: req.cmd.clone(),
         user: req.user.clone(),
         tty: req.tty.unwrap_or(false),
+        // Empty here; the caller (`create_box`) injects the resolved mounts
+        // through the pub `volumes` field. Volume resolution is async, so it
+        // cannot run inside this sync builder.
+        volumes: Vec::new(),
         advanced: boxlite::AdvancedBoxOptions {
             capabilities: boxlite::ContainerCapabilities {
                 add: req.advanced.capabilities.add.clone(),
@@ -1430,6 +1468,114 @@ mod tests {
             msg.contains("unknown field") && msg.contains("security_settings"),
             "expected deny-unknown-fields rejection mentioning `security_settings`; got {msg}"
         );
+    }
+
+    // ============================================================
+    // REST named-volume wire contract: `volume_id` only, never `host_path`.
+    //
+    // Mirrors the `security` boundary above: `CreateVolumeMount` carries
+    // `#[serde(deny_unknown_fields)]`, so a client cannot smuggle a
+    // `host_path` (arbitrary host directory) into a mount request. The
+    // server resolves the backing directory from the volume id itself.
+    // ============================================================
+
+    #[test]
+    fn create_volume_mount_rejects_client_supplied_host_path() {
+        let json = r#"{"volume_id":"v1","guest_path":"/data","host_path":"/etc"}"#;
+        let msg = match serde_json::from_str::<super::types::CreateVolumeMount>(json) {
+            Ok(_) => panic!("`host_path` must be rejected at deserialize"),
+            Err(e) => e.to_string(),
+        };
+        assert!(
+            msg.contains("unknown field") && msg.contains("host_path"),
+            "expected deny-unknown-fields rejection mentioning `host_path`; got {msg}"
+        );
+    }
+
+    #[test]
+    fn create_box_request_accepts_volume_mounts() {
+        let json = r#"{"image":"alpine:latest","volumes":[{"volume_id":"v1","guest_path":"/data","read_only":false}]}"#;
+        let req: super::types::CreateBoxRequest =
+            serde_json::from_str(json).expect("volume mounts must deserialize");
+        assert_eq!(req.volumes.len(), 1);
+        assert_eq!(req.volumes[0].volume_id, "v1");
+        assert_eq!(req.volumes[0].guest_path, "/data");
+        assert!(!req.volumes[0].read_only);
+    }
+
+    #[test]
+    fn validate_guest_path_rejects_non_absolute() {
+        for bad in ["", "   ", "relative/path", "data"] {
+            let err = validate_guest_path(bad).expect_err("non-absolute guest_path must fail");
+            assert!(
+                matches!(err, boxlite::BoxliteError::InvalidArgument(_)),
+                "expected InvalidArgument for {bad:?}, got {err}"
+            );
+        }
+        assert!(validate_guest_path("/data").is_ok());
+        assert!(validate_guest_path("/").is_ok());
+    }
+
+    #[tokio::test]
+    async fn resolve_volume_mounts_maps_volume_id_to_host_path() {
+        let home = tempfile::tempdir().expect("runtime home");
+        let runtime = BoxliteRuntime::new(boxlite::BoxliteOptions {
+            home_dir: home.path().join("boxlite"),
+            ..Default::default()
+        })
+        .expect("local runtime");
+
+        let volume = runtime
+            .volumes()
+            .expect("volumes handle")
+            .create()
+            .await
+            .expect("create volume");
+        let mounts = [CreateVolumeMount {
+            volume_id: volume.id.clone(),
+            guest_path: "/data".to_string(),
+            read_only: true,
+        }];
+
+        let specs = resolve_volume_mounts(&runtime, &mounts)
+            .await
+            .expect("resolve mounts");
+
+        assert_eq!(specs.len(), 1);
+        assert_eq!(
+            specs[0].host_path,
+            volume.host_path.to_string_lossy().into_owned()
+        );
+        assert_eq!(specs[0].guest_path, "/data");
+        assert!(specs[0].read_only);
+
+        runtime.shutdown(Some(1)).await.expect("shutdown runtime");
+    }
+
+    #[tokio::test]
+    async fn resolve_volume_mounts_rejects_missing_volume() {
+        let home = tempfile::tempdir().expect("runtime home");
+        let runtime = BoxliteRuntime::new(boxlite::BoxliteOptions {
+            home_dir: home.path().join("boxlite"),
+            ..Default::default()
+        })
+        .expect("local runtime");
+
+        let mounts = [CreateVolumeMount {
+            volume_id: "no-such-volume".to_string(),
+            guest_path: "/data".to_string(),
+            read_only: false,
+        }];
+
+        let err = resolve_volume_mounts(&runtime, &mounts)
+            .await
+            .expect_err("missing volume must fail");
+        assert!(
+            matches!(err, boxlite::BoxliteError::NotFound(_)),
+            "expected NotFound, got {err}"
+        );
+
+        runtime.shutdown(Some(1)).await.expect("shutdown runtime");
     }
 
     fn uploaded_v3_archive(box_options: serde_json::Value) -> Vec<u8> {

--- a/src/cli/src/commands/serve/types.rs
+++ b/src/cli/src/commands/serve/types.rs
@@ -43,6 +43,8 @@ pub(super) struct CreateBoxRequest {
     #[serde(default)]
     pub advanced: CreateBoxAdvancedOptions,
     #[serde(default)]
+    pub volumes: Vec<CreateVolumeMount>,
+    #[serde(default)]
     pub network: Option<NetworkSpec>,
     #[serde(default)]
     pub auto_stop: Option<u32>,
@@ -113,6 +115,15 @@ pub(super) struct ListBoxesResponse {
 // ============================================================================
 // Named volume types (`/v1/volumes`)
 // ============================================================================
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct CreateVolumeMount {
+    pub volume_id: String,
+    pub guest_path: String,
+    #[serde(default)]
+    pub read_only: bool,
+}
 
 #[derive(Serialize)]
 pub(super) struct VolumeResponse {


### PR DESCRIPTION
## Summary
Implement `LocalRuntime`'s named-volume backend with `NamedVolumeStore`, persisting each volume under `{home}/volumes/{id}`, and expose the backing `host_path` on the REST `VolumeResponse`.

## Call graph
<!-- Required. The end-to-end path this PR touches, before and after; one line
     per hop, only the hops that change. Worked example and the bug-fix markers:
     CONTRIBUTING.md#commit--pr-messages. -->
Before
  create_volume / list_volumes / get_volume / remove_volume
    (VolumeBackend · src/boxlite/src/runtime/rt_impl.rs:1828)
      └─ volumes_unsupported() — every operation → `Unsupported`

After
  create_volume / list_volumes / get_volume / remove_volume
    (VolumeBackend · src/boxlite/src/runtime/rt_impl.rs:1828)
      └─ NamedVolumeStore::{create,list,get,remove} (store.rs:53/72/104/113)
           └─ volume_dir() (store.rs:140)
  VolumeResponse (rest/types.rs:394) — `host_path` lets a client resolve a volume id → mount source

## Changes
- `src/boxlite/src/volumes/store.rs`: add `NamedVolumeStore` (create/list/get/remove) that stores each named volume as a directory under `{home}/volumes/{id}`; `volume_dir()` rejects path-traversal ids and the reserved `anonymous/` subtree; `VolumeInfo` gains a `host_path` field.
- `src/boxlite/src/runtime/rt_impl.rs`: wire `VolumeBackend for LocalRuntime` to the store — each operation checks the shutdown token, then delegates to `NamedVolumeStore`; delete the dead `volumes_unsupported()` helper.
- `src/boxlite/src/volumes/mod.rs`: export `NamedVolumeStore`.
- `src/boxlite/src/rest/types.rs`: add `host_path` to `VolumeResponse` and populate it in `to_volume_info`, so a client can resolve a volume id to a host mount source.

## How to verify
- `cargo nextest run -p boxlite volumes` — 15 volume tests pass (create/get round-trip, list excludes `anonymous/`, remove + force, not-found, traversal rejection).
- Serve smoke: `boxlite serve`, then
  - `curl -X POST http://localhost:8100/v1/volumes` → 201, response carries a `host_path` under `{home}/volumes/{id}`
  - `curl http://localhost:8100/v1/volumes` → lists the created volume
  - `curl -X DELETE http://localhost:8100/v1/volumes/{id}` → 204, the volume directory is removed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating, listing, retrieving, and removing local named volumes.
  * Added named-volume mounts when creating boxes, including read-only mounts and guest-path validation.
  * Volume responses now include the local host path.
  * Added safeguards for invalid volume identifiers, path traversal, and protected anonymous volumes.
* **Bug Fixes**
  * Volume mount resolution errors are now reported during box creation instead of being silently unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->