### PR TITLE
fix(proto): stop wrapping capabilities in a process submessage

### DIFF
--- a/src/boxlite/src/litebox/init/tasks/guest_init.rs
+++ b/src/boxlite/src/litebox/init/tasks/guest_init.rs
@@ -136,7 +136,7 @@ async fn run_guest_init(
     // Step 1: Guest Init (volumes + network)
     tracing::info!("Sending guest initialization request");
     let mut guest_interface = guest_session.guest().await?;
-    if !bootstrap.container.advanced.process.capabilities.is_empty() {
+    if !bootstrap.container.advanced.capabilities.is_empty() {
         guest_interface
             .require_min_version(MIN_CAPABILITY_GUEST_VERSION)
             .await?;

--- a/src/boxlite/src/portal/interfaces/container.rs
+++ b/src/boxlite/src/portal/interfaces/container.rs
@@ -6,14 +6,14 @@ use boxlite_shared::{
     ContainerCapabilities as ProtoContainerCapabilities, ContainerClient,
     ContainerConfig as ProtoContainerConfig, ContainerDevice, ContainerInitErrorKind,
     ContainerInitRequest, DiskRootfs, LinuxOptions, MergedRootfs, MountOptions, OverlayRootfs,
-    ProcessOptions, RootfsInit, container_init_response,
+    RootfsInit, container_init_response,
 };
 use tonic::transport::Channel;
 
 use crate::images::ContainerImageConfig;
 use crate::runtime::advanced_options::{
-    ResolvedContainerSecurityConfig, ResolvedLinuxSecurity, ResolvedMountSecurity,
-    ResolvedProcessSecurity,
+    ContainerCapabilities, ResolvedContainerSecurityConfig, ResolvedLinuxSecurity,
+    ResolvedMountSecurity,
 };
 use crate::volumes::ContainerMount;
 
@@ -95,7 +95,7 @@ pub struct ContainerInitConfig {
 
 #[derive(Debug, Clone, Default)]
 pub struct ContainerAdvancedConfig {
-    pub process: ResolvedProcessSecurity,
+    pub capabilities: ContainerCapabilities,
     pub(crate) linux: ResolvedLinuxSecurity,
     pub(crate) mount: ResolvedMountSecurity,
 }
@@ -103,7 +103,7 @@ pub struct ContainerAdvancedConfig {
 impl From<ResolvedContainerSecurityConfig> for ContainerAdvancedConfig {
     fn from(value: ResolvedContainerSecurityConfig) -> Self {
         Self {
-            process: value.process,
+            capabilities: value.capabilities,
             linux: value.linux,
             mount: value.mount,
         }
@@ -148,11 +148,9 @@ impl ContainerInterface {
             // process it applies to (OCI `process.terminal`).
             tty,
             advanced: Some(ProtoContainerAdvancedOptions {
-                process: Some(ProcessOptions {
-                    capabilities: Some(ProtoContainerCapabilities {
-                        add: advanced.process.capabilities.add,
-                        drop: advanced.process.capabilities.drop,
-                    }),
+                capabilities: Some(ProtoContainerCapabilities {
+                    add: advanced.capabilities.add,
+                    drop: advanced.capabilities.drop,
                 }),
                 linux: Some(LinuxOptions {
                     readonly_paths: advanced.linux.readonly_paths,
@@ -471,11 +469,9 @@ mod tests {
                     file_mode: Some(0o666),
                 }],
                 advanced: ContainerAdvancedConfig {
-                    process: ResolvedProcessSecurity {
-                        capabilities: crate::runtime::advanced_options::ContainerCapabilities {
-                            add: vec!["ALL".into()],
-                            ..Default::default()
-                        },
+                    capabilities: crate::runtime::advanced_options::ContainerCapabilities {
+                        add: vec!["ALL".into()],
+                        ..Default::default()
                     },
                     linux: ResolvedLinuxSecurity {
                         readonly_paths: Vec::new(),
@@ -505,6 +501,13 @@ mod tests {
         let advanced = container_config.advanced.expect("advanced options");
         // Non-default resolved values, so they prove the fields are threaded
         // verbatim rather than defaulted or recomputed on the way to the wire.
+        // capabilities is flat on this message (not nested under a process
+        // submessage the way linux/mount are) — see ContainerAdvancedOptions
+        // in service.proto for why.
+        assert_eq!(
+            advanced.capabilities.expect("capabilities").add,
+            vec!["ALL".to_string()]
+        );
         assert!(
             advanced
                 .linux

--- a/src/boxlite/src/runtime/advanced_options.rs
+++ b/src/boxlite/src/runtime/advanced_options.rs
@@ -809,9 +809,7 @@ impl AdvancedBoxOptions {
         };
 
         Ok(ResolvedContainerSecurityConfig {
-            process: ResolvedProcessSecurity {
-                capabilities: normalized.capabilities,
-            },
+            capabilities: normalized.capabilities,
             linux: ResolvedLinuxSecurity { readonly_paths },
             mount: ResolvedMountSecurity {
                 options: mount_options(normalized.privileged),
@@ -858,25 +856,20 @@ fn mount_options(privileged: bool) -> Vec<String> {
 /// tolerated running without a private cgroup namespace view. The guest keeps
 /// applying its own oci-spec masked-path default unconditionally.
 ///
-/// Grouped under `process`/`linux`/`mount` the same way OCI runtime-spec
-/// groups the fields these resolve to — parallel top-level fields of one
-/// Spec — rather than flattened across a level of structure that doesn't
-/// exist in the source concept. Matches the wire shape
-/// (`ContainerAdvancedOptions`) it eventually becomes verbatim.
+/// `linux`/`mount` are grouped the same way OCI runtime-spec groups the
+/// fields they resolve to — parallel top-level fields of one Spec — rather
+/// than flattened across a level of structure that doesn't exist in the
+/// source concept. Matches the wire shape (`ContainerAdvancedOptions`) it
+/// eventually becomes verbatim. `capabilities` stays flat, not nested under
+/// a matching `process` field: it predates this grouping (added in #1047,
+/// guest version floor 0.9.8) as a plain field on the wire message, and
+/// wrapping it now would collide with what already-deployed guests expect
+/// there — see `ContainerAdvancedOptions.capabilities` in service.proto.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(crate) struct ResolvedContainerSecurityConfig {
-    pub(crate) process: ResolvedProcessSecurity,
+    pub(crate) capabilities: ContainerCapabilities,
     pub(crate) linux: ResolvedLinuxSecurity,
     pub(crate) mount: ResolvedMountSecurity,
-}
-
-// `pub`, not `pub(crate)`: `ContainerAdvancedConfig::process` (portal layer)
-// re-exposes this one publicly, matching `ContainerCapabilities`'s own
-// visibility — the same reason `ContainerAdvancedConfig::linux`/`::mount`
-// stay `pub(crate)` and so do `ResolvedLinuxSecurity`/`ResolvedMountSecurity`.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct ResolvedProcessSecurity {
-    pub capabilities: ContainerCapabilities,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -930,7 +923,7 @@ mod resolved_security_tests {
 
         assert!(resolved.linux.readonly_paths.is_empty());
         assert!(!resolved.mount.options.contains(&"rro".to_string()));
-        assert_eq!(resolved.process.capabilities.add, ["ALL"]);
+        assert_eq!(resolved.capabilities.add, ["ALL"]);
     }
 
     /// Capabilities and the OCI path/mount shape are resolved from the same

--- a/src/boxlite/src/runtime/options.rs
+++ b/src/boxlite/src/runtime/options.rs
@@ -1437,8 +1437,8 @@ mod tests {
 
         assert!(resolved.linux.readonly_paths.is_empty());
         assert!(!resolved.mount.options.contains(&"rro".to_string()));
-        assert_eq!(resolved.process.capabilities.add, ["ALL"]);
-        assert!(resolved.process.capabilities.drop.is_empty());
+        assert_eq!(resolved.capabilities.add, ["ALL"]);
+        assert!(resolved.capabilities.drop.is_empty());
     }
 
     #[test]

--- a/src/guest/src/service/container.rs
+++ b/src/guest/src/service/container.rs
@@ -202,11 +202,7 @@ impl ContainerService for GuestServer {
         };
         validate_mount_override(&mount_options.destination, &mount_override)
             .map_err(BoxliteError::into_validation_status)?;
-        let capability_policy = advanced
-            .process
-            .unwrap_or_default()
-            .capabilities
-            .unwrap_or_default();
+        let capability_policy = advanced.capabilities.unwrap_or_default();
         let capabilities = CapabilitySet::resolve(&capability_policy.add, &capability_policy.drop)
             .map_err(BoxliteError::into_validation_status)?;
         let readonly_paths = advanced.linux.unwrap_or_default().readonly_paths;

--- a/src/shared/proto/boxlite/v1/service.proto
+++ b/src/shared/proto/boxlite/v1/service.proto
@@ -383,23 +383,27 @@ message ContainerConfig {
   ContainerAdvancedOptions advanced = 6;
 }
 
-// Grouped the same way OCI runtime-spec groups them — process/linux/mounts
-// are parallel top-level fields of a Spec, so the fields that resolve to each
-// (capabilities -> process, readonly_paths -> linux, options -> one mount's
-// options) are nested under their own submessage here too, instead of
-// sitting flat as three unrelated siblings.
+// linux/mount are grouped the same way OCI runtime-spec groups them —
+// process/linux/mounts are parallel top-level fields of a Spec, so
+// readonly_paths and one mount's options are nested under their own
+// submessage here too, matching where they resolve to. capabilities is the
+// exception — see the field's own comment below for why it stays flat.
 message ContainerAdvancedOptions {
-  ProcessOptions process = 1;
+  // Flat, not nested under a ProcessOptions submessage the way linux/mount
+  // are nested below: this field predates this message (added in #1047,
+  // guest version floor 0.9.8, long since deployed) as a direct
+  // ContainerCapabilities on field 1, not wrapped. Wrapping it now would
+  // reuse field 1's tag for a different wire shape — old, already-running
+  // guests would decode the new bytes against their old field-1 layout and
+  // get garbage. linux/mount are new in this feature with no such
+  // constraint, so they get the cleaner shape capabilities can't.
+  ContainerCapabilities capabilities = 1;
   LinuxOptions linux = 2;
   MountOptions mount = 3;
 
   // No masked-path field: masked paths never varied with `privileged` in
   // practice (see docs/architecture/privileged-mode-design.md, Trade-offs) —
   // the guest keeps applying its own oci-spec default unconditionally.
-}
-
-message ProcessOptions {
-  ContainerCapabilities capabilities = 1;
 }
 
 message LinuxOptions {


### PR DESCRIPTION
Fixes a real production incident: restarting an existing, non-privileged box failed with "unknown Linux capability ''" because #646 wrapped `capabilities` in a new `ProcessOptions` submessage on the same wire field number every already-deployed 0.9.8+ guest still expects a flat `ContainerCapabilities` on.

Test plan:
- [x] make clippy
- [x] make fmt:check:rust
- [x] make test:unit:rust (1025 + 49 passed)
