### PR TITLE
fix(lint): satisfy clippy 1.98 lints

### DIFF
--- a/src/boxlite/src/disk/qcow2.rs
+++ b/src/boxlite/src/disk/qcow2.rs
@@ -1258,8 +1258,10 @@ impl FlattenLayer {
             ))
         })?;
         let l1_table: Vec<u64> = l1_buf
-            .chunks_exact(8)
-            .map(|c| u64::from_be_bytes(c.try_into().unwrap()))
+            .as_chunks::<8>()
+            .0
+            .iter()
+            .map(|c| u64::from_be_bytes(*c))
             .collect();
 
         Ok((

--- a/src/cli/src/commands/serve/mod.rs
+++ b/src/cli/src/commands/serve/mod.rs
@@ -940,6 +940,7 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 // Box Handle Cache Helper
 // ============================================================================
 
+#[allow(clippy::result_large_err)]
 async fn get_or_fetch_box(state: &AppState, box_id: &str) -> Result<Arc<LiteBox>, Response> {
     // Check cache first.
     //
@@ -1071,6 +1072,7 @@ where
 /// so attaching to a finished job would silently run the job again. `attach()`
 /// already does the right thing for every status by itself: it boots a
 /// `Configured` box (which has never run) and refuses a `Stopped` one.
+#[allow(clippy::result_large_err)]
 async fn get_or_attach_main_session(
     state: &AppState,
     box_id: &str,

--- a/src/guest/src/service/exec/output.rs
+++ b/src/guest/src/service/exec/output.rs
@@ -139,6 +139,10 @@ impl OutputManager {
         }
     }
 
+    // `tonic::Status` is the guest's gRPC error type and is wide enough to trip
+    // `result_large_err`; these control-plane methods fail rarely, so boxing
+    // every `Err` costs more than it saves.
+    #[allow(clippy::result_large_err)]
     pub(crate) async fn attach(&self) -> Result<AttachStream, Status> {
         let lease = self.claim_consumer().await?;
         if self.inner.lock().await.sealed {
@@ -149,6 +153,7 @@ impl OutputManager {
         Ok(self.attach_stream(lease))
     }
 
+    #[allow(clippy::result_large_err)]
     pub(crate) async fn attach_retained(&self) -> Result<AttachStream, Status> {
         let lease = self.claim_consumer().await?;
         Ok(self.attach_stream(lease))
@@ -159,6 +164,7 @@ impl OutputManager {
         Arc::clone(&self.consumer_lease)
     }
 
+    #[allow(clippy::result_large_err)]
     async fn claim_consumer(&self) -> Result<ConsumerLease, Status> {
         if self
             .consumer_lease

--- a/src/guest/src/service/ssh/sftp.rs
+++ b/src/guest/src/service/ssh/sftp.rs
@@ -789,8 +789,10 @@ fn unpack_ids(data: &[u8]) -> Result<Vec<u32>, StatusReply> {
         return Err(StatusCode::Failure.with_message("too many account ID lookups"));
     }
     Ok(data
-        .chunks_exact(4)
-        .map(|id| u32::from_be_bytes(id.try_into().expect("four-byte chunk")))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|id| u32::from_be_bytes(*id))
         .collect())
 }
 


### PR DESCRIPTION
## Summary
Rust stable advanced to 1.98, whose clippy added two lints that the Lint job's `-D warnings` turns into hard errors, breaking the `Run Clippy` job on any Rust-touching PR. Replace the two `chunks_exact` call sites with `as_chunks`, and allow `result_large_err` on control-plane methods returning `tonic::Status`/`axum::Response`, matching the convention already used in `executions.rs` and `files.rs`.

## Call graph

Before
  FlattenLayer::open  (FlattenLayer · src/boxlite/src/disk/qcow2.rs:1186)  — parses L1 table via chunks_exact(8)
  unpack_ids          (fn · src/guest/src/service/ssh/sftp.rs:783)         — decodes id list via chunks_exact(4)

After
  FlattenLayer::open  (FlattenLayer · src/boxlite/src/disk/qcow2.rs:1186)  — parses L1 table via as_chunks::<8>()
  unpack_ids          (fn · src/guest/src/service/ssh/sftp.rs:783)         — decodes id list via as_chunks::<4>()

## Changes
- Replace `.chunks_exact(N)` with `.as_chunks::<N>().0.iter()` in `qcow2.rs` and `sftp.rs` (`clippy::chunks_exact_to_as_chunks`).
- Allow `clippy::result_large_err` on `attach`/`attach_retained`/`claim_consumer` (`output.rs`) and `get_or_fetch_box`/`get_or_attach_main_session` (`mod.rs`).

## How to verify
- `BOXLITE_DEPS_STUB=1 cargo clippy --workspace --all-targets --all-features -- -D warnings` (Rust 1.98)
- `cargo test -p boxlite --lib disk::qcow2`
- `cargo test -p boxlite-guest --bin boxlite-guest -- service::exec::output service::ssh::sftp`

## Risks / rollout
- None — the `as_chunks` refactors are behavior-preserving (both call sites already guarantee a multiple-of-N length), and `#[allow]` adds no runtime effect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when reading virtual disk metadata and decoding file transfer identifiers.
  * Preserved correct big-endian identifier handling while avoiding fragile conversions.

* **Chores**
  * Addressed static analysis warnings in command execution and output handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->