### PR TITLE
ci(api): preserve tests after quota removal

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -304,62 +304,6 @@ jobs:
       - name: Run Go unit tests
         run: make test:unit:go
 
-  api:
-    name: API Tests
-    needs: [config, changes]
-    if: ${{ needs.changes.outputs.api == 'true' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    services:
-      redis:
-        image: redis:7
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: boxlite
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U postgres"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-    env:
-      REDIS_HOST: localhost
-      DB_HOST: localhost
-      DB_PORT: 5432
-      DB_USERNAME: postgres
-      DB_PASSWORD: postgres
-      DB_DATABASE: boxlite
-    defaults:
-      run:
-        working-directory: apps
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          submodules: recursive
-          persist-credentials: false
-      - name: Enable Corepack
-        run: corepack enable
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: yarn
-          cache-dependency-path: apps/yarn.lock
-      - name: Install dependencies
-        run: yarn install --immutable
-      - name: Run API unit tests
-        run: yarn nx run api:test
-
   guest-rootfs:
     name: Guest Rootfs (${{ matrix.os }} / ${{ matrix.target }} / ${{ matrix.profile }})
     needs: [config, changes]
@@ -402,6 +346,65 @@ jobs:
 
       - name: Build and qualify guest rootfs
         run: make test:guest-rootfs GUEST_TARGET=${{ matrix.target }} PROFILE=${{ matrix.profile }}
+
+  # API tests need real Redis and Postgres services for integration coverage.
+  api:
+    name: API Tests
+    needs: ["config", "changes"]
+    if: ${{ needs.changes.outputs.api == 'true' }}
+    runs-on: "ubuntu-latest"
+    permissions: # Repository-controlled tests need no write scopes.
+      contents: "read"
+    services: # Integration dependencies used by API specs.
+      redis: # Distributed-lock integration tests.
+        image: "redis:7"
+        ports: # Bind only on the ephemeral CI runner.
+          - "6379:6379"
+        options: >- # Wait for Redis before Jest starts.
+          --health-cmd="redis-cli ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: boxlite
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env: # Service connection values are non-secret CI-local defaults.
+      REDIS_HOST: "localhost"
+      DB_HOST: localhost
+      DB_PORT: 5432
+      DB_USERNAME: postgres
+      DB_PASSWORD: postgres
+      DB_DATABASE: boxlite
+    defaults: # Keep package-manager commands inside the apps workspace.
+      run: # Applies only to shell steps, not actions.
+        working-directory: "apps"
+    steps: # Install exactly the lockfile-defined workspace before testing.
+      - uses: actions/checkout@v5
+        with: # Native workspace dependencies are submodules.
+          submodules: "recursive"
+          persist-credentials: ${{ false }}
+      - name: Enable Corepack
+        run: "corepack enable"
+      - uses: actions/setup-node@v4
+        with: # Match the apps workspace toolchain and cache key.
+          node-version: "22"
+          cache: "yarn"
+          cache-dependency-path: "apps/yarn.lock"
+      - name: Install app dependencies
+        run: "yarn install --immutable"
+      - name: Run API unit tests
+        run: "yarn nx run api:test"
+
+  # End API test job.
 
   # Single required status check for branch protection / merge queue.
   # Passes only if every job above succeeded or was skipped (path-filtered).

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,9 +46,9 @@ repos:
             src/ffi/|
             src/guest/|
             sdks/|
-            apps/|
             \.github/workflows/|
             \.github/actions/|
+            apps/.*|
             .*/Cargo\.toml$|
             Cargo\.lock$
           )


### PR DESCRIPTION
## Summary

- re-establish the generic API test job as current CI infrastructure after #1292
- keep app changes in the local pre-push test matrix
- remove the final line ancestry retained from #1028 without reducing test coverage

## Before

```text
apps/API changes
  -> #1028-owned workflow and pre-push lines
    -> API test coverage
```

## After

```text
apps/API changes
  -> current generic workflow and pre-push configuration
    -> Redis and Postgres-backed API tests
```

## Verification

- `BOXLITE_DEPS_STUB=1 SETUP_DONE=1 NX_TUI=false make test:apps`
- pre-push changed-component test matrix
- no live lines blamed to #1028 merge commit `fd593cc1d207`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated API testing workflow configuration while preserving Redis, PostgreSQL, and test execution coverage.
  * Refined the pre-push test hook to run the full test matrix for relevant application file changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->