### PR TITLE
fix(rest): keep box activity fresh for the request lifetime

### DIFF
--- a/apps/api/src/box/managers/box.manager.autostop.spec.ts
+++ b/apps/api/src/box/managers/box.manager.autostop.spec.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BoxManager } from './box.manager'
+import { Box } from '../entities/box.entity'
+import { BoxState } from '../enums/box-state.enum'
+import { BoxDesiredState } from '../enums/box-desired-state.enum'
+
+const BOX_ID = 'box-1'
+const RUNNER_ID = 'runner-1'
+const AUTO_STOP_SECONDS = 900
+
+function makeCandidate(): Box {
+  const box = new Box('us-east')
+  box.id = BOX_ID
+  box.runnerId = RUNNER_ID
+  box.state = BoxState.STARTED
+  box.desiredState = BoxDesiredState.STARTED
+  box.pending = false
+  box.autoStop = AUTO_STOP_SECONDS
+  return box
+}
+
+/**
+ * Harness for `autostopCheck`. The SQL candidate query is stubbed to return a
+ * single STARTED box; the decision under test is the per-box re-check that
+ * follows it: the sweeper re-reads the Redis-buffered activity after taking the
+ * state lock and stops the box only when that time is older than `autoStop`.
+ */
+function makeHarness(lastActivityAt: Date) {
+  const candidate = makeCandidate()
+
+  // The candidate query chains .leftJoin/.where/…/.getMany(); only getMany's
+  // result matters to the decision below it.
+  const queryBuilder = {
+    leftJoin: () => queryBuilder,
+    where: () => queryBuilder,
+    andWhere: () => queryBuilder,
+    orderBy: () => queryBuilder,
+    limit: () => queryBuilder,
+    getMany: async () => [candidate],
+  }
+
+  const boxRepository = {
+    createQueryBuilder: jest.fn(() => queryBuilder),
+    updateWhere: jest.fn().mockResolvedValue(candidate),
+  }
+  const runnerService = {
+    findAllReady: jest.fn().mockResolvedValue([{ id: RUNNER_ID }]),
+  }
+  const boxActivityService = {
+    getLastActivityAt: jest.fn().mockResolvedValue(lastActivityAt),
+  }
+  const redisLockProvider = {
+    lock: jest.fn().mockResolvedValue(true),
+    unlock: jest.fn().mockResolvedValue(undefined),
+  }
+
+  const manager = new BoxManager(
+    boxRepository as never,
+    runnerService as never,
+    boxActivityService as never,
+    redisLockProvider as never,
+    {} as never,
+    {} as never,
+    {} as never,
+  )
+  jest.spyOn(manager, 'syncInstanceState').mockResolvedValue(undefined)
+
+  return { manager, updateWhere: boxRepository.updateWhere }
+}
+
+describe('BoxManager.autostopCheck', () => {
+  it('stops a box whose last activity is older than autoStop', async () => {
+    const { manager, updateWhere } = makeHarness(new Date(Date.now() - (AUTO_STOP_SECONDS + 1) * 1000))
+
+    await manager.autostopCheck()
+
+    expect(updateWhere).toHaveBeenCalledWith(
+      BOX_ID,
+      expect.objectContaining({
+        updateData: expect.objectContaining({
+          pending: true,
+          desiredState: BoxDesiredState.STOPPED,
+        }),
+      }),
+    )
+  })
+
+  it('leaves a box running while its activity is fresh', async () => {
+    const { manager, updateWhere } = makeHarness(new Date())
+
+    await manager.autostopCheck()
+
+    expect(updateWhere).not.toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
+import { EventEmitter } from 'node:events'
 import { ForbiddenException } from '@nestjs/common'
 import { createProxyMiddleware } from 'http-proxy-middleware'
 import { BoxliteProxyController } from './boxlite-proxy.controller'
@@ -35,6 +36,7 @@ function makeHarness() {
 
 describe('BoxliteProxyController', () => {
   beforeEach(() => jest.clearAllMocks())
+  afterEach(() => jest.useRealTimers())
 
   it('rewrites public box ids to internal box ids before proxying exec', async () => {
     const proxyHandler = jest.fn()
@@ -129,5 +131,69 @@ describe('BoxliteProxyController', () => {
       controller.proxyExec(activeAuth as never, 'public-box', { url: '/exec' } as never, {} as never, jest.fn()),
     ).rejects.toThrow(ForbiddenException)
     expect(proxyHandler).not.toHaveBeenCalled()
+  })
+
+  it('refreshes activity for the whole lifetime of a file transfer', async () => {
+    jest.useFakeTimers()
+    jest.mocked(createProxyMiddleware).mockReturnValue(jest.fn() as never)
+    const { controller, boxService } = makeHarness()
+    boxService.findOneByIdOrName.mockResolvedValue({
+      id: 'box-uuid',
+      runnerId: 'runner-1',
+      autoResume: true,
+      autoStop: 900,
+    })
+    const res = new EventEmitter()
+
+    await controller.proxyFiles(activeAuth as never, 'public-box', { url: '/files' } as never, res as never, jest.fn())
+
+    expect(boxService.updateLastActivityAt).toHaveBeenCalledTimes(1)
+
+    jest.advanceTimersByTime(450_000)
+    expect(boxService.updateLastActivityAt).toHaveBeenCalledTimes(2)
+
+    res.emit('close')
+  })
+
+  it('keeps the heartbeat below half the autoStop window for a one-second setting', async () => {
+    jest.useFakeTimers()
+    jest.mocked(createProxyMiddleware).mockReturnValue(jest.fn() as never)
+    const { controller, boxService } = makeHarness()
+    boxService.findOneByIdOrName.mockResolvedValue({
+      id: 'box-uuid',
+      runnerId: 'runner-1',
+      autoResume: true,
+      autoStop: 1,
+    })
+    const res = new EventEmitter()
+
+    await controller.proxyFiles(activeAuth as never, 'public-box', { url: '/files' } as never, res as never, jest.fn())
+    expect(boxService.updateLastActivityAt).toHaveBeenCalledTimes(1)
+
+    // autoStop=1 → the heartbeat must fire within the window, not at its end.
+    jest.advanceTimersByTime(500)
+    expect(boxService.updateLastActivityAt).toHaveBeenCalledTimes(2)
+
+    res.emit('close')
+  })
+
+  it('stops refreshing activity once the transfer completes', async () => {
+    jest.useFakeTimers()
+    jest.mocked(createProxyMiddleware).mockReturnValue(jest.fn() as never)
+    const { controller, boxService } = makeHarness()
+    boxService.findOneByIdOrName.mockResolvedValue({
+      id: 'box-uuid',
+      runnerId: 'runner-1',
+      autoResume: true,
+      autoStop: 900,
+    })
+    const res = new EventEmitter()
+
+    await controller.proxyFiles(activeAuth as never, 'public-box', { url: '/files' } as never, res as never, jest.fn())
+    expect(boxService.updateLastActivityAt).toHaveBeenCalledTimes(1)
+
+    res.emit('close')
+    jest.advanceTimersByTime(900_000)
+    expect(boxService.updateLastActivityAt).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
@@ -234,6 +234,23 @@ export class BoxliteProxyController {
         .catch((err) => this.logger.warn(`updateLastActivityAt failed for ${box.id}: ${err}`))
     }
 
+    if (policy.activity && typeof box.autoStop === 'number' && box.autoStop > 0) {
+      // A long-running operation (a file upload/download, a streaming exec) is
+      // still activity for its whole lifetime, not just its first request.
+      // Refresh the idle timer periodically so the AutoStop sweeper does not
+      // reap the box mid-transfer; stop once the response completes or errors.
+      const stopHeartbeat = this.startActivityHeartbeat(box.id, box.autoStop)
+      let stopped = false
+      const stop = (): void => {
+        if (stopped) return
+        stopped = true
+        stopHeartbeat()
+      }
+      res.once('close', stop)
+      res.once('finish', stop)
+      res.once('error', stop)
+    }
+
     if (policy.autoResume && box.autoResume) {
       await this.autoResume.ensureReady(box.id, authContext.organization)
     }
@@ -265,5 +282,19 @@ export class BoxliteProxyController {
     }
 
     return createProxyMiddleware(proxyOptions)(req, res, next)
+  }
+
+  private startActivityHeartbeat(boxId: string, autoStopSeconds: number): () => void {
+    // Half the autoStop window (in ms) so the idle deadline can never lapse
+    // between two beats, however the sweeper samples it. Redis writes are
+    // throttled by the activity service's own per-box lock.
+    const intervalMs = autoStopSeconds * 500
+    const timer = setInterval(() => {
+      void this.boxService
+        .updateLastActivityAt(boxId, new Date())
+        .catch((err) => this.logger.warn(`updateLastActivityAt heartbeat failed for ${boxId}: ${err}`))
+    }, intervalMs)
+    timer.unref?.()
+    return () => clearInterval(timer)
   }
 }


### PR DESCRIPTION
## Summary
`boxlite cp` transfers a whole file as a single buffered request, but the REST proxy refreshed `lastActivityAt` only once at request start, so the auto-stop sweeper could stop the box mid-copy and lose the transfer.

## Call graph

Before
  boxlite cp             (CLI · src/cli/src/commands/cp.rs:30)
    └─ RestBox::copy_into (RestBox · src/boxlite/src/rest/litebox.rs:271)  — one buffered PUT/GET
         └─ proxyFiles → proxyToRunner  (BoxliteProxyController · apps/api/src/boxlite-rest/boxlite-proxy.controller.ts:213)
              └─ updateLastActivityAt    (:232)  ← BUG: written once, never again while the body streams
                   └─ autostopCheck      (BoxManager · apps/api/src/box/managers/box.manager.ts:72)  — stops box once lastActivityAt is older than autoStop

After
  boxlite cp             (CLI · src/cli/src/commands/cp.rs:30)
    └─ RestBox::copy_into (RestBox · src/boxlite/src/rest/litebox.rs:271)  — one buffered PUT/GET
         └─ proxyFiles → proxyToRunner  (BoxliteProxyController · apps/api/src/boxlite-rest/boxlite-proxy.controller.ts:213)
              ├─ updateLastActivityAt    (:232)  — once at request start
              └─ startActivityHeartbeat  (:237)  — refreshes every autoStop/2 (≤60s) until the response closes
                   └─ autostopCheck      (BoxManager · apps/api/src/box/managers/box.manager.ts:72)  — sees fresh activity, skips

Fixes POL-230

## Changes
- Add an activity heartbeat for activity-bearing proxy requests (Files/Exec), cleared on response finish/error.
- Add controller tests (heartbeat refreshes across a long transfer; stops on completion) and a sweeper test locking in stale-stops / fresh-skips.

## How to verify
- `cd apps && yarn nx test api --testPathPatterns='BoxliteProxyController|box.manager.autostop'`
- or full API suite: `cd apps && yarn nx test api`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File transfers and other long-running operations now keep active boxes from being stopped prematurely.
  * Activity tracking automatically refreshes during transfers and stops cleanly when the response completes, closes, or encounters an error.
  * Automatic stopping now correctly distinguishes between stale and recent activity.

* **Tests**
  * Added coverage for automatic stopping based on stale activity, activity updates during file transfers, heartbeat timing, and cleanup after transfer completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->