### PR TITLE
feat(runtime): build minimal guest rootfs image in background

### DIFF
--- a/scripts/build/build-runtime.sh
+++ b/scripts/build/build-runtime.sh
@@ -222,6 +222,20 @@ assemble_runtime() {
     cp "$GUEST_BINARY" "$RUNTIME_LIBS_DIR/"
     echo "✓"
 
+    # Guest e2fsprogs tools, embedded under distinct names so they never shadow
+    # the host mke2fs bundled by e2fsprogs-sys. Optional: absent unless `make guest`
+    # (or the CI guest build) produced them.
+    if [ -f "$PROJECT_ROOT/target/$GUEST_TARGET/$PROFILE/mke2fs" ]; then
+        print_step "Copying guest-mke2fs... "
+        cp "$PROJECT_ROOT/target/$GUEST_TARGET/$PROFILE/mke2fs" "$RUNTIME_LIBS_DIR/guest-mke2fs"
+        echo "✓"
+    fi
+    if [ -f "$PROJECT_ROOT/target/$GUEST_TARGET/$PROFILE/resize2fs" ]; then
+        print_step "Copying guest-resize2fs... "
+        cp "$PROJECT_ROOT/target/$GUEST_TARGET/$PROFILE/resize2fs" "$RUNTIME_LIBS_DIR/guest-resize2fs"
+        echo "✓"
+    fi
+
     # Sign shim on macOS (always, to ensure proper entitlements)
     if [ "$OS" = "macos" ] && [ -f "$RUNTIME_LIBS_DIR/boxlite-shim" ]; then
         echo ""

--- a/src/boxlite/build.rs
+++ b/src/boxlite/build.rs
@@ -898,6 +898,20 @@ impl EmbeddedManifest {
             &profile,
             Self::find_prebuilt_guest,
         );
+        // Guest e2fsprogs tools, embedded under distinct names so they never
+        // shadow the host mke2fs bundled by bundle_boxlite_deps (disk/ext4.rs).
+        self.copy_prebuilt_binary(
+            workspace_root,
+            "guest-mke2fs",
+            &profile,
+            Self::find_prebuilt_guest_mke2fs,
+        );
+        self.copy_prebuilt_binary(
+            workspace_root,
+            "guest-resize2fs",
+            &profile,
+            Self::find_prebuilt_guest_resize2fs,
+        );
 
         let entries = self.scan_entries();
         Self::emit_manifest(&manifest_path, &entries);
@@ -997,6 +1011,38 @@ impl EmbeddedManifest {
                 .join(format!("{}-unknown-linux-musl", arch))
                 .join(profile)
                 .join("boxlite-guest");
+            if path.is_file() {
+                return Some(path);
+            }
+        }
+
+        None
+    }
+
+    /// Find a pre-built guest e2fsprogs tool for the given build profile.
+    ///
+    /// Same musl-triple + arch-preference logic as `find_prebuilt_guest`, but for
+    /// the standalone `mke2fs`/`resize2fs` emitted by build-guest-deps.sh.
+    fn find_prebuilt_guest_mke2fs(workspace_root: &Path, profile: &str) -> Option<PathBuf> {
+        Self::find_prebuilt_guest_tool(workspace_root, profile, "mke2fs")
+    }
+
+    fn find_prebuilt_guest_resize2fs(workspace_root: &Path, profile: &str) -> Option<PathBuf> {
+        Self::find_prebuilt_guest_tool(workspace_root, profile, "resize2fs")
+    }
+
+    fn find_prebuilt_guest_tool(
+        workspace_root: &Path,
+        profile: &str,
+        name: &str,
+    ) -> Option<PathBuf> {
+        let target_dir = workspace_root.join("target");
+
+        for arch in Self::preferred_arches() {
+            let path = target_dir
+                .join(format!("{}-unknown-linux-musl", arch))
+                .join(profile)
+                .join(name);
             if path.is_file() {
                 return Some(path);
             }

--- a/src/boxlite/src/experimental.rs
+++ b/src/boxlite/src/experimental.rs
@@ -21,6 +21,7 @@ pub const EXPERIMENTAL_FEATURES_ENV: &str = "BOXLITE_EXPERIMENTAL";
 pub enum ExperimentalFeature {
     CustomKernel,
     NestedVirtualization,
+    MinimalRootfs,
 }
 
 impl ExperimentalFeature {
@@ -29,6 +30,7 @@ impl ExperimentalFeature {
         match self {
             Self::CustomKernel => "custom-kernel",
             Self::NestedVirtualization => "nested-virtualization",
+            Self::MinimalRootfs => "minimal-rootfs",
         }
     }
 
@@ -36,6 +38,7 @@ impl ExperimentalFeature {
         match self {
             Self::CustomKernel => "custom kernel support",
             Self::NestedVirtualization => "nested virtualization support",
+            Self::MinimalRootfs => "minimal rootfs",
         }
     }
 }
@@ -58,6 +61,7 @@ impl ExperimentalFeatures {
             let feature = match token {
                 "custom-kernel" => ExperimentalFeature::CustomKernel,
                 "nested-virtualization" => ExperimentalFeature::NestedVirtualization,
+                "minimal-rootfs" => ExperimentalFeature::MinimalRootfs,
                 "" => {
                     return Err(BoxliteError::Config(format!(
                         "{EXPERIMENTAL_FEATURES_ENV} contains an empty feature name"
@@ -65,7 +69,7 @@ impl ExperimentalFeatures {
                 }
                 unknown => {
                     return Err(BoxliteError::Config(format!(
-                        "unknown feature '{unknown}' in {EXPERIMENTAL_FEATURES_ENV}; supported values: custom-kernel, nested-virtualization"
+                        "unknown feature '{unknown}' in {EXPERIMENTAL_FEATURES_ENV}; supported values: custom-kernel, nested-virtualization, minimal-rootfs"
                     )));
                 }
             };
@@ -160,6 +164,18 @@ mod tests {
 
         assert!(!features.is_enabled(ExperimentalFeature::CustomKernel));
         assert!(!features.is_enabled(ExperimentalFeature::NestedVirtualization));
+        assert!(!features.is_enabled(ExperimentalFeature::MinimalRootfs));
+    }
+
+    #[test]
+    fn minimal_rootfs_token_enables_the_feature() {
+        let features = ExperimentalFeatures::parse("minimal-rootfs").unwrap();
+        assert!(features.is_enabled(ExperimentalFeature::MinimalRootfs));
+
+        assert!(
+            !ExperimentalFeatures::default().is_enabled(ExperimentalFeature::MinimalRootfs),
+            "minimal rootfs must be disabled by default"
+        );
     }
 
     #[test]

--- a/src/boxlite/src/litebox/init/tasks/guest_rootfs.rs
+++ b/src/boxlite/src/litebox/init/tasks/guest_rootfs.rs
@@ -5,12 +5,14 @@
 
 use super::{InitCtx, log_task_error, task_start};
 use crate::disk::{BackingFormat, Disk, DiskFormat, Qcow2Helper};
+use crate::experimental::ExperimentalFeature;
 use crate::images::ImageDiskManager;
 use crate::pipeline::PipelineTask;
 use crate::rootfs::guest::{GuestRootfs, GuestRootfsManager, Strategy};
 use crate::runtime::constants::images;
 use crate::runtime::layout::BoxFilesystemLayout;
 use crate::runtime::rt_impl::SharedRuntimeImpl;
+use crate::vmm::guest_artifacts::GuestArtifacts;
 use async_trait::async_trait;
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 use std::path::Path;
@@ -79,11 +81,55 @@ async fn run_guest_rootfs(
         .await?
         .clone();
 
+    // Prepare the minimal rootfs image in the background (feature-gated,
+    // best-effort); it never blocks or fails this OCI boot path.
+    maybe_kick_off_minimal_rootfs(runtime);
+
     // Now create or reuse the per-box COW disk
     let (_updated_guest_rootfs, disk) =
         create_or_reuse_cow_disk(&guest_rootfs, layout, reuse_rootfs)?;
 
     Ok(disk)
+}
+
+/// Kick off a detached, best-effort build of the minimal guest rootfs image.
+///
+/// Gated behind `ExperimentalFeature::MinimalRootfs`. Runs off the boot path via
+/// `tokio::spawn` (precedent `box_impl.rs`) and single-flights on
+/// `runtime.minimal_rootfs`, so it only prepares the image the later "switch"
+/// step will consume. Failures are logged, never propagated.
+fn maybe_kick_off_minimal_rootfs(runtime: &SharedRuntimeImpl) {
+    if !runtime
+        .experimental_features
+        .is_enabled(ExperimentalFeature::MinimalRootfs)
+    {
+        return;
+    }
+    // Once built, the OnceCell is initialized — skip re-spawning so later box
+    // starts/restarts don't schedule no-op background tasks.
+    if runtime.minimal_rootfs.initialized() {
+        return;
+    }
+
+    let runtime = runtime.clone();
+    tokio::spawn(async move {
+        let result = runtime
+            .minimal_rootfs
+            .get_or_try_init(|| async {
+                let artifacts = GuestArtifacts::get()?;
+                runtime
+                    .guest_rootfs_mgr
+                    .get_or_create_minimal(artifacts)
+                    .await
+            })
+            .await;
+        match result {
+            Ok(_) => tracing::info!("Background minimal rootfs build ready"),
+            Err(e) => {
+                tracing::warn!(error = %e, "Background minimal rootfs build failed (boot unaffected)")
+            }
+        }
+    });
 }
 
 /// Create new COW disk or reuse existing one for restart.

--- a/src/boxlite/src/rootfs/guest.rs
+++ b/src/boxlite/src/rootfs/guest.rs
@@ -6,12 +6,14 @@ use std::path::{Path, PathBuf};
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 
 use crate::disk::{
-    BaseDisk, BaseDiskKind, BaseDiskManager, Disk, DiskFormat, inject_file_into_ext4,
+    BaseDisk, BaseDiskKind, BaseDiskManager, Disk, DiskFormat, create_ext4_from_dir,
+    inject_file_into_ext4,
 };
 use crate::images::{ImageDiskManager, ImageObject};
 #[cfg(test)]
 use crate::runtime::id::BaseDiskID;
 use crate::runtime::id::BaseDiskIDMint;
+use crate::vmm::guest_artifacts::GuestArtifacts;
 use crate::vmm::guest_binary::GuestBinary;
 
 /// A fully resolved and ready-to-use guest rootfs.
@@ -324,6 +326,60 @@ impl GuestRootfsManager {
         Self::disk_to_guest_rootfs(disk, env)
     }
 
+    /// Get or create the minimal guest rootfs from the standalone artifacts.
+    ///
+    /// The minimal rootfs is just `boxlite-guest` plus the static
+    /// `mke2fs`/`resize2fs`; it is built straight into an ext4 (no OCI image,
+    /// nothing injected afterward) and cached content-addressed in `bases/`
+    /// under the combined artifact hash, tracked and GC'd like the Debian rootfs.
+    pub async fn get_or_create_minimal(
+        &self,
+        artifacts: &GuestArtifacts,
+    ) -> BoxliteResult<GuestRootfs> {
+        let key = Self::minimal_version_key(artifacts);
+
+        if let Some(disk) = self.find(&key) {
+            tracing::debug!(version_key = %key, "get_or_create_minimal: cache hit");
+            return Self::disk_to_guest_rootfs(disk, Vec::new());
+        }
+
+        tracing::info!(version_key = %key, "get_or_create_minimal: cache miss — building");
+        let disk = self.build_minimal_and_install(artifacts, &key).await?;
+        Self::disk_to_guest_rootfs(disk, Vec::new())
+    }
+
+    /// Stage the artifacts into a tree, build an ext4, and install it through
+    /// the shared cache (`install`), so the minimal rootfs is tracked and GC'd
+    /// like the Debian rootfs.
+    async fn build_minimal_and_install(
+        &self,
+        artifacts: &GuestArtifacts,
+        key: &str,
+    ) -> BoxliteResult<Disk> {
+        let temp = tempfile::tempdir_in(&self.temp_dir).map_err(|e| {
+            BoxliteError::Storage(format!(
+                "Failed to create minimal rootfs temp dir in {}: {}",
+                self.temp_dir.display(),
+                e
+            ))
+        })?;
+
+        let tree_root = temp.path().join("rootfs");
+        stage_tree(&tree_root, artifacts)?;
+        let staged_path = temp.path().join("minimal-rootfs.ext4");
+
+        // mke2fs runs as a subprocess plus disk I/O; keep it off the async path.
+        let tree_for_build = tree_root.clone();
+        let staged_for_build = staged_path.clone();
+        let disk = tokio::task::spawn_blocking(move || {
+            create_ext4_from_dir(&tree_for_build, &staged_for_build, 0)
+        })
+        .await
+        .map_err(|e| BoxliteError::Storage(format!("minimal rootfs build task failed: {e}")))??;
+
+        self.install(key, disk)
+    }
+
     /// Convert a persistent `Disk` into a `GuestRootfs` with `Strategy::Disk`.
     ///
     /// Leaks the disk (prevents drop cleanup) since ownership transfers to
@@ -518,7 +574,15 @@ impl GuestRootfsManager {
             }
         };
 
-        let result = self.gc_inner(boxes_dir, &current_guest_suffix);
+        // The minimal rootfs is keyed by the combined artifact id (not the guest
+        // suffix), so keep the current one when it resolves.
+        let current_minimal_key = GuestArtifacts::get().ok().map(|a| a.id().to_string());
+
+        let result = self.gc_inner(
+            boxes_dir,
+            &current_guest_suffix,
+            current_minimal_key.as_deref(),
+        );
 
         tracing::info!(
             elapsed_ms = gc_start.elapsed().as_millis() as u64,
@@ -533,10 +597,16 @@ impl GuestRootfsManager {
     ///
     /// Queries the DB for all rootfs entries, then determines which to keep:
     /// - Entries whose version key (name) ends with `current_guest_suffix`
+    /// - The current minimal rootfs entry (name == `current_minimal_key`)
     /// - Entries whose base_path any box overlay backs onto (see
     ///   [`BaseDiskManager::referenced_backing_paths`], which covers both
     ///   `disk.qcow2` and `disks/guest-rootfs.qcow2`)
-    fn gc_inner(&self, boxes_dir: &Path, current_guest_suffix: &str) -> BoxliteResult<usize> {
+    fn gc_inner(
+        &self,
+        boxes_dir: &Path,
+        current_guest_suffix: &str,
+        current_minimal_key: Option<&str>,
+    ) -> BoxliteResult<usize> {
         let records = self
             .base_disk_mgr
             .store()
@@ -579,6 +649,16 @@ impl GuestRootfsManager {
                 continue;
             }
 
+            // Keep the current minimal rootfs entry
+            if current_minimal_key == Some(version_key) {
+                preserved_current += 1;
+                tracing::debug!(
+                    version_key = %version_key,
+                    "GC: keeping current minimal rootfs"
+                );
+                continue;
+            }
+
             // Delete stale entries (old guest version, no box references)
             tracing::info!(
                 id = %record.id(),
@@ -616,6 +696,54 @@ impl GuestRootfsManager {
         let g = &guest_hash[..12.min(guest_hash.len())];
         format!("{}-{}", d, g)
     }
+
+    /// Version key for the minimal rootfs: the combined artifact content id.
+    fn minimal_version_key(artifacts: &GuestArtifacts) -> String {
+        artifacts.id().to_string()
+    }
+}
+
+/// Stage the minimal rootfs tree: `boxlite/bin/{boxlite-guest, mke2fs, resize2fs, mkfs.ext4}`.
+fn stage_tree(rootfs: &Path, artifacts: &GuestArtifacts) -> BoxliteResult<()> {
+    let bin = rootfs.join("boxlite").join("bin");
+    std::fs::create_dir_all(&bin).map_err(|e| {
+        BoxliteError::Storage(format!(
+            "Failed to create minimal rootfs tree {}: {}",
+            bin.display(),
+            e
+        ))
+    })?;
+
+    copy_artifact(artifacts.guest_path(), &bin.join("boxlite-guest"))?;
+    copy_artifact(artifacts.mke2fs().path(), &bin.join("mke2fs"))?;
+    copy_artifact(artifacts.resize2fs().path(), &bin.join("resize2fs"))?;
+    // The guest invokes `mkfs.ext4` (`src/guest/src/storage/block_device.rs`);
+    // mke2fs dispatches on argv[0], so a byte-identical copy is the alias.
+    copy_artifact(artifacts.mke2fs().path(), &bin.join("mkfs.ext4"))?;
+
+    Ok(())
+}
+
+/// Copy a host artifact into the tree with mode 0755, matching the build contract.
+fn copy_artifact(src: &Path, dst: &Path) -> BoxliteResult<()> {
+    std::fs::copy(src, dst).map_err(|e| {
+        BoxliteError::Storage(format!(
+            "Failed to copy {} -> {}: {}",
+            src.display(),
+            dst.display(),
+            e
+        ))
+    })?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(dst, std::fs::Permissions::from_mode(0o755)).map_err(|e| {
+            BoxliteError::Storage(format!("Failed to chmod 0755 {}: {}", dst.display(), e))
+        })?;
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -885,7 +1013,7 @@ mod tests {
         let mgr = GuestRootfsManager::new(base_disk_mgr, dir.path().to_path_buf());
 
         // No boxes reference anything, old guest hash → both removed
-        let removed = mgr.gc_inner(&boxes_dir, "-currentguest").unwrap();
+        let removed = mgr.gc_inner(&boxes_dir, "-currentguest", None).unwrap();
         assert_eq!(removed, 2);
         assert!(!file1.exists());
         assert!(!file2.exists());
@@ -924,7 +1052,7 @@ mod tests {
         let base_disk_mgr = BaseDiskManager::new(bases_dir, store);
         let mgr = GuestRootfsManager::new(base_disk_mgr, dir.path().to_path_buf());
 
-        let removed = mgr.gc_inner(&boxes_dir, "-currentguest").unwrap();
+        let removed = mgr.gc_inner(&boxes_dir, "-currentguest", None).unwrap();
         assert_eq!(removed, 1);
         assert!(
             current_file.exists(),
@@ -982,7 +1110,7 @@ mod tests {
         let base_disk_mgr = BaseDiskManager::new(bases_dir, store);
         let mgr = GuestRootfsManager::new(base_disk_mgr, dir.path().to_path_buf());
 
-        let removed = mgr.gc_inner(&boxes_dir, "-currentguest").unwrap();
+        let removed = mgr.gc_inner(&boxes_dir, "-currentguest", None).unwrap();
         assert_eq!(removed, 1);
         assert!(referenced_file.exists(), "Referenced entry should be kept");
         assert!(
@@ -996,7 +1124,7 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let mgr = make_mgr(dir.path().join("bases"), dir.path().to_path_buf());
 
-        let removed = mgr.gc_inner(dir.path(), "-anything").unwrap();
+        let removed = mgr.gc_inner(dir.path(), "-anything", None).unwrap();
         assert_eq!(removed, 0);
     }
 
@@ -1017,8 +1145,117 @@ mod tests {
         let mgr = GuestRootfsManager::new(base_disk_mgr, dir.path().to_path_buf());
 
         let removed = mgr
-            .gc_inner(&dir.path().join("nonexistent-boxes"), "-currentguest")
+            .gc_inner(&dir.path().join("nonexistent-boxes"), "-currentguest", None)
             .unwrap();
         assert_eq!(removed, 1);
+    }
+
+    /// Smallest byte sequence `GuestBinary::resolve_at` accepts for this host.
+    fn fake_guest(filler: u8) -> Vec<u8> {
+        let mut elf = vec![0u8; 128];
+        elf[..4].copy_from_slice(&[0x7f, b'E', b'L', b'F']);
+        elf[4] = 2; // 64-bit
+        let machine: u16 = match std::env::consts::ARCH {
+            "x86_64" => 0x3E,
+            _ => 0xB7,
+        };
+        elf[18..20].copy_from_slice(&machine.to_le_bytes());
+        elf[64..].fill(filler);
+        elf
+    }
+
+    fn fake_artifacts(dir: &tempfile::TempDir) -> GuestArtifacts {
+        let guest_path = dir.path().join("boxlite-guest");
+        std::fs::write(&guest_path, fake_guest(0xAA)).unwrap();
+        let guest = GuestBinary::resolve_at(guest_path).unwrap();
+
+        let mke2fs = dir.path().join("guest-mke2fs");
+        let resize2fs = dir.path().join("guest-resize2fs");
+        std::fs::write(&mke2fs, b"mke2fs-bytes").unwrap();
+        std::fs::write(&resize2fs, b"resize2fs-bytes").unwrap();
+
+        GuestArtifacts::resolve_at(&guest, mke2fs, resize2fs).unwrap()
+    }
+
+    #[test]
+    fn stage_tree_copies_artifacts_and_mkfs_ext4_alias() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let artifacts = fake_artifacts(&dir);
+
+        let tree = dir.path().join("rootfs");
+        stage_tree(&tree, &artifacts).unwrap();
+
+        let bin = tree.join("boxlite").join("bin");
+        for name in ["boxlite-guest", "mke2fs", "resize2fs", "mkfs.ext4"] {
+            let path = bin.join(name);
+            assert!(path.is_file(), "{name} must be staged");
+            assert_eq!(
+                std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+                0o755,
+                "{name} must be mode 0755"
+            );
+        }
+
+        assert_eq!(
+            std::fs::read(bin.join("mkfs.ext4")).unwrap(),
+            std::fs::read(bin.join("mke2fs")).unwrap(),
+            "mkfs.ext4 must be a byte-copy of mke2fs"
+        );
+    }
+
+    /// The full build must land the artifacts inside a real ext4 image, tracked
+    /// in the bases/ cache. Skipped without the host e2fsprogs binaries.
+    #[tokio::test]
+    async fn get_or_create_minimal_builds_ext4_with_artifacts() {
+        use crate::util::find_binary;
+
+        if find_binary("mke2fs").is_err() || find_binary("debugfs").is_err() {
+            eprintln!("skipping: mke2fs/debugfs not found (run `make runtime:debug`)");
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let artifacts = fake_artifacts(&dir);
+        let temp_dir = dir.path().join("tmp");
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let mgr = make_mgr(dir.path().join("bases"), temp_dir);
+
+        let rootfs = mgr.get_or_create_minimal(&artifacts).await.unwrap();
+        let Strategy::Disk { disk_path, .. } = rootfs.strategy else {
+            panic!("minimal rootfs must be disk-based");
+        };
+        assert!(disk_path.is_file());
+
+        let debugfs = find_binary("debugfs").unwrap();
+        let ls = std::process::Command::new(&debugfs)
+            .args(["-R", "ls /boxlite/bin"])
+            .arg(&disk_path)
+            .output()
+            .expect("run debugfs ls");
+        assert!(
+            ls.status.success(),
+            "debugfs ls failed: {}",
+            String::from_utf8_lossy(&ls.stderr)
+        );
+        let listing = String::from_utf8_lossy(&ls.stdout);
+        for name in ["boxlite-guest", "mke2fs", "resize2fs", "mkfs.ext4"] {
+            assert!(
+                listing.contains(name),
+                "image /boxlite/bin must contain {name}:\n{listing}"
+            );
+        }
+
+        // Second call is a cache hit — same path, no rebuild.
+        let rootfs2 = mgr.get_or_create_minimal(&artifacts).await.unwrap();
+        let Strategy::Disk {
+            disk_path: disk_path2,
+            ..
+        } = rootfs2.strategy
+        else {
+            panic!("minimal rootfs must be disk-based");
+        };
+        assert_eq!(disk_path, disk_path2);
     }
 }

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -145,6 +145,8 @@ pub struct RuntimeImpl {
     pub(crate) guest_rootfs_mgr: GuestRootfsManager,
     /// Guest rootfs lazy initialization (Arc<OnceCell>)
     pub(crate) guest_rootfs: Arc<OnceCell<GuestRootfs>>,
+    /// Minimal rootfs lazy initialization (Arc<OnceCell>, background single-flight).
+    pub(crate) minimal_rootfs: Arc<OnceCell<GuestRootfs>>,
     /// Runtime-wide metrics (AtomicU64 based, lock-free)
     pub(crate) runtime_metrics: RuntimeMetricsStorage,
 
@@ -354,6 +356,7 @@ impl RuntimeImpl {
             image_disk_mgr,
             guest_rootfs_mgr,
             guest_rootfs: Arc::new(OnceCell::new()),
+            minimal_rootfs: Arc::new(OnceCell::new()),
             runtime_metrics: RuntimeMetricsStorage::new(),
             experimental_features,
             base_disk_mgr,

--- a/src/boxlite/src/vmm/guest_artifacts.rs
+++ b/src/boxlite/src/vmm/guest_artifacts.rs
@@ -1,0 +1,233 @@
+//! The three standalone guest artifacts this process packages into a minimal rootfs.
+//!
+//! `build-guest.sh` + `build-guest-deps.sh` emit `boxlite-guest` plus static
+//! `mke2fs`/`resize2fs`. The guest binary is resolved through [`GuestBinary`];
+//! the two tools are embedded under distinct host names (`guest-mke2fs`,
+//! `guest-resize2fs`) so they never shadow the *host* `mke2fs` bundled by
+//! `e2fsprogs-sys` (resolved by `disk/ext4.rs` to build images).
+//!
+//! [`GuestArtifacts`] is the single place all three are resolved, and the one
+//! value that binds the three host paths to their identity. The combined
+//! content identity (`id()`) keys the minimal-rootfs cache, so a rebuild of any
+//! one artifact moves the key — the same "path and identity from the same value"
+//! contract [`GuestBinary`] documents.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use boxlite_shared::errors::{BoxliteError, BoxliteResult};
+use sha2::{Digest, Sha256};
+
+use super::guest_binary::GuestBinary;
+use crate::util::find_binary;
+
+/// Hex characters of the content digest used as the identity.
+const ID_LEN: usize = 12;
+
+/// Host-side name the guest `mke2fs` is embedded under.
+const HOST_GUEST_MKE2FS: &str = "guest-mke2fs";
+/// Host-side name the guest `resize2fs` is embedded under.
+const HOST_GUEST_RESIZE2FS: &str = "guest-resize2fs";
+
+/// A resolved guest tool, identified by its host path.
+pub struct GuestTool {
+    path: PathBuf,
+}
+
+impl GuestTool {
+    /// Host path to the tool (to be copied into the minimal rootfs).
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+/// The three guest artifacts, resolved once with a combined content identity.
+pub struct GuestArtifacts {
+    guest_path: PathBuf,
+    mke2fs: GuestTool,
+    resize2fs: GuestTool,
+    combined_id: String,
+}
+
+impl GuestArtifacts {
+    /// Resolve the guest artifacts once per process.
+    ///
+    /// Only success is memoised, mirroring [`GuestBinary::get`]: a failure here
+    /// (e.g. the guest tools were not built) must not be cached as a rendered
+    /// string that hides the actionable error. Callers run this in a background
+    /// best-effort task, so a retry on a later boot costs nothing that matters.
+    pub fn get() -> BoxliteResult<&'static Self> {
+        static INSTANCE: OnceLock<GuestArtifacts> = OnceLock::new();
+
+        if let Some(artifacts) = INSTANCE.get() {
+            return Ok(artifacts);
+        }
+        let resolved = Self::resolve()?;
+        Ok(INSTANCE.get_or_init(|| resolved))
+    }
+
+    /// Host path to the `boxlite-guest` binary.
+    pub fn guest_path(&self) -> &Path {
+        &self.guest_path
+    }
+
+    /// The resolved guest `mke2fs`.
+    pub fn mke2fs(&self) -> &GuestTool {
+        &self.mke2fs
+    }
+
+    /// The resolved guest `resize2fs`.
+    pub fn resize2fs(&self) -> &GuestTool {
+        &self.resize2fs
+    }
+
+    /// Combined content identity, for cache keys and log fields.
+    pub fn id(&self) -> &str {
+        &self.combined_id
+    }
+
+    fn resolve() -> BoxliteResult<Self> {
+        let guest = GuestBinary::get()?;
+        let mke2fs = find_binary(HOST_GUEST_MKE2FS)?;
+        let resize2fs = find_binary(HOST_GUEST_RESIZE2FS)?;
+        Self::resolve_at(guest, mke2fs, resize2fs)
+    }
+
+    /// Resolve and identify the artifacts from explicit paths.
+    ///
+    /// Split from [`Self::resolve`] so the read-hash-identify step can be
+    /// exercised against known files without touching `BOXLITE_RUNTIME_DIR` or
+    /// the process-wide cache.
+    pub(crate) fn resolve_at(
+        guest: &GuestBinary,
+        mke2fs: PathBuf,
+        resize2fs: PathBuf,
+    ) -> BoxliteResult<Self> {
+        let mke2fs_id = content_id(&mke2fs)?;
+        let resize2fs_id = content_id(&resize2fs)?;
+
+        let mut hasher = Sha256::new();
+        hasher.update(guest.id().as_bytes());
+        hasher.update(mke2fs_id.as_bytes());
+        hasher.update(resize2fs_id.as_bytes());
+        let combined_id = hex::encode(hasher.finalize())[..ID_LEN].to_string();
+
+        tracing::info!(
+            guest_id = %guest.id(),
+            mke2fs_id = %mke2fs_id,
+            resize2fs_id = %resize2fs_id,
+            combined_id = %combined_id,
+            "Resolved guest artifacts"
+        );
+
+        Ok(Self {
+            guest_path: guest.path().to_path_buf(),
+            mke2fs: GuestTool { path: mke2fs },
+            resize2fs: GuestTool { path: resize2fs },
+            combined_id,
+        })
+    }
+}
+
+/// First 12 hex chars of a file's SHA-256 content digest.
+fn content_id(path: &Path) -> BoxliteResult<String> {
+    let bytes = std::fs::read(path).map_err(|e| {
+        BoxliteError::Storage(format!("Cannot read guest tool {}: {}", path.display(), e))
+    })?;
+    Ok(hex::encode(Sha256::digest(&bytes))[..ID_LEN].to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Smallest byte sequence `GuestBinary::resolve_at` accepts for this host.
+    fn fake_guest(filler: u8) -> Vec<u8> {
+        let mut elf = vec![0u8; 128];
+        elf[..4].copy_from_slice(&[0x7f, b'E', b'L', b'F']);
+        elf[4] = 2; // 64-bit
+        let machine: u16 = match std::env::consts::ARCH {
+            "x86_64" => 0x3E,
+            _ => 0xB7,
+        };
+        elf[18..20].copy_from_slice(&machine.to_le_bytes());
+        elf[64..].fill(filler);
+        elf
+    }
+
+    fn resolve(dir: &tempfile::TempDir, guest_filler: u8, tool_filler: u8) -> GuestArtifacts {
+        let guest_path = dir.path().join("boxlite-guest");
+        std::fs::write(&guest_path, fake_guest(guest_filler)).unwrap();
+        let guest = GuestBinary::resolve_at(guest_path).unwrap();
+
+        let mke2fs = dir.path().join("guest-mke2fs");
+        let resize2fs = dir.path().join("guest-resize2fs");
+        std::fs::write(&mke2fs, vec![tool_filler; 64]).unwrap();
+        std::fs::write(&resize2fs, vec![tool_filler; 64]).unwrap();
+
+        GuestArtifacts::resolve_at(&guest, mke2fs, resize2fs).unwrap()
+    }
+
+    /// The identity must come from the bytes of all three artifacts.
+    ///
+    /// NOTE ON VERIFICATION: this cannot be a revert-and-watch-it-fail
+    /// reproducer — it calls `resolve_at`, which the change introduces, so
+    /// removing the production change stops it compiling rather than failing it.
+    /// Verified by mutation (digest a path rather than the bytes makes the
+    /// assertion fire).
+    #[test]
+    fn id_tracks_tool_bytes_on_disk() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let before = resolve(&dir, 0xAA, 0x11);
+        let first_id = before.id().to_string();
+
+        // Same paths, different tool contents — as after `make guest`.
+        let after = resolve(&dir, 0xAA, 0x22);
+
+        assert_ne!(
+            first_id,
+            after.id(),
+            "a rebuilt guest tool must not keep the previous identity"
+        );
+    }
+
+    #[test]
+    fn id_is_stable_for_unchanged_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let first = resolve(&dir, 0xAA, 0x11);
+        let second = resolve(&dir, 0xAA, 0x11);
+
+        assert_eq!(
+            first.id(),
+            second.id(),
+            "identical bytes must reuse the cached minimal rootfs"
+        );
+        assert_eq!(first.id().len(), ID_LEN);
+    }
+
+    /// Resolution must fail and name the missing tool, so a build without the
+    /// guest tools degrades to a logged skip rather than a confusing error.
+    #[test]
+    fn a_missing_tool_is_reported_by_name() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let guest_path = dir.path().join("boxlite-guest");
+        std::fs::write(&guest_path, fake_guest(0xAA)).unwrap();
+        let guest = GuestBinary::resolve_at(guest_path).unwrap();
+
+        let error = GuestArtifacts::resolve_at(
+            &guest,
+            dir.path().join("guest-mke2fs"),
+            dir.path().join("guest-resize2fs"),
+        )
+        .err()
+        .expect("a missing tool must not resolve");
+
+        assert!(
+            error.to_string().contains("Cannot read") && error.to_string().contains("guest-mke2fs"),
+            "error should name the unreadable tool: {error}"
+        );
+    }
+}

--- a/src/boxlite/src/vmm/mod.rs
+++ b/src/boxlite/src/vmm/mod.rs
@@ -9,6 +9,7 @@ pub mod controller;
 pub mod engine;
 pub mod exit_info;
 pub mod factory;
+pub(crate) mod guest_artifacts;
 pub mod guest_binary;
 pub mod guest_check;
 #[cfg(feature = "krun")]


### PR DESCRIPTION
## Summary

Build the minimal guest rootfs (standalone `boxlite-guest` + static `mke2fs`/`resize2fs`) into an ext4 image at box start, as a feature-gated, best-effort background task. It never blocks or fails the current Debian boot path — it only caches the image for the later switch to the minimal rootfs.

## Call graph

Before
```text
run_guest_rootfs  (GuestRootfsTask · src/boxlite/src/litebox/init/tasks/guest_rootfs.rs:53)
  └─ guest_rootfs.get_or_try_init → GuestRootfsManager::get_or_create  — Debian image → ext4 + inject boxlite-guest
       └─ create_or_reuse_cow_disk                                     — per-box qcow2 overlay
```

After
```text
run_guest_rootfs  (GuestRootfsTask · src/boxlite/src/litebox/init/tasks/guest_rootfs.rs:53)
  ├─ guest_rootfs.get_or_try_init → GuestRootfsManager::get_or_create  — Debian boot path (unchanged)
  └─ maybe_kick_off_minimal_rootfs                                     — gated; detached tokio::spawn, best-effort
       └─ minimal_rootfs.get_or_try_init → MinimalRootfsManager::get_or_create  (rootfs/minimal.rs:40)
            └─ stage_tree + create_ext4_from_dir                        — 3 artifacts → minimal rootfs ext4 (cached)
```

## Changes

- Embed the guest tools under distinct names (`guest-mke2fs`/`guest-resize2fs`) via `build.rs` + `build-runtime.sh`, so they never shadow the host `mke2fs`.
- Add `GuestArtifacts` (resolve the three artifacts once + combined content id).
- Add `MinimalRootfsManager` — stages `boxlite/bin/{boxlite-guest, mke2fs, resize2fs, mkfs.ext4}` and builds a content-addressed ext4 under `~/.boxlite/minimal-rootfs/` (no DB).
- Gate behind `BOXLITE_EXPERIMENTAL=minimal-rootfs` (default off).

## How to verify

- `make guest`, then boot a box with `BOXLITE_EXPERIMENTAL=minimal-rootfs`: the box still boots from Debian, and `~/.boxlite/minimal-rootfs/{key}.ext4` appears.
- `BOXLITE_DEPS_STUB=1 cargo test -p boxlite --lib -- guest_artifacts minimal experimental`

## Risks / rollout

- Default-off, so zero impact on the current boot path until the experimental flag is enabled.
- The minimal rootfs is built and cached but not yet booted from; guest `PATH` and COW-overlay integration land with the later switch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the experimental `minimal-rootfs` capability for creating a smaller guest root filesystem.
  - Minimal root filesystems are prepared asynchronously and reused when the same guest tools are available.
  - Added support for required guest filesystem tools, including ext4 formatting and resizing utilities.
- **Bug Fixes**
  - Improved artifact validation and caching, with clearer errors when required tools are unavailable.
  - Preserved the active minimal root filesystem during cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->