### PR TITLE
fix(rest): stop turning un-coded server errors into internal errors

### DIFF
--- a/apps/api/src/box/services/box.service.ts
+++ b/apps/api/src/box/services/box.service.ts
@@ -360,7 +360,9 @@ export class BoxService {
     }
 
     if (!warmPoolBox.runnerId) {
-      throw new BoxError('Runner not found for warm pool box')
+      // Not a state-machine guard: the box is fine, the platform lost its
+      // runner. Keep it classified as a server-side fault.
+      throw new BoxError('Runner not found for warm pool box', 'internal')
     }
 
     // Resolve the name at persist time. A caller-provided name updates in one

--- a/apps/api/src/exceptions/box-error.exception.ts
+++ b/apps/api/src/exceptions/box-error.exception.ts
@@ -6,8 +6,21 @@
 
 import { HttpException, HttpStatus } from '@nestjs/common'
 
+/**
+ * A box-lifecycle guard rejected the request.
+ *
+ * Carries a machine-readable `code` because the SDKs dispatch on it: without
+ * one, `AllExceptionsFilter` emits the flat envelope with no `code`, and the
+ * client can only guess from the status. That guess used to be
+ * `BoxliteError::Internal`, which reads to the user as a server crash and is
+ * invisible to retry logic keyed on typed variants — a transient
+ * "State change in progress" is exactly the case worth retrying.
+ *
+ * Defaults to `invalid_state` since every current caller is a state-machine
+ * guard; pass an explicit code for anything else.
+ */
 export class BoxError extends HttpException {
-  constructor(message: string) {
-    super(message, HttpStatus.BAD_REQUEST)
+  constructor(message: string, code = 'invalid_state') {
+    super({ message, code }, HttpStatus.BAD_REQUEST)
   }
 }

--- a/apps/api/src/filters/all-exceptions.filter.spec.ts
+++ b/apps/api/src/filters/all-exceptions.filter.spec.ts
@@ -7,6 +7,7 @@
 import { ArgumentsHost, HttpStatus } from '@nestjs/common'
 import { AllExceptionsFilter } from './all-exceptions.filter'
 import { RunnerApiError } from '../box/errors/runner-api-error'
+import { BoxError } from '../exceptions/box-error.exception'
 
 describe('AllExceptionsFilter', () => {
   it('serializes HttpException code fields into the JSON response', async () => {
@@ -35,5 +36,48 @@ describe('AllExceptionsFilter', () => {
         code: 'runner_non_json_error',
       }),
     )
+  })
+
+  // Without a code the SDKs cannot tell a lifecycle guard from a server
+  // crash: the flat envelope is all they get, and a code-less body used to
+  // be read as `internal`. A transient state conflict is precisely the case
+  // a client should be able to retry on.
+  it('carries a machine code for box lifecycle guards', async () => {
+    const json = jest.fn()
+    const status = jest.fn().mockReturnValue({ json })
+    const filter = new AllExceptionsFilter({ incrementFailedAuth: jest.fn() } as never)
+    const host = {
+      switchToHttp: () => ({
+        getResponse: () => ({ status }),
+        getRequest: () => ({ path: '/api/v1/org/boxes/abc/start', url: '/api/v1/org/boxes/abc/start' }),
+      }),
+    } as ArgumentsHost
+
+    await filter.catch(new BoxError('State change in progress'), host)
+
+    expect(status).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST)
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: HttpStatus.BAD_REQUEST,
+        message: 'State change in progress',
+        code: 'invalid_state',
+      }),
+    )
+  })
+
+  it('lets a non-lifecycle BoxError override the code', async () => {
+    const json = jest.fn()
+    const status = jest.fn().mockReturnValue({ json })
+    const filter = new AllExceptionsFilter({ incrementFailedAuth: jest.fn() } as never)
+    const host = {
+      switchToHttp: () => ({
+        getResponse: () => ({ status }),
+        getRequest: () => ({ path: '/api/v1/org/boxes', url: '/api/v1/org/boxes' }),
+      }),
+    } as ArgumentsHost
+
+    await filter.catch(new BoxError('Runner not found for warm pool box', 'internal'), host)
+
+    expect(json).toHaveBeenCalledWith(expect.objectContaining({ code: 'internal' }))
   })
 })

--- a/src/boxlite/src/rest/client.rs
+++ b/src/boxlite/src/rest/client.rs
@@ -215,7 +215,13 @@ impl ApiClient {
         if let Ok(err_resp) = serde_json::from_str::<ErrorResponse>(&text) {
             Err(map_http_error(status, &err_resp.error))
         } else if let Ok(err_resp) = serde_json::from_str::<FlatErrorResponse>(&text) {
-            Err(map_http_error(status, &err_resp.into_error_model()))
+            // A flat envelope without a `code` carries no machine identifier
+            // to dispatch on, so fall back to the status with the server's own
+            // message rather than guessing a code.
+            match err_resp.into_error_model() {
+                Ok(model) => Err(map_http_error(status, &model)),
+                Err(message) => Err(map_http_status(status, &message)),
+            }
         } else {
             Err(map_http_status(status, &text))
         }
@@ -907,13 +913,45 @@ mod tests {
         )
         .expect("flat error response");
 
-        let err = map_http_error(StatusCode::BAD_GATEWAY, &parsed.into_error_model());
+        let model = parsed
+            .into_error_model()
+            .expect("a flat envelope carrying a code maps by code");
+        let err = map_http_error(StatusCode::BAD_GATEWAY, &model);
 
         match err {
             BoxliteError::Network(message) => {
                 assert!(message.contains("Runner API returned a non-JSON error response"))
             }
             other => panic!("expected Network error for runner non-JSON response, got {other:?}"),
+        }
+    }
+
+    /// The control plane emits the flat envelope for any `HttpException`
+    /// raised without an explicit code — a transient lifecycle conflict on
+    /// stop/start being the common case. Defaulting the absent code to
+    /// `"internal"` turned that 400 into `BoxliteError::Internal`, which
+    /// reads as a server crash and is invisible to retry logic keyed on
+    /// typed variants.
+    #[test]
+    fn flat_error_response_without_code_maps_by_status_not_internal() {
+        let parsed: FlatErrorResponse = serde_json::from_str(
+            r#"{"statusCode":400,"error":"Bad Request","message":"State change in progress"}"#,
+        )
+        .expect("flat error response");
+
+        let err = match parsed.into_error_model() {
+            Ok(model) => map_http_error(StatusCode::BAD_REQUEST, &model),
+            Err(message) => map_http_status(StatusCode::BAD_REQUEST, &message),
+        };
+
+        match err {
+            BoxliteError::InvalidArgument(message) => {
+                assert!(
+                    message.contains("State change in progress"),
+                    "server message must survive: {message}"
+                );
+            }
+            other => panic!("expected InvalidArgument for an un-coded 400, got {other:?}"),
         }
     }
 

--- a/src/boxlite/src/rest/error.rs
+++ b/src/boxlite/src/rest/error.rs
@@ -55,6 +55,17 @@ pub(crate) fn map_http_error(status: StatusCode, body: &ErrorModel) -> BoxliteEr
 /// produces a bare 5xx without our wire envelope.
 pub(crate) fn map_http_status(status: StatusCode, text: &str) -> BoxliteError {
     match status.as_u16() {
+        // A 4xx is the caller's situation by definition, so it must not land
+        // in the `Internal` catch-all below: that reads as "the server broke"
+        // and, worse, hides the response from retry logic keyed on typed
+        // variants. These arms only run when the body carried no `code` — the
+        // runner answers with a bare `{"error": ...}` and the control plane
+        // omits the code for any `HttpException` raised without one.
+        400 | 422 => BoxliteError::InvalidArgument(text.to_string()),
+        // The runner returns 409 for a box that exists but is not accepting
+        // the operation right now (stopped, or mid state change).
+        409 => BoxliteError::InvalidState(text.to_string()),
+        429 => BoxliteError::ResourceExhausted(text.to_string()),
         404 => BoxliteError::NotFound(text.to_string()),
         // Keep the `auth:` prefix (callers key on it) but state the actual
         // failure: 401 = credentials rejected (expired, or wrong credential
@@ -204,6 +215,36 @@ mod tests {
                 );
             }
             other => panic!("expected Internal fallback, got {other:?}"),
+        }
+    }
+
+    /// A 4xx without an envelope must keep its class. Before this, every
+    /// arm below fell through to `Internal`, so a caller mistake and a
+    /// transient lifecycle conflict both surfaced as "internal error".
+    #[test]
+    fn bare_4xx_without_envelope_keeps_its_class() {
+        let cases: &[(u16, fn(&BoxliteError) -> bool)] = &[
+            (400, |e| matches!(e, BoxliteError::InvalidArgument(_))),
+            (422, |e| matches!(e, BoxliteError::InvalidArgument(_))),
+            (409, |e| matches!(e, BoxliteError::InvalidState(_))),
+            (429, |e| matches!(e, BoxliteError::ResourceExhausted(_))),
+        ];
+
+        for (status_u16, predicate) in cases {
+            let status = StatusCode::from_u16(*status_u16).expect("valid HTTP status");
+            let err = map_http_status(status, "State change in progress");
+            assert!(
+                predicate(&err),
+                "bare HTTP {} mapped to unexpected variant: {:?}",
+                status_u16,
+                err
+            );
+            assert!(
+                format!("{err}").contains("State change in progress"),
+                "server message must survive HTTP {}: {:?}",
+                status_u16,
+                err
+            );
         }
     }
 

--- a/src/boxlite/src/rest/error.rs
+++ b/src/boxlite/src/rest/error.rs
@@ -107,6 +107,10 @@ mod tests {
     /// flag the tuple as overly complex.
     type RoundTripRow = (u16, &'static str, &'static str, fn(&BoxliteError) -> bool);
 
+    /// One row of the bare-status table: `(http_status, variant_predicate)`.
+    /// Aliased for the same reason as [`RoundTripRow`].
+    type StatusRow = (u16, fn(&BoxliteError) -> bool);
+
     /// Canonical round-trip table — for every `(status, type, code)`
     /// the server can emit per `BoxliteError::http()`, the client must
     /// reconstruct a `BoxliteError` of the matching variant.
@@ -223,7 +227,7 @@ mod tests {
     /// transient lifecycle conflict both surfaced as "internal error".
     #[test]
     fn bare_4xx_without_envelope_keeps_its_class() {
-        let cases: &[(u16, fn(&BoxliteError) -> bool)] = &[
+        let cases: &[StatusRow] = &[
             (400, |e| matches!(e, BoxliteError::InvalidArgument(_))),
             (422, |e| matches!(e, BoxliteError::InvalidArgument(_))),
             (409, |e| matches!(e, BoxliteError::InvalidState(_))),

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -29,12 +29,25 @@ pub(crate) struct FlatErrorResponse {
 }
 
 impl FlatErrorResponse {
-    pub(crate) fn into_error_model(self) -> ErrorModel {
-        ErrorModel {
-            message: self.message,
-            error_type: "HttpError".to_string(),
-            code: self.code.unwrap_or_else(|| "internal".to_string()),
-            request_id: None,
+    /// The flat envelope into an [`ErrorModel`], or `Err(message)` when it
+    /// carries no `code` to dispatch on.
+    ///
+    /// A missing `code` must not be read as `"internal"`: the flat shape is
+    /// what the control plane emits for any `HttpException` raised without an
+    /// explicit code, so defaulting turned every such 4xx — a caller mistake,
+    /// or a transient lifecycle conflict — into `BoxliteError::Internal`. That
+    /// reads to the user as "the server broke", and hides the response from
+    /// retry logic that keys on typed variants. Returning the message instead
+    /// sends the caller to status-driven mapping, which preserves the class.
+    pub(crate) fn into_error_model(self) -> Result<ErrorModel, String> {
+        match self.code {
+            Some(code) => Ok(ErrorModel {
+                message: self.message,
+                error_type: "HttpError".to_string(),
+                code,
+                request_id: None,
+            }),
+            None => Err(self.message),
         }
     }
 }


### PR DESCRIPTION
Stop the REST client from reporting an un-coded server error as `internal`, so a box-lifecycle guard no longer reads as a server crash.

## Call graph

**Before:**
```
API: BoxError('State change in progress')      (apps/api/src/exceptions/box-error.exception.ts)
  -> HttpException(message, 400)               ← BUG: no machine code
  -> AllExceptionsFilter                       (apps/api/src/filters/all-exceptions.filter.ts:70)
       emits {statusCode, error, message}       — code omitted, nothing to dispatch on
  -> ApiClient::handle_error                   (src/boxlite/src/rest/client.rs:215)
  -> FlatErrorResponse::into_error_model        (src/boxlite/src/rest/types.rs:32)
       code: self.code.unwrap_or("internal")   ← BUG: invents a code, status never consulted
  -> map_http_error(.., code="internal")        (src/boxlite/src/rest/error.rs:42)
  -> BoxliteError::Internal("State change in progress")
       => user sees "FATAL: internal error"; retry logic keyed on typed
          variants never sees InvalidState
```

**After:**
```
API: BoxError('State change in progress')
  -> HttpException({message, code: 'invalid_state'}, 400)
  -> AllExceptionsFilter                        emits code
  -> map_http_error(.., code="invalid_state")
  -> BoxliteError::InvalidState(..)

and for any response still lacking a code:
  -> FlatErrorResponse::into_error_model -> Err(message)   (no invented code)
  -> map_http_status                                       (src/boxlite/src/rest/error.rs:57)
       400 | 422 -> InvalidArgument
       409       -> InvalidState    (the runner's bare {"error":..} for stopped boxes)
       429       -> ResourceExhausted
  -> class preserved instead of Internal
```

Unblocks #635, which retries only on `BoxliteError::InvalidState` — a variant this path could never produce.

Test plan:
- [x] `cargo test -p boxlite --lib --features rest -- rest::error rest::client` — 2 new tests green; `round_trip_canonical_table`, `unknown_code_falls_back_to_status_mapping`, `bare_404/500/5xx` unchanged
- [x] Two-side, reverting each cause separately: without the 4xx arms → `bare HTTP 400 mapped to unexpected variant: Internal("HTTP 400 Bad Request: State change in progress")`; without the code-default fix → `expected InvalidArgument for an un-coded 400, got Internal("State change in progress")` (the literal production symptom)
- [x] `jest --config api/jest.config.ts --testPathPatterns "filters"` — 3 passed (2 new)
- [x] `jest --config api/jest.config.ts --testPathPatterns "box.service"` — 13 suites, 93 passed
- [x] `cargo fmt --check -p boxlite`, `cargo clippy -p boxlite --lib --features rest` — clean
- [ ] E2E against dev — not run; the failing cases that motivated this (`test_node_lifecycle_stop_start`) need a deployed API
- Note: `rest::client::tests::control_request_keeps_total_timeout` fails on untouched `origin/main` too (timing-sensitive, pre-existing)

HTTP status left at 400 for `BoxError` even though the canonical table puts `invalid_state` at 409 — clients dispatch on the code, and changing the status is wire-visible beyond this fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error responses with consistent machine-readable error codes.
  - More accurately classifies invalid requests, conflicting states, rate limits, and internal errors.
  - Preserves the original server-provided error message when no code is available.
  - Correctly identifies missing runners as internal errors.

- **SDK Improvements**
  - Client-side error handling now uses available error codes for reliable classification and retry behavior.
  - Uncoded HTTP errors now fall back to status-based classifications instead of being treated as generic internal errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->