### PR TITLE
fix(dashboard): restore Volumes navigation

### DIFF
--- a/apps/dashboard/src/components/Sidebar.test.tsx
+++ b/apps/dashboard/src/components/Sidebar.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+/*
+ * Modified by BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { Sidebar } from './Sidebar'
+
+vi.mock('posthog-js/react', () => ({
+  usePostHog: () => ({ capture: vi.fn(), reset: vi.fn() }),
+}))
+
+vi.mock('react-oidc-context', () => ({
+  useAuth: () => ({
+    user: { profile: { name: 'BoxLite User', email: 'user@example.com' } },
+    signoutRedirect: vi.fn(),
+  }),
+}))
+
+vi.mock('usehooks-ts', () => ({
+  useCopyToClipboard: () => [undefined, vi.fn()],
+}))
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn() } }))
+
+vi.mock('@/assets/Logo', () => ({ LogoText: () => <span>BoxLite</span> }))
+vi.mock('@/components/BoxSearchCommands', () => ({ BoxSearchCommands: () => null }))
+vi.mock('@/contexts/ThemeContext', () => ({
+  useTheme: () => ({ theme: 'dark', setTheme: vi.fn() }),
+}))
+vi.mock('@/hooks/useSelectedOrganization', () => ({
+  useSelectedOrganization: () => ({ selectedOrganization: { id: 'org-1' } }),
+}))
+vi.mock('./CommandPalette', () => ({
+  useCommandPaletteActions: () => ({ setIsOpen: vi.fn() }),
+  useRegisterCommands: () => undefined,
+}))
+
+describe('Sidebar primary navigation', () => {
+  let root: Root | null = null
+
+  beforeAll(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  })
+
+  afterEach(() => {
+    act(() => root?.unmount())
+    root = null
+    document.body.innerHTML = ''
+  })
+
+  it('keeps Volumes in primary navigation', () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+
+    act(() => {
+      root = createRoot(host)
+      root.render(
+        <MemoryRouter initialEntries={['/dashboard/boxes']}>
+          <Sidebar isBannerVisible={false} version="test" />
+        </MemoryRouter>,
+      )
+    })
+
+    const volumeLinks = Array.from(document.querySelectorAll<HTMLAnchorElement>('a')).filter(
+      (link) => link.getAttribute('href') === '/dashboard/volumes',
+    )
+
+    expect(volumeLinks.length).toBeGreaterThan(0)
+    expect(volumeLinks.every((link) => link.textContent === 'Volumes')).toBe(true)
+  })
+})

--- a/apps/dashboard/src/components/Sidebar.tsx
+++ b/apps/dashboard/src/components/Sidebar.tsx
@@ -63,6 +63,7 @@ interface NavItem {
 // may see is decided in the page, not here.
 const PRIMARY_NAV_ITEMS: NavItem[] = [
   { label: 'Boxes', path: RoutePath.BOXES },
+  { label: 'Volumes', path: RoutePath.VOLUMES },
   { label: 'Billing', path: RoutePath.BILLING },
 ]
 


### PR DESCRIPTION
## Summary

Restore the Volumes entry in the dashboard's primary navigation. The Volumes route remained registered after the navigation item was removed in #1287.

## Call graph

Before

```text
Sidebar             (React component · apps/dashboard/src/components/Sidebar.tsx:132) — builds primary navigation
  └─ PRIMARY_NAV_ITEMS (NavItem[] · apps/dashboard/src/components/Sidebar.tsx:64)     ← BUG: omits RoutePath.VOLUMES
       └─ Link       (React Router · apps/dashboard/src/components/Sidebar.tsx:244)    — no Volumes link is rendered
```

After

```text
Sidebar             (React component · apps/dashboard/src/components/Sidebar.tsx:132) — builds primary navigation
  └─ PRIMARY_NAV_ITEMS (NavItem[] · apps/dashboard/src/components/Sidebar.tsx:64)      — includes RoutePath.VOLUMES
       └─ Link       (React Router · apps/dashboard/src/components/Sidebar.tsx:244)     — renders /dashboard/volumes
```

Follow-up to #1287.

## Changes

- Add Volumes back to the desktop and mobile primary navigation data source.
- Add a Sidebar regression test that verifies the real component renders links to `/dashboard/volumes`.

## How to verify

- `cd apps && yarn vitest run dashboard/src/components/Sidebar.test.tsx --config dashboard/vite.config.mts`
- `cd apps && yarn prettier --check dashboard/src/components/Sidebar.tsx dashboard/src/components/Sidebar.test.tsx --config ../.prettierrc`
- `make lint:apps`

## Risks / rollout

- Navigation-only change; the existing Volumes route and page are unchanged.
- The broader local smart matrix is currently blocked by existing API failures: PostgreSQL/Redis are unavailable on `127.0.0.1:25432`, and `apps/api/src/box/services/job.service.ts:471` reports TS2554.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Volumes” option to the dashboard sidebar for both desktop and mobile navigation.
  * Selecting “Volumes” now opens the volumes section.

* **Tests**
  * Added coverage to verify the new sidebar navigation link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->