### PR TITLE
refactor(runtime): stop mutating capabilities from privileged mode

### DIFF
--- a/sdks/c/src/advanced_options.rs
+++ b/sdks/c/src/advanced_options.rs
@@ -8,7 +8,9 @@
 
 use std::os::raw::{c_char, c_int};
 
-use boxlite::runtime::advanced_options::{AdvancedBoxOptions, SecurityOptions};
+use boxlite::runtime::advanced_options::{
+    AdvancedBoxOptions, ContainerCapabilities, SecurityOptions,
+};
 
 use crate::CAdvancedBoxOptions;
 use crate::error::{BoxliteErrorCode, FFIError, null_pointer_error, write_error};
@@ -89,8 +91,8 @@ pub unsafe extern "C" fn boxlite_advanced_options_set_capabilities_add(
     capabilities: *const *const c_char,
     count: c_int,
 ) -> BoxliteErrorCode {
-    set_capability_list(opts, capabilities, count, |options, values| {
-        options.capabilities.add = values;
+    set_capability_list(opts, capabilities, count, |caps, values| {
+        caps.add = values;
     })
 }
 
@@ -104,8 +106,8 @@ pub unsafe extern "C" fn boxlite_advanced_options_set_capabilities_drop(
     capabilities: *const *const c_char,
     count: c_int,
 ) -> BoxliteErrorCode {
-    set_capability_list(opts, capabilities, count, |options, values| {
-        options.capabilities.drop = values;
+    set_capability_list(opts, capabilities, count, |caps, values| {
+        caps.drop = values;
     })
 }
 
@@ -115,28 +117,38 @@ fn set_capability_list(
     handle: *mut CAdvancedBoxOptions,
     capabilities: *const *const c_char,
     count: c_int,
-    assign: impl FnOnce(&mut AdvancedBoxOptions, Vec<String>),
+    assign: impl FnOnce(&mut ContainerCapabilities, Vec<String>),
 ) -> BoxliteErrorCode {
     let Some(handle) = (unsafe { handle.as_mut() }) else {
         return BoxliteErrorCode::InvalidArgument;
     };
 
-    match parse_capability_array(capabilities, count) {
+    let mut current = handle.options.capabilities().cloned().unwrap_or_default();
+
+    let parse_result = match parse_capability_array(capabilities, count) {
         Ok(values) => {
-            assign(&mut handle.options, values);
+            assign(&mut current, values);
             BoxliteErrorCode::Ok
         }
         Err(()) => {
             // Keep the handle invalid if a caller ignores the return code. The
             // subsequent BoxOptions::sanitize call then rejects the policy
             // instead of silently falling back to the baseline.
-            assign(
-                &mut handle.options,
-                vec![INVALID_CAPABILITY_INPUT.to_string()],
-            );
+            assign(&mut current, vec![INVALID_CAPABILITY_INPUT.to_string()]);
             BoxliteErrorCode::InvalidArgument
         }
+    };
+
+    // Only reachable if this handle's options were already resolved (used to
+    // build a box request) — not possible through this C API today, since
+    // `boxlite_options_set_advanced` clones the options rather than resolving
+    // this handle directly, but fail closed rather than silently keep stale
+    // capabilities if that ever changes.
+    if handle.options.set_capabilities(Some(current)).is_err() {
+        return BoxliteErrorCode::InvalidArgument;
     }
+
+    parse_result
 }
 
 fn parse_capability_array(

--- a/sdks/c/src/tests.rs
+++ b/sdks/c/src/tests.rs
@@ -439,8 +439,7 @@ fn capability_lists_default_empty_and_preserve_custom_values() {
     );
 
     unsafe {
-        assert!((*advanced).options.capabilities.add.is_empty());
-        assert!((*advanced).options.capabilities.drop.is_empty());
+        assert!((*advanced).options.capabilities().is_none());
     }
 
     let cap_add = [
@@ -475,14 +474,13 @@ fn capability_lists_default_empty_and_preserve_custom_values() {
         );
         boxlite_options_set_advanced(opts, advanced);
 
-        assert_eq!(
-            (*opts).options.advanced.capabilities.add,
-            ["NET_ADMIN", "SYS_PTRACE"]
-        );
-        assert_eq!(
-            (*opts).options.advanced.capabilities.drop,
-            ["MKNOD", "NET_RAW"]
-        );
+        let capabilities = (*opts)
+            .options
+            .advanced
+            .capabilities()
+            .expect("capabilities set");
+        assert_eq!(capabilities.add, ["NET_ADMIN", "SYS_PTRACE"]);
+        assert_eq!(capabilities.drop, ["MKNOD", "NET_RAW"]);
         boxlite_advanced_options_free(advanced);
         boxlite_options_free(opts);
     }

--- a/sdks/node/src/options.rs
+++ b/sdks/node/src/options.rs
@@ -1,7 +1,9 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use boxlite::runtime::advanced_options::{AdvancedBoxOptions, HealthCheckOptions, SecurityOptions};
+use boxlite::runtime::advanced_options::{
+    AdvancedBoxOptions, ContainerCapabilities, HealthCheckOptions, SecurityOptions,
+};
 use boxlite::runtime::constants::images;
 use boxlite::runtime::options::{
     BoxOptions, BoxliteOptions, ImageRegistry, ImageRegistryAuth, NetworkMode, NetworkSpec,
@@ -455,11 +457,10 @@ impl TryFrom<JsBoxOptions> for BoxOptions {
             .unwrap_or_default();
 
         let health_check = js_opts.health_check.map(HealthCheckOptions::from);
-        let capabilities = js_opts
+        let capabilities: Option<ContainerCapabilities> = js_opts
             .advanced
             .and_then(|advanced| advanced.capabilities)
-            .map(Into::into)
-            .unwrap_or_default();
+            .map(Into::into);
         let secrets = js_opts
             .secrets
             .unwrap_or_default()
@@ -474,6 +475,11 @@ impl TryFrom<JsBoxOptions> for BoxOptions {
             })
             .collect();
 
+        let mut advanced = AdvancedBoxOptions::default();
+        advanced.set_capabilities(capabilities)?;
+        advanced.security = security;
+        advanced.health_check = health_check;
+
         Ok(BoxOptions {
             cpus: js_opts.cpus,
             memory_mib: js_opts.memory_mib,
@@ -486,12 +492,7 @@ impl TryFrom<JsBoxOptions> for BoxOptions {
             inbound_network: Default::default(),
             ports,
             auto_remove,
-            advanced: AdvancedBoxOptions {
-                capabilities,
-                security,
-                health_check,
-                ..Default::default()
-            },
+            advanced,
             auto_stop: js_opts.auto_stop,
             auto_delete,
             auto_resume: js_opts.auto_resume,
@@ -844,20 +845,17 @@ mod tests {
             }),
         });
         let with_capabilities = BoxOptions::try_from(with_capabilities).unwrap();
-        assert_eq!(
-            with_capabilities.advanced.capabilities.add,
-            ["NET_ADMIN", "SYS_PTRACE"]
-        );
-        assert_eq!(
-            with_capabilities.advanced.capabilities.drop,
-            ["MKNOD", "NET_RAW"]
-        );
+        let capabilities = with_capabilities
+            .advanced
+            .capabilities()
+            .expect("capabilities set");
+        assert_eq!(capabilities.add, ["NET_ADMIN", "SYS_PTRACE"]);
+        assert_eq!(capabilities.drop, ["MKNOD", "NET_RAW"]);
 
         let opts = BoxOptions::try_from(js).unwrap();
         assert!(!opts.auto_remove);
         assert_eq!(opts.auto_delete, None);
-        assert!(opts.advanced.capabilities.add.is_empty());
-        assert!(opts.advanced.capabilities.drop.is_empty());
+        assert!(opts.advanced.capabilities().is_none());
         match opts.network {
             NetworkSpec::Enabled { allow_net } => {
                 assert_eq!(allow_net, vec!["example.com", "*.openai.com"]);

--- a/sdks/python/src/advanced_options.rs
+++ b/sdks/python/src/advanced_options.rs
@@ -308,8 +308,15 @@ pub struct PyAdvancedBoxOptions {
     pub health_check: Option<PyHealthCheckOptions>,
 
     /// Linux capability policy for the container process.
+    ///
+    /// `None` when the caller never passes `capabilities=` — distinct from
+    /// an explicit, empty policy, the same distinction the core
+    /// `AdvancedBoxOptions.capabilities` makes. Collapsing this to a
+    /// concrete default here would make every security/health-check-only
+    /// `AdvancedBoxOptions` look like it explicitly asked for an empty
+    /// capability override.
     #[pyo3(get, set)]
-    pub capabilities: PyContainerCapabilities,
+    pub capabilities: Option<PyContainerCapabilities>,
 }
 
 #[pymethods]
@@ -324,7 +331,7 @@ impl PyAdvancedBoxOptions {
         Self {
             security,
             health_check,
-            capabilities: capabilities.unwrap_or_default(),
+            capabilities,
         }
     }
 }

--- a/sdks/python/src/options.rs
+++ b/sdks/python/src/options.rs
@@ -564,7 +564,8 @@ impl TryFrom<PyBoxOptions> for BoxOptions {
             if let Some(health_check) = advanced.health_check {
                 opts.advanced.health_check = Some(HealthCheckOptions::from(health_check));
             }
-            opts.advanced.capabilities = advanced.capabilities.into();
+            opts.advanced
+                .set_capabilities(Some(advanced.capabilities.into()))?;
         }
 
         // Convert Python secrets to Rust secrets

--- a/sdks/python/src/options.rs
+++ b/sdks/python/src/options.rs
@@ -564,8 +564,9 @@ impl TryFrom<PyBoxOptions> for BoxOptions {
             if let Some(health_check) = advanced.health_check {
                 opts.advanced.health_check = Some(HealthCheckOptions::from(health_check));
             }
-            opts.advanced
-                .set_capabilities(Some(advanced.capabilities.into()))?;
+            if let Some(capabilities) = advanced.capabilities {
+                opts.advanced.set_capabilities(Some(capabilities.into()))?;
+            }
         }
 
         // Convert Python secrets to Rust secrets
@@ -966,6 +967,101 @@ impl From<PyBoxliteRestOptions> for BoxliteRestOptions {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::advanced_options::{PyContainerCapabilities, PySecurityOptions};
+
+    /// Builds a `PyBoxOptions` with everything at its "untouched" default
+    /// except `advanced`, so the conversion under test is exercised without
+    /// needing the Python interpreter (plain struct literals, no
+    /// `Python::attach` — `cargo test -p boxlite-python` can't link libpython
+    /// in this sandbox, but a pure `TryFrom` call between plain Rust structs
+    /// doesn't need it).
+    fn py_box_options_with_advanced(advanced: PyAdvancedBoxOptions) -> PyBoxOptions {
+        PyBoxOptions {
+            image: None,
+            rootfs_path: None,
+            cpus: None,
+            memory_mib: None,
+            disk_size_gb: None,
+            working_dir: None,
+            env: vec![],
+            volumes: vec![],
+            network: None,
+            ports: vec![],
+            auto_remove: None,
+            auto_stop: None,
+            auto_delete: None,
+            auto_resume: None,
+            detach: None,
+            entrypoint: None,
+            cmd: None,
+            user: None,
+            advanced: Some(advanced),
+            secrets: vec![],
+        }
+    }
+
+    fn default_py_security() -> PySecurityOptions {
+        PySecurityOptions {
+            jailer_enabled: false,
+            seccomp_enabled: false,
+            max_open_files: None,
+            max_file_size: None,
+            max_processes: None,
+            max_memory: None,
+            max_cpu_time: None,
+            network_enabled: true,
+            close_fds: true,
+        }
+    }
+
+    /// A caller who only sets `security=` (never mentions `capabilities=`)
+    /// must not have `capabilities` silently become an explicit, empty
+    /// policy — that's the exact None-vs-Some(empty) distinction this PR's
+    /// core API is built to preserve (see AdvancedBoxOptions::capabilities'
+    /// own doc comment), and Some(empty) trips `archive_version_for_options`
+    /// and `RestRuntime::create`'s `require_linux_capabilities_enabled` gate
+    /// for a caller who never touched capabilities at all.
+    #[test]
+    fn security_only_advanced_options_leaves_capabilities_unspecified() {
+        let advanced = PyAdvancedBoxOptions {
+            security: Some(default_py_security()),
+            health_check: None,
+            capabilities: None,
+        };
+
+        let opts = BoxOptions::try_from(py_box_options_with_advanced(advanced))
+            .expect("security-only options should convert");
+
+        assert!(
+            opts.advanced.capabilities().is_none(),
+            "expected capabilities to stay unspecified, got {:?}",
+            opts.advanced.capabilities()
+        );
+    }
+
+    /// Mirror of the above for the case a Python caller DOES explicitly ask
+    /// for a capability policy — must still come through as `Some`.
+    #[test]
+    fn explicit_capabilities_still_convert() {
+        let advanced = PyAdvancedBoxOptions {
+            security: None,
+            health_check: None,
+            capabilities: Some(PyContainerCapabilities {
+                add: vec!["SYS_ADMIN".to_string()],
+                drop: vec![],
+            }),
+        };
+
+        let opts = BoxOptions::try_from(py_box_options_with_advanced(advanced))
+            .expect("explicit capabilities should convert");
+
+        let capabilities = opts
+            .advanced
+            .capabilities()
+            .expect("capabilities should be set");
+        assert_eq!(capabilities.add, ["SYS_ADMIN"]);
+    }
+
     #[test]
     fn py_volume_source_requires_volume_scheme() {
         Python::attach(|py| {

--- a/sdks/python/tests/test_options.py
+++ b/sdks/python/tests/test_options.py
@@ -36,11 +36,19 @@ class TestBoxOptionsDefaults:
         # Python side defaults to None, Rust side defaults to False
         assert opts.detach is None
 
-    def test_capability_lists_default_to_empty(self):
-        """Test that capability overrides are empty under advanced options."""
+    def test_capabilities_default_to_unspecified(self):
+        """An AdvancedBoxOptions that never mentions capabilities must leave
+        the policy unspecified (None), not an explicit-but-empty override —
+        the two carry different meaning (see the Rust-side
+        AdvancedBoxOptions.capabilities doc comment)."""
         advanced = boxlite.AdvancedBoxOptions()
-        assert advanced.capabilities.add == []
-        assert advanced.capabilities.drop == []
+        assert advanced.capabilities is None
+
+    def test_security_only_advanced_options_leaves_capabilities_unspecified(self):
+        """Setting an unrelated advanced option must not implicitly turn
+        capabilities into an explicit, empty override."""
+        advanced = boxlite.AdvancedBoxOptions(security=boxlite.SecurityOptions())
+        assert advanced.capabilities is None
 
     def test_custom_capability_lists_are_preserved(self):
         """Test supplying Docker-style capability additions and removals."""

--- a/src/boxlite/src/db/migration/mod.rs
+++ b/src/boxlite/src/db/migration/mod.rs
@@ -11,6 +11,7 @@ mod v5_to_v6;
 mod v6_to_v7;
 mod v7_to_v8;
 mod v8_to_v9;
+mod v9_to_v10;
 
 use std::path::Path;
 
@@ -81,5 +82,6 @@ fn all_migrations() -> Vec<Box<dyn Migration>> {
         Box::new(v6_to_v7::MoveDisksAndAddBaseDisk),
         Box::new(v7_to_v8::RenameNetworkSpec),
         Box::new(v8_to_v9::PreservePublishedPorts),
+        Box::new(v9_to_v10::DropAmbiguousEmptyCapabilities),
     ]
 }

--- a/src/boxlite/src/db/migration/v9_to_v10.rs
+++ b/src/boxlite/src/db/migration/v9_to_v10.rs
@@ -1,0 +1,207 @@
+//! Migration v9 → v10: drop the now-ambiguous empty capability policy.
+//!
+//! Before this PR's capability-policy work, `advanced.capabilities` was a
+//! plain, always-serialized `ContainerCapabilities`, so every ordinary
+//! (never customized) box's persisted JSON already contained
+//! `"capabilities":{"add":[],"drop":[]}`. After the field became
+//! `Option<ContainerCapabilities>`, that exact JSON shape deserializes as
+//! `Some(empty)` — "the caller explicitly asked for an empty policy" — not
+//! `None` — "the caller never touched it" — which is what it actually meant
+//! for every box persisted before this migration exists. `Some(empty)` and
+//! `None` are otherwise indistinguishable on the wire, so there is no way to
+//! tell them apart after the fact except by rewriting the old rows once,
+//! here, while we still know which shape produced them.
+//!
+//! Without this, `archive_version_for_options` stamps every such
+//! pre-existing box's export as `CAPABILITY_POLICY_ARCHIVE_VERSION` instead
+//! of `ARCHIVE_VERSION`, even though it never had a real capability
+//! override — an older, v3-only importer would then refuse a perfectly
+//! ordinary archive that it accepted before the host upgraded.
+//!
+//! Only the exact empty shape is dropped. A box whose `add`/`drop` carries
+//! anything — including a privileged box's persisted `add:["ALL"]` — keeps
+//! its `capabilities` key untouched; that's a real, meaningful policy, not
+//! an artifact of the old always-present field.
+
+use std::path::Path;
+
+use rusqlite::Connection;
+
+use boxlite_shared::errors::{BoxliteError, BoxliteResult};
+
+use super::{Migration, db_err};
+
+pub(crate) struct DropAmbiguousEmptyCapabilities;
+
+impl Migration for DropAmbiguousEmptyCapabilities {
+    fn source_version(&self) -> i32 {
+        9
+    }
+
+    fn target_version(&self) -> i32 {
+        10
+    }
+
+    fn description(&self) -> &str {
+        "Drop the now-ambiguous empty capability policy from legacy box configs"
+    }
+
+    fn run(&self, conn: &Connection, _home_dir: Option<&Path>) -> BoxliteResult<()> {
+        let configs = {
+            let mut statement = db_err!(conn.prepare("SELECT id, json FROM box_config"))?;
+            let rows = db_err!(statement.query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            }))?;
+            db_err!(rows.collect::<Result<Vec<_>, _>>())?
+        };
+
+        let mut updates = Vec::new();
+
+        for (id, json) in configs {
+            let mut config: serde_json::Value = serde_json::from_str(&json).map_err(|error| {
+                BoxliteError::Database(format!(
+                    "parse box_config {id} while migrating capability policy: {error}"
+                ))
+            })?;
+
+            let Some(advanced) = config.pointer_mut("/options/advanced") else {
+                continue;
+            };
+            let Some(advanced_obj) = advanced.as_object_mut() else {
+                continue;
+            };
+            let is_empty_policy = advanced_obj
+                .get("capabilities")
+                .and_then(|c| c.as_object())
+                .is_some_and(|c| {
+                    c.get("add")
+                        .is_none_or(|v| v.as_array().is_some_and(Vec::is_empty))
+                        && c.get("drop")
+                            .is_none_or(|v| v.as_array().is_some_and(Vec::is_empty))
+                });
+            if !is_empty_policy {
+                continue;
+            }
+            advanced_obj.remove("capabilities");
+
+            let json = serde_json::to_string(&config).map_err(|error| {
+                BoxliteError::Database(format!(
+                    "serialize box_config {id} while migrating capability policy: {error}"
+                ))
+            })?;
+            updates.push((id, json));
+        }
+
+        let transaction = db_err!(conn.unchecked_transaction())?;
+        for (id, json) in &updates {
+            db_err!(transaction.execute(
+                "UPDATE box_config SET json = ?1 WHERE id = ?2",
+                rusqlite::params![json, id],
+            ))?;
+        }
+        db_err!(transaction.commit())?;
+
+        if !updates.is_empty() {
+            tracing::info!(
+                boxes = updates.len(),
+                "Cleared ambiguous empty capability policy on legacy box configs"
+            );
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn open_with_box_config(rows: &[(&str, &str)]) -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE box_config (
+                id TEXT PRIMARY KEY,
+                name TEXT,
+                created_at INTEGER,
+                json TEXT NOT NULL
+            )",
+        )
+        .unwrap();
+        for (id, json) in rows {
+            conn.execute(
+                "INSERT INTO box_config (id, name, created_at, json) VALUES (?1, NULL, 0, ?2)",
+                rusqlite::params![id, json],
+            )
+            .unwrap();
+        }
+        conn
+    }
+
+    fn load_json(conn: &Connection, id: &str) -> serde_json::Value {
+        let json: String = conn
+            .query_row("SELECT json FROM box_config WHERE id = ?1", [id], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        serde_json::from_str(&json).unwrap()
+    }
+
+    #[test]
+    fn drops_the_legacy_always_present_empty_policy() {
+        let conn = open_with_box_config(&[(
+            "ordinary",
+            r#"{"options":{"advanced":{"capabilities":{"add":[],"drop":[]},"privileged":false}}}"#,
+        )]);
+
+        DropAmbiguousEmptyCapabilities.run(&conn, None).unwrap();
+
+        let value = load_json(&conn, "ordinary");
+        assert!(value.pointer("/options/advanced/capabilities").is_none());
+    }
+
+    #[test]
+    fn keeps_a_real_non_empty_policy_untouched() {
+        let conn = open_with_box_config(&[(
+            "customized",
+            r#"{"options":{"advanced":{"capabilities":{"add":["SYS_ADMIN"],"drop":[]},"privileged":false}}}"#,
+        )]);
+
+        DropAmbiguousEmptyCapabilities.run(&conn, None).unwrap();
+
+        let value = load_json(&conn, "customized");
+        assert_eq!(
+            value.pointer("/options/advanced/capabilities/add"),
+            Some(&serde_json::json!(["SYS_ADMIN"]))
+        );
+    }
+
+    #[test]
+    fn keeps_a_legacy_privileged_boxs_all_shape_untouched() {
+        // An old build mutated `capabilities` to `add:["ALL"]` when privileged
+        // was enabled — that's a real, meaningful policy (handled by
+        // `is_privileged_capability_shape`), not the ambiguous empty case.
+        let conn = open_with_box_config(&[(
+            "legacy_privileged",
+            r#"{"options":{"advanced":{"capabilities":{"add":["ALL"],"drop":[]},"privileged":true}}}"#,
+        )]);
+
+        DropAmbiguousEmptyCapabilities.run(&conn, None).unwrap();
+
+        let value = load_json(&conn, "legacy_privileged");
+        assert_eq!(
+            value.pointer("/options/advanced/capabilities/add"),
+            Some(&serde_json::json!(["ALL"]))
+        );
+    }
+
+    #[test]
+    fn leaves_a_config_with_no_advanced_section_alone() {
+        let conn = open_with_box_config(&[("bare", r#"{"options":{}}"#)]);
+
+        // Must not error when there's nothing to migrate.
+        DropAmbiguousEmptyCapabilities.run(&conn, None).unwrap();
+
+        let value = load_json(&conn, "bare");
+        assert!(value.pointer("/options/advanced").is_none());
+    }
+}

--- a/src/boxlite/src/db/schema.rs
+++ b/src/boxlite/src/db/schema.rs
@@ -7,7 +7,7 @@
 //! Each table has queryable columns for efficient filtering + JSON blob for full data.
 
 /// Current schema version.
-pub const SCHEMA_VERSION: i32 = 9;
+pub const SCHEMA_VERSION: i32 = 10;
 
 /// Schema version tracking table.
 pub const SCHEMA_VERSION_TABLE: &str = r#"

--- a/src/boxlite/src/litebox/archive.rs
+++ b/src/boxlite/src/litebox/archive.rs
@@ -41,7 +41,11 @@ pub(crate) const MAX_SUPPORTED_VERSION: u32 = PUBLISHED_PORTS_ARCHIVE_VERSION;
 pub(crate) fn archive_version_for_options(options: &crate::runtime::options::BoxOptions) -> u32 {
     if !options.ports.is_empty() {
         PUBLISHED_PORTS_ARCHIVE_VERSION
-    } else if options.advanced.capabilities.is_empty() {
+    } else if options
+        .advanced
+        .capabilities()
+        .is_none_or(|capabilities| capabilities.is_empty())
+    {
         ARCHIVE_VERSION
     } else {
         CAPABILITY_POLICY_ARCHIVE_VERSION
@@ -284,14 +288,17 @@ mod tests {
         let ordinary = crate::runtime::options::BoxOptions::default();
         assert_eq!(archive_version_for_options(&ordinary), ARCHIVE_VERSION);
 
-        let custom = crate::runtime::options::BoxOptions {
-            advanced: crate::runtime::advanced_options::AdvancedBoxOptions {
-                capabilities: crate::runtime::advanced_options::ContainerCapabilities {
+        let mut custom_advanced = crate::runtime::advanced_options::AdvancedBoxOptions::default();
+        custom_advanced
+            .set_capabilities(Some(
+                crate::runtime::advanced_options::ContainerCapabilities {
                     drop: vec!["NET_RAW".into()],
                     ..Default::default()
                 },
-                ..Default::default()
-            },
+            ))
+            .unwrap();
+        let custom = crate::runtime::options::BoxOptions {
+            advanced: custom_advanced,
             ..Default::default()
         };
         assert_eq!(

--- a/src/boxlite/src/litebox/archive.rs
+++ b/src/boxlite/src/litebox/archive.rs
@@ -38,14 +38,16 @@ pub(crate) const PUBLISHED_PORTS_ARCHIVE_VERSION: u32 = 5;
 pub(crate) const MAX_SUPPORTED_VERSION: u32 = PUBLISHED_PORTS_ARCHIVE_VERSION;
 
 /// Pick the archive format an exported box needs.
+///
+/// Any explicit policy — including an explicitly empty one — is stamped v4:
+/// `capabilities()` returning `Some` means the caller configured something,
+/// which a pre-capability importer has no way to represent and must refuse
+/// rather than silently drop. Only `None` (the caller never touched the
+/// field) is indistinguishable from what a v3 importer already does.
 pub(crate) fn archive_version_for_options(options: &crate::runtime::options::BoxOptions) -> u32 {
     if !options.ports.is_empty() {
         PUBLISHED_PORTS_ARCHIVE_VERSION
-    } else if options
-        .advanced
-        .capabilities()
-        .is_none_or(|capabilities| capabilities.is_empty())
-    {
+    } else if options.advanced.capabilities().is_none() {
         ARCHIVE_VERSION
     } else {
         CAPABILITY_POLICY_ARCHIVE_VERSION
@@ -303,6 +305,25 @@ mod tests {
         };
         assert_eq!(
             archive_version_for_options(&custom),
+            CAPABILITY_POLICY_ARCHIVE_VERSION
+        );
+
+        // An explicit, empty capability policy is still an explicit policy,
+        // not the same as never touching the field — a pre-capability
+        // importer must not decide that distinction was safe to drop.
+        let mut explicit_empty_advanced =
+            crate::runtime::advanced_options::AdvancedBoxOptions::default();
+        explicit_empty_advanced
+            .set_capabilities(Some(
+                crate::runtime::advanced_options::ContainerCapabilities::default(),
+            ))
+            .unwrap();
+        let explicit_empty = crate::runtime::options::BoxOptions {
+            advanced: explicit_empty_advanced,
+            ..Default::default()
+        };
+        assert_eq!(
+            archive_version_for_options(&explicit_empty),
             CAPABILITY_POLICY_ARCHIVE_VERSION
         );
 

--- a/src/boxlite/src/litebox/init/mod.rs
+++ b/src/boxlite/src/litebox/init/mod.rs
@@ -421,11 +421,10 @@ mod plan_tests {
 
     #[test]
     fn persisted_nested_virtualization_uses_injected_feature_state() {
+        let mut advanced = crate::runtime::advanced_options::AdvancedBoxOptions::default();
+        advanced.nested_virtualization = true;
         let options = crate::BoxOptions {
-            advanced: crate::runtime::advanced_options::AdvancedBoxOptions {
-                nested_virtualization: true,
-                ..Default::default()
-            },
+            advanced,
             ..Default::default()
         };
 

--- a/src/boxlite/src/rest/runtime.rs
+++ b/src/boxlite/src/rest/runtime.rs
@@ -127,11 +127,10 @@ impl RuntimeBackend for RestRuntime {
 
         // A server that does not advertise the capability policy would accept
         // the request and drop the field, silently granting default privileges.
-        if options
-            .advanced
-            .capabilities()
-            .is_some_and(|capabilities| !capabilities.is_empty())
-        {
+        // `Some` alone is the trigger, even an explicitly empty policy: the
+        // caller configured something, and a server that can't represent the
+        // concept at all can't be trusted to preserve that from a no-op value.
+        if options.advanced.capabilities().is_some() {
             self.client.require_linux_capabilities_enabled().await?;
         }
 
@@ -398,6 +397,34 @@ mod tests {
         let error = match RuntimeBackend::create(&runtime, capability_options(), None).await {
             Err(error) => error,
             Ok(_) => panic!("an old server must not silently ignore a capability policy"),
+        };
+
+        assert!(matches!(error, BoxliteError::Unsupported(_)));
+        assert_eq!(server.await.unwrap(), ["GET /v1/config HTTP/1.1"]);
+    }
+
+    /// An explicitly empty policy is still explicit — the caller configured
+    /// something, even if it happens to be a no-op value. A server that
+    /// can't advertise the capability feature at all can't be trusted to
+    /// honor that distinction either, so this must still be probed for.
+    #[tokio::test]
+    async fn explicit_empty_capabilities_still_require_server_advertisement() {
+        let (port, server) = json_server(vec![r#"{"capabilities":{}}"#]).await;
+        let runtime =
+            RestRuntime::new(&BoxliteRestOptions::new(format!("http://127.0.0.1:{port}"))).unwrap();
+
+        let mut advanced = crate::AdvancedBoxOptions::default();
+        advanced
+            .set_capabilities(Some(crate::ContainerCapabilities::default()))
+            .unwrap();
+        let opts = BoxOptions {
+            advanced,
+            ..Default::default()
+        };
+
+        let error = match RuntimeBackend::create(&runtime, opts, None).await {
+            Err(error) => error,
+            Ok(_) => panic!("an explicit, even empty, capability policy must still be probed for"),
         };
 
         assert!(matches!(error, BoxliteError::Unsupported(_)));

--- a/src/boxlite/src/rest/runtime.rs
+++ b/src/boxlite/src/rest/runtime.rs
@@ -127,7 +127,11 @@ impl RuntimeBackend for RestRuntime {
 
         // A server that does not advertise the capability policy would accept
         // the request and drop the field, silently granting default privileges.
-        if !options.advanced.capabilities.is_empty() {
+        if options
+            .advanced
+            .capabilities()
+            .is_some_and(|capabilities| !capabilities.is_empty())
+        {
             self.client.require_linux_capabilities_enabled().await?;
         }
 
@@ -296,14 +300,15 @@ mod tests {
     const BOX_RESPONSE: &str = r#"{"box_id":"01HJK4TNRPQSXYZ8WM6NCVT9R5","name":"named","status":"configured","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z","pid":null,"image":"alpine:latest","cpus":2,"memory_mib":512,"labels":{}}"#;
 
     fn capability_options() -> BoxOptions {
-        BoxOptions {
-            advanced: crate::AdvancedBoxOptions {
-                capabilities: crate::ContainerCapabilities {
-                    drop: vec!["NET_RAW".into()],
-                    ..Default::default()
-                },
+        let mut advanced = crate::AdvancedBoxOptions::default();
+        advanced
+            .set_capabilities(Some(crate::ContainerCapabilities {
+                drop: vec!["NET_RAW".into()],
                 ..Default::default()
-            },
+            }))
+            .unwrap();
+        BoxOptions {
+            advanced,
             ..Default::default()
         }
     }
@@ -464,13 +469,12 @@ mod tests {
         std::fs::write(&kernel, b"custom kernel").unwrap();
         let options = BoxliteRestOptions::new("http://localhost:1");
         let runtime = RestRuntime::new(&options).expect("failed to create REST runtime");
+        let mut advanced = crate::runtime::advanced_options::AdvancedBoxOptions::default();
+        advanced.kernel = Some(crate::experimental::custom_kernel::KernelOptions::new(
+            kernel,
+        ));
         let opts = BoxOptions {
-            advanced: crate::runtime::advanced_options::AdvancedBoxOptions {
-                kernel: Some(crate::experimental::custom_kernel::KernelOptions::new(
-                    kernel,
-                )),
-                ..Default::default()
-            },
+            advanced,
             ..Default::default()
         };
 
@@ -487,11 +491,10 @@ mod tests {
     async fn create_rejects_nested_virtualization_in_rest_mode() {
         let options = BoxliteRestOptions::new("http://localhost:1");
         let runtime = RestRuntime::new(&options).expect("failed to create REST runtime");
+        let mut advanced = crate::runtime::advanced_options::AdvancedBoxOptions::default();
+        advanced.nested_virtualization = true;
         let box_options = BoxOptions {
-            advanced: crate::runtime::advanced_options::AdvancedBoxOptions {
-                nested_virtualization: true,
-                ..Default::default()
-            },
+            advanced,
             ..Default::default()
         };
 
@@ -511,13 +514,12 @@ mod tests {
         std::fs::write(&kernel, b"custom kernel").unwrap();
         let options = BoxliteRestOptions::new("http://localhost:1");
         let runtime = RestRuntime::new(&options).expect("failed to create REST runtime");
+        let mut advanced = crate::runtime::advanced_options::AdvancedBoxOptions::default();
+        advanced.kernel = Some(crate::experimental::custom_kernel::KernelOptions::new(
+            kernel,
+        ));
         let opts = BoxOptions {
-            advanced: crate::runtime::advanced_options::AdvancedBoxOptions {
-                kernel: Some(crate::experimental::custom_kernel::KernelOptions::new(
-                    kernel,
-                )),
-                ..Default::default()
-            },
+            advanced,
             ..Default::default()
         };
 
@@ -534,11 +536,10 @@ mod tests {
     async fn get_or_create_rejects_nested_virtualization_in_rest_mode() {
         let options = BoxliteRestOptions::new("http://localhost:1");
         let runtime = RestRuntime::new(&options).expect("failed to create REST runtime");
+        let mut advanced = crate::runtime::advanced_options::AdvancedBoxOptions::default();
+        advanced.nested_virtualization = true;
         let box_options = BoxOptions {
-            advanced: crate::runtime::advanced_options::AdvancedBoxOptions {
-                nested_virtualization: true,
-                ..Default::default()
-            },
+            advanced,
             ..Default::default()
         };
 

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -196,11 +196,13 @@ impl CreateBoxRequest {
             volumes,
             detach: Some(options.detach),
             tty: options.tty.then_some(true),
-            advanced: (!options.advanced.capabilities.is_empty()).then(|| {
-                CreateBoxAdvancedOptions {
-                    capabilities: options.advanced.capabilities.clone(),
-                }
-            }),
+            advanced: options
+                .advanced
+                .capabilities()
+                .filter(|capabilities| !capabilities.is_empty())
+                .map(|capabilities| CreateBoxAdvancedOptions {
+                    capabilities: capabilities.clone(),
+                }),
             // The deprecated remove-on-stop flag was never applied by the cloud
             // control-plane mapper. Keep remote defaults unchanged and only send
             // the modern lifecycle fields when callers explicitly configure them.
@@ -729,14 +731,15 @@ mod tests {
 
     #[test]
     fn test_create_box_request_carries_container_capabilities() {
+        let mut advanced = crate::AdvancedBoxOptions::default();
+        advanced
+            .set_capabilities(Some(ContainerCapabilities {
+                add: vec!["SYS_ADMIN".into()],
+                drop: vec!["CAP_NET_RAW".into()],
+            }))
+            .unwrap();
         let opts = BoxOptions {
-            advanced: crate::AdvancedBoxOptions {
-                capabilities: ContainerCapabilities {
-                    add: vec!["SYS_ADMIN".into()],
-                    drop: vec!["CAP_NET_RAW".into()],
-                },
-                ..Default::default()
-            },
+            advanced,
             ..Default::default()
         };
 
@@ -832,12 +835,11 @@ mod tests {
         use crate::runtime::advanced_options::AdvancedBoxOptions;
         use crate::runtime::options::{BoxOptions, RootfsSpec};
 
+        let mut advanced = AdvancedBoxOptions::default();
+        advanced.security = SecurityOptions::enabled();
         let opts = BoxOptions {
             rootfs: RootfsSpec::Image("alpine:latest".into()),
-            advanced: AdvancedBoxOptions {
-                security: SecurityOptions::enabled(),
-                ..Default::default()
-            },
+            advanced,
             ..Default::default()
         };
         let req = CreateBoxRequest::from_options(&opts, None);

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -196,13 +196,15 @@ impl CreateBoxRequest {
             volumes,
             detach: Some(options.detach),
             tty: options.tty.then_some(true),
-            advanced: options
-                .advanced
-                .capabilities()
-                .filter(|capabilities| !capabilities.is_empty())
-                .map(|capabilities| CreateBoxAdvancedOptions {
+            // `Some`, not "non-empty", decides whether this reaches the wire:
+            // an explicitly empty policy is still explicit, and collapsing it
+            // into the same shape as "never touched" would leave the server
+            // unable to tell the two apart.
+            advanced: options.advanced.capabilities().map(|capabilities| {
+                CreateBoxAdvancedOptions {
                     capabilities: capabilities.clone(),
-                }),
+                }
+            }),
             // The deprecated remove-on-stop flag was never applied by the cloud
             // control-plane mapper. Keep remote defaults unchanged and only send
             // the modern lifecycle fields when callers explicitly configure them.
@@ -757,6 +759,30 @@ mod tests {
         let defaults = CreateBoxRequest::from_options(&BoxOptions::default(), None);
         let defaults_json = serde_json::to_value(defaults).expect("serialize defaults");
         assert!(defaults_json.get("advanced").is_none());
+    }
+
+    /// An explicit, empty policy is still explicit — it must reach the wire,
+    /// not collapse into the same "advanced omitted" shape an untouched
+    /// field produces, or the server can no longer tell the two apart.
+    #[test]
+    fn test_create_box_request_carries_an_explicitly_empty_capability_policy() {
+        let mut advanced = crate::AdvancedBoxOptions::default();
+        advanced
+            .set_capabilities(Some(ContainerCapabilities::default()))
+            .unwrap();
+        let opts = BoxOptions {
+            advanced,
+            ..Default::default()
+        };
+
+        let req = CreateBoxRequest::from_options(&opts, None);
+        assert!(
+            req.advanced.is_some(),
+            "an explicit empty policy must still be serialized"
+        );
+
+        let json = serde_json::to_value(&req).expect("serialize create request");
+        assert!(json.get("advanced").is_some());
     }
 
     #[test]

--- a/src/boxlite/src/runtime/advanced_options.rs
+++ b/src/boxlite/src/runtime/advanced_options.rs
@@ -669,11 +669,20 @@ fn validate_capability_names(
 ///
 /// Entry-level users can ignore this — the defaults are secure and sensible.
 /// Only modify these if you understand the security implications.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct AdvancedBoxOptions {
     /// Linux capability policy for the container process.
+    ///
+    /// `None` means the caller left it unspecified. That's a distinct state
+    /// from `Some` of an empty policy: combined with `privileged`, leaving
+    /// this unspecified is the one-flag DinD case (see `privileged`'s own
+    /// doc comment), while an explicit override — even an empty one — is a
+    /// conflict `validate_privileged_capability_conflict` rejects. Private;
+    /// read via `capabilities()`, write via `set_capabilities`, which also
+    /// enforces that this can't change out from under an already-resolved
+    /// request (see `resolved`).
     #[serde(default)]
-    pub capabilities: ContainerCapabilities,
+    capabilities: Option<ContainerCapabilities>,
 
     /// Security isolation options (jailer, seccomp, namespaces, resource limits).
     ///
@@ -737,32 +746,94 @@ pub struct AdvancedBoxOptions {
     /// the caller" ambiguity to track.
     #[serde(default)]
     pub privileged: bool,
+
+    /// Set once `resolve_container_security` has run on this instance.
+    /// `set_capabilities` refuses to change the policy afterward — a
+    /// resolved request's capabilities shouldn't shift under it before the
+    /// resolved value is actually used. `AtomicBool`, not a plain `bool` or
+    /// `Cell`, for two reasons: `resolve_container_security` only borrows
+    /// `&self` (it's a read-only computation over everything except this
+    /// bookkeeping bit), and `AdvancedBoxOptions` crosses `Send`/`Sync`
+    /// boundaries (it lives inside `BoxOptions`, held across `.await`
+    /// points) where `Cell` doesn't qualify. Not persisted: a freshly
+    /// deserialized instance hasn't resolved anything yet in *this*
+    /// process, regardless of the box it was loaded for. `Clone` is
+    /// implemented manually below because atomics aren't `Clone` — a clone
+    /// is a fresh, unresolved copy, which is the right default for building
+    /// a new request off of an old one's data.
+    #[serde(skip)]
+    resolved: std::sync::atomic::AtomicBool,
+}
+
+impl Clone for AdvancedBoxOptions {
+    fn clone(&self) -> Self {
+        Self {
+            capabilities: self.capabilities.clone(),
+            security: self.security.clone(),
+            isolate_mounts: self.isolate_mounts,
+            health_check: self.health_check.clone(),
+            kernel: self.kernel.clone(),
+            nested_virtualization: self.nested_virtualization,
+            privileged: self.privileged,
+            resolved: std::sync::atomic::AtomicBool::new(false),
+        }
+    }
 }
 
 impl AdvancedBoxOptions {
+    /// The caller's capability policy, if one was configured. `None` means
+    /// unspecified — see the field's own doc comment for why that's not the
+    /// same as an explicit empty policy.
+    pub fn capabilities(&self) -> Option<&ContainerCapabilities> {
+        self.capabilities.as_ref()
+    }
+
+    /// Replace the capability policy. `None` clears back to "unspecified".
+    ///
+    /// Errors if this options object has already been resolved (used to
+    /// build a box request via `resolve_container_security`) — capabilities
+    /// cannot change after that point.
+    pub fn set_capabilities(
+        &mut self,
+        capabilities: Option<ContainerCapabilities>,
+    ) -> boxlite_shared::errors::BoxliteResult<()> {
+        if self.resolved.load(std::sync::atomic::Ordering::Relaxed) {
+            return Err(boxlite_shared::errors::BoxliteError::InvalidArgument(
+                "capabilities cannot be changed after these options have been resolved".to_string(),
+            ));
+        }
+        self.capabilities = capabilities;
+        Ok(())
+    }
+
     /// Reject capability overrides that conflict with privileged mode.
     ///
     /// Moby's own `TweakCapabilities` silently ignores `CapAdd`/`CapDrop`
     /// once `--privileged` is set — a real, reported footgun. Failing loudly
     /// here instead means a caller who sets both finds out at request time,
     /// not by wondering later why their capability override had no effect.
-    /// The canonical `add=["ALL"]` shape is allowed: it is what a box already
-    /// created under an earlier version of this option (which mutated
-    /// `capabilities` in place) has persisted, and it's the same effective
-    /// result `resolve_container_security` would produce anyway.
+    /// `None` (unspecified) is the only value privileged mode tolerates; an
+    /// explicit `Some`, even an empty one, is rejected unless it's already
+    /// the canonical `add=["ALL"]` shape — that's what a box created under
+    /// an earlier version of this option (which mutated `capabilities` in
+    /// place) has persisted, and it's the same effective result
+    /// `resolve_container_security` would produce anyway.
     pub(crate) fn validate_privileged_capability_conflict(
         &self,
     ) -> boxlite_shared::errors::BoxliteResult<()> {
-        if self.privileged
-            && !self.capabilities.is_empty()
-            && !self.capabilities.is_privileged_capability_shape()
-        {
-            return Err(boxlite_shared::errors::BoxliteError::InvalidArgument(
-                "privileged mode cannot be combined with cap_add or cap_drop".to_string(),
-            ));
+        if !self.privileged {
+            return Ok(());
         }
 
-        Ok(())
+        match &self.capabilities {
+            None => Ok(()),
+            Some(caps) if caps.is_privileged_capability_shape() => Ok(()),
+            Some(_) => Err(boxlite_shared::errors::BoxliteError::InvalidArgument(
+                "privileged mode cannot be combined with an explicit capabilities override, \
+                 including an explicitly empty one — leave capabilities unspecified instead"
+                    .to_string(),
+            )),
+        }
     }
 
     /// Toggle privileged mode.
@@ -794,7 +865,7 @@ impl AdvancedBoxOptions {
                 drop: Vec::new(),
             }
         } else {
-            self.capabilities.clone()
+            self.capabilities.clone().unwrap_or_default()
         }
     }
 
@@ -817,6 +888,8 @@ impl AdvancedBoxOptions {
         &self,
     ) -> boxlite_shared::errors::BoxliteResult<ResolvedContainerSecurityConfig> {
         self.validate_privileged_capability_conflict()?;
+        self.resolved
+            .store(true, std::sync::atomic::Ordering::Relaxed);
 
         let capabilities = self.effective_capabilities();
 
@@ -975,7 +1048,7 @@ mod resolved_security_tests {
             .resolve_container_security()
             .expect("privileged security should resolve");
 
-        assert!(options.capabilities.is_empty());
+        assert!(options.capabilities.is_none());
     }
 
     /// Capabilities and the OCI path/mount shape are resolved from the same
@@ -984,10 +1057,10 @@ mod resolved_security_tests {
     #[test]
     fn capability_override_without_privileged_keeps_hardened_paths() {
         let options = AdvancedBoxOptions {
-            capabilities: ContainerCapabilities {
+            capabilities: Some(ContainerCapabilities {
                 add: vec!["SYS_ADMIN".to_string()],
                 ..Default::default()
-            },
+            }),
             ..Default::default()
         };
 
@@ -1008,10 +1081,10 @@ mod resolved_security_tests {
     fn privileged_rejects_conflicting_capability_override() {
         let options = AdvancedBoxOptions {
             privileged: true,
-            capabilities: ContainerCapabilities {
+            capabilities: Some(ContainerCapabilities {
                 add: vec!["SYS_ADMIN".to_string()],
                 ..Default::default()
-            },
+            }),
             ..Default::default()
         };
 

--- a/src/boxlite/src/runtime/advanced_options.rs
+++ b/src/boxlite/src/runtime/advanced_options.rs
@@ -765,6 +765,18 @@ impl AdvancedBoxOptions {
         Ok(())
     }
 
+    /// Toggle privileged mode.
+    ///
+    /// A thin wrapper over the `privileged` field itself — kept as a stable
+    /// method for existing callers of this crate's public API rather than
+    /// requiring a field assignment. It no longer does anything beyond
+    /// `self.privileged = enabled`: `capabilities` isn't installed or
+    /// withdrawn here (see `resolve_container_security`, which computes the
+    /// effective capability set fresh instead).
+    pub fn set_privileged(&mut self, enabled: bool) {
+        self.privileged = enabled;
+    }
+
     /// The capability policy actually enforced, after moby-style privileged
     /// resolution — not just the caller's raw `capabilities` field.
     ///
@@ -918,15 +930,24 @@ mod resolved_security_tests {
         assert!(resolved.mount.options.contains(&"rro".to_string()));
     }
 
+    #[test]
+    fn set_privileged_toggles_the_plain_field() {
+        let mut options = AdvancedBoxOptions::default();
+
+        options.set_privileged(true);
+        assert!(options.privileged);
+
+        options.set_privileged(false);
+        assert!(!options.privileged);
+    }
+
     /// Matches moby's `TweakCapabilities`: `privileged` alone resolves every
     /// capability, the same one-flag DinD enabler Docker's `--privileged`
     /// is — no separate `capabilities.add = ["ALL"]` required.
     #[test]
     fn privileged_resolves_cleared_readonly_paths_and_writable_sys() {
-        let options = AdvancedBoxOptions {
-            privileged: true,
-            ..Default::default()
-        };
+        let mut options = AdvancedBoxOptions::default();
+        options.set_privileged(true);
 
         let resolved = options
             .resolve_container_security()

--- a/src/boxlite/src/runtime/advanced_options.rs
+++ b/src/boxlite/src/runtime/advanced_options.rs
@@ -725,6 +725,16 @@ pub struct AdvancedBoxOptions {
     pub nested_virtualization: bool,
 
     /// Docker-style privileged OCI spec shape for DinD.
+    ///
+    /// Mirrors how moby itself resolves this (`oci/caps.TweakCapabilities`):
+    /// privileged short-circuits straight to every capability, and never
+    /// writes that result back into `CapAdd`/`CapDrop` — those stay exactly
+    /// what the caller set, and the container's *effective* capabilities are
+    /// computed fresh from `privileged` + `capabilities` every time a spec is
+    /// built. `resolve_container_security` is BoxLite's equivalent of that
+    /// computation: `capabilities` here is never mutated by `privileged` in
+    /// either direction, so there is no "did privileged install this or did
+    /// the caller" ambiguity to track.
     #[serde(default)]
     pub privileged: bool,
 }
@@ -732,9 +742,14 @@ pub struct AdvancedBoxOptions {
 impl AdvancedBoxOptions {
     /// Reject capability overrides that conflict with privileged mode.
     ///
-    /// The canonical `add=["ALL"]` shape is allowed for persisted and FFI
-    /// options that have already been normalized. Other explicit overrides
-    /// must not be silently discarded by privileged mode.
+    /// Moby's own `TweakCapabilities` silently ignores `CapAdd`/`CapDrop`
+    /// once `--privileged` is set — a real, reported footgun. Failing loudly
+    /// here instead means a caller who sets both finds out at request time,
+    /// not by wondering later why their capability override had no effect.
+    /// The canonical `add=["ALL"]` shape is allowed: it is what a box already
+    /// created under an earlier version of this option (which mutated
+    /// `capabilities` in place) has persisted, and it's the same effective
+    /// result `resolve_container_security` would produce anyway.
     pub(crate) fn validate_privileged_capability_conflict(
         &self,
     ) -> boxlite_shared::errors::BoxliteResult<()> {
@@ -750,34 +765,24 @@ impl AdvancedBoxOptions {
         Ok(())
     }
 
-    /// Toggle privileged mode, keeping the capability policy consistent in
-    /// both directions.
+    /// The capability policy actually enforced, after moby-style privileged
+    /// resolution — not just the caller's raw `capabilities` field.
     ///
-    /// Enabling expands to the canonical shape; disabling withdraws it again,
-    /// so a handle that is toggled off does not leave a non-privileged box
-    /// holding `ALL`. An explicit policy the caller set themselves is left
-    /// alone — only the shape this method produced is taken back.
-    pub fn set_privileged(&mut self, enabled: bool) {
-        self.privileged = enabled;
-
-        if enabled {
-            self.normalize_privileged();
-        } else if self.capabilities.is_privileged_capability_shape() {
-            self.capabilities = ContainerCapabilities::default();
-        }
-    }
-
-    /// Expand the high-level privileged mode into the explicit capability
-    /// policy consumed by the guest. Call
-    /// `validate_privileged_capability_conflict` before this method; a
-    /// conflicting explicit override is deliberately left untouched so it
-    /// cannot be silently discarded.
-    pub(crate) fn normalize_privileged(&mut self) {
-        if self.privileged
-            && (self.capabilities.is_empty() || self.capabilities.is_privileged_capability_shape())
-        {
-            self.capabilities.add = vec!["ALL".to_string()];
-            self.capabilities.drop.clear();
+    /// Used wherever the *effective* policy matters rather than what happens
+    /// to be stored: box-reuse compatibility in particular, where an
+    /// already-persisted privileged box's raw field may predate this —  an
+    /// earlier version of this option mutated `capabilities` to `add=["ALL"]`
+    /// on enable, so that box's raw field looks different from a new
+    /// privileged request that leaves `capabilities` empty even though both
+    /// resolve to the same thing.
+    pub(crate) fn effective_capabilities(&self) -> ContainerCapabilities {
+        if self.privileged {
+            ContainerCapabilities {
+                add: vec!["ALL".to_string()],
+                drop: Vec::new(),
+            }
+        } else {
+            self.capabilities.clone()
         }
     }
 
@@ -791,28 +796,29 @@ impl AdvancedBoxOptions {
     /// DinD reads a masked path, so the guest keeps applying its own oci-spec
     /// default unconditionally, the same way it did before `privileged`
     /// existed — see the Trade-offs note on the finding that motivated
-    /// dropping it. The guest still resolves the canonical capability names
-    /// against its own kernel ceiling, but it must not reinterpret
-    /// `privileged` or silently discard capability overrides.
+    /// dropping it. Capabilities follow moby's own `TweakCapabilities`:
+    /// privileged short-circuits to every capability and `self.capabilities`
+    /// is read, never written — call `validate_privileged_capability_conflict`
+    /// first so a conflicting explicit override is rejected rather than
+    /// silently overridden here.
     pub(crate) fn resolve_container_security(
         &self,
     ) -> boxlite_shared::errors::BoxliteResult<ResolvedContainerSecurityConfig> {
         self.validate_privileged_capability_conflict()?;
 
-        let mut normalized = self.clone();
-        normalized.normalize_privileged();
+        let capabilities = self.effective_capabilities();
 
-        let readonly_paths = if normalized.privileged {
+        let readonly_paths = if self.privileged {
             Vec::new()
         } else {
             default_readonly_paths()
         };
 
         Ok(ResolvedContainerSecurityConfig {
-            capabilities: normalized.capabilities,
+            capabilities,
             linux: ResolvedLinuxSecurity { readonly_paths },
             mount: ResolvedMountSecurity {
-                options: mount_options(normalized.privileged),
+                options: mount_options(self.privileged),
             },
         })
     }
@@ -912,10 +918,15 @@ mod resolved_security_tests {
         assert!(resolved.mount.options.contains(&"rro".to_string()));
     }
 
+    /// Matches moby's `TweakCapabilities`: `privileged` alone resolves every
+    /// capability, the same one-flag DinD enabler Docker's `--privileged`
+    /// is — no separate `capabilities.add = ["ALL"]` required.
     #[test]
     fn privileged_resolves_cleared_readonly_paths_and_writable_sys() {
-        let mut options = AdvancedBoxOptions::default();
-        options.set_privileged(true);
+        let options = AdvancedBoxOptions {
+            privileged: true,
+            ..Default::default()
+        };
 
         let resolved = options
             .resolve_container_security()
@@ -924,6 +935,26 @@ mod resolved_security_tests {
         assert!(resolved.linux.readonly_paths.is_empty());
         assert!(!resolved.mount.options.contains(&"rro".to_string()));
         assert_eq!(resolved.capabilities.add, ["ALL"]);
+    }
+
+    /// Also like moby's `TweakCapabilities`: privileged resolution reads
+    /// `capabilities`, it never writes it. Unlike an earlier version of this
+    /// option (which mutated `capabilities` in place on enable, then had to
+    /// track whether it was safe to take that mutation back on disable),
+    /// there is nothing here to withdraw — the field the caller set is
+    /// exactly the field they get back.
+    #[test]
+    fn privileged_resolution_does_not_mutate_capabilities() {
+        let options = AdvancedBoxOptions {
+            privileged: true,
+            ..Default::default()
+        };
+
+        options
+            .resolve_container_security()
+            .expect("privileged security should resolve");
+
+        assert!(options.capabilities.is_empty());
     }
 
     /// Capabilities and the OCI path/mount shape are resolved from the same
@@ -945,5 +976,28 @@ mod resolved_security_tests {
 
         assert!(!resolved.linux.readonly_paths.is_empty());
         assert!(resolved.mount.options.contains(&"rro".to_string()));
+        assert_eq!(resolved.capabilities.add, ["SYS_ADMIN"]);
+    }
+
+    /// The conflict guard mirrors a real moby footgun (`--privileged` +
+    /// `--cap-drop` silently ignores the drop) but fails loudly instead: a
+    /// caller combining `privileged` with an explicit, non-canonical
+    /// capability override finds out at request time.
+    #[test]
+    fn privileged_rejects_conflicting_capability_override() {
+        let options = AdvancedBoxOptions {
+            privileged: true,
+            capabilities: ContainerCapabilities {
+                add: vec!["SYS_ADMIN".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let error = options
+            .resolve_container_security()
+            .expect_err("privileged mode plus an explicit override should be rejected");
+
+        assert!(error.to_string().contains("cannot be combined"));
     }
 }

--- a/src/boxlite/src/runtime/advanced_options.rs
+++ b/src/boxlite/src/runtime/advanced_options.rs
@@ -1094,4 +1094,27 @@ mod resolved_security_tests {
 
         assert!(error.to_string().contains("cannot be combined"));
     }
+
+    /// The conflict guard runs on the final state at `resolve_container_security`
+    /// time, not on each setter call — so it doesn't matter which knob a caller
+    /// (e.g. CLI flags, or an SDK's builder) happens to set first. Setting an
+    /// explicit capability override and only then turning on `privileged` must
+    /// be rejected exactly like setting them in the opposite order.
+    #[test]
+    fn privileged_rejects_conflicting_override_regardless_of_setter_order() {
+        let mut options = AdvancedBoxOptions::default();
+        options
+            .set_capabilities(Some(ContainerCapabilities {
+                add: vec!["SYS_ADMIN".to_string()],
+                ..Default::default()
+            }))
+            .unwrap();
+        options.set_privileged(true);
+
+        let error = options.resolve_container_security().expect_err(
+            "capabilities-then-privileged should be rejected same as the reverse order",
+        );
+
+        assert!(error.to_string().contains("cannot be combined"));
+    }
 }

--- a/src/boxlite/src/runtime/advanced_options.rs
+++ b/src/boxlite/src/runtime/advanced_options.rs
@@ -681,7 +681,17 @@ pub struct AdvancedBoxOptions {
     /// read via `capabilities()`, write via `set_capabilities`, which also
     /// enforces that this can't change out from under an already-resolved
     /// request (see `resolved`).
-    #[serde(default)]
+    ///
+    /// `skip_serializing_if` on top of `default` is load-bearing, not
+    /// cosmetic: without it, `None` serializes as an explicit `"capabilities":
+    /// null`, which a pre-Option build's plain `ContainerCapabilities` field
+    /// rejects with "invalid type: null, expected struct
+    /// ContainerCapabilities" — `#[serde(default)]` alone only covers an
+    /// *absent* key. Omitting the key on `None` keeps an ordinary box's
+    /// exported manifest byte-for-byte what a pre-#1296 importer already
+    /// handles, which is the entire premise `archive_version_for_options`
+    /// relies on to leave that case at `ARCHIVE_VERSION` instead of bumping it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     capabilities: Option<ContainerCapabilities>,
 
     /// Security isolation options (jailer, seccomp, namespaces, resource limits).

--- a/src/boxlite/src/runtime/import.rs
+++ b/src/boxlite/src/runtime/import.rs
@@ -298,11 +298,10 @@ mod tests {
 
     #[test]
     fn untrusted_import_rejects_nested_virtualization() {
+        let mut advanced = crate::runtime::advanced_options::AdvancedBoxOptions::default();
+        advanced.nested_virtualization = true;
         let options = BoxOptions {
-            advanced: crate::runtime::advanced_options::AdvancedBoxOptions {
-                nested_virtualization: true,
-                ..Default::default()
-            },
+            advanced,
             ..Default::default()
         };
 
@@ -316,11 +315,10 @@ mod tests {
 
     #[test]
     fn untrusted_import_rejects_privileged() {
+        let mut advanced = crate::runtime::advanced_options::AdvancedBoxOptions::default();
+        advanced.privileged = true;
         let options = BoxOptions {
-            advanced: crate::runtime::advanced_options::AdvancedBoxOptions {
-                privileged: true,
-                ..Default::default()
-            },
+            advanced,
             ..Default::default()
         };
 
@@ -396,15 +394,14 @@ mod tests {
 
     #[test]
     fn trusted_import_preserves_archive_configuration() {
-        let mut options = BoxOptions {
-            advanced: crate::runtime::advanced_options::AdvancedBoxOptions {
-                nested_virtualization: true,
-                privileged: true,
-                ..Default::default()
-            },
+        let mut advanced = crate::runtime::advanced_options::AdvancedBoxOptions::default();
+        advanced.nested_virtualization = true;
+        advanced.privileged = true;
+        advanced.security = SecurityOptions::disabled();
+        let options = BoxOptions {
+            advanced,
             ..Default::default()
         };
-        options.advanced.security = SecurityOptions::disabled();
 
         let resolved =
             options_from_manifest(&v3_manifest(options), ArchiveImportPolicy::Trusted).unwrap();
@@ -416,18 +413,21 @@ mod tests {
 
     #[test]
     fn imported_capability_policy_is_validated_before_install() {
+        let mut advanced = crate::runtime::advanced_options::AdvancedBoxOptions::default();
+        advanced
+            .set_capabilities(Some(
+                crate::runtime::advanced_options::ContainerCapabilities {
+                    drop: vec!["NET-ADMIN".into()],
+                    ..Default::default()
+                },
+            ))
+            .unwrap();
         let manifest = ArchiveManifest {
             version: 3,
             box_name: Some("untrusted".into()),
             image: "alpine:latest".into(),
             box_options: Some(BoxOptions {
-                advanced: crate::runtime::advanced_options::AdvancedBoxOptions {
-                    capabilities: crate::runtime::advanced_options::ContainerCapabilities {
-                        drop: vec!["NET-ADMIN".into()],
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                },
+                advanced,
                 ..Default::default()
             }),
             guest_disk_checksum: String::new(),

--- a/src/boxlite/src/runtime/options.rs
+++ b/src/boxlite/src/runtime/options.rs
@@ -588,7 +588,9 @@ impl BoxOptions {
         }
 
         self.advanced.validate_privileged_capability_conflict()?;
-        self.advanced.capabilities.validate()?;
+        if let Some(capabilities) = self.advanced.capabilities() {
+            capabilities.validate()?;
+        }
 
         if matches!(self.network, NetworkSpec::Disabled) && !self.ports.is_empty() {
             return Err(boxlite_shared::errors::BoxliteError::Config(
@@ -1077,8 +1079,8 @@ mod tests {
         );
         assert!(!opts.detach, "detach should default to false");
         assert!(
-            opts.advanced.capabilities.is_empty(),
-            "advanced capabilities should default to empty"
+            opts.advanced.capabilities().is_none(),
+            "advanced capabilities should default to unspecified"
         );
     }
 
@@ -1094,30 +1096,29 @@ mod tests {
         }"#;
 
         let opts: BoxOptions = serde_json::from_str(json).unwrap();
-        assert_eq!(
-            opts.advanced.capabilities.add,
-            ["SYS_ADMIN", "CAP_NET_ADMIN"]
-        );
-        assert_eq!(opts.advanced.capabilities.drop, ["NET_RAW"]);
+        let capabilities = opts.advanced.capabilities().expect("capabilities set");
+        assert_eq!(capabilities.add, ["SYS_ADMIN", "CAP_NET_ADMIN"]);
+        assert_eq!(capabilities.drop, ["NET_RAW"]);
 
         let serialized = serde_json::to_string(&opts).unwrap();
         let roundtripped: BoxOptions = serde_json::from_str(&serialized).unwrap();
         assert_eq!(
-            roundtripped.advanced.capabilities,
-            opts.advanced.capabilities
+            roundtripped.advanced.capabilities(),
+            opts.advanced.capabilities()
         );
     }
 
     #[test]
     fn box_options_sanitize_accepts_valid_capability_names() {
+        let mut advanced = AdvancedBoxOptions::default();
+        advanced
+            .set_capabilities(Some(ContainerCapabilities {
+                add: vec!["sys_admin".into(), "CAP_NET_ADMIN".into()],
+                drop: vec!["NET_RAW".into()],
+            }))
+            .unwrap();
         let opts = BoxOptions {
-            advanced: AdvancedBoxOptions {
-                capabilities: ContainerCapabilities {
-                    add: vec!["sys_admin".into(), "CAP_NET_ADMIN".into()],
-                    drop: vec!["NET_RAW".into()],
-                },
-                ..Default::default()
-            },
+            advanced,
             ..Default::default()
         };
 
@@ -1127,14 +1128,15 @@ mod tests {
 
     #[test]
     fn box_options_sanitize_accepts_future_capability_names() {
-        let opts = BoxOptions {
-            advanced: AdvancedBoxOptions {
-                capabilities: ContainerCapabilities {
-                    add: vec!["FUTURE_KERNEL_FEATURE".into()],
-                    ..Default::default()
-                },
+        let mut advanced = AdvancedBoxOptions::default();
+        advanced
+            .set_capabilities(Some(ContainerCapabilities {
+                add: vec!["FUTURE_KERNEL_FEATURE".into()],
                 ..Default::default()
-            },
+            }))
+            .unwrap();
+        let opts = BoxOptions {
+            advanced,
             ..Default::default()
         };
 
@@ -1144,48 +1146,33 @@ mod tests {
 
     #[test]
     fn box_options_sanitize_rejects_malformed_capability_names() {
-        for opts in [
-            BoxOptions {
-                advanced: AdvancedBoxOptions {
-                    capabilities: ContainerCapabilities {
-                        add: vec!["".into()],
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                },
+        let malformed = [
+            ContainerCapabilities {
+                add: vec!["".into()],
                 ..Default::default()
             },
-            BoxOptions {
-                advanced: AdvancedBoxOptions {
-                    capabilities: ContainerCapabilities {
-                        drop: vec!["NET-ADMIN".into()],
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                },
+            ContainerCapabilities {
+                drop: vec!["NET-ADMIN".into()],
                 ..Default::default()
             },
-            BoxOptions {
-                advanced: AdvancedBoxOptions {
-                    capabilities: ContainerCapabilities {
-                        add: vec!["123".into()],
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                },
+            ContainerCapabilities {
+                add: vec!["123".into()],
                 ..Default::default()
             },
-            BoxOptions {
-                advanced: AdvancedBoxOptions {
-                    capabilities: ContainerCapabilities {
-                        add: vec!["ß".into()],
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                },
+            ContainerCapabilities {
+                add: vec!["ß".into()],
                 ..Default::default()
             },
-        ] {
+        ];
+
+        for capabilities in malformed {
+            let mut advanced = AdvancedBoxOptions::default();
+            advanced.set_capabilities(Some(capabilities)).unwrap();
+            let opts = BoxOptions {
+                advanced,
+                ..Default::default()
+            };
+
             let err = opts
                 .sanitize()
                 .expect_err("malformed capability should be rejected");
@@ -1218,16 +1205,15 @@ mod tests {
         #[cfg(target_arch = "aarch64")]
         let format = KernelFormat::PeGz;
 
+        let mut advanced = AdvancedBoxOptions::default();
+        advanced.kernel = Some(
+            KernelOptions::new(&kernel)
+                .with_format(format)
+                .with_initramfs(&initramfs)
+                .with_command_line("console=ttyS0 panic=-1"),
+        );
         let opts = BoxOptions {
-            advanced: AdvancedBoxOptions {
-                kernel: Some(
-                    KernelOptions::new(&kernel)
-                        .with_format(format)
-                        .with_initramfs(&initramfs)
-                        .with_command_line("console=ttyS0 panic=-1"),
-                ),
-                ..Default::default()
-            },
+            advanced,
             ..Default::default()
         };
 
@@ -1242,11 +1228,10 @@ mod tests {
 
     #[test]
     fn custom_kernel_must_be_a_file() {
+        let mut advanced = AdvancedBoxOptions::default();
+        advanced.kernel = Some(KernelOptions::new("/definitely/missing/vmlinux"));
         let opts = BoxOptions {
-            advanced: AdvancedBoxOptions {
-                kernel: Some(KernelOptions::new("/definitely/missing/vmlinux")),
-                ..Default::default()
-            },
+            advanced,
             ..Default::default()
         };
 
@@ -1262,15 +1247,14 @@ mod tests {
         let format = KernelFormat::Elf;
         #[cfg(target_arch = "aarch64")]
         let format = KernelFormat::PeGz;
+        let mut advanced = AdvancedBoxOptions::default();
+        advanced.kernel = Some(
+            KernelOptions::new("/source/removed/after-create")
+                .with_format(format)
+                .with_command_line("console=ttyS0"),
+        );
         let opts = BoxOptions {
-            advanced: AdvancedBoxOptions {
-                kernel: Some(
-                    KernelOptions::new("/source/removed/after-create")
-                        .with_format(format)
-                        .with_command_line("console=ttyS0"),
-                ),
-                ..Default::default()
-            },
+            advanced,
             ..Default::default()
         };
 
@@ -1283,15 +1267,14 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let kernel = temp.path().join("vmlinux");
         std::fs::write(&kernel, b"\x7fELFcustom kernel").unwrap();
+        let mut advanced = AdvancedBoxOptions::default();
+        advanced.kernel = Some(
+            KernelOptions::new(&kernel)
+                .with_format(KernelFormat::Elf)
+                .with_initramfs(temp.path().join("missing-initramfs")),
+        );
         let opts = BoxOptions {
-            advanced: AdvancedBoxOptions {
-                kernel: Some(
-                    KernelOptions::new(&kernel)
-                        .with_format(KernelFormat::Elf)
-                        .with_initramfs(temp.path().join("missing-initramfs")),
-                ),
-                ..Default::default()
-            },
+            advanced,
             ..Default::default()
         };
 
@@ -1419,17 +1402,17 @@ mod tests {
             .validate_privileged_capability_conflict()
             .expect("canonical privileged shape should be accepted");
 
-        assert_eq!(options.advanced.capabilities.add, ["ALL"]);
-        assert!(options.advanced.capabilities.drop.is_empty());
+        let capabilities = options.advanced.capabilities().expect("capabilities set");
+        assert_eq!(capabilities.add, ["ALL"]);
+        assert!(capabilities.drop.is_empty());
     }
 
     #[test]
     fn privileged_security_is_resolved_before_guest_init() {
+        let mut advanced = crate::AdvancedBoxOptions::default();
+        advanced.privileged = true;
         let options = BoxOptions {
-            advanced: crate::AdvancedBoxOptions {
-                privileged: true,
-                ..Default::default()
-            },
+            advanced,
             ..Default::default()
         };
 

--- a/src/boxlite/src/runtime/options.rs
+++ b/src/boxlite/src/runtime/options.rs
@@ -1108,6 +1108,27 @@ mod tests {
         );
     }
 
+    /// An ordinary box (no explicit capability policy) must serialize with
+    /// the `capabilities` key absent, not present-as-`null` — a pre-#1296
+    /// build's plain, non-Option `capabilities` field parses an absent key
+    /// via its own `#[serde(default)]`, but rejects an explicit `null` with
+    /// "invalid type: null, expected struct ContainerCapabilities" (reproduced
+    /// standalone against that exact field shape before this test was added).
+    /// `archive_version_for_options` leaves this case at `ARCHIVE_VERSION`
+    /// specifically because it assumes the wire shape matches what a v3
+    /// importer already handles; this test is what keeps that true.
+    #[test]
+    fn box_options_omits_capabilities_key_when_unspecified() {
+        let json = serde_json::to_string(&BoxOptions::default()).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let advanced = parsed.get("advanced").unwrap();
+
+        assert!(
+            !advanced.as_object().unwrap().contains_key("capabilities"),
+            "unspecified capabilities must omit the key, not serialize null: {advanced}"
+        );
+    }
+
     #[test]
     fn box_options_sanitize_accepts_valid_capability_names() {
         let mut advanced = AdvancedBoxOptions::default();

--- a/src/boxlite/src/runtime/options.rs
+++ b/src/boxlite/src/runtime/options.rs
@@ -1403,9 +1403,13 @@ mod tests {
         assert!(error.to_string().contains("cannot be combined"));
     }
 
+    /// The canonical shape is accepted, not rewritten: unlike an earlier
+    /// version of this option, `capabilities` is never mutated by
+    /// `privileged` — this exists for a box persisted by that earlier
+    /// version, whose stored `capabilities` already looks like this.
     #[test]
     fn privileged_canonical_capability_shape_remains_accepted() {
-        let mut options: BoxOptions = serde_json::from_str(
+        let options: BoxOptions = serde_json::from_str(
             r#"{"advanced":{"privileged":true,"capabilities":{"add":["ALL"],"drop":[]}}}"#,
         )
         .unwrap();
@@ -1413,8 +1417,7 @@ mod tests {
         options
             .advanced
             .validate_privileged_capability_conflict()
-            .expect("normalized privileged shape should be accepted");
-        options.advanced.normalize_privileged();
+            .expect("canonical privileged shape should be accepted");
 
         assert_eq!(options.advanced.capabilities.add, ["ALL"]);
         assert!(options.advanced.capabilities.drop.is_empty());

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -553,6 +553,17 @@ impl RuntimeImpl {
                 "box '{box_name}' was created without privileged support and cannot satisfy a required privileged request; use a different name or recreate the box"
             )));
         }
+        // The mirror case: privileged governs mount hardening (readonly
+        // paths, /sys write access) as well as capabilities, so a privileged
+        // box can look capability-compatible with a non-privileged request
+        // (e.g. one that explicitly asks for `capabilities.add = ["ALL"]`)
+        // while still granting more than that request asked for. Reject
+        // instead of silently upgrading it.
+        if !requested.advanced.privileged && actual.options.advanced.privileged {
+            return Err(BoxliteError::Unsupported(format!(
+                "box '{box_name}' was created with privileged mode and would grant more than the requested non-privileged security policy; use a different name or recreate the box"
+            )));
+        }
 
         // Compare effective capabilities, not the raw field: a privileged
         // box persisted by an earlier version of this option has `add=["ALL"]`
@@ -1957,6 +1968,34 @@ mod tests {
         };
 
         assert!(RuntimeImpl::check_options_compatibility(&requested, &actual).is_ok());
+    }
+
+    #[test]
+    fn check_options_compatibility_rejects_non_privileged_request_reusing_a_privileged_box() {
+        // A privileged box's effective capabilities are `add=["ALL"]` — the
+        // same shape a non-privileged request can reach explicitly. Matching
+        // only on effective capabilities would let this request silently
+        // adopt the privileged box and inherit its cleared readonly paths
+        // and writable /sys, even though it never asked for privileged mode.
+        let mut actual = test_box_config(false);
+        actual.options.advanced.privileged = true;
+
+        let mut requested_advanced = crate::AdvancedBoxOptions::default();
+        requested_advanced
+            .set_capabilities(Some(crate::ContainerCapabilities {
+                add: vec!["ALL".to_string()],
+                ..Default::default()
+            }))
+            .unwrap();
+        let requested = BoxOptions {
+            advanced: requested_advanced,
+            ..Default::default()
+        };
+
+        assert!(matches!(
+            RuntimeImpl::check_options_compatibility(&requested, &actual),
+            Err(BoxliteError::Unsupported(_))
+        ));
     }
 
     #[tokio::test]

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -1936,16 +1936,23 @@ mod tests {
     #[test]
     fn options_compatibility_normalizes_capability_names() {
         let mut actual = test_box_config(false);
-        actual.options.advanced.capabilities.add =
-            vec!["NET_ADMIN".to_string(), "CAP_SYS_ADMIN".to_string()];
-        let requested = BoxOptions {
-            advanced: crate::AdvancedBoxOptions {
-                capabilities: crate::ContainerCapabilities {
-                    add: vec!["sys_admin".to_string(), "CAP_NET_ADMIN".to_string()],
-                    ..Default::default()
-                },
+        actual
+            .options
+            .advanced
+            .set_capabilities(Some(crate::ContainerCapabilities {
+                add: vec!["NET_ADMIN".to_string(), "CAP_SYS_ADMIN".to_string()],
                 ..Default::default()
-            },
+            }))
+            .unwrap();
+        let mut requested_advanced = crate::AdvancedBoxOptions::default();
+        requested_advanced
+            .set_capabilities(Some(crate::ContainerCapabilities {
+                add: vec!["sys_admin".to_string(), "CAP_NET_ADMIN".to_string()],
+                ..Default::default()
+            }))
+            .unwrap();
+        let requested = BoxOptions {
+            advanced: requested_advanced,
             ..Default::default()
         };
 
@@ -1957,7 +1964,14 @@ mod tests {
         let (runtime, _dir) = create_test_runtime();
         let mut config = test_box_config_in_layout(false, &runtime);
         config.name = Some("existing".to_string());
-        config.options.advanced.capabilities.drop = vec!["NET_RAW".to_string()];
+        config
+            .options
+            .advanced
+            .set_capabilities(Some(crate::ContainerCapabilities {
+                drop: vec!["NET_RAW".to_string()],
+                ..Default::default()
+            }))
+            .unwrap();
         runtime
             .box_manager
             .add_box(&config, &BoxState::new())
@@ -1998,11 +2012,10 @@ mod tests {
 
     #[tokio::test]
     async fn nested_virtualization_validation_uses_injected_features() {
+        let mut advanced = crate::runtime::advanced_options::AdvancedBoxOptions::default();
+        advanced.nested_virtualization = true;
         let options = BoxOptions {
-            advanced: crate::runtime::advanced_options::AdvancedBoxOptions {
-                nested_virtualization: true,
-                ..Default::default()
-            },
+            advanced,
             ..Default::default()
         };
 
@@ -2021,11 +2034,10 @@ mod tests {
 
     #[tokio::test]
     async fn privileged_options_do_not_require_experimental_features() {
+        let mut advanced = crate::runtime::advanced_options::AdvancedBoxOptions::default();
+        advanced.privileged = true;
         let options = BoxOptions {
-            advanced: crate::runtime::advanced_options::AdvancedBoxOptions {
-                privileged: true,
-                ..Default::default()
-            },
+            advanced,
             ..Default::default()
         };
 
@@ -3096,14 +3108,13 @@ mod tests {
             .unwrap();
         assert!(created);
 
+        let mut nested_advanced = crate::runtime::advanced_options::AdvancedBoxOptions::default();
+        nested_advanced.nested_virtualization = true;
         let result = runtime
             .get_or_create(
                 BoxOptions {
                     rootfs: RootfsSpec::Image("alpine:latest".into()),
-                    advanced: crate::runtime::advanced_options::AdvancedBoxOptions {
-                        nested_virtualization: true,
-                        ..Default::default()
-                    },
+                    advanced: nested_advanced,
                     ..Default::default()
                 },
                 name,
@@ -3166,14 +3177,13 @@ mod tests {
         let (runtime, _dir) = create_test_runtime();
         let name = Some("nested-box".to_string());
 
+        let mut nested_advanced = crate::runtime::advanced_options::AdvancedBoxOptions::default();
+        nested_advanced.nested_virtualization = true;
         let (nested_box, created) = runtime
             .get_or_create(
                 BoxOptions {
                     rootfs: RootfsSpec::Image("alpine:latest".into()),
-                    advanced: crate::runtime::advanced_options::AdvancedBoxOptions {
-                        nested_virtualization: true,
-                        ..Default::default()
-                    },
+                    advanced: nested_advanced,
                     ..Default::default()
                 },
                 name.clone(),

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -435,18 +435,6 @@ impl RuntimeImpl {
         name: Option<String>,
         reuse_existing: bool,
     ) -> BoxliteResult<(LiteBox, bool)> {
-        // Every reachable caller is `LocalRuntime` (`RuntimeImpl` isn't
-        // re-exported), which normalizes via `sanitize_local_options` before
-        // reaching here — assert the invariant instead of re-normalizing.
-        debug_assert!(
-            !options.advanced.privileged
-                || options
-                    .advanced
-                    .capabilities
-                    .is_privileged_capability_shape(),
-            "create_inner expects options already normalized by sanitize_local_options"
-        );
-
         // Check if runtime has been shut down
         if self.shutdown_token.is_cancelled() {
             return Err(BoxliteError::Stopped(
@@ -549,8 +537,6 @@ impl RuntimeImpl {
         actual: &BoxConfig,
     ) -> BoxliteResult<()> {
         let box_name = actual.name.as_deref().unwrap_or_else(|| actual.id.as_str());
-        let mut actual_advanced = actual.options.advanced.clone();
-        actual_advanced.normalize_privileged();
 
         // One-way: a nested-capable box satisfies any request, but a plain box
         // cannot satisfy one that needs /dev/kvm. Reusing it would look like a
@@ -562,16 +548,21 @@ impl RuntimeImpl {
                 "box '{box_name}' was created without nested virtualization and cannot satisfy a required nested virtualization request; use a different name or recreate the box"
             )));
         }
-        if requested.advanced.privileged && !actual_advanced.privileged {
+        if requested.advanced.privileged && !actual.options.advanced.privileged {
             return Err(BoxliteError::Unsupported(format!(
                 "box '{box_name}' was created without privileged support and cannot satisfy a required privileged request; use a different name or recreate the box"
             )));
         }
 
+        // Compare effective capabilities, not the raw field: a privileged
+        // box persisted by an earlier version of this option has `add=["ALL"]`
+        // mutated into its stored capabilities, while a new privileged
+        // request idiomatically leaves capabilities empty — both resolve to
+        // the same thing.
         requested
             .advanced
-            .capabilities
-            .check_compatibility(&actual_advanced.capabilities, box_name)?;
+            .effective_capabilities()
+            .check_compatibility(&actual.options.advanced.effective_capabilities(), box_name)?;
 
         Ok(())
     }
@@ -1221,12 +1212,10 @@ impl RuntimeImpl {
         self: &Arc<Self>,
         staging_dir: std::path::PathBuf,
         name: Option<String>,
-        mut options: BoxOptions,
+        options: BoxOptions,
         initial_status: BoxStatus,
     ) -> BoxliteResult<LiteBox> {
         use crate::litebox::config::ContainerRuntimeConfig;
-
-        options.advanced.normalize_privileged();
 
         let box_id = BoxIDMint::mint();
         let container_id = ContainerID::new();
@@ -1748,12 +1737,11 @@ fn reject_local_lifecycle_policy(options: &BoxOptions) -> BoxliteResult<()> {
 
 async fn sanitize_local_options(
     features: &ExperimentalFeatures,
-    mut options: BoxOptions,
+    options: BoxOptions,
 ) -> BoxliteResult<BoxOptions> {
     features.require_for_options(&options)?;
     tokio::task::spawn_blocking(move || {
         options.sanitize()?;
-        options.advanced.normalize_privileged();
         Ok(options)
     })
     .await
@@ -3149,11 +3137,10 @@ mod tests {
             .unwrap();
         assert!(created);
 
-        // set_privileged (not a hand-built struct literal) so this request is
-        // already in the normalized shape a real caller produces — create_inner
-        // itself no longer normalizes; it trusts sanitize_local_options did.
-        let mut advanced = crate::runtime::advanced_options::AdvancedBoxOptions::default();
-        advanced.set_privileged(true);
+        let advanced = crate::runtime::advanced_options::AdvancedBoxOptions {
+            privileged: true,
+            ..Default::default()
+        };
 
         let result = runtime
             .get_or_create(

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -3137,10 +3137,8 @@ mod tests {
             .unwrap();
         assert!(created);
 
-        let advanced = crate::runtime::advanced_options::AdvancedBoxOptions {
-            privileged: true,
-            ..Default::default()
-        };
+        let mut advanced = crate::runtime::advanced_options::AdvancedBoxOptions::default();
+        advanced.set_privileged(true);
 
         let result = runtime
             .get_or_create(

--- a/src/boxlite/src/vmm/controller/spawn.rs
+++ b/src/boxlite/src/vmm/controller/spawn.rs
@@ -325,14 +325,13 @@ mod tests {
             FsLayoutConfig::without_bind_mount(),
             false,
         );
+        let mut advanced = AdvancedBoxOptions::default();
+        advanced.security = SecurityOptions {
+            jailer_enabled: true,
+            ..SecurityOptions::default()
+        };
         let options = BoxOptions {
-            advanced: AdvancedBoxOptions {
-                security: SecurityOptions {
-                    jailer_enabled: true,
-                    ..SecurityOptions::default()
-                },
-                ..AdvancedBoxOptions::default()
-            },
+            advanced,
             ..BoxOptions::default()
         };
 
@@ -378,15 +377,14 @@ mod tests {
             FsLayoutConfig::without_bind_mount(),
             false,
         );
+        let mut advanced = AdvancedBoxOptions::default();
+        advanced.security = SecurityOptions {
+            jailer_enabled: true,
+            sandbox_profile: Some(PathBuf::from("/tmp/custom.sbpl")),
+            ..SecurityOptions::default()
+        };
         let options = BoxOptions {
-            advanced: AdvancedBoxOptions {
-                security: SecurityOptions {
-                    jailer_enabled: true,
-                    sandbox_profile: Some(PathBuf::from("/tmp/custom.sbpl")),
-                    ..SecurityOptions::default()
-                },
-                ..AdvancedBoxOptions::default()
-            },
+            advanced,
             ..BoxOptions::default()
         };
 

--- a/src/boxlite/tests/health_check.rs
+++ b/src/boxlite/tests/health_check.rs
@@ -24,17 +24,16 @@ fn health_check_opts(
     retries: u32,
     start_period: Duration,
 ) -> BoxOptions {
+    let mut advanced = AdvancedBoxOptions::default();
+    advanced.health_check = Some(HealthCheckOptions {
+        interval,
+        timeout,
+        retries,
+        start_period,
+    });
     BoxOptions {
         rootfs: RootfsSpec::Image("alpine:latest".into()),
-        advanced: AdvancedBoxOptions {
-            health_check: Some(HealthCheckOptions {
-                interval,
-                timeout,
-                retries,
-                start_period,
-            }),
-            ..Default::default()
-        },
+        advanced,
         auto_delete: Some(0),
         ..Default::default()
     }

--- a/src/boxlite/tests/jailer.rs
+++ b/src/boxlite/tests/jailer.rs
@@ -84,27 +84,25 @@ impl JailerHome {
 }
 
 fn jailer_enabled_options() -> BoxOptions {
+    let mut advanced = AdvancedBoxOptions::default();
+    advanced.security = SecurityOptions {
+        jailer_enabled: true,
+        ..SecurityOptions::default()
+    };
     BoxOptions {
-        advanced: AdvancedBoxOptions {
-            security: SecurityOptions {
-                jailer_enabled: true,
-                ..SecurityOptions::default()
-            },
-            ..Default::default()
-        },
+        advanced,
         ..common::alpine_opts()
     }
 }
 
 fn jailer_disabled_options() -> BoxOptions {
+    let mut advanced = AdvancedBoxOptions::default();
+    advanced.security = SecurityOptions {
+        jailer_enabled: false,
+        ..SecurityOptions::default()
+    };
     BoxOptions {
-        advanced: AdvancedBoxOptions {
-            security: SecurityOptions {
-                jailer_enabled: false,
-                ..SecurityOptions::default()
-            },
-            ..Default::default()
-        },
+        advanced,
         ..common::alpine_opts()
     }
 }

--- a/src/boxlite/tests/timing_profile.rs
+++ b/src/boxlite/tests/timing_profile.rs
@@ -182,16 +182,15 @@ async fn boot_timing_profile_no_jailer() {
     })
     .expect("create runtime");
 
+    let mut advanced = boxlite::AdvancedBoxOptions::default();
+    advanced.security = boxlite::SecurityOptions {
+        jailer_enabled: false,
+        ..Default::default()
+    };
     let opts = BoxOptions {
         rootfs: boxlite::runtime::options::RootfsSpec::Image("alpine:latest".into()),
         auto_delete: Some(0),
-        advanced: boxlite::AdvancedBoxOptions {
-            security: boxlite::SecurityOptions {
-                jailer_enabled: false,
-                ..Default::default()
-            },
-            ..Default::default()
-        },
+        advanced,
         ..Default::default()
     };
 

--- a/src/cli/src/cli.rs
+++ b/src/cli/src/cli.rs
@@ -10,8 +10,8 @@ use boxlite::runtime::options::{
     NetworkMode, OutboundNetworkConfig, PortProtocol, PortSpec, VolumeSpec,
 };
 use boxlite::{
-    BoxCommand, BoxOptions, BoxliteOptions, BoxliteRestOptions, BoxliteRuntime, ImageRegistry,
-    NetworkSpec,
+    BoxCommand, BoxOptions, BoxliteOptions, BoxliteRestOptions, BoxliteRuntime,
+    ContainerCapabilities, ImageRegistry, NetworkSpec,
 };
 use clap::{Args, Command, Parser, Subcommand, ValueEnum};
 use clap_complete::shells::{Bash, Fish, Zsh};
@@ -485,8 +485,15 @@ pub struct CapabilityFlags {
 
 impl CapabilityFlags {
     pub fn apply_to(&self, opts: &mut BoxOptions) {
-        opts.advanced.capabilities.add.clone_from(&self.cap_add);
-        opts.advanced.capabilities.drop.clone_from(&self.cap_drop);
+        if self.cap_add.is_empty() && self.cap_drop.is_empty() {
+            return;
+        }
+        opts.advanced
+            .set_capabilities(Some(ContainerCapabilities {
+                add: self.cap_add.clone(),
+                drop: self.cap_drop.clone(),
+            }))
+            .expect("apply_to runs before options are resolved");
     }
 }
 

--- a/src/cli/src/commands/create.rs
+++ b/src/cli/src/commands/create.rs
@@ -186,7 +186,8 @@ mod tests {
         let opts = args
             .to_box_options(&cli.global)
             .expect("options should build");
-        assert_eq!(opts.advanced.capabilities.add, vec!["SYS_ADMIN"]);
-        assert_eq!(opts.advanced.capabilities.drop, vec!["CAP_NET_RAW"]);
+        let capabilities = opts.advanced.capabilities().expect("capabilities set");
+        assert_eq!(capabilities.add, vec!["SYS_ADMIN"]);
+        assert_eq!(capabilities.drop, vec!["CAP_NET_RAW"]);
     }
 }

--- a/src/cli/src/commands/serve/mod.rs
+++ b/src/cli/src/commands/serve/mod.rs
@@ -789,10 +789,13 @@ fn build_box_options(req: &CreateBoxRequest) -> Result<BoxOptions, boxlite::Boxl
         tty: req.tty.unwrap_or(false),
         advanced: {
             let mut advanced = boxlite::AdvancedBoxOptions::default();
-            advanced.set_capabilities(Some(boxlite::ContainerCapabilities {
-                add: req.advanced.capabilities.add.clone(),
-                drop: req.advanced.capabilities.drop.clone(),
-            }))?;
+            let capabilities = req.advanced.capabilities.as_ref().map(|capabilities| {
+                boxlite::ContainerCapabilities {
+                    add: capabilities.add.clone(),
+                    drop: capabilities.drop.clone(),
+                }
+            });
+            advanced.set_capabilities(capabilities)?;
             advanced
         },
         auto_stop: req.auto_stop,
@@ -1368,6 +1371,23 @@ mod tests {
         let capabilities = opts.advanced.capabilities().expect("capabilities set");
         assert_eq!(capabilities.add, vec!["SYS_ADMIN"]);
         assert_eq!(capabilities.drop, vec!["CAP_NET_RAW"]);
+    }
+
+    /// A request that never mentions `advanced`/`capabilities` at all must
+    /// resolve to `None` (unspecified), not an explicit empty policy — that
+    /// distinction is what a privileged request needs, and what an older
+    /// archive importer needs (`archive_version_for_options` keys off it).
+    #[test]
+    fn build_box_options_leaves_capabilities_unspecified_when_the_wire_omits_them() {
+        let req: super::types::CreateBoxRequest =
+            serde_json::from_str(r#"{"image":"alpine:latest"}"#)
+                .expect("ordinary request must deserialize");
+
+        let opts = build_box_options(&req).expect("build ordinary options");
+        assert!(
+            opts.advanced.capabilities().is_none(),
+            "omitting capabilities on the wire must not become an explicit empty policy"
+        );
     }
 
     #[test]

--- a/src/cli/src/commands/serve/mod.rs
+++ b/src/cli/src/commands/serve/mod.rs
@@ -787,12 +787,13 @@ fn build_box_options(req: &CreateBoxRequest) -> Result<BoxOptions, boxlite::Boxl
         cmd: req.cmd.clone(),
         user: req.user.clone(),
         tty: req.tty.unwrap_or(false),
-        advanced: boxlite::AdvancedBoxOptions {
-            capabilities: boxlite::ContainerCapabilities {
+        advanced: {
+            let mut advanced = boxlite::AdvancedBoxOptions::default();
+            advanced.set_capabilities(Some(boxlite::ContainerCapabilities {
                 add: req.advanced.capabilities.add.clone(),
                 drop: req.advanced.capabilities.drop.clone(),
-            },
-            ..Default::default()
+            }))?;
+            advanced
         },
         auto_stop: req.auto_stop,
         auto_delete: Some(auto_delete),
@@ -1364,8 +1365,9 @@ mod tests {
         .expect("capability request must deserialize");
 
         let opts = build_box_options(&req).expect("build capability options");
-        assert_eq!(opts.advanced.capabilities.add, vec!["SYS_ADMIN"]);
-        assert_eq!(opts.advanced.capabilities.drop, vec!["CAP_NET_RAW"]);
+        let capabilities = opts.advanced.capabilities().expect("capabilities set");
+        assert_eq!(capabilities.add, vec!["SYS_ADMIN"]);
+        assert_eq!(capabilities.drop, vec!["CAP_NET_RAW"]);
     }
 
     #[test]

--- a/src/cli/src/commands/serve/types.rs
+++ b/src/cli/src/commands/serve/types.rs
@@ -65,7 +65,12 @@ pub(super) struct CreateBoxRequest {
 #[derive(Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub(super) struct CreateBoxAdvancedOptions {
-    pub capabilities: ContainerCapabilitiesRequest,
+    /// `None` when the wire omits `capabilities` (or sends `null`) — distinct
+    /// from `Some` of an empty policy, the same distinction the core
+    /// `AdvancedBoxOptions.capabilities` makes and for the same reason: an
+    /// explicit empty policy conflicts with `privileged`, an unspecified one
+    /// doesn't, and `archive_version_for_options` keys off which one this is.
+    pub capabilities: Option<ContainerCapabilitiesRequest>,
 }
 
 #[derive(Clone, Default, Deserialize)]

--- a/src/test-utils/src/config_matrix.rs
+++ b/src/test-utils/src/config_matrix.rs
@@ -98,9 +98,10 @@ pub fn default_configs() -> Vec<BoxConfig> {
             options: BoxOptions {
                 rootfs: RootfsSpec::Image("alpine:latest".into()),
                 auto_delete: Some(0),
-                advanced: AdvancedBoxOptions {
-                    security: SecurityOptions::enabled(),
-                    ..Default::default()
+                advanced: {
+                    let mut advanced = AdvancedBoxOptions::default();
+                    advanced.security = SecurityOptions::enabled();
+                    advanced
                 },
                 ..Default::default()
             },
@@ -111,9 +112,10 @@ pub fn default_configs() -> Vec<BoxConfig> {
             options: BoxOptions {
                 rootfs: RootfsSpec::Image("alpine:latest".into()),
                 auto_delete: Some(0),
-                advanced: AdvancedBoxOptions {
-                    security: SecurityOptions::disabled(),
-                    ..Default::default()
+                advanced: {
+                    let mut advanced = AdvancedBoxOptions::default();
+                    advanced.security = SecurityOptions::disabled();
+                    advanced
                 },
                 ..Default::default()
             },
@@ -163,9 +165,10 @@ pub fn default_configs() -> Vec<BoxConfig> {
             options: BoxOptions {
                 rootfs: RootfsSpec::Image("alpine:latest".into()),
                 auto_delete: Some(0),
-                advanced: AdvancedBoxOptions {
-                    security: SecurityOptions::enabled(),
-                    ..Default::default()
+                advanced: {
+                    let mut advanced = AdvancedBoxOptions::default();
+                    advanced.security = SecurityOptions::enabled();
+                    advanced
                 },
                 ..Default::default()
             },


### PR DESCRIPTION
`set_privileged`/`normalize_privileged` mutated `capabilities` in place on enable and tried to withdraw exactly that on disable, needing an ownership bit to tell an auto-install apart from a caller's own identical-looking policy. Checked how moby resolves this (`oci/caps.TweakCapabilities`): privileged short-circuits to every capability but never writes that back into `CapAdd`/`CapDrop` — the effective set is computed fresh every time a spec is built, so there's no mutation to track ownership of. `capabilities` is never mutated by `privileged` now, in either direction; `resolve_container_security` computes the effective set the same way moby does, so `privileged` alone remains a complete, one-flag DinD enabler.

Second commit closes two related gaps: `capabilities` is now `Option<ContainerCapabilities>` so an explicitly-empty override is distinguishable from the caller never touching the field (privileged mode rejects the former, same as any other explicit non-canonical override, and allows the latter). The field is private; `set_capabilities()` is the only way to write it, and it refuses to change the policy once `resolve_container_security` has already run on the object.

Test plan:
- [x] make clippy
- [x] make fmt:check:rust
- [x] make test:unit:rust (1028 + 49 passed)
- [x] cargo nextest run -p boxlite-c (75 passed)
- [x] cargo nextest run -p boxlite-node (22 passed)
- [x] cargo nextest run -p boxlite-cli --bins (185 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security & Reliability**
  - Privileged mode now consistently applies the full capability set when capabilities are unspecified.
  - Non-privileged configurations default to no capabilities unless explicitly configured.
  - Explicitly conflicting capability overrides are rejected, while valid policies remain supported.
  - Capability settings can no longer be changed after security resolution.
  - Runtime option evaluation no longer mutates configuration.

- **Tests**
  - Expanded coverage for optional capability policies, privileged-mode behavior, conflict detection, and security resolution.
  - Updated SDK, CLI, REST, and runtime validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->