### PR TITLE
fix(dashboard): align billing tabs with page content

### DIFF
--- a/apps/dashboard/src/pages/Billing.test.tsx
+++ b/apps/dashboard/src/pages/Billing.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+/*
+ * Modified by BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import Billing from './Billing'
+
+vi.mock('@/hooks/useConfig', () => ({
+  useConfig: () => ({ billingApiUrl: 'https://billing.example.test' }),
+}))
+
+vi.mock('@/components/billing/BillingAlerts', () => ({ BillingAlerts: () => null }))
+vi.mock('@/components/billing/PlanSection', () => ({
+  PlanSection: () => <div data-testid="plan-section">Plan section</div>,
+}))
+vi.mock('@/components/billing/UsageSection', () => ({ UsageSection: () => <div>Usage section</div> }))
+vi.mock('@/components/billing/WalletSection', () => ({ WalletSection: () => <div>Wallet section</div> }))
+
+function closestMaxWidthContainer(element: Element | null): Element | null {
+  let current = element
+
+  while (current) {
+    if (current.classList.contains('max-w-[1440px]')) {
+      return current
+    }
+    current = current.parentElement
+  }
+
+  return null
+}
+
+describe('Billing layout', () => {
+  let root: Root | null = null
+
+  beforeAll(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  })
+
+  afterEach(() => {
+    act(() => root?.unmount())
+    root = null
+    document.body.innerHTML = ''
+  })
+
+  it('keeps the title, tabs, and active panel in one wide-page container', () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+
+    act(() => {
+      root = createRoot(host)
+      root.render(<Billing />)
+    })
+
+    const heading = Array.from(document.querySelectorAll('h1')).find((element) => element.textContent === 'Billing')
+    const tabs = document.querySelector('[data-slot="tabs-list"]')
+    const activePanel = document.querySelector('[data-testid="plan-section"]')
+    const headingContainer = closestMaxWidthContainer(heading ?? null)
+
+    expect(headingContainer).not.toBeNull()
+    expect(closestMaxWidthContainer(tabs)).toBe(headingContainer)
+    expect(closestMaxWidthContainer(activePanel)).toBe(headingContainer)
+  })
+})

--- a/apps/dashboard/src/pages/Billing.tsx
+++ b/apps/dashboard/src/pages/Billing.tsx
@@ -18,7 +18,8 @@ import { Link } from 'react-router-dom'
 // Verbatim from the design: square segments, right-divided, accent fill when active.
 const TAB_TRIGGER =
   'h-full gap-1.5 rounded-none border-0 border-r border-border px-5 text-xs text-muted-foreground transition-colors hover:text-foreground data-[state=active]:bg-accent data-[state=active]:font-semibold data-[state=active]:text-foreground data-[state=active]:shadow-none'
-const TAB_PANE = 'mx-auto w-full max-w-[1440px] px-4 py-6 sm:px-5 2xl:px-0'
+const BILLING_PAGE_CONTAINER = 'mx-auto w-full max-w-[1440px] px-4 sm:px-5 2xl:px-0'
+const TAB_PANE = 'py-6'
 const TAB_TRIGGER_LAST =
   'h-full gap-1.5 rounded-none border-0 px-5 text-xs text-muted-foreground transition-colors hover:text-foreground data-[state=active]:bg-accent data-[state=active]:font-semibold data-[state=active]:text-foreground data-[state=active]:shadow-none'
 
@@ -96,38 +97,40 @@ function Billing() {
 
   return (
     <Tabs value={tab} onValueChange={setTab} className="w-full gap-0">
-      <div className="px-6 pt-6">
-        <h1 className="font-display text-2xl font-semibold leading-none tracking-tight">Billing</h1>
-        <TabsList className="mt-5 h-9 gap-0 rounded-none border border-border bg-transparent p-0">
-          <TabsTrigger value="overview" className={TAB_TRIGGER}>
-            Overview
-          </TabsTrigger>
-          <TabsTrigger value="usage" className={TAB_TRIGGER}>
-            Usage
-          </TabsTrigger>
-          <TabsTrigger value="wallet" className={TAB_TRIGGER_LAST}>
-            Wallet
-          </TabsTrigger>
-        </TabsList>
-      </div>
-      <TabsContent value="overview">
-        <div className={TAB_PANE}>
-          <div className="mb-8 flex flex-col gap-4 empty:hidden">
-            <BillingAlerts />
+      <div className={BILLING_PAGE_CONTAINER}>
+        <div className="pt-6">
+          <h1 className="font-display text-2xl font-semibold leading-none tracking-tight">Billing</h1>
+          <TabsList className="mt-5 h-9 gap-0 rounded-none border border-border bg-transparent p-0">
+            <TabsTrigger value="overview" className={TAB_TRIGGER}>
+              Overview
+            </TabsTrigger>
+            <TabsTrigger value="usage" className={TAB_TRIGGER}>
+              Usage
+            </TabsTrigger>
+            <TabsTrigger value="wallet" className={TAB_TRIGGER_LAST}>
+              Wallet
+            </TabsTrigger>
+          </TabsList>
+        </div>
+        <TabsContent value="overview">
+          <div className={TAB_PANE}>
+            <div className="mb-8 flex flex-col gap-4 empty:hidden">
+              <BillingAlerts />
+            </div>
+            <PlanSection />
           </div>
-          <PlanSection />
-        </div>
-      </TabsContent>
-      <TabsContent value="usage">
-        <div className={TAB_PANE}>
-          <UsageSection onGoToWallet={() => setTab('wallet')} />
-        </div>
-      </TabsContent>
-      <TabsContent value="wallet">
-        <div className={TAB_PANE}>
-          <WalletSection />
-        </div>
-      </TabsContent>
+        </TabsContent>
+        <TabsContent value="usage">
+          <div className={TAB_PANE}>
+            <UsageSection onGoToWallet={() => setTab('wallet')} />
+          </div>
+        </TabsContent>
+        <TabsContent value="wallet">
+          <div className={TAB_PANE}>
+            <WalletSection />
+          </div>
+        </TabsContent>
+      </div>
     </Tabs>
   )
 }


### PR DESCRIPTION
## Summary

Align the Billing title and tab navigation with the centered billing panels. The regression came from applying the 1440px page boundary only to tab content while the header kept independent viewport padding.

## Call graph

Before

```text
Billing                  (React page · apps/dashboard/src/pages/Billing.tsx:88) — composes billing navigation and panels
  ├─ header wrapper      (layout boundary · apps/dashboard/src/pages/Billing.tsx:99) ← BUG: uses viewport padding outside the centered panel boundary
  └─ TAB_PANE            (layout class · apps/dashboard/src/pages/Billing.tsx:21) — independently centers each panel at 1440px
```

After

```text
Billing                  (React page · apps/dashboard/src/pages/Billing.tsx:88) — composes billing navigation and panels
  └─ BILLING_PAGE_CONTAINER (layout class · apps/dashboard/src/pages/Billing.tsx:21) — owns one width and gutter policy
       ├─ header wrapper (layout boundary · apps/dashboard/src/pages/Billing.tsx:101) — inherits the shared page boundary
       └─ TAB_PANE       (layout class · apps/dashboard/src/pages/Billing.tsx:22) — supplies vertical spacing only
```

Fixes #1287 regression.

## Changes

- Move the Billing title, tabs, and all tab panels under one responsive page container.
- Add a regression test asserting that the title, tab list, and active panel share that container.

## How to verify

- `make test:apps FILTER='keeps the title'`
- `make lint:apps`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the Billing page layout with a consistent wide-page container.
  * Grouped billing tabs and sections into a unified layout while preserving existing tab behavior.
  * Simplified spacing between tab panels for a cleaner presentation.

* **Tests**
  * Added coverage verifying the Billing page title, tabs, and active plan panel share the same container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->