### PR TITLE
chore(setup): auto-init worktree submodules

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,5 +13,19 @@
   },
   "enabledPlugins": {
     "boxlite-agent-tooling@boxlite-agent-tooling": true
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "make -C \"$CLAUDE_PROJECT_DIR\" setup:submodules",
+            "timeout": 600
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -1,0 +1,5 @@
+version = 1
+name = "BoxLite"
+
+[setup]
+script = "make setup:submodules"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,7 @@ jobs:
       go: ${{ steps.filter.outputs.go }}
       api: ${{ steps.filter.outputs.api }}
       guest_artifacts: ${{ steps.filter.outputs.guest_artifacts }}
+      setup: ${{ steps.filter.outputs.setup }}
     steps:
       - uses: actions/checkout@v5
       - uses: dorny/paths-filter@v4
@@ -122,6 +123,13 @@ jobs:
               - '**/Cargo.toml'
               - 'Cargo.lock'
               - '.github/workflows/config.yml'
+              - '.github/workflows/test.yml'
+            setup:
+              - '.gitmodules'
+              - 'scripts/setup/setup-submodules.sh'
+              - 'scripts/test/test-setup-submodules.sh'
+              - 'make/setup.mk'
+              - 'make/test.mk'
               - '.github/workflows/test.yml'
 
   # Rust unit tests (boxlite-shared only - boxlite requires native libs not available in CI)
@@ -347,6 +355,18 @@ jobs:
       - name: Build and qualify guest artifacts
         run: make test:guest-artifacts GUEST_TARGET=${{ matrix.target }} PROFILE=${{ matrix.profile }}
 
+  setup:
+    name: Submodule setup tests
+    needs: changes
+    if: ${{ needs.changes.outputs.setup == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Test worktree submodule setup
+        run: make test:setup:submodules
+
   # API tests need real Redis and Postgres services for integration coverage.
   api:
     name: API Tests
@@ -413,7 +433,7 @@ jobs:
   # NOTE: keep `needs` in sync with the jobs above when adding/removing jobs.
   test-conclusion:
     name: Test (conclusion)
-    needs: [config, changes, rust, cli, python, node, go, api, guest_artifacts]
+    needs: [config, changes, rust, cli, python, node, go, setup, api, guest_artifacts]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     permissions: {}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -360,9 +360,13 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.setup == 'true' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Test worktree submodule setup
         run: make test:setup:submodules

--- a/make/help.mk
+++ b/make/help.mk
@@ -5,6 +5,7 @@ help:
 	@echo ""
 	@echo "  Setup:"
 	@echo "    make setup          - Dev setup (same as make setup:dev)"
+	@echo "    make setup:submodules - Initialize missing Git submodules only"
 	@echo "    make setup:build    - Build-only deps (recommended for CI)"
 	@echo "    make setup:test     - Test/dev extras (nextest, node deps, hooks, python venv)"
 	@echo "    make setup:dev      - setup:build + setup:test"

--- a/make/setup.mk
+++ b/make/setup.mk
@@ -3,6 +3,9 @@ PHONY_TARGETS += setup
 # Local-dev default: same as before (build + test/dev extras)
 setup: setup\:dev
 
+setup\:submodules:
+	@bash $(SCRIPT_DIR)/setup/setup-submodules.sh
+
 setup\:dev: setup\:build setup\:test
 
 # Build-only setup (preferred for CI)

--- a/make/test.mk
+++ b/make/test.mk
@@ -85,6 +85,9 @@ endef
 test:
 	@$(MAKE) test:changed
 
+test\:setup\:submodules:
+	@bash $(SCRIPT_DIR)/test/test-setup-submodules.sh
+
 # Pinned BoxLite diagram skill validator. This suite is deterministic: it uses
 # local stand-ins for gh and Mermaid CLI while exercising the real parser,
 # source, diff, and cross-view validation code from agent-tooling.

--- a/scripts/setup/setup-common.sh
+++ b/scripts/setup/setup-common.sh
@@ -80,22 +80,7 @@ install_rust() {
 
 # Initialize git submodules
 init_submodules() {
-    print_step "Checking git submodules... "
-
-    # Check if we're in a git repository
-    if ! git rev-parse --git-dir > /dev/null 2>&1; then
-        print_error "Not in a git repository"
-        return 1
-    fi
-
-    # Check if submodules are already initialized
-    if git submodule status | grep -q "^-"; then
-        echo -e "${YELLOW}Initializing...${NC}"
-        git submodule update --init --recursive --depth 1
-        print_success "Submodules initialized"
-    else
-        print_success "Already initialized"
-    fi
+    "$SCRIPT_DIR/setup/setup-submodules.sh"
 }
 
 # Install cargo-nextest

--- a/scripts/setup/setup-submodules.sh
+++ b/scripts/setup/setup-submodules.sh
@@ -1,69 +1,105 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/bin/bash
+# Setup git submodules for BoxLite development.
+#
+# This script is safe to run repeatedly. It initializes only missing
+# submodules and leaves existing submodule checkouts untouched.
 
-repo_root="${1:-$(git rev-parse --show-toplevel 2>/dev/null || true)}"
-if [[ -z "$repo_root" || ! -f "$repo_root/.gitmodules" ]]; then
-    printf 'setup:submodules: expected a BoxLite checkout with .gitmodules\n' >&2
-    exit 1
-fi
+set -e
 
+SETUP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$SETUP_DIR/.." && pwd)"
+# common.sh is resolved from this script's directory above.
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/common.sh"
+
+# Fail closed before an automatic checkout can contact an unexpected remote.
 validate_submodule() {
-    local name="$1"
-    local expected_path="$2"
-    local expected_url="$3"
+    local repo_root="$1"
+    local name="$2"
+    local expected_path="$3"
+    local expected_url="$4"
     local actual_path
     local actual_url
 
     actual_path="$(git config -f "$repo_root/.gitmodules" --get "submodule.$name.path" || true)"
     actual_url="$(git config -f "$repo_root/.gitmodules" --get "submodule.$name.url" || true)"
     if [[ "$actual_path" != "$expected_path" || "$actual_url" != "$expected_url" ]]; then
-        printf 'setup:submodules: refusing unexpected submodule %s (path=%s, url=%s)\n' \
-            "$name" "$actual_path" "$actual_url" >&2
-        exit 1
+        print_error "Refusing unexpected submodule $name (path=$actual_path, url=$actual_url)"
+        return 1
     fi
 }
 
-submodule_count="$(git config -f "$repo_root/.gitmodules" --get-regexp '^submodule\..*\.path$' 2>/dev/null | wc -l | tr -d ' ')"
-if [[ "$submodule_count" != "4" ]]; then
-    printf 'setup:submodules: expected 4 submodules, found %s\n' "$submodule_count" >&2
-    exit 1
-fi
+# Validate the complete set because this script performs an automatic network checkout.
+validate_submodules() {
+    local repo_root="$1"
+    local submodule_count
 
-validate_submodule \
-    "src/deps/libkrun-sys/vendor/libkrun" \
-    "src/deps/libkrun-sys/vendor/libkrun" \
-    "https://github.com/boxlite-ai/libkrun.git"
-validate_submodule \
-    "src/deps/libkrun-sys/vendor/libkrunfw" \
-    "src/deps/libkrun-sys/vendor/libkrunfw" \
-    "https://github.com/boxlite-ai/libkrunfw.git"
-validate_submodule \
-    "src/deps/e2fsprogs-sys/vendor/e2fsprogs" \
-    "src/deps/e2fsprogs-sys/vendor/e2fsprogs" \
-    "https://github.com/tytso/e2fsprogs.git"
-validate_submodule \
-    "src/deps/bubblewrap-sys/vendor/bubblewrap" \
-    "src/deps/bubblewrap-sys/vendor/bubblewrap" \
-    "https://github.com/containers/bubblewrap.git"
+    if [[ ! -f "$repo_root/.gitmodules" ]]; then
+        print_error "Expected a BoxLite checkout with .gitmodules"
+        return 1
+    fi
 
-jobs="${BOXLITE_SUBMODULE_JOBS:-4}"
-if [[ ! "$jobs" =~ ^[1-9][0-9]*$ ]] || ((jobs > 16)); then
-    printf 'setup:submodules: BOXLITE_SUBMODULE_JOBS must be between 1 and 16, got %s\n' "$jobs" >&2
-    exit 1
-fi
+    submodule_count="$(git config -f "$repo_root/.gitmodules" --get-regexp '^submodule\..*\.path$' 2>/dev/null | wc -l | tr -d ' ')"
+    if [[ "$submodule_count" != "4" ]]; then
+        print_error "Expected 4 submodules, found $submodule_count"
+        return 1
+    fi
 
-submodule_status="$(git -C "$repo_root" submodule status --recursive)"
-if grep -q '^U' <<<"$submodule_status"; then
-    printf 'setup:submodules: refusing to update conflicted submodules\n' >&2
-    exit 1
-fi
+    validate_submodule \
+        "$repo_root" \
+        "src/deps/libkrun-sys/vendor/libkrun" \
+        "src/deps/libkrun-sys/vendor/libkrun" \
+        "https://github.com/boxlite-ai/libkrun.git"
+    validate_submodule \
+        "$repo_root" \
+        "src/deps/libkrun-sys/vendor/libkrunfw" \
+        "src/deps/libkrun-sys/vendor/libkrunfw" \
+        "https://github.com/boxlite-ai/libkrunfw.git"
+    validate_submodule \
+        "$repo_root" \
+        "src/deps/e2fsprogs-sys/vendor/e2fsprogs" \
+        "src/deps/e2fsprogs-sys/vendor/e2fsprogs" \
+        "https://github.com/tytso/e2fsprogs.git"
+    validate_submodule \
+        "$repo_root" \
+        "src/deps/bubblewrap-sys/vendor/bubblewrap" \
+        "src/deps/bubblewrap-sys/vendor/bubblewrap" \
+        "https://github.com/containers/bubblewrap.git"
+}
 
-if ! grep -q '^-' <<<"$submodule_status"; then
-    printf 'setup:submodules: already initialized\n'
-    exit 0
-fi
+validate_jobs() {
+    local jobs="$1"
 
-printf 'setup:submodules: initializing missing submodules with %s jobs\n' "$jobs"
-git -C "$repo_root" submodule sync --recursive
-git -C "$repo_root" submodule update --init --recursive --depth 1 --jobs "$jobs"
-printf 'setup:submodules: initialized\n'
+    if [[ ! "$jobs" =~ ^[1-9][0-9]*$ ]] || ((jobs > 16)); then
+        print_error "BOXLITE_SUBMODULE_JOBS must be between 1 and 16, got $jobs"
+        return 1
+    fi
+}
+
+main() {
+    local repo_root="${1:-$PROJECT_ROOT}"
+    local jobs="${BOXLITE_SUBMODULE_JOBS:-4}"
+    local submodule_status
+
+    validate_submodules "$repo_root"
+    validate_jobs "$jobs"
+
+    submodule_status="$(git -C "$repo_root" submodule status --recursive)"
+    if grep -q '^U' <<<"$submodule_status"; then
+        print_error "Refusing to update conflicted submodules"
+        return 1
+    fi
+
+    print_step "Checking git submodules... "
+    if ! grep -q '^-' <<<"$submodule_status"; then
+        print_success "Already initialized"
+        return 0
+    fi
+
+    echo -e "${YELLOW}Initializing with $jobs jobs...${NC}"
+    git -C "$repo_root" submodule sync --recursive
+    git -C "$repo_root" submodule update --init --recursive --depth 1 --jobs "$jobs"
+    print_success "Submodules initialized"
+}
+
+main "$@"

--- a/scripts/setup/setup-submodules.sh
+++ b/scripts/setup/setup-submodules.sh
@@ -24,7 +24,7 @@ validate_submodule() {
     actual_path="$(git config -f "$repo_root/.gitmodules" --get "submodule.$name.path" || true)"
     actual_url="$(git config -f "$repo_root/.gitmodules" --get "submodule.$name.url" || true)"
     if [[ "$actual_path" != "$expected_path" || "$actual_url" != "$expected_url" ]]; then
-        print_error "Refusing unexpected submodule $name (path=$actual_path, url=$actual_url)"
+        print_error "Refusing unexpected submodule $name (path=$actual_path, url=$actual_url)" >&2
         return 1
     fi
 }
@@ -35,13 +35,13 @@ validate_submodules() {
     local submodule_count
 
     if [[ ! -f "$repo_root/.gitmodules" ]]; then
-        print_error "Expected a BoxLite checkout with .gitmodules"
+        print_error "Expected a BoxLite checkout with .gitmodules" >&2
         return 1
     fi
 
     submodule_count="$(git config -f "$repo_root/.gitmodules" --get-regexp '^submodule\..*\.path$' 2>/dev/null | wc -l | tr -d ' ')"
     if [[ "$submodule_count" != "4" ]]; then
-        print_error "Expected 4 submodules, found $submodule_count"
+        print_error "Expected 4 submodules, found $submodule_count" >&2
         return 1
     fi
 
@@ -71,7 +71,7 @@ validate_jobs() {
     local jobs="$1"
 
     if [[ ! "$jobs" =~ ^[1-9][0-9]*$ ]] || ((jobs > 16)); then
-        print_error "BOXLITE_SUBMODULE_JOBS must be between 1 and 16, got $jobs"
+        print_error "BOXLITE_SUBMODULE_JOBS must be between 1 and 16, got $jobs" >&2
         return 1
     fi
 }
@@ -86,7 +86,7 @@ main() {
 
     submodule_status="$(git -C "$repo_root" submodule status --recursive)"
     if grep -q '^U' <<<"$submodule_status"; then
-        print_error "Refusing to update conflicted submodules"
+        print_error "Refusing to update conflicted submodules" >&2
         return 1
     fi
 

--- a/scripts/setup/setup-submodules.sh
+++ b/scripts/setup/setup-submodules.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="${1:-$(git rev-parse --show-toplevel 2>/dev/null || true)}"
+if [[ -z "$repo_root" || ! -f "$repo_root/.gitmodules" ]]; then
+    printf 'setup:submodules: expected a BoxLite checkout with .gitmodules\n' >&2
+    exit 1
+fi
+
+validate_submodule() {
+    local name="$1"
+    local expected_path="$2"
+    local expected_url="$3"
+    local actual_path
+    local actual_url
+
+    actual_path="$(git config -f "$repo_root/.gitmodules" --get "submodule.$name.path" || true)"
+    actual_url="$(git config -f "$repo_root/.gitmodules" --get "submodule.$name.url" || true)"
+    if [[ "$actual_path" != "$expected_path" || "$actual_url" != "$expected_url" ]]; then
+        printf 'setup:submodules: refusing unexpected submodule %s (path=%s, url=%s)\n' \
+            "$name" "$actual_path" "$actual_url" >&2
+        exit 1
+    fi
+}
+
+submodule_count="$(git config -f "$repo_root/.gitmodules" --get-regexp '^submodule\..*\.path$' 2>/dev/null | wc -l | tr -d ' ')"
+if [[ "$submodule_count" != "4" ]]; then
+    printf 'setup:submodules: expected 4 submodules, found %s\n' "$submodule_count" >&2
+    exit 1
+fi
+
+validate_submodule \
+    "src/deps/libkrun-sys/vendor/libkrun" \
+    "src/deps/libkrun-sys/vendor/libkrun" \
+    "https://github.com/boxlite-ai/libkrun.git"
+validate_submodule \
+    "src/deps/libkrun-sys/vendor/libkrunfw" \
+    "src/deps/libkrun-sys/vendor/libkrunfw" \
+    "https://github.com/boxlite-ai/libkrunfw.git"
+validate_submodule \
+    "src/deps/e2fsprogs-sys/vendor/e2fsprogs" \
+    "src/deps/e2fsprogs-sys/vendor/e2fsprogs" \
+    "https://github.com/tytso/e2fsprogs.git"
+validate_submodule \
+    "src/deps/bubblewrap-sys/vendor/bubblewrap" \
+    "src/deps/bubblewrap-sys/vendor/bubblewrap" \
+    "https://github.com/containers/bubblewrap.git"
+
+jobs="${BOXLITE_SUBMODULE_JOBS:-4}"
+if [[ ! "$jobs" =~ ^[1-9][0-9]*$ ]] || ((jobs > 16)); then
+    printf 'setup:submodules: BOXLITE_SUBMODULE_JOBS must be between 1 and 16, got %s\n' "$jobs" >&2
+    exit 1
+fi
+
+submodule_status="$(git -C "$repo_root" submodule status --recursive)"
+if grep -q '^U' <<<"$submodule_status"; then
+    printf 'setup:submodules: refusing to update conflicted submodules\n' >&2
+    exit 1
+fi
+
+if ! grep -q '^-' <<<"$submodule_status"; then
+    printf 'setup:submodules: already initialized\n'
+    exit 0
+fi
+
+printf 'setup:submodules: initializing missing submodules with %s jobs\n' "$jobs"
+git -C "$repo_root" submodule sync --recursive
+git -C "$repo_root" submodule update --init --recursive --depth 1 --jobs "$jobs"
+printf 'setup:submodules: initialized\n'

--- a/scripts/setup/setup-submodules.sh
+++ b/scripts/setup/setup-submodules.sh
@@ -84,7 +84,7 @@ main() {
     validate_submodules "$repo_root"
     validate_jobs "$jobs"
 
-    submodule_status="$(git -C "$repo_root" submodule status --recursive)"
+    submodule_status="$(git -C "$repo_root" submodule status)"
     if grep -q '^U' <<<"$submodule_status"; then
         print_error "Refusing to update conflicted submodules" >&2
         return 1
@@ -97,8 +97,8 @@ main() {
     fi
 
     echo -e "${YELLOW}Initializing with $jobs jobs...${NC}"
-    git -C "$repo_root" submodule sync --recursive
-    git -C "$repo_root" submodule update --init --recursive --depth 1 --jobs "$jobs"
+    git -C "$repo_root" submodule sync
+    git -C "$repo_root" submodule update --init --depth 1 --jobs "$jobs"
     print_success "Submodules initialized"
 }
 

--- a/scripts/test/test-setup-submodules.sh
+++ b/scripts/test/test-setup-submodules.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+subject="$repo_root/scripts/setup/setup-submodules.sh"
+scratch="$(mktemp -d "${TMPDIR:-/tmp}/boxlite-submodules-test.XXXXXX")"
+
+cleanup() {
+    case "$scratch" in
+        "${TMPDIR:-/tmp}"/boxlite-submodules-test.*) rm -rf -- "$scratch" ;;
+        *) printf 'refusing to clean unexpected test path: %s\n' "$scratch" >&2 ;;
+    esac
+}
+trap cleanup EXIT
+
+fail() {
+    printf 'test-setup-submodules: %s\n' "$1" >&2
+    exit 1
+}
+
+[[ -x "$subject" ]] || fail "production setup script is missing or not executable"
+
+create_remote() {
+    local owner="$1"
+    local repository="$2"
+    local seed="$scratch/seed-$owner-$repository"
+    local bare="$scratch/remotes/$owner/$repository.git"
+
+    mkdir -p "$seed" "$(dirname "$bare")"
+    git -C "$seed" init -q -b main
+    git -C "$seed" config user.name "BoxLite Setup Test"
+    git -C "$seed" config user.email "setup-test@boxlite.invalid"
+    printf '%s/%s\n' "$owner" "$repository" >"$seed/README.md"
+    git -C "$seed" add README.md
+    git -C "$seed" commit -qm "seed $owner/$repository"
+    git clone -q --bare "$seed" "$bare"
+    git -C "$seed" rev-parse HEAD
+}
+
+libkrun_oid="$(create_remote boxlite-ai libkrun)"
+libkrunfw_oid="$(create_remote boxlite-ai libkrunfw)"
+e2fsprogs_oid="$(create_remote tytso e2fsprogs)"
+bubblewrap_oid="$(create_remote containers bubblewrap)"
+
+fixture="$scratch/superproject"
+mkdir -p "$fixture"
+git -C "$fixture" init -q -b main
+git -C "$fixture" config user.name "BoxLite Setup Test"
+git -C "$fixture" config user.email "setup-test@boxlite.invalid"
+git config -f "$scratch/gitconfig" "url.file://$scratch/remotes/boxlite-ai/.insteadOf" "https://github.com/boxlite-ai/"
+git config -f "$scratch/gitconfig" "url.file://$scratch/remotes/tytso/.insteadOf" "https://github.com/tytso/"
+git config -f "$scratch/gitconfig" "url.file://$scratch/remotes/containers/.insteadOf" "https://github.com/containers/"
+cp "$repo_root/.gitmodules" "$fixture/.gitmodules"
+git -C "$fixture" add .gitmodules
+git -C "$fixture" update-index --add --cacheinfo "160000,$libkrun_oid,src/deps/libkrun-sys/vendor/libkrun"
+git -C "$fixture" update-index --add --cacheinfo "160000,$libkrunfw_oid,src/deps/libkrun-sys/vendor/libkrunfw"
+git -C "$fixture" update-index --add --cacheinfo "160000,$e2fsprogs_oid,src/deps/e2fsprogs-sys/vendor/e2fsprogs"
+git -C "$fixture" update-index --add --cacheinfo "160000,$bubblewrap_oid,src/deps/bubblewrap-sys/vendor/bubblewrap"
+git -C "$fixture" commit -qm "add fixture submodules"
+
+cp "$fixture/.gitmodules" "$scratch/gitmodules.original"
+git config -f "$fixture/.gitmodules" submodule.src/deps/libkrun-sys/vendor/libkrun.url \
+    "https://example.invalid/libkrun.git"
+if "$subject" "$fixture" >"$scratch/unexpected-url.log" 2>&1; then
+    fail "unexpected URL was accepted"
+fi
+grep -q 'refusing unexpected submodule' "$scratch/unexpected-url.log" || \
+    fail "unexpected URL failure was not explicit"
+cp "$scratch/gitmodules.original" "$fixture/.gitmodules"
+
+git config -f "$fixture/.gitmodules" submodule.src/deps/libkrun-sys/vendor/libkrun.path \
+    "src/deps/libkrun-sys/vendor/unexpected"
+if "$subject" "$fixture" >"$scratch/unexpected-path.log" 2>&1; then
+    fail "unexpected submodule path was accepted"
+fi
+grep -q 'refusing unexpected submodule' "$scratch/unexpected-path.log" || \
+    fail "unexpected path failure was not explicit"
+cp "$scratch/gitmodules.original" "$fixture/.gitmodules"
+
+git config -f "$fixture/.gitmodules" submodule.extra.path extra
+if "$subject" "$fixture" >"$scratch/unexpected-count.log" 2>&1; then
+    fail "unexpected submodule count was accepted"
+fi
+grep -q 'expected 4 submodules, found 5' "$scratch/unexpected-count.log" || \
+    fail "unexpected count failure was not explicit"
+cp "$scratch/gitmodules.original" "$fixture/.gitmodules"
+
+for invalid_jobs in 0 17; do
+    if BOXLITE_SUBMODULE_JOBS="$invalid_jobs" "$subject" "$fixture" \
+        >"$scratch/invalid-jobs-$invalid_jobs.log" 2>&1; then
+        fail "invalid job count $invalid_jobs was accepted"
+    fi
+    grep -q 'must be between 1 and 16' "$scratch/invalid-jobs-$invalid_jobs.log" || \
+        fail "job-count $invalid_jobs failure was not explicit"
+done
+
+missing_count="$(git -C "$fixture" submodule status --recursive | grep -c '^-')"
+[[ "$missing_count" == "4" ]] || fail "expected 4 missing submodules, found $missing_count"
+
+GIT_CONFIG_GLOBAL="$scratch/gitconfig" GIT_ALLOW_PROTOCOL=file:https \
+    BOXLITE_SUBMODULE_JOBS=2 "$subject" "$fixture" \
+    >"$scratch/first-run.log"
+grep -q 'initialized' "$scratch/first-run.log" || fail "first run did not initialize submodules"
+
+verify_oid() {
+    local path="$1"
+    local expected
+    local actual
+
+    expected="$(git -C "$fixture" rev-parse "HEAD:$path")"
+    actual="$(git -C "$fixture/$path" rev-parse HEAD)"
+    [[ "$actual" == "$expected" ]] || fail "$path checked out $actual instead of $expected"
+}
+
+verify_oid "src/deps/libkrun-sys/vendor/libkrun"
+verify_oid "src/deps/libkrun-sys/vendor/libkrunfw"
+verify_oid "src/deps/e2fsprogs-sys/vendor/e2fsprogs"
+verify_oid "src/deps/bubblewrap-sys/vendor/bubblewrap"
+
+if git -C "$fixture" submodule status --recursive | grep -q '^[+-U]'; then
+    fail "initialized submodule status was not clean"
+fi
+
+GIT_CONFIG_GLOBAL="$scratch/gitconfig" GIT_ALLOW_PROTOCOL=file:https \
+    "$subject" "$fixture" >"$scratch/second-run.log"
+grep -q 'already initialized' "$scratch/second-run.log" || fail "second run was not idempotent"
+
+printf 'test-setup-submodules: all checks passed\n'

--- a/scripts/test/test-setup-submodules.sh
+++ b/scripts/test/test-setup-submodules.sh
@@ -64,7 +64,7 @@ git config -f "$fixture/.gitmodules" submodule.src/deps/libkrun-sys/vendor/libkr
 if "$subject" "$fixture" >"$scratch/unexpected-url.log" 2>&1; then
     fail "unexpected URL was accepted"
 fi
-grep -q 'refusing unexpected submodule' "$scratch/unexpected-url.log" || \
+grep -qi 'refusing unexpected submodule' "$scratch/unexpected-url.log" || \
     fail "unexpected URL failure was not explicit"
 cp "$scratch/gitmodules.original" "$fixture/.gitmodules"
 
@@ -73,7 +73,7 @@ git config -f "$fixture/.gitmodules" submodule.src/deps/libkrun-sys/vendor/libkr
 if "$subject" "$fixture" >"$scratch/unexpected-path.log" 2>&1; then
     fail "unexpected submodule path was accepted"
 fi
-grep -q 'refusing unexpected submodule' "$scratch/unexpected-path.log" || \
+grep -qi 'refusing unexpected submodule' "$scratch/unexpected-path.log" || \
     fail "unexpected path failure was not explicit"
 cp "$scratch/gitmodules.original" "$fixture/.gitmodules"
 
@@ -81,7 +81,7 @@ git config -f "$fixture/.gitmodules" submodule.extra.path extra
 if "$subject" "$fixture" >"$scratch/unexpected-count.log" 2>&1; then
     fail "unexpected submodule count was accepted"
 fi
-grep -q 'expected 4 submodules, found 5' "$scratch/unexpected-count.log" || \
+grep -qi 'expected 4 submodules, found 5' "$scratch/unexpected-count.log" || \
     fail "unexpected count failure was not explicit"
 cp "$scratch/gitmodules.original" "$fixture/.gitmodules"
 
@@ -100,7 +100,7 @@ missing_count="$(git -C "$fixture" submodule status --recursive | grep -c '^-')"
 GIT_CONFIG_GLOBAL="$scratch/gitconfig" GIT_ALLOW_PROTOCOL=file:https \
     BOXLITE_SUBMODULE_JOBS=2 "$subject" "$fixture" \
     >"$scratch/first-run.log"
-grep -q 'initialized' "$scratch/first-run.log" || fail "first run did not initialize submodules"
+grep -qi 'initialized' "$scratch/first-run.log" || fail "first run did not initialize submodules"
 
 verify_oid() {
     local path="$1"
@@ -123,6 +123,6 @@ fi
 
 GIT_CONFIG_GLOBAL="$scratch/gitconfig" GIT_ALLOW_PROTOCOL=file:https \
     "$subject" "$fixture" >"$scratch/second-run.log"
-grep -q 'already initialized' "$scratch/second-run.log" || fail "second run was not idempotent"
+grep -qi 'already initialized' "$scratch/second-run.log" || fail "second run was not idempotent"
 
 printf 'test-setup-submodules: all checks passed\n'

--- a/scripts/test/test-setup-submodules.sh
+++ b/scripts/test/test-setup-submodules.sh
@@ -20,6 +20,16 @@ fail() {
 
 [[ -x "$subject" ]] || fail "production setup script is missing or not executable"
 
+missing_checkout="$scratch/missing-checkout"
+mkdir -p "$missing_checkout"
+if "$subject" "$missing_checkout" >"$scratch/missing-checkout.stdout" \
+    2>"$scratch/missing-checkout.stderr"; then
+    fail "missing checkout was accepted"
+fi
+[[ ! -s "$scratch/missing-checkout.stdout" ]] || fail "missing-checkout error was written to stdout"
+grep -qi 'expected a BoxLite checkout' "$scratch/missing-checkout.stderr" || \
+    fail "missing-checkout failure was not written to stderr"
+
 create_remote() {
     local owner="$1"
     local repository="$2"

--- a/scripts/test/test-setup-submodules.sh
+++ b/scripts/test/test-setup-submodules.sh
@@ -33,6 +33,7 @@ grep -qi 'expected a BoxLite checkout' "$scratch/missing-checkout.stderr" || \
 create_remote() {
     local owner="$1"
     local repository="$2"
+    local nested_oid="${3:-}"
     local seed="$scratch/seed-$owner-$repository"
     local bare="$scratch/remotes/$owner/$repository.git"
 
@@ -42,12 +43,19 @@ create_remote() {
     git -C "$seed" config user.email "setup-test@boxlite.invalid"
     printf '%s/%s\n' "$owner" "$repository" >"$seed/README.md"
     git -C "$seed" add README.md
+    if [[ -n "$nested_oid" ]]; then
+        printf '[submodule "nested"]\n\tpath = nested\n\turl = https://example.invalid/unvalidated.git\n' \
+            >"$seed/.gitmodules"
+        git -C "$seed" add .gitmodules
+        git -C "$seed" update-index --add --cacheinfo "160000,$nested_oid,nested"
+    fi
     git -C "$seed" commit -qm "seed $owner/$repository"
     git clone -q --bare "$seed" "$bare"
     git -C "$seed" rev-parse HEAD
 }
 
-libkrun_oid="$(create_remote boxlite-ai libkrun)"
+nested_oid="$(create_remote untrusted nested)"
+libkrun_oid="$(create_remote boxlite-ai libkrun "$nested_oid")"
 libkrunfw_oid="$(create_remote boxlite-ai libkrunfw)"
 e2fsprogs_oid="$(create_remote tytso e2fsprogs)"
 bubblewrap_oid="$(create_remote containers bubblewrap)"
@@ -110,6 +118,8 @@ missing_count="$(git -C "$fixture" submodule status --recursive | grep -c '^-')"
 GIT_CONFIG_GLOBAL="$scratch/gitconfig" GIT_ALLOW_PROTOCOL=file:https \
     BOXLITE_SUBMODULE_JOBS=2 "$subject" "$fixture" \
     >"$scratch/first-run.log"
+grep -qi 'initializing with 2 jobs' "$scratch/first-run.log" || \
+    fail "first run did not use the configured job count"
 grep -qi 'initialized' "$scratch/first-run.log" || fail "first run did not initialize submodules"
 
 verify_oid() {
@@ -126,6 +136,10 @@ verify_oid "src/deps/libkrun-sys/vendor/libkrun"
 verify_oid "src/deps/libkrun-sys/vendor/libkrunfw"
 verify_oid "src/deps/e2fsprogs-sys/vendor/e2fsprogs"
 verify_oid "src/deps/bubblewrap-sys/vendor/bubblewrap"
+
+libkrun_path="$fixture/src/deps/libkrun-sys/vendor/libkrun"
+git -C "$libkrun_path" submodule status | grep -q '^-' || \
+    fail "unvalidated nested submodule was initialized"
 
 if git -C "$fixture" submodule status --recursive | grep -q '^[+-U]'; then
     fail "initialized submodule status was not clean"


### PR DESCRIPTION
## Summary

- add an idempotent `make setup:submodules` entry point with parallelism bounded to 1–16 jobs
- provide a checked-in BoxLite Local Environment configuration (select it once in the agent client) and run the target from Claude's `SessionStart` startup hook
- validate the expected submodule paths and HTTPS URLs before automatic checkout
- keep the existing platform setup flows on the same implementation

## Before

```text
An agent or Claude creates a worktree
└─ no submodule-specific startup action
   └─ developer runs the full setup manually
      └─ init_submodules — scripts/setup/setup-common.sh:82
         └─ git submodule update --init --recursive --depth 1
```

## After

```text
selected agent Local Environment — environment.toml:4
Claude SessionStart — .claude/settings.json:18
existing platform setup — scripts/setup/setup-common.sh:82
└─ make setup:submodules — make/setup.mk:6
   └─ setup-submodules.sh — scripts/setup/setup-submodules.sh:1
      ├─ validate_submodule — scripts/setup/setup-submodules.sh:16
      ├─ detect missing or conflicted modules — scripts/setup/setup-submodules.sh:87
      └─ shallow parallel update — scripts/setup/setup-submodules.sh:101
```

## Validation

- first `make setup:submodules` run initialized all four pinned gitlink commits
- repeated Make and Claude startup commands returned `already initialized`
- committed isolated-repository regression test covers path, URL, count, job-count, fresh-init/OID, clean-status, and idempotence behavior
- `make test:setup:submodules`
- `shellcheck` and `bash -n` for the production and test scripts
- JSON and TOML configuration parse checks
- `git diff --check`

The local `make fmt:check` change detector compared against a stale local `main` ref and broadened the scan beyond this PR. That scan found 156 existing Prettier failures in generated `apps/libs/*-api-client` files; none are touched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated setup for initializing and synchronizing required Git submodules.
  * Added validation for repository configuration, submodule sources, checkout state, and parallelism settings.
  * Added development environment and startup support for running submodule setup automatically.

* **Bug Fixes**
  * Improved handling of missing, conflicting, or incorrectly configured submodules.

* **Tests**
  * Added integration coverage for validation, initialization, clean checkouts, and repeatable setup.
  * CI now runs submodule setup tests when relevant changes are detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->