### PR TITLE
Add custom billing plan card

### DIFF
--- a/apps/dashboard/src/components/billing/PlanCards.tsx
+++ b/apps/dashboard/src/components/billing/PlanCards.tsx
@@ -23,6 +23,9 @@ import { formatWholeDollars } from '@/lib/utils'
 import { useState } from 'react'
 import { toast } from 'sonner'
 
+const CUSTOM_PLAN_CONTACT_URL =
+  'mailto:sales@boxlite.ai?subject=Custom%20Plan%20Inquiry&body=Hi%20BoxLite%20Team%2C%0A%0AI%27m%20interested%20in%20a%20custom%20plan%20and%20would%20like%20to%20learn%20more%20about%20your%20options.%0A%0AHere%27s%20some%20context%3A%0A%0A-%20Your%20use%20case%3A%20%0A-%20Current%20technology%3A%20%0A-%20Requirements%3A%20%0A-%20Typical%20box%20size%3A%20%0A-%20Peak%20concurrent%20boxes%3A%20%0A%0AThanks.'
+
 /**
  * Plan catalogue as a card grid. Every value comes from `Plan` — price,
  * included quota, and the concurrency ceiling — the catalog's own sellable
@@ -110,6 +113,44 @@ function PlanCard({
   )
 }
 
+/**
+ * The open-ended plan belongs beside the fixed catalogue, but its dashed
+ * border makes clear that its limits and price are scoped rather than preset.
+ */
+export function CustomPlanCard() {
+  return (
+    <div className="flex flex-col border border-dashed border-brand/50 bg-card px-[22px] py-5 transition-colors hover:border-brand">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <span className="font-mono text-[10px] uppercase tracking-[1.5px] text-muted-foreground">
+          <span style={{ color: BRAND }}>▸</span> Custom
+        </span>
+        <span className="border border-brand/30 px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[1px] text-brand">
+          by request
+        </span>
+      </div>
+
+      <div className="mb-4">
+        <span className="font-mono text-[26px] font-semibold leading-none tracking-tight text-foreground">Custom</span>
+        <p className="mt-2 font-mono text-[11px] leading-relaxed text-muted-foreground">
+          Tailored limits, compliance, and support.
+        </p>
+      </div>
+
+      <div className="mb-5 flex-1 divide-y divide-border/40">
+        <SpecRow label="Included quota" value="Tailored" />
+        <SpecRow label="Concurrency limit" value="Tailored" />
+      </div>
+
+      <a
+        href={CUSTOM_PLAN_CONTACT_URL}
+        className="inline-flex w-full items-center justify-center border border-brand/40 px-4 py-2 font-mono text-[12px] text-foreground transition-colors hover:border-brand hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/30"
+      >
+        Contact sales →
+      </a>
+    </div>
+  )
+}
+
 /** Loading state shaped like the grid it replaces. */
 export function PlanCardsSkeleton({ count = 3 }: { count?: number }) {
   return (
@@ -122,33 +163,6 @@ export function PlanCardsSkeleton({ count = 3 }: { count?: number }) {
           <Skeleton className="h-9 w-full" />
         </div>
       ))}
-    </div>
-  )
-}
-
-/**
- * Enterprise sits below the grid rather than in it: the catalog's own
- * non-self-serve entry is filtered out of `plans` before it ever reaches
- * here, so this stays the fixed contact-sales row it always was.
- */
-export function EnterpriseRow() {
-  return (
-    <div className="flex flex-wrap items-center justify-between gap-3 border border-border bg-card px-[22px] py-4">
-      <div className="flex flex-col gap-1">
-        <span className="font-mono text-[11px] text-muted-foreground">
-          Custom limits and compliance review. Contact sales at{' '}
-          <a href="mailto:sales@boxlite.ai" className="underline hover:text-foreground">
-            sales@boxlite.ai
-          </a>
-          .
-        </span>
-      </div>
-      <a
-        href="mailto:sales@boxlite.ai?subject=Custom%20Plan%20Inquiry&body=Hi%20BoxLite%20Team%2C%0A%0AI%27m%20interested%20in%20a%20custom%20plan%20and%20would%20like%20to%20learn%20more%20about%20your%20options.%0A%0AHere%27s%20some%20context%3A%0A%0A-%20Your%20use%20case%3A%20%0A-%20Current%20technology%3A%20%0A-%20Requirements%3A%20%0A-%20Typical%20box%20size%3A%20%0A-%20Peak%20concurrent%20boxes%3A%20%0A%0AThanks."
-        className="border border-border px-4 py-2 font-mono text-[12px] text-foreground transition-colors hover:border-brand"
-      >
-        Contact sales →
-      </a>
     </div>
   )
 }
@@ -212,6 +226,7 @@ export function PlanCards({
             pending={pending}
           />
         ))}
+        <CustomPlanCard />
       </div>
 
       <AlertDialog open={!!confirmPlan} onOpenChange={(open) => !open && setConfirmPlan(null)}>

--- a/apps/dashboard/src/components/billing/PlanSection.tsx
+++ b/apps/dashboard/src/components/billing/PlanSection.tsx
@@ -6,7 +6,7 @@
 
 import { Panel, PanelNote, SectionTitle } from '@/components/ascii'
 import { CycleOverview } from '@/components/billing/CycleOverview'
-import { EnterpriseRow, PlanCards, PlanCardsSkeleton } from '@/components/billing/PlanCards'
+import { CustomPlanCard, PlanCards, PlanCardsSkeleton } from '@/components/billing/PlanCards'
 import { Button } from '@/components/ui/button'
 import { useOwnerPlanQuery, useOwnerWalletQuery } from '@/hooks/queries/billingQueries'
 import { usePlansQuery } from '@/hooks/queries/usePlansQuery'
@@ -27,8 +27,8 @@ export function PlanSection() {
   // Sort a copy: the array belongs to the query cache, so reordering it in place would leave a
   // second consumer reading a mutated array behind a reference that never changed. This is the
   // only consumer today, and the sort is idempotent, so nothing observes it yet. Non-self-serve
-  // entries (Enterprise) are filtered out here: they have no price to switch to and the static
-  // contact-sales row below is their only UI.
+  // entries are filtered out here: they have no price to switch to. The grid adds one static
+  // Custom card as the contact-sales path instead.
   const plans = plansQuery.data
     ?.filter((plan) => plan.selfServe)
     .slice()
@@ -70,9 +70,9 @@ export function PlanSection() {
 
           {config.billingApiUrl && isOwner && selectedOrganization && (
             <section>
-              <SectionTitle title="All Plans" count={plans?.length ? `${plans.length} plans` : undefined} />
+              <SectionTitle title="All Plans" count={plans ? `${plans.length + 1} plans` : undefined} />
               {isLoading ? (
-                <PlanCardsSkeleton count={3} />
+                <PlanCardsSkeleton count={4} />
               ) : (
                 <PlanCards
                   plans={plans || []}
@@ -83,12 +83,16 @@ export function PlanSection() {
             </section>
           )}
 
-          {/* Contact-sales stays outside the owner gate: any member could reach it
-              from the old /dashboard/limits page. */}
-          <section>
-            <SectionTitle title="Enterprise" />
-            <EnterpriseRow />
-          </section>
+          {/* The old contact-sales row was available to every member. Owners see
+              Custom in the plan grid; other members keep the same contact path. */}
+          {!isOwner && (
+            <section>
+              <SectionTitle title="Custom Plan" />
+              <div className="grid grid-cols-1 gap-[14px] md:grid-cols-2 xl:grid-cols-4">
+                <CustomPlanCard />
+              </div>
+            </section>
+          )}
 
           <section>
             <SectionTitle title="Resource Ceilings" count="per-organization" />


### PR DESCRIPTION
## Summary

- replace the standalone Enterprise contact row with a Custom card in the plan catalogue
- show tailored quota and concurrency values with the existing prefilled sales inquiry
- keep the contact-sales path available to non-owner organization members
- update the plan count and loading grid for the fourth card

## Why

The negotiated plan should read as part of the available plan catalogue while remaining visually distinct from fixed, self-serve SKUs.

## Before

```text
PlanSection
├─ PlanCards → Starter / Pro / Max
└─ Enterprise section → EnterpriseRow → Contact sales
```

## After

```text
PlanSection
├─ owner → PlanCards → Starter / Pro / Max / Custom → Contact sales
└─ non-owner → Custom Plan → CustomPlanCard → Contact sales
```

## Impact

Owners see one coherent four-card plan grid. Other members retain the same sales contact path without an Enterprise-labelled UI.

## Validation

- `make test:apps`
- pre-push changed-component test matrix
- `make lint:apps` (zero errors)
- dashboard production bundle
- local mock billing page: four plans, one sales link, no Enterprise UI, zero error-level browser logs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Custom plan card to the billing plan grid.
  * Displays tailored limits, compliance, and support details, with included quota and concurrency marked as customizable.
  * Added a direct “Contact sales” option for custom plan inquiries.
  * Custom plans now appear consistently for eligible account viewers, including during loading states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->