### PR TITLE
Require source metadata in sequence diagram messages

### DIFF
--- a/.agents/skills/boxlite-diagrams/SKILL.md
+++ b/.agents/skills/boxlite-diagrams/SKILL.md
@@ -161,6 +161,20 @@ messages.
 ## Source grounding
 
 - Cite the exact revision, repository-relative path, and inclusive line range.
+- When a sequence message resolves to an implemented function, keep the action
+  short and explicitly label every source field:
+  `<action><br/>File: <path><br/>Namespace: <full-chain><br/>Class: <owner><br/>Function: <name><br/>LOC: L<start>-L<end>`.
+  `File` is the repository-relative path. `Namespace` is the complete declared
+  crate, module, or package chain from outermost to innermost; never collapse a
+  nested namespace to its leaf. Use `Namespace: —` when none exists. `Class` is
+  the owning class, struct, type, or receiver and is `—` for a free function.
+  `Function` is the unqualified function or method name. `LOC` is its inclusive
+  line range. Never show a partial source block. Omit the whole block only when
+  the message has no concrete source symbol, such as an external actor or
+  explicitly proposed behavior; never invent one.
+- For sequence-call target nodes, record `evidence[].symbol` as the complete
+  namespace, owner, and function chain so the validator can check every
+  displayed field rather than only their presence.
 - Include narrow evidence tokens that prove each node or relationship.
 - For a direct call, the edge evidence contains the callee's leaf symbol.
 - For RPC, dispatch, spawn, data flow, or state transitions, cite the concrete
@@ -179,6 +193,9 @@ hop cites the base revision; an added hop cites the head revision.
 - Keep every node at the selected altitude and in service of one scope sentence.
 - Architecture shows ownership, network, trust, process, and storage boundaries.
 - Sequence shows time, calls, responses, alternatives, concurrency, and failure.
+- Sequence messages keep the action concise while explicitly showing `File`,
+  `Namespace`, `Class`, `Function`, and `LOC` when source is available, for
+  example `create box<br/>File: apps/api/src/box/services/box.service.ts<br/>Namespace: —<br/>Class: BoxService<br/>Function: create<br/>LOC: L203-L348`.
 - Call graph uses one hop per line:
   `symbol (Type · path/file.ext:line) — role`.
 - Prefer `flowchart TB` for a whole cloud deployment and `LR` for a short path.

--- a/.agents/skills/boxlite-diagrams/references/output-contract.md
+++ b/.agents/skills/boxlite-diagrams/references/output-contract.md
@@ -123,10 +123,32 @@ sequenceDiagram
   participant runtime as BoxliteRuntime
   participant box as LiteBox
   %% edge:create_box
-  runtime->>box: create
+  runtime->>box: create box<br/>File: src/boxlite/src/runtime/core.rs<br/>Namespace: boxlite::runtime::core<br/>Class: BoxliteRuntime<br/>Function: create<br/>LOC: L291-L300
 ```
 
 Notes and grouping statements may be untracked because they are not edges.
+
+Keep the message's action short, then explicitly label every source field:
+
+`<action><br/>File: <path><br/>Namespace: <full-chain><br/>Class: <owner><br/>Function: <name><br/>LOC: L<start>-L<end>`
+
+- `File` is the repository-relative path.
+- `Namespace` is the complete declared crate, module, or package chain from the
+  outermost scope to the innermost scope. Preserve every nested segment and use
+  the language's native separator. Use `Namespace: —` when none exists.
+- `Class` is the owning class, struct, type, or receiver. Use `Class: —` for a
+  free function so the field remains explicit.
+- `Function` is the unqualified function or method name.
+- `LOC` is the exact inclusive line range.
+
+Do not show only some of these fields. Omit the entire source block only when no
+concrete source symbol exists, such as an external interaction or explicitly
+proposed behavior. Never invent a value to fill the format.
+
+For a source-backed sequence call, the target node's source evidence uses the
+complete language-native symbol chain. The example above therefore uses
+`boxlite::runtime::core::BoxliteRuntime::create`, allowing the validator to
+derive and check `Namespace`, `Class`, and `Function` independently.
 
 ## Call graph
 
@@ -160,7 +182,7 @@ Source evidence:
   "path": "src/boxlite/src/runtime/core.rs",
   "line_start": 291,
   "line_end": 299,
-  "symbol": "BoxliteRuntime::create",
+  "symbol": "boxlite::runtime::core::BoxliteRuntime::create",
   "tokens": ["pub async fn create", "self.backend.create"]
 }
 ```

--- a/.agents/skills/boxlite-diagrams/scripts/validate_diagrams.py
+++ b/.agents/skills/boxlite-diagrams/scripts/validate_diagrams.py
@@ -15,6 +15,7 @@ from validator.consistency import validate_consistency
 from validator.document import validate_document
 from validator.mermaid import validate_mermaid
 from validator.models import ValidationContext
+from validator.sequence import validate_sequence_source_labels
 from validator.source import validate_manifest, validate_source_evidence
 
 
@@ -54,6 +55,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         validate_document(ctx)
         validate_source_evidence(ctx)
         validate_mermaid(ctx)
+        validate_sequence_source_labels(ctx)
         validate_call_graph(ctx)
         validate_changes(ctx)
         validate_consistency(ctx)

--- a/.agents/skills/boxlite-diagrams/scripts/validator/sequence.py
+++ b/.agents/skills/boxlite-diagrams/scripts/validator/sequence.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from .models import ValidationContext
+
+SOURCE_LABEL_RE = re.compile(
+    r"^(?P<action>.+?)<br/>"
+    r"File: (?P<path>[^<]+)<br/>"
+    r"Namespace: (?P<namespace>[^<]+)<br/>"
+    r"Class: (?P<class_name>[^<]+)<br/>"
+    r"Function: (?P<function>[^<]+)<br/>"
+    r"LOC: L(?P<line_start>[1-9][0-9]*)-L(?P<line_end>[1-9][0-9]*)$"
+)
+SOURCE_FIELD_MARKERS = ("File:", "Namespace:", "Class:", "Function:", "LOC:")
+
+
+def validate_sequence_source_labels(ctx: ValidationContext) -> None:
+    if ctx.parsed is None:
+        ctx.add("sequence.source_labels", "fail", "sequence labels require a parsed document")
+        return
+
+    errors: list[str] = []
+    edge_map = ctx.item_map("edge")
+    node_map = ctx.item_map("node")
+    states = ctx.state_map()
+
+    for (state_id, edge_id), label in ctx.parsed.sequence_edge_labels.items():
+        edge = edge_map.get(edge_id)
+        if edge is None:
+            continue
+
+        match = SOURCE_LABEL_RE.fullmatch(label)
+        has_source_field = any(marker in label for marker in SOURCE_FIELD_MARKERS)
+        state = states.get(state_id, {})
+        requires_source_block = (
+            edge.get("kind") == "call"
+            and not edge.get("proposed", False)
+            and not state.get("proposed", False)
+        )
+
+        if match is None:
+            if requires_source_block or has_source_field:
+                errors.append(
+                    f"sequence/{state_id} edge {edge_id!r} must include complete "
+                    "File, Namespace, Class, Function, and LOC fields"
+                )
+            continue
+
+        target = node_map.get(edge.get("to"), {})
+        candidates = [
+            evidence
+            for evidence in target.get("evidence", [])
+            if evidence.get("type") == "source" and evidence.get("state") == state_id
+        ]
+        if not candidates:
+            if requires_source_block:
+                errors.append(
+                    f"sequence/{state_id} edge {edge_id!r} has no target source evidence for its label"
+                )
+            continue
+
+        if not any(_matches_evidence(match.groupdict(), evidence) for evidence in candidates):
+            expected = [_source_label_description(evidence) for evidence in candidates]
+            errors.append(
+                f"sequence/{state_id} edge {edge_id!r} source fields do not match target "
+                f"node:{edge.get('to')} evidence; expected one of {expected}"
+            )
+
+    if errors:
+        ctx.add("sequence.source_labels", "fail", "sequence source labels are incomplete or stale", errors)
+    else:
+        ctx.add(
+            "sequence.source_labels",
+            "pass",
+            "sequence call messages expose complete source fields matching target evidence",
+        )
+
+
+def _matches_evidence(fields: dict[str, str], evidence: dict[str, Any]) -> bool:
+    namespace, class_name, function = _symbol_fields(evidence["symbol"])
+    return (
+        fields["path"] == evidence["path"]
+        and fields["namespace"] == namespace
+        and fields["class_name"] == class_name
+        and fields["function"] == function
+        and int(fields["line_start"]) == evidence["line_start"]
+        and int(fields["line_end"]) == evidence["line_end"]
+    )
+
+
+def _source_label_description(evidence: dict[str, Any]) -> str:
+    namespace, class_name, function = _symbol_fields(evidence["symbol"])
+    return (
+        f"File: {evidence['path']}; Namespace: {namespace}; Class: {class_name}; "
+        f"Function: {function}; LOC: L{evidence['line_start']}-L{evidence['line_end']}"
+    )
+
+
+def _symbol_fields(symbol: str) -> tuple[str, str, str]:
+    separator = "::" if "::" in symbol else "."
+    parts = [part for part in symbol.split(separator) if part]
+    if len(parts) == 1:
+        return "—", "—", parts[0]
+    if len(parts) == 2:
+        return "—", parts[0], parts[1]
+    return separator.join(parts[:-2]), parts[-2], parts[-1]

--- a/.agents/skills/boxlite-diagrams/tests/test_validate_diagrams.py
+++ b/.agents/skills/boxlite-diagrams/tests/test_validate_diagrams.py
@@ -326,6 +326,40 @@ class DiagramValidatorTests(unittest.TestCase):
         result, report = self.validate(document, manifest)
         self.assertEqual(result.returncode, 0, json.dumps(report, indent=2))
 
+    def test_sequence_message_without_source_fields_is_rejected(self) -> None:
+        document, manifest = overview_fixture(self.head)
+        document = document.replace(sequence_message("load", "load", 8, 9), "load", 1)
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "sequence.source_labels")
+
+    def test_sequence_message_preserves_complete_nested_namespace(self) -> None:
+        document, manifest = overview_fixture(self.head)
+        load = next(node for node in manifest["nodes"] if node["id"] == "load")
+        load["evidence"][0]["symbol"] = "package.module.Loader.load"
+        document = document.replace(
+            sequence_message("load", "load", 8, 9),
+            sequence_message(
+                "load", "load", 8, 9, namespace="package.module", class_name="Loader"
+            ),
+            1,
+        )
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 0, json.dumps(report, indent=2))
+
+    def test_sequence_message_rejects_collapsed_nested_namespace(self) -> None:
+        document, manifest = overview_fixture(self.head)
+        load = next(node for node in manifest["nodes"] if node["id"] == "load")
+        load["evidence"][0]["symbol"] = "package.module.Loader.load"
+        document = document.replace(
+            sequence_message("load", "load", 8, 9),
+            sequence_message("load", "load", 8, 9, namespace="module", class_name="Loader"),
+            1,
+        )
+        result, report = self.validate(document, manifest)
+        self.assertEqual(result.returncode, 1)
+        self.assert_check_failed(report, "sequence.source_labels")
+
     def test_mermaid_left_arrow_is_not_treated_as_html(self) -> None:
         document, manifest = overview_fixture(self.head)
         document = document.replace("start_load@-->", "start_load@<-->", 1)
@@ -495,7 +529,7 @@ class DiagramValidatorTests(unittest.TestCase):
         document = diagrams(
             [("current", "Current")],
             {"current": [f"  fake (Module · {path}:1) — entry", "    └─ load (Module · app.py:8) — result"]},
-            {"current": [("fake_load", "fake", "load", "load")]},
+            {"current": [("fake_load", "fake", "load", "load", sequence_message("load", "load", 8, 9))]},
             {"current": [("fake", "fake"), ("load", "load")]},
         )
         data = manifest(
@@ -563,20 +597,36 @@ def manifest(context: dict[str, object], states: list[dict[str, object]], nodes:
             "annotations": annotations or []}
 
 
-def diagrams(states: list[tuple[str, str]], state_hops: dict[str, list[str]], state_edges: dict[str, list[tuple[str, str, str, str]]],
+def sequence_message(
+    action: str,
+    function: str,
+    line_start: int,
+    line_end: int,
+    *,
+    path: str = "app.py",
+    namespace: str = "—",
+    class_name: str = "—",
+) -> str:
+    return (
+        f"{action}<br/>File: {path}<br/>Namespace: {namespace}<br/>"
+        f"Class: {class_name}<br/>Function: {function}<br/>LOC: L{line_start}-L{line_end}"
+    )
+
+
+def diagrams(states: list[tuple[str, str]], state_hops: dict[str, list[str]], state_edges: dict[str, list[tuple[str, str, str, str, str]]],
              state_nodes: dict[str, list[tuple[str, str]]], footer: str = "") -> str:
     parts = ["# Diagram", "", "## Architecture", ""]
     for state_id, label in states:
         parts += [f"### {label}", "", "```mermaid", "flowchart LR"]
         parts += [f'  {item_id}["{item_label}"]' for item_id, item_label in state_nodes[state_id]]
-        parts += [f'  {source} {edge_id}@-->|"{edge_label}"| {target}' for edge_id, source, target, edge_label in state_edges[state_id]]
+        parts += [f'  {source} {edge_id}@-->|"{edge_label}"| {target}' for edge_id, source, target, edge_label, _sequence_label in state_edges[state_id]]
         parts += ["```", ""]
     parts += ["## Sequence", ""]
     for state_id, label in states:
         parts += [f"### {label}", "", "```mermaid", "sequenceDiagram"]
         parts += [f"  participant {item_id} as {item_label}" for item_id, item_label in state_nodes[state_id]]
-        for edge_id, source, target, edge_label in state_edges[state_id]:
-            parts += [f"  %% edge:{edge_id}", f"  {source}->>{target}: {edge_label}"]
+        for edge_id, source, target, _edge_label, sequence_label in state_edges[state_id]:
+            parts += [f"  %% edge:{edge_id}", f"  {source}->>{target}: {sequence_label}"]
         parts += ["```", ""]
     parts += ["## Call graph", ""]
     for state_id, label in states:
@@ -596,7 +646,7 @@ def overview_fixture(head: str) -> tuple[str, dict[str, object]]:
                   [source_evidence("current", head, "start", 1, 3, "load()")])]
     doc = diagrams([("current", "Current")], {"current": [
         "  start (Module · app.py:1) — entry", "    └─ load (Module · app.py:8) — load result"]},
-        {"current": [("start_load", "start", "load", "load")]},
+        {"current": [("start_load", "start", "load", "load", sequence_message("load", "load", 8, 9))]},
         {"current": [("start", "start"), ("load", "load")]})
     return doc, manifest({"kind": "overview", "change_kind": "none", "sources": {"repository": "local"}}, states, nodes, edges)
 
@@ -679,8 +729,8 @@ def issue_fixture(head: str) -> tuple[str, dict[str, object]]:
         [("current", "Current"), ("expected", "Expected (proposed)")],
         {"current": ["  start (Module · app.py:1) — entry", "    └─ load (Module · app.py:8) — load result"],
          "expected": ["  start (Module · app.py:1) — entry", "    └─ load (Module · app.py:8) — load result ← PROPOSED: validation behavior"]},
-        {"current": [("start_load", "start", "load", "load")],
-         "expected": [("start_load", "start", "load", "load PROPOSED: validation behavior")]},
+        {"current": [("start_load", "start", "load", "load", sequence_message("load", "load", 8, 9))],
+         "expected": [("start_load", "start", "load", "load PROPOSED: validation behavior", sequence_message("load PROPOSED: validation behavior", "load", 8, 9))]},
         {"current": [("start", "start"), ("load", "load")], "expected": [("start", "start"), ("load", "load")]},
     )
     return doc, data
@@ -703,8 +753,9 @@ def feature_pr_fixture(base: str, head: str) -> tuple[str, dict[str, object]]:
         [("before", "Before"), ("after", "After")],
         {"before": ["  start (Module · app.py:1) — entry", "    └─ load (Module · app.py:4) — load result"],
          "after": ["  start (Module · app.py:1) — entry", "    ├─ validate (Module · app.py:5) — validate input ← ADDED: validate input", "    └─ load (Module · app.py:8) — load result"]},
-        {"before": [("start_load", "start", "load", "load")],
-         "after": [("start_validate", "start", "validate", "validate ADDED: validate input"), ("start_load", "start", "load", "load")]},
+        {"before": [("start_load", "start", "load", "load", sequence_message("load", "load", 4, 5))],
+         "after": [("start_validate", "start", "validate", "validate ADDED: validate input", sequence_message("validate ADDED: validate input", "validate", 5, 6)),
+                   ("start_load", "start", "load", "load", sequence_message("load", "load", 8, 9))]},
         {"before": [("start", "start"), ("load", "load")],
          "after": [("start", "start"), ("validate", "validate ADDED: validate input"), ("load", "load")]})
     context = {"kind": "pr", "change_kind": "feature", "sources": {"repository": "local", "pr": 3,


### PR DESCRIPTION
## Summary

- require source-backed sequence calls to show `File`, full `Namespace`, `Class`, `Function`, and `LOC`
- validate displayed metadata against the target node source evidence
- reject missing, partial, stale, or collapsed namespace labels

## Before

```text
diagram request
└─ sequence message
   └─ short action only ← source identity unavailable to the reader
```

## After

```text
diagram request
└─ boxlite-diagrams skill
   └─ fully qualified target evidence
      └─ sequence source-label validator
         └─ action + File + Namespace + Class + Function + LOC
```

## Verification

- `python3 .agents/skills/boxlite-diagrams/tests/test_validate_diagrams.py` — 53 tests passed, 1 skipped
- skill quick validation passed
- `git diff --check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated diagram guidance to require complete source metadata for sequence messages and call targets.

* **Validation**
  * Added checks ensuring sequence diagrams include accurate file, namespace, class, function, and line information.
  * Improved validation feedback for missing, incomplete, or mismatched source evidence.

* **Tests**
  * Expanded coverage for nested namespaces, missing metadata, and sequence-label rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->