### PR TITLE
feat(rest): support big file copies

### DIFF
--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.spec.ts
@@ -53,6 +53,19 @@ describe('BoxliteProxyController', () => {
     expect(proxyHandler).toHaveBeenCalledWith(req, res, next)
   })
 
+  it('disables the runner timeout for files only', async () => {
+    jest.mocked(createProxyMiddleware).mockReturnValue(jest.fn() as never)
+    const { controller } = makeHarness()
+
+    await controller.proxyFiles(activeAuth as never, 'public-box', { url: '/files' } as never, {} as never, jest.fn())
+    await controller.proxyExec(activeAuth as never, 'public-box', { url: '/exec' } as never, {} as never, jest.fn())
+
+    const fileOptions = jest.mocked(createProxyMiddleware).mock.calls[0][0]
+    const execOptions = jest.mocked(createProxyMiddleware).mock.calls[1][0]
+    expect(fileOptions.proxyTimeout).toBe(0)
+    expect(execOptions.proxyTimeout).toBe(300000)
+  })
+
   it('returns the public endpoint for JSON tunnel requests', async () => {
     const { controller, boxService } = makeHarness()
 

--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
@@ -176,6 +176,7 @@ export class BoxliteProxyController {
       res,
       next,
       USER_OPERATION,
+      { proxyTimeoutMs: 0 },
     )
   }
 
@@ -217,7 +218,7 @@ export class BoxliteProxyController {
     res: Response,
     next: NextFunction,
     policy: ProxyActivityPolicy,
-    opts?: { ws?: boolean },
+    opts?: { ws?: boolean; proxyTimeoutMs?: number },
   ) {
     const box = await this.boxService.findOneByIdOrName(boxId, authContext.organizationId)
     if (!box) {
@@ -260,7 +261,7 @@ export class BoxliteProxyController {
           fixRequestBody(proxyReq, originalReq)
         },
       },
-      proxyTimeout: 5 * 60 * 1000,
+      proxyTimeout: opts?.proxyTimeoutMs ?? 5 * 60 * 1000,
     }
 
     return createProxyMiddleware(proxyOptions)(req, res, next)

--- a/apps/api/src/main.spec.ts
+++ b/apps/api/src/main.spec.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import * as ts from 'typescript'
+
+describe('API HTTP server timeout configuration', () => {
+  it('disables the request body timeout for slow file uploads', () => {
+    const source = readFileSync(join(__dirname, 'main.ts'), 'utf8')
+    const sourceFile = ts.createSourceFile('main.ts', source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS)
+    let disablesRequestTimeout = false
+
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isBinaryExpression(node) &&
+        node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+        ts.isPropertyAccessExpression(node.left) &&
+        ts.isIdentifier(node.left.expression) &&
+        node.left.expression.text === 'httpServer' &&
+        node.left.name.text === 'requestTimeout' &&
+        ts.isNumericLiteral(node.right) &&
+        node.right.text === '0'
+      ) {
+        disablesRequestTimeout = true
+      }
+      ts.forEachChild(node, visit)
+    }
+
+    visit(sourceFile)
+
+    expect(disablesRequestTimeout).toBe(true)
+  })
+})

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -186,6 +186,9 @@ async function bootstrap() {
     const httpServer = app.getHttpServer()
     httpServer.keepAliveTimeout = 65 * 60 * 1000
     httpServer.headersTimeout = 66 * 60 * 1000
+    // File uploads can legitimately exceed Node's default five-minute request
+    // body deadline. Node exposes this setting only at the server level.
+    httpServer.requestTimeout = 0
 
     // WebSocket upgrade routing for the BoxLite REST `/attach` endpoint.
     // NestJS controllers only fire on Express's `request` event; WS upgrades

--- a/make/test.mk
+++ b/make/test.mk
@@ -20,6 +20,7 @@ export NEXTEST_FILTER_EXPR
 NEXTEST_FILTER   = $(if $(NEXTEST_FILTER_EXPR),-E '$(NEXTEST_FILTER_EXPR)',$(if $(FILTER),-E 'test(~$(FILTER))',))
 NEXTEST_CLI_FILTER = $(if $(NEXTEST_FILTER_EXPR),-E '$(NEXTEST_FILTER_EXPR)',$(if $(FILTER),-E 'test(~$(FILTER))',-E 'not binary(stress_disk)'))
 CARGOTEST_FILTER = $(if $(FILTER),$(FILTER),)
+REST_CLIENT_CARGOTEST_FILTER = $(if $(FILTER),$(FILTER),rest::client::tests::)
 PYTEST_FILTER    = $(if $(FILTER),-k '$(FILTER)',)
 VITEST_FILTER    = $(if $(FILTER),-t '$(FILTER)',)
 CTEST_FILTER     = $(if $(FILTER),-R '$(FILTER)',)
@@ -217,6 +218,7 @@ test\:unit\:rust:
 		cargo test -p boxlite --no-default-features --lib -- --test-threads=1 $(CARGOTEST_FILTER) || rc=$$?; \
 		cargo test -p boxlite-shared --lib -- --test-threads=1 $(CARGOTEST_FILTER) || rc=$$?; \
 	fi; \
+	cargo test -p boxlite --no-default-features --features rest --lib -- --test-threads=1 $(REST_CLIENT_CARGOTEST_FILTER) || rc=$$?; \
 	exit $$rc
 
 # Guest crate unit tests. Linux-only (the crate does not build elsewhere) and

--- a/src/boxlite/Cargo.toml
+++ b/src/boxlite/Cargo.toml
@@ -128,3 +128,4 @@ boxlite-test-utils = { path = "../test-utils" }
 notify = "6.1"
 proptest = "1.4"
 toml = "0.8"
+tokio = { version = "1.37", features = ["test-util"] }

--- a/src/boxlite/src/rest/client.rs
+++ b/src/boxlite/src/rest/client.rs
@@ -18,6 +18,8 @@ use crate::runtime::auth::Principal;
 
 /// Re-request a token once it is within this leeway of `expires_at`.
 const REFRESH_LEEWAY: Duration = Duration::from_secs(60);
+/// File transfers cannot outlive the runner's 24-hour box lifetime cap.
+const FILE_REQUEST_TIMEOUT: Duration = Duration::from_secs(24 * 60 * 60);
 const TUNNEL_SETUP_TIMEOUT: Duration = Duration::from_secs(30);
 
 type TunnelConnector =
@@ -64,6 +66,7 @@ impl ApiClient {
         let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
         let http = Client::builder()
             .timeout(std::time::Duration::from_secs(300))
+            .connect_timeout(std::time::Duration::from_secs(300))
             .build()
             .map_err(|e| BoxliteError::Config(format!("failed to create HTTP client: {}", e)))?;
         let tunnel_connector = hyper_rustls::HttpsConnectorBuilder::new()
@@ -439,13 +442,16 @@ impl ApiClient {
         Ok(descriptor.uri)
     }
 
-    /// Build an authorized request (for custom operations like file upload/download).
+    /// Build an authorized file request bounded by the box lifetime.
     pub async fn authorized_request(
         &self,
         method: Method,
         path: &str,
     ) -> BoxliteResult<RequestBuilder> {
-        let builder = self.http.request(method, self.url(path));
+        let builder = self
+            .http
+            .request(method, self.url(path))
+            .timeout(FILE_REQUEST_TIMEOUT);
         self.authorize(builder).await
     }
 
@@ -644,6 +650,31 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
+    use tokio::sync::oneshot;
+
+    async fn serve_response_body_on_signal(
+        listener: TcpListener,
+        response_started: oneshot::Sender<()>,
+        finish_body: oneshot::Receiver<()>,
+    ) {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut headers = Vec::new();
+        while !headers.ends_with(b"\r\n\r\n") {
+            headers.push(socket.read_u8().await.unwrap());
+        }
+        socket
+            .write_all(
+                b"HTTP/1.1 200 OK\r\n\
+                  Content-Type: application/json\r\n\
+                  Content-Length: 2\r\n\
+                  Connection: close\r\n\r\n{",
+            )
+            .await
+            .unwrap();
+        response_started.send(()).unwrap();
+        finish_body.await.unwrap();
+        let _ = socket.write_all(b"}").await;
+    }
 
     /// Rotating credential with a finite expiry already in the past, so
     /// `current_bearer` must re-request on every call. Proves the cache
@@ -673,6 +704,74 @@ mod tests {
     fn client_with(cred: Arc<dyn Credential>) -> ApiClient {
         let opts = BoxliteRestOptions::new("http://localhost:1").with_credential(cred);
         ApiClient::new(&opts).expect("client")
+    }
+
+    #[tokio::test]
+    async fn file_request_outlives_default_timeout() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (response_started_tx, response_started_rx) = oneshot::channel();
+        let (finish_body_tx, finish_body_rx) = oneshot::channel();
+        let server = tokio::spawn(serve_response_body_on_signal(
+            listener,
+            response_started_tx,
+            finish_body_rx,
+        ));
+
+        let client =
+            ApiClient::new(&BoxliteRestOptions::new(format!("http://127.0.0.1:{port}"))).unwrap();
+        let request = client
+            .authorized_request(Method::GET, "/boxes/box1/files")
+            .await
+            .unwrap();
+        let response = request.send().await.unwrap();
+
+        response_started_rx.await.unwrap();
+        tokio::time::pause();
+        tokio::time::sleep(Duration::from_secs(301)).await;
+        tokio::time::resume();
+        finish_body_tx.send(()).unwrap();
+
+        let bytes = tokio::time::timeout(Duration::from_secs(5), response.bytes())
+            .await
+            .expect("file response body must arrive after the timeout boundary")
+            .expect("file request must outlive the default 300-second timeout");
+        assert_eq!(bytes.as_ref(), b"{}");
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn control_request_keeps_total_timeout() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (response_started_tx, response_started_rx) = oneshot::channel();
+        let (finish_body_tx, finish_body_rx) = oneshot::channel();
+        let server = tokio::spawn(serve_response_body_on_signal(
+            listener,
+            response_started_tx,
+            finish_body_rx,
+        ));
+
+        let client =
+            ApiClient::new(&BoxliteRestOptions::new(format!("http://127.0.0.1:{port}"))).unwrap();
+        let control_request =
+            tokio::spawn(async move { client.get::<serde_json::Value>("/slow").await });
+
+        response_started_rx.await.unwrap();
+        tokio::time::pause();
+        tokio::time::sleep(Duration::from_secs(301)).await;
+        tokio::time::resume();
+
+        let error = control_request
+            .await
+            .unwrap()
+            .expect_err("control request must retain its total timeout");
+        assert!(
+            matches!(&error, BoxliteError::Network(detail) if detail.contains("timed out")),
+            "control request must fail because its total timeout elapsed, got {error:?}"
+        );
+        finish_body_tx.send(()).unwrap();
+        server.await.unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Support BoxLite file uploads and downloads over slow networks for longtime(24h, a box should not longer then it in fact). Control requests and connection establishment keep their existing 300-second limits.

## Call graph

Before
  copy_into / copy_out (LiteBox · src/boxlite/src/rest/litebox.rs:271) — streams file archives
    └─ authorized_request (ApiClient · src/boxlite/src/rest/client.rs:446) — inherits the client-wide 300-second deadline ← BUG: slow copies time out
         └─ HTTP request ingress (bootstrap · apps/api/src/main.ts:183) — accepts the upload body ← BUG: Node returns 408 after 300 seconds
              └─ proxyFiles (BoxliteProxyController · apps/api/src/boxlite-rest/boxlite-proxy.controller.ts:163) — selects the files route
                   └─ proxyToRunner (BoxliteProxyController · apps/api/src/boxlite-rest/boxlite-proxy.controller.ts:213) — forwards the stream ← BUG: proxy aborts after 300 seconds

After
  copy_into / copy_out (LiteBox · src/boxlite/src/rest/litebox.rs:271) — streams file archives
    └─ authorized_request (ApiClient · src/boxlite/src/rest/client.rs:446) — applies a 24-hour file deadline; connect remains 300 seconds
         └─ HTTP request ingress (bootstrap · apps/api/src/main.ts:183) — accepts slow request bodies without a server deadline
              └─ proxyFiles (BoxliteProxyController · apps/api/src/boxlite-rest/boxlite-proxy.controller.ts:163) — disables the proxy timeout for files only
                   └─ proxyToRunner (BoxliteProxyController · apps/api/src/boxlite-rest/boxlite-proxy.controller.ts:213) — preserves 300 seconds for other proxy routes

Fixes [POL-244](https://linear.app/polygala/issue/POL-244/cp-error-for-network-slow)

## Changes

- Override the shared reqwest client's 300-second total timeout with a 24-hour timeout only for file requests.
- Keep a 300-second connection timeout for every REST request.
- Disable the files proxy timeout and Node request-body timeout while preserving the proxy default for non-file routes.
- Cover the timeout boundary with Tokio virtual-time tests and focused Jest contracts.

## How to verify

- `make test:unit:rust FILTER=file_request_uses_24_hour_timeout_and_outlives_default_timeout BOXLITE_DEPS_STUB=1`
- `make test:unit:rust FILTER=control_request_keeps_total_timeout BOXLITE_DEPS_STUB=1`
- `cd apps && NX_DAEMON=false NX_ISOLATE_PLUGINS=false yarn nx test api -- --runInBand --runTestsByPath src/boxlite-rest/boxlite-proxy.controller.spec.ts src/main.spec.ts`
- `make fmt:check:rust`
- `make clippy`

## Risks / rollout

- The files proxy and Node server no longer impose a five-minute request deadline. File requests remain bounded by the client's 24-hour box-lifetime deadline and box lifecycle cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* File uploads and downloads can now run longer than the standard request timeout.
* Slow uploads are no longer interrupted by the server’s default request deadline.
* Standard control requests continue to use the existing five-minute timeout.
* File-transfer connections support extended operations without affecting control request limits.

## Tests

* Added coverage verifying timeout behavior for file-transfer and control requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->