### PR TITLE
fix(api): resolve box migration import target before the transaction

### DIFF
--- a/apps/api/src/box/managers/box-migration.manager.pool.integration.spec.ts
+++ b/apps/api/src/box/managers/box-migration.manager.pool.integration.spec.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { randomUUID } from 'node:crypto'
+import { DataSource, Repository } from 'typeorm'
+import { CustomNamingStrategy } from '../../common/utils/naming-strategy.util'
+import { Box } from '../entities/box.entity'
+import { BoxLastActivity } from '../entities/box-last-activity.entity'
+import { BoxMigration } from '../entities/box-migration.entity'
+import { Job } from '../entities/job.entity'
+import { BoxDesiredState } from '../enums/box-desired-state.enum'
+import { BoxMigrationState } from '../enums/box-migration-state.enum'
+import { BoxState } from '../enums/box-state.enum'
+import { JobType } from '../enums/job-type.enum'
+import { BoxMigrationManager } from './box-migration.manager'
+
+const describeIfDatabase = process.env.DB_HOST ? describe : describe.skip
+const schemaName = `box_migrate_pool_${process.pid}_${randomUUID().replaceAll('-', '')}`
+const drainingRunnerId = '00000000-0000-4000-8000-00000000000a'
+const targetRunnerId = '00000000-0000-4000-8000-00000000000b'
+const organizationId = '00000000-0000-4000-8000-0000000000ff'
+const SUBMIT_BUDGET_MS = 10_000
+
+/**
+ * The import leg of a migration used to resolve its target runner *inside* the
+ * transaction that already holds a pool connection, so submitting needed two
+ * connections at once. With one connection in the pool that is unsatisfiable by
+ * construction — the same shape that deadlocked the production pool once ten
+ * imports were pending at the same time (pool max defaults to 10).
+ *
+ * A single connection is the whole point of this suite: it turns "needs a second
+ * connection" from a load-dependent race into a deterministic hang.
+ */
+describeIfDatabase('BoxMigrationManager import submission (integration, single-connection pool)', () => {
+  let dataSource: DataSource
+  let boxes: Repository<Box>
+  let migrations: Repository<BoxMigration>
+  let jobs: Repository<Job>
+  let ownsSchema = false
+
+  beforeAll(async () => {
+    dataSource = await new DataSource({
+      type: 'postgres',
+      host: process.env.DB_HOST,
+      port: Number(process.env.DB_PORT || 5432),
+      username: process.env.DB_USERNAME,
+      password: process.env.DB_PASSWORD,
+      database: process.env.DB_DATABASE,
+      schema: schemaName,
+      entities: [Box, BoxLastActivity, BoxMigration, Job],
+      namingStrategy: new CustomNamingStrategy(),
+      entitySkipConstructor: true,
+      synchronize: false,
+      // max: 1 is the reproducer. connectionTimeoutMillis mirrors production's
+      // default (0 = wait forever) so the failure is the real one — a hang —
+      // rather than an acquire error this test invented.
+      extra: {
+        max: 1,
+        connectionTimeoutMillis: 0,
+        options: `-c search_path=${schemaName},public`,
+      },
+    }).initialize()
+
+    await dataSource.query(`CREATE SCHEMA "${schemaName}"`)
+    ownsSchema = true
+    await dataSource.synchronize()
+    boxes = dataSource.getRepository(Box)
+    migrations = dataSource.getRepository(BoxMigration)
+    jobs = dataSource.getRepository(Job)
+  })
+
+  afterAll(async () => {
+    if (!dataSource?.isInitialized) {
+      return
+    }
+    try {
+      if (ownsSchema) {
+        await dataSource.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`)
+      }
+    } finally {
+      await dataSource.destroy()
+    }
+  })
+
+  beforeEach(async () => {
+    await dataSource.query(`DELETE FROM "${schemaName}"."job"`)
+    await dataSource.query(`DELETE FROM "${schemaName}"."box_migration"`)
+    await dataSource.query(`DELETE FROM "${schemaName}"."box_last_activity"`)
+    await dataSource.query(`DELETE FROM "${schemaName}"."box"`)
+  })
+
+  /** A parked box with a migration already waiting to be imported. */
+  async function pendingImport(): Promise<Box> {
+    const box = new Box('us', 'pool-import')
+    box.organizationId = organizationId
+    box.osUser = 'boxlite'
+    box.runnerId = drainingRunnerId
+    box.state = BoxState.STOPPED
+    box.desiredState = BoxDesiredState.STOPPED
+    box.pending = false
+    await boxes.insert(box)
+
+    const stored = await boxes.findOneByOrFail({ id: box.id })
+    const migration = new BoxMigration()
+    migration.boxId = stored.id
+    migration.state = BoxMigrationState.PENDING_IMPORT
+    migration.arcPath = `box-migrations/${stored.id}.boxlite`
+    // The marker's invariant: the migration carries a copy of the box's stamp,
+    // which is what ValidCheck compares against.
+    migration.updatedAt = stored.updatedAt
+    await migrations.insert(migration)
+    return stored
+  }
+
+  /**
+   * The manager with real Postgres and stubs that keep the connection behaviour
+   * honest: the scheduler stub queries through the same DataSource (as
+   * `RunnerService.getRandomAvailableRunner` does), and the job stub writes
+   * through the entity manager it is handed (as `JobService.createJob` does).
+   */
+  function makeManager(): BoxMigrationManager {
+    const runnerService = {
+      getRandomAvailableRunner: async () => {
+        await dataSource.getRepository(Box).count()
+        return { id: targetRunnerId }
+      },
+    } as any
+    const jobService = {
+      createJob: async (manager: any, type: JobType, runnerId: string, resourceType: any, resourceId: string) => {
+        const job = new Job({ type, runnerId, resourceType, resourceId })
+        await manager.getRepository(Job).insert(job)
+        return job
+      },
+    } as any
+    const redisLockProvider = {
+      lock: async () => true,
+      unlock: async () => undefined,
+    } as any
+    const configService = { getOrThrow: () => 'box-migrations/' } as any
+
+    return new BoxMigrationManager(dataSource, runnerService, jobService, redisLockProvider, configService)
+  }
+
+  it(
+    'submits IMPORT_BOX with only one pool connection available',
+    async () => {
+      const box = await pendingImport()
+      const manager = makeManager()
+
+      let stallTimer: NodeJS.Timeout | undefined
+      const outcome = await Promise.race([
+        manager.submitMigrationJobs().then(() => 'completed' as const),
+        new Promise<'stalled'>((resolve) => {
+          stallTimer = setTimeout(() => resolve('stalled'), SUBMIT_BUDGET_MS)
+        }),
+      ]).finally(() => clearTimeout(stallTimer))
+
+      expect(outcome).toBe('completed')
+      const job = await jobs.findOneByOrFail({ resourceId: box.id })
+      expect(job.type).toBe(JobType.IMPORT_BOX)
+      expect(job.runnerId).toBe(targetRunnerId)
+    },
+    SUBMIT_BUDGET_MS + 10_000,
+  )
+})

--- a/apps/api/src/box/managers/box-migration.manager.spec.ts
+++ b/apps/api/src/box/managers/box-migration.manager.spec.ts
@@ -92,13 +92,29 @@ function makeHarness(
     createQueryBuilder,
   }
   const find = jest.fn().mockResolvedValue(migrations)
+  // Whether a transaction is open right now, and what each target resolution
+  // saw: a resolver that queries from inside the transaction needs a second
+  // pool connection while the first is still held, which deadlocks the pool
+  // under fan-out.
+  let inTransaction = false
+  const resolverSawTransaction: boolean[] = []
   const dataSource = {
     getRepository: jest.fn().mockReturnValue({ find }),
-    transaction: jest.fn().mockImplementation((run: any) => run(entityManager)),
+    transaction: jest.fn().mockImplementation(async (run: any) => {
+      inTransaction = true
+      try {
+        return await run(entityManager)
+      } finally {
+        inTransaction = false
+      }
+    }),
     manager: entityManager,
   } as any
   const runnerService = {
-    getRandomAvailableRunner: jest.fn().mockResolvedValue({ id: TARGET_RUNNER }),
+    getRandomAvailableRunner: jest.fn().mockImplementation(async () => {
+      resolverSawTransaction.push(inTransaction)
+      return { id: TARGET_RUNNER }
+    }),
   } as any
   const jobService = {
     createJob: jest.fn().mockResolvedValue(undefined),
@@ -119,6 +135,7 @@ function makeHarness(
     jobService,
     redisLockProvider,
     writes,
+    resolverSawTransaction,
   }
 }
 
@@ -209,6 +226,40 @@ describe('BoxMigrationManager submitter loop', () => {
       boxClass: migration.box.class,
       excludedRunnerIds: [SOURCE_RUNNER],
     })
+    expect(h.jobService.createJob).toHaveBeenCalledWith(
+      h.entityManager,
+      JobType.IMPORT_BOX,
+      TARGET_RUNNER,
+      ResourceType.BACKUP,
+      BOX_ID,
+      { arcPath: 'box-migrations/box-1.boxlite' },
+    )
+  })
+
+  /**
+   * The import resolver asks the scheduler for a target runner, which is a
+   * query. Issued from inside `submitValidated`'s transaction it needs a
+   * *second* pool connection while the transaction still holds the first, and
+   * the submit loop fans out over every pending migration at once — so at
+   * pool-size concurrency (10 by default, `DB_POOL_MAX` unset) every connection
+   * ends up held by a transaction waiting for one only its peers could release.
+   *
+   * Observed on the local stack: 10 sessions `idle in transaction`, every
+   * IMPORT_BOX submission dying with `QueryRunnerAlreadyReleasedError` on the
+   * job insert, `GET /v1/{prefix}/boxes` timing out at 60s while
+   * `/api/health` answered in 1ms, and the drained runner never emptying.
+   */
+  it('resolves the import target before opening the transaction', async () => {
+    const migration = makeMigration(BoxMigrationState.PENDING_IMPORT, {
+      arcPath: 'box-migrations/box-1.boxlite',
+    })
+    const h = makeHarness([migration])
+
+    await h.manager.submitMigrationJobs()
+
+    expect(h.runnerService.getRandomAvailableRunner).toHaveBeenCalledTimes(1)
+    expect(h.resolverSawTransaction).toEqual([false])
+    // Still submitted, and still inside the transaction that holds the locks.
     expect(h.jobService.createJob).toHaveBeenCalledWith(
       h.entityManager,
       JobType.IMPORT_BOX,

--- a/apps/api/src/box/managers/box-migration.manager.ts
+++ b/apps/api/src/box/managers/box-migration.manager.ts
@@ -286,6 +286,20 @@ export class BoxMigrationManager implements TrackableJobExecutions, OnApplicatio
 
     let submitted = false
     try {
+      // Resolved BEFORE the transaction opens, never inside it. The import's
+      // resolver asks the scheduler for a target runner, which is a query: from
+      // inside the transaction it would need a *second* pool connection while
+      // this submission already holds the first, and the submit loop runs every
+      // pending migration concurrently — so at pool-size concurrency every
+      // connection ends up held by a transaction waiting for one only its peers
+      // could release. That deadlock starved the API's whole pool.
+      //
+      // `migration.box` is the row `findMigrations` already loaded, so this
+      // costs no extra query, and resolving from a copy that may have gone
+      // stale is safe: the locked re-read below runs ValidCheck against the
+      // same stamp and turns the migration around instead of submitting.
+      const target = await resolveTarget(migration.box, migration)
+
       submitted = await this.dataSource.transaction(async (entityManager) => {
         const box = await entityManager.findOne(Box, {
           where: { id: migration.boxId },
@@ -308,7 +322,6 @@ export class BoxMigrationManager implements TrackableJobExecutions, OnApplicatio
           return false
         }
 
-        const target = await resolveTarget(box, current)
         await this.jobService.createJob(
           entityManager,
           jobType,


### PR DESCRIPTION
## Summary

The import leg of a box migration asked the scheduler for a target runner from
*inside* `submitValidated`'s transaction. That query needs a second pool
connection while the transaction still holds the first, and the submit loop fans
out over every pending migration at once — so at pool-size concurrency (10 by
default) every connection ends up held by a transaction waiting for one only its
peers could release, starving the API's whole pool. This resolves the target
before the transaction opens and adds the coverage that pins the shape.

## Call graph

```text
Before
  submitMigrationJobs           (BoxMigrationManager · apps/api/src/box/managers/box-migration.manager.ts:101)  — fans out over every pending migration at once
    └─ submitImport             (BoxMigrationManager · box-migration.manager.ts:241)
         └─ submitValidated     (BoxMigrationManager · box-migration.manager.ts:277)
              └─ transaction    (DataSource · box-migration.manager.ts:289)                        — holds pool connection #1
                   ├─ resolveTarget → getRandomAvailableRunner
                   │                  (RunnerService · apps/api/src/box/services/runner.service.ts:755)
                   │                  ← BUG: queries from inside the transaction, so it needs a *second*
                   │                    connection while the first is still held; at pool-size concurrency
                   │                    every connection waits on one only its peers could release
                   └─ createJob  (JobService · apps/api/src/box/services/job.service.ts:42)         — never reached

After
  submitMigrationJobs           (BoxMigrationManager · box-migration.manager.ts:101)
    └─ submitImport             (BoxMigrationManager · box-migration.manager.ts:241)
         └─ submitValidated     (BoxMigrationManager · box-migration.manager.ts:277)
              ├─ resolveTarget → getRandomAvailableRunner
              │                  (RunnerService · runner.service.ts:755)                            — resolved from the box row
              │                    `findMigrations` already loaded, before any transaction opens
              └─ transaction    (DataSource · box-migration.manager.ts:303)                         — one connection: locked
                   │              re-read + ValidCheck, then submit
                   └─ createJob  (JobService · job.service.ts:42)
```

Resolving from a possibly-stale copy is safe: the locked re-read inside the
transaction still runs ValidCheck against the same `box.updatedAt` stamp, so a
box touched in between turns the migration around instead of submitting.

No issue tracks this defect. Adjacent to the migration hardening in #1226,
but not one of its items.

## Changes

- `submitValidated` resolves the job target before opening its transaction;
  submission and the locked ValidCheck stay inside it.
- Unit spec asserts the resolver never runs with a transaction open, and that
  the job is still created with the transaction's `EntityManager`.
- New single-connection-pool integration spec (`max: 1`,
  `connectionTimeoutMillis: 0`): turns "needs a second connection" from a
  load-dependent race into a deterministic hang.
- New drain lifecycle integration spec: drives the marker, both submitter loops,
  the job receiver and runner selection against a real Postgres and Redis
  through to `COMPLETED`, with the runner played by reporting its jobs done.
  Covers waiting rather than importing onto another draining runner, the
  turn-around when the box is started during either data-moving leg, and one
  migration per box however often the loops tick.
- CI comment in `test.yml` updated for the new specs' service dependencies; the
  Postgres and Redis services were already there.

## How to verify

```bash
# unit — no services needed
cd apps && yarn nx test api --testPathPattern box-migration.manager.spec

# integration — self-skip unless both are set
cd apps && DB_HOST=localhost DB_PORT=5432 DB_USERNAME=postgres DB_PASSWORD=postgres \
  DB_DATABASE=boxlite REDIS_HOST=localhost \
  yarn nx test api --testPathPattern 'box-migration.*integration'
```

Reverting the `box-migration.manager.ts` hunk makes the pool spec hang until its
10s submit budget expires, and the unit spec report a resolver that ran inside
the transaction.

## Risks / rollout

- Behavior change is confined to *when* the target is resolved. Nothing here
  fires until a runner is flagged `draining`.
- Both integration specs create and drop their own throwaway schema and skip
  entirely when `DB_HOST` / `REDIS_HOST` are unset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved box migration job submission by resolving migration targets before opening a database transaction.
  * Reduced the time database connections remain occupied during import processing.
  * Added coverage to verify reliable job creation with limited database connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->