### PR TITLE
update billing tab

### DIFF
--- a/apps/dashboard/src/billing-api/types/tier.ts
+++ b/apps/dashboard/src/billing-api/types/tier.ts
@@ -9,6 +9,22 @@ export type Tier = {
   tierLimit: TierLimit
   minTopUpAmountCents: number
   topUpIntervalDays: number
+  /**
+   * The plan riding this rung, when one does. The billing service composes
+   * these onto the catalog from its own constant, so a rung without a plan
+   * simply omits them rather than carrying zeros.
+   *
+   * `concurrencyLimit` is the plan's ceiling on simultaneously running boxes.
+   * It is DISPLAY ONLY: nothing enforces it yet, so a count at or above it
+   * means the customer has reached what they bought, not that the next box
+   * was refused. `null` is a negotiated deal with no stated ceiling.
+   */
+  planId?: string
+  planName?: string
+  priceMonthlyCents?: number | null
+  includedQuotaCents?: number | null
+  concurrencyLimit?: number | null
+  selfServe?: boolean
 }
 
 export type TierLimit = {

--- a/apps/dashboard/src/components/billing/ThisCycleCard.tsx
+++ b/apps/dashboard/src/components/billing/ThisCycleCard.tsx
@@ -7,6 +7,9 @@ import { OrganizationPlan } from '@/billing-api'
 import { Metric, Panel, PanelNote, SectionTitle, SegmentedBar } from '@/components/ascii'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useOwnerTierQuery, useOwnerWalletQuery } from '@/hooks/queries/billingQueries'
+import { useRunningBoxCountQuery } from '@/hooks/queries/useRunningBoxCountQuery'
+import { useTiersQuery } from '@/hooks/queries/useTiersQuery'
+import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { formatAmount } from '@/lib/utils'
 import { differenceInCalendarDays, format } from 'date-fns'
 
@@ -42,7 +45,19 @@ export function cycleFacts(plan: OrganizationPlan, now: Date) {
 export function ThisCycleCard() {
   const { data: tier, isLoading } = useOwnerTierQuery()
   const { data: wallet } = useOwnerWalletQuery()
+  const { data: tiers } = useTiersQuery()
+  const { selectedOrganization } = useSelectedOrganization()
   const plan = tier?.plan
+
+  // The ceiling is the catalog's, matched to the plan the organization is on
+  // rather than to its tier rung: the two ladders are independent axes, and a
+  // negotiated deal sits on no public rung at all. `null` on the rung means a
+  // deal with no stated ceiling, which is not a ceiling of zero.
+  const concurrencyLimit = tiers?.find((rung) => rung.planId === plan?.planId)?.concurrencyLimit ?? null
+  const { data: runningBoxes } = useRunningBoxCountQuery({
+    organizationId: selectedOrganization?.id,
+    enabled: Boolean(plan && concurrencyLimit != null),
+  })
 
   if (isLoading) {
     return (
@@ -84,6 +99,22 @@ export function ThisCycleCard() {
               <SegmentedBar used={plan.quotaConsumedCents} limit={plan.includedQuotaCents ?? 0} />
             </div>
             <PanelNote>Included in plan · resets each cycle · unused quota does not carry over</PanelNote>
+          </div>
+        )}
+
+        {concurrencyLimit != null && runningBoxes != null && (
+          <div className="border-t border-border px-[22px] py-4">
+            <div className="flex items-center gap-4 font-mono text-[12px]">
+              <span className="w-[100px] shrink-0 uppercase tracking-[0.5px] text-muted-foreground">Concurrent</span>
+              <span className="w-[140px] shrink-0 tabular-nums text-foreground">
+                {runningBoxes} / {concurrencyLimit}
+              </span>
+              <SegmentedBar used={runningBoxes} limit={concurrencyLimit} />
+            </div>
+            <PanelNote>
+              Boxes running now, against the plan&apos;s ceiling · not yet enforced, so this reports what is used rather
+              than what is refused
+            </PanelNote>
           </div>
         )}
 

--- a/apps/dashboard/src/hooks/queries/queryKeys.ts
+++ b/apps/dashboard/src/hooks/queries/queryKeys.ts
@@ -80,6 +80,7 @@ export const queryKeys = {
     all: ['boxes'] as const,
     detail: (organizationId: string, boxId: string) =>
       [...queryKeys.boxes.all, organizationId, boxId, 'detail'] as const,
+    runningCount: (organizationId: string) => [...queryKeys.boxes.all, organizationId, 'running-count'] as const,
     terminalSession: (boxId: string) => [...queryKeys.boxes.all, boxId, 'terminal-session'] as const,
   },
   telemetry: {

--- a/apps/dashboard/src/hooks/queries/useRunningBoxCountQuery.ts
+++ b/apps/dashboard/src/hooks/queries/useRunningBoxCountQuery.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { ListBoxesPaginatedStatesEnum } from '@boxlite-ai/api-client'
+import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { useApi } from '../useApi'
+import { queryKeys } from './queryKeys'
+
+/**
+ * How many boxes are running right now — the count a concurrency ceiling is
+ * spent against.
+ *
+ * `started` alone, because that is the state the box table itself labels
+ * "Running": a box that is `starting` has not taken its slot yet and one that
+ * is `stopping` is giving it back, so counting either would report a ceiling
+ * reached that the customer has not reached.
+ *
+ * Read from the LIST endpoint's own `total` with `limit: 1`, so the answer
+ * costs one row rather than a page of boxes nobody renders. It is a
+ * point-in-time number and nothing more: there is no concurrency series
+ * anywhere in the platform, so this can say what is running now and can never
+ * say what was running an hour ago.
+ */
+export const useRunningBoxCountQuery = ({
+  organizationId,
+  enabled = true,
+  ...queryOptions
+}: {
+  organizationId: string | undefined
+  enabled?: boolean
+} & Omit<UseQueryOptions<number>, 'queryKey' | 'queryFn'>) => {
+  const { boxApi } = useApi()
+
+  return useQuery<number>({
+    queryKey: queryKeys.boxes.runningCount(organizationId ?? ''),
+    queryFn: async () => {
+      const response = await boxApi.listBoxesPaginated(
+        organizationId,
+        1,
+        1,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        [ListBoxesPaginatedStatesEnum.STARTED],
+      )
+      return response.data.total
+    },
+    enabled: Boolean(enabled && organizationId),
+    refetchOnWindowFocus: true,
+    ...queryOptions,
+  })
+}


### PR DESCRIPTION
## Summary
<!-- 1-2 sentences: what this changes and why. -->

## Call graph
<!-- Required. The end-to-end path this PR touches, before and after; one line
     per hop, only the hops that change. Worked example and the bug-fix markers:
     CONTRIBUTING.md#commit--pr-messages. -->

Before
<!-- replace with the hops: fn_name (Type · path/file.rs:LOC) — role -->

After
<!-- replace with the same hops, post-change -->

Fixes #<!-- issue number — bug fixes only; delete this line otherwise -->

## Changes
- <!-- notable change — what changed, not a restatement of the diff -->

## How to verify
- <!-- a command or step a reviewer can run -->

## Risks / rollout
- <!-- only if any; delete this section otherwise -->

<!-- Describe the change, not the process: no pasted logs, no AI/conversation
     narrative, no secrets. Keep it tight and delete sections that don't apply. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a concurrency usage meter to billing cycle details when a plan limit is available.
  * Displayed the current running-box count alongside the organization’s concurrency limit.
  * Added plan metadata, including pricing, quota, concurrency limits, and self-serve availability.
* **Bug Fixes**
  * Running-box counts now refresh when the browser window regains focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->