### PR TITLE
feat(net): add per-direction net I/O rate limit

### DIFF
--- a/src/boxlite/src/lib.rs
+++ b/src/boxlite/src/lib.rs
@@ -55,8 +55,8 @@ pub use runtime::advanced_options::{
 };
 pub use runtime::options::{
     BoxArchive, BoxOptions, BoxliteOptions, CloneOptions, ExportOptions, ImageRegistry,
-    ImageRegistryAuth, NetworkMode, NetworkSpec, PortProtocol, RegistryTransport, RootfsSpec,
-    Secret, SnapshotOptions,
+    ImageRegistryAuth, NetworkIoRateLimit, NetworkMode, NetworkSpec, PortProtocol,
+    RegistryTransport, RootfsSpec, Secret, SnapshotOptions,
 };
 /// Boxlite library version (from CARGO_PKG_VERSION at compile time).
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/src/boxlite/src/litebox/init/tasks/port_publish.rs
+++ b/src/boxlite/src/litebox/init/tasks/port_publish.rs
@@ -530,6 +530,7 @@ mod tests {
                 secrets: Vec::new(),
                 ca_cert_pem: None,
                 ca_key_pem: None,
+                rate_limit: None,
             }
         }
 

--- a/src/boxlite/src/litebox/init/tasks/vmm_attach.rs
+++ b/src/boxlite/src/litebox/init/tasks/vmm_attach.rs
@@ -96,6 +96,9 @@ impl PipelineTask<InitCtx> for VmmAttachTask {
                 allow_net,
                 secrets,
                 ca_dir: layout.ca_dir(),
+                // Reattach produces no wire spec; the running gvproxy already has
+                // its rate limit baked in at spawn. Control only needs the socket.
+                rate_limit: None,
             };
             runtime.network_factory.create(&config)
         });

--- a/src/boxlite/src/litebox/init/tasks/vmm_spawn.rs
+++ b/src/boxlite/src/litebox/init/tasks/vmm_spawn.rs
@@ -366,6 +366,7 @@ fn build_network_backend(
         allow_net,
         secrets: options.secrets.clone(),
         ca_dir: layout.ca_dir(),
+        rate_limit: options.advanced.net_io_rate_limit.clone(),
     };
 
     // Hand the config to the backend abstraction — the one backend for this box.

--- a/src/boxlite/src/net/gvproxy/config.rs
+++ b/src/boxlite/src/net/gvproxy/config.rs
@@ -1,5 +1,6 @@
 //! Gvproxy configuration structures
 
+use crate::runtime::options::NetworkIoRateLimit;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -97,6 +98,11 @@ pub struct GvproxyConfig {
     /// PEM-encoded MITM CA private key (PKCS8 format, consumed by Go).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ca_key_pem: Option<String>,
+
+    /// Per-direction network I/O rate limit (upload/download, bytes/sec).
+    /// `None` (or all-zero) = unlimited.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rate_limit: Option<NetworkIoRateLimit>,
 }
 
 /// Secret configuration for gvproxy MITM proxy.
@@ -139,6 +145,7 @@ impl std::fmt::Debug for GvproxyConfig {
                 "ca_key_pem",
                 &self.ca_key_pem.as_ref().map(|_| "[REDACTED]"),
             )
+            .field("rate_limit", &self.rate_limit)
             .finish()
     }
 }
@@ -187,6 +194,7 @@ fn defaults_with_socket_path(socket_path: PathBuf) -> GvproxyConfig {
         secrets: Vec::new(),
         ca_cert_pem: None,
         ca_key_pem: None,
+        rate_limit: None,
     }
 }
 
@@ -297,6 +305,12 @@ impl GvproxyConfig {
     pub fn with_ca(mut self, cert_pem: String, key_pem: String) -> Self {
         self.ca_cert_pem = Some(cert_pem);
         self.ca_key_pem = Some(key_pem);
+        self
+    }
+
+    /// Set the per-direction network I/O rate limit (upload/download, bytes/sec).
+    pub fn with_net_io_rate_limit(mut self, rate_limit: NetworkIoRateLimit) -> Self {
+        self.rate_limit = Some(rate_limit);
         self
     }
 }
@@ -568,6 +582,32 @@ mod tests {
         assert_eq!(
             HOST_HOSTNAME,
             format!("{}.{}", record.name, zone.name.trim_end_matches('.'))
+        );
+    }
+
+    #[test]
+    fn test_rate_limit_defaults_to_none_and_serializes() {
+        let config = GvproxyConfig::new(test_socket_path());
+        assert!(config.rate_limit.is_none());
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(!json.contains("rate_limit"));
+
+        let limited = config.with_net_io_rate_limit(NetworkIoRateLimit {
+            upload_bytes_per_sec: Some(1_000_000),
+            download_bytes_per_sec: Some(2_000_000),
+        });
+        let json = serde_json::to_string(&limited).unwrap();
+        assert!(json.contains("\"rate_limit\""));
+        assert!(json.contains("\"upload_bytes_per_sec\":1000000"));
+        assert!(json.contains("\"download_bytes_per_sec\":2000000"));
+
+        let back: GvproxyConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            back.rate_limit,
+            Some(NetworkIoRateLimit {
+                upload_bytes_per_sec: Some(1_000_000),
+                download_bytes_per_sec: Some(2_000_000),
+            })
         );
     }
 }

--- a/src/boxlite/src/net/gvproxy/instance.rs
+++ b/src/boxlite/src/net/gvproxy/instance.rs
@@ -7,6 +7,8 @@ use std::path::{Path, PathBuf};
 
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 
+use crate::runtime::options::NetworkIoRateLimit;
+
 use super::ffi;
 use super::logging;
 use super::stats::NetworkStats;
@@ -61,6 +63,7 @@ impl GvproxyInstance {
         secrets: Vec<super::config::GvproxySecretConfig>,
         ca_cert_pem: Option<&str>,
         ca_key_pem: Option<&str>,
+        rate_limit: Option<NetworkIoRateLimit>,
     ) -> BoxliteResult<Self> {
         // Initialize logging callback (one-time setup)
         logging::init_logging();
@@ -75,6 +78,10 @@ impl GvproxyInstance {
 
         if let (Some(cert), Some(key)) = (ca_cert_pem, ca_key_pem) {
             config = config.with_ca(cert.to_string(), key.to_string());
+        }
+
+        if let Some(rate_limit) = rate_limit {
+            config = config.with_net_io_rate_limit(rate_limit);
         }
 
         let id = ffi::create_instance(&config)?;
@@ -108,6 +115,7 @@ impl GvproxyInstance {
             secrets,
             spec.ca_cert_pem.as_deref(),
             spec.ca_key_pem.as_deref(),
+            spec.rate_limit.clone(),
         )?;
 
         let connection_type = if cfg!(target_os = "macos") {
@@ -219,7 +227,8 @@ mod tests {
     fn test_gvproxy_create_destroy() {
         let socket_path = PathBuf::from("/tmp/test-gvproxy-instance.sock");
         let instance =
-            GvproxyInstance::new(socket_path.clone(), Vec::new(), Vec::new(), None, None).unwrap();
+            GvproxyInstance::new(socket_path.clone(), Vec::new(), Vec::new(), None, None, None)
+                .unwrap();
 
         // Socket path matches what we provided
         assert_eq!(instance.socket_path(), socket_path);
@@ -234,9 +243,9 @@ mod tests {
         let path2 = PathBuf::from("/tmp/test-gvproxy-2.sock");
 
         let instance1 =
-            GvproxyInstance::new(path1.clone(), Vec::new(), Vec::new(), None, None).unwrap();
+            GvproxyInstance::new(path1.clone(), Vec::new(), Vec::new(), None, None, None).unwrap();
         let instance2 =
-            GvproxyInstance::new(path2.clone(), Vec::new(), Vec::new(), None, None).unwrap();
+            GvproxyInstance::new(path2.clone(), Vec::new(), Vec::new(), None, None, None).unwrap();
 
         assert_ne!(instance1.id(), instance2.id());
         assert_ne!(instance1.socket_path(), instance2.socket_path());

--- a/src/boxlite/src/net/gvproxy/services.rs
+++ b/src/boxlite/src/net/gvproxy/services.rs
@@ -341,6 +341,7 @@ impl NetworkBackend for GvproxyBackend {
             secrets: cfg.secrets.clone(),
             ca_cert_pem: None,
             ca_key_pem: None,
+            rate_limit: cfg.rate_limit.clone(),
         };
 
         // Mint the ephemeral MITM CA when secrets are configured. The cert+key
@@ -593,6 +594,7 @@ mod tests {
             allow_net: vec!["example.com".to_string()],
             secrets: Vec::new(),
             ca_dir: PathBuf::from("/tmp/bl-box/does-not-exist"),
+            rate_limit: None,
         };
         let spec = GvproxyBackend::from_config(&config).spec();
         assert_eq!(spec.socket_path, config.socket_path);
@@ -669,6 +671,7 @@ mod tests {
             allow_net: Vec::new(),
             secrets: Vec::new(),
             ca_dir: dir.path().to_path_buf(),
+            rate_limit: None,
         };
         (
             GvproxyBackend::from_config(&config),
@@ -768,6 +771,7 @@ mod tests {
             allow_net: Vec::new(),
             secrets: vec![test_secret()],
             ca_dir: ca_dir.path().to_path_buf(),
+            rate_limit: None,
         };
         let spec = GvproxyBackend::from_config(&config).spec();
         assert!(
@@ -799,6 +803,7 @@ mod tests {
             allow_net: Vec::new(),
             secrets: vec![test_secret()],
             ca_dir,
+            rate_limit: None,
         };
 
         let spec = GvproxyBackend::from_config(&config).spec();
@@ -1411,6 +1416,7 @@ mod tests {
             allow_net: Vec::new(),
             secrets: Vec::new(),
             ca_dir: dir.path().to_path_buf(),
+            rate_limit: None,
         };
         let target: SocketAddr = "192.168.127.2:8080".parse().unwrap();
         let mut tunnel = GvproxyBackend::from_config(&config)
@@ -1460,6 +1466,7 @@ mod tests {
             allow_net: Vec::new(),
             secrets: Vec::new(),
             ca_dir: dir.path().to_path_buf(),
+            rate_limit: None,
         };
         let target: SocketAddr = "192.168.127.2:8080".parse().unwrap();
         let err = GvproxyBackend::from_config(&config)
@@ -1496,6 +1503,7 @@ mod tests {
             allow_net: Vec::new(),
             secrets: Vec::new(),
             ca_dir: dir.path().to_path_buf(),
+            rate_limit: None,
         };
         let ctl = GvproxyBackend::from_config(&config);
 
@@ -1553,6 +1561,7 @@ mod tests {
             allow_net: Vec::new(),
             secrets: Vec::new(),
             ca_dir: dir.path().to_path_buf(),
+            rate_limit: None,
         };
         let backend = GvproxyBackend::from_config(&config);
 

--- a/src/boxlite/src/net/mod.rs
+++ b/src/boxlite/src/net/mod.rs
@@ -66,6 +66,8 @@ pub struct NetworkBackendConfig {
     /// Directory in which to mint the ephemeral MITM CA — used only when
     /// `secrets` is non-empty. The backend mints the CA in [`NetworkBackend::spec`].
     pub ca_dir: PathBuf,
+    /// Per-direction network I/O rate limit. `None` (or all-zero) = unlimited.
+    pub rate_limit: Option<crate::runtime::options::NetworkIoRateLimit>,
 }
 
 /// The wire blob a [`NetworkBackend`] produces (via [`NetworkBackend::spec`]) for
@@ -91,6 +93,9 @@ pub struct NetworkBackendSpec {
     /// PEM-encoded MITM CA private key (PKCS8, minted when secrets are configured).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ca_key_pem: Option<String>,
+    /// Per-direction network I/O rate limit. `None` (or all-zero) = unlimited.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rate_limit: Option<crate::runtime::options::NetworkIoRateLimit>,
 }
 
 impl std::fmt::Debug for NetworkBackendSpec {
@@ -107,6 +112,7 @@ impl std::fmt::Debug for NetworkBackendSpec {
                 "ca_key_pem",
                 &self.ca_key_pem.as_ref().map(|_| "[REDACTED]"),
             )
+            .field("rate_limit", &self.rate_limit)
             .finish()
     }
 }
@@ -488,6 +494,7 @@ mod tests {
             secrets: Vec::new(),
             ca_cert_pem: Some(cert_sentinel.to_string()),
             ca_key_pem: Some(key_sentinel.to_string()),
+            rate_limit: None,
         };
 
         let rendered = format!("{:?}", spec);
@@ -520,6 +527,7 @@ mod tests {
             secrets: Vec::new(),
             ca_cert_pem: Some("CERTDATA".to_string()),
             ca_key_pem: Some("KEYDATA".to_string()),
+            rate_limit: None,
         };
         let json = serde_json::to_string(&spec).unwrap();
         let back: NetworkBackendSpec = serde_json::from_str(&json).unwrap();
@@ -546,6 +554,7 @@ mod tests {
             allow_net: vec!["example.com".to_string()],
             secrets: Vec::new(),
             ca_dir: PathBuf::from("/tmp/default-factory/ca"),
+            rate_limit: None,
         };
 
         let backend = default_factory()
@@ -626,6 +635,7 @@ mod tests {
                 secrets: Vec::new(),
                 ca_cert_pem: None,
                 ca_key_pem: None,
+                rate_limit: None,
             }
         }
     }

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -757,6 +757,34 @@ mod tests {
     }
 
     #[test]
+    fn test_create_box_request_drops_net_io_rate_limit() {
+        // Local-only guarantee: the REST wire never carries net_io_rate_limit,
+        // so a cloud box always uses the default (unlimited) no matter what a
+        // local client passes. A forged `advanced` field cannot set it — the
+        // projection only ever keeps `capabilities`.
+        let opts = BoxOptions {
+            advanced: crate::AdvancedBoxOptions {
+                net_io_rate_limit: Some(crate::NetworkIoRateLimit {
+                    upload_bytes_per_sec: Some(1_000_000),
+                    download_bytes_per_sec: Some(2_000_000),
+                }),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let req = CreateBoxRequest::from_options(&opts, None);
+        let json = serde_json::to_value(&req).expect("serialize create request");
+        assert!(
+            !json.to_string().contains("net_io_rate_limit"),
+            "rate limit must not reach the REST wire: {json}"
+        );
+        // `advanced` is absent entirely when only a rate limit was set (no
+        // capabilities), so the field cannot even ride along as an empty object.
+        assert!(json.get("advanced").is_none(), "advanced should be absent: {json}");
+    }
+
+    #[test]
     fn test_create_box_request_preserves_scheme_volume_source() {
         use crate::runtime::options::{BoxOptions, VolumeSpec};
 

--- a/src/boxlite/src/runtime/advanced_options.rs
+++ b/src/boxlite/src/runtime/advanced_options.rs
@@ -6,6 +6,7 @@
 //! compatibility. Direct custom-kernel boot is also grouped here because it
 //! changes the VM boot contract.
 
+use crate::runtime::options::NetworkIoRateLimit;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::time::Duration;
@@ -727,6 +728,14 @@ pub struct AdvancedBoxOptions {
     /// Docker-style privileged OCI spec shape for DinD.
     #[serde(default)]
     pub privileged: bool,
+
+    /// Per-direction network I/O rate limit (upload/download, bytes/sec).
+    ///
+    /// Local-only: the REST/cloud wire never carries this field, so cloud boxes
+    /// always use the default (`None` = unlimited). `None`/`0` per direction
+    /// means unlimited.
+    #[serde(default)]
+    pub net_io_rate_limit: Option<NetworkIoRateLimit>,
 }
 
 impl AdvancedBoxOptions {

--- a/src/boxlite/src/runtime/options.rs
+++ b/src/boxlite/src/runtime/options.rs
@@ -842,6 +842,22 @@ impl Default for NetworkSpec {
     }
 }
 
+/// Per-direction network I/O rate limit, in bytes per second.
+///
+/// `None` (or `0`) for a direction means no limit. Enforced host-side in the
+/// gvproxy transport relay (guest → internet / internet → guest), so it is
+/// transparent to the guest's TCP stack, which only sees backpressure.
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct NetworkIoRateLimit {
+    /// Upload (guest → internet) limit, bytes/sec. `None`/`0` = unlimited.
+    #[serde(default)]
+    pub upload_bytes_per_sec: Option<u64>,
+
+    /// Download (internet → guest) limit, bytes/sec. `None`/`0` = unlimited.
+    #[serde(default)]
+    pub download_bytes_per_sec: Option<u64>,
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum PortProtocol {
     #[default]

--- a/src/boxlite/tests/gvproxy_backend.rs
+++ b/src/boxlite/tests/gvproxy_backend.rs
@@ -35,6 +35,7 @@ fn backend_for(
         secrets: Vec::new(),
         ca_cert_pem: None,
         ca_key_pem: None,
+        rate_limit: None,
     };
     let (instance, endpoint) = GvproxyInstance::from_config(&spec).expect("create gvproxy");
     let config = NetworkBackendConfig {
@@ -42,6 +43,7 @@ fn backend_for(
         allow_net: Vec::new(),
         secrets: Vec::new(),
         ca_dir: dir.path().to_path_buf(),
+        rate_limit: None,
     };
     (
         instance,

--- a/src/boxlite/tests/network.rs
+++ b/src/boxlite/tests/network.rs
@@ -10,6 +10,7 @@ fn test_config(socket_path: PathBuf) -> NetworkBackendConfig {
         allow_net: Vec::new(),
         secrets: Vec::new(),
         ca_dir: PathBuf::from("/tmp/test-ca"),
+        rate_limit: None,
     }
 }
 
@@ -24,6 +25,7 @@ fn spec_carries_unique_socket_path_across_serde() {
         secrets: Vec::new(),
         ca_cert_pem: None,
         ca_key_pem: None,
+        rate_limit: None,
     };
 
     // socket_path survives serde — this is how it crosses to the shim.
@@ -88,6 +90,31 @@ fn factory_backend_carries_allowlist_and_secret_metadata_in_spec() {
     assert_eq!(spec.secrets[0].name, "openai");
     assert_eq!(spec.secrets[0].hosts, vec!["api.openai.com"]);
     assert_eq!(spec.secrets[0].placeholder, "<BOXLITE_SECRET:openai>");
+}
+
+#[test]
+fn factory_backend_carries_rate_limit_in_spec() {
+    // The rate limit crosses the config → spec boundary (the hop that feeds the
+    // shim), so a locally-created box's advanced setting reaches gvproxy.
+    use boxlite::net::{NetworkBackendFactory, default_factory};
+    use boxlite::NetworkIoRateLimit;
+
+    let mut config = test_config(PathBuf::from("/tmp/factory-rate-limit/net.sock"));
+    config.rate_limit = Some(NetworkIoRateLimit {
+        upload_bytes_per_sec: Some(1_000_000),
+        download_bytes_per_sec: Some(2_000_000),
+    });
+
+    let factory: std::sync::Arc<dyn NetworkBackendFactory> = default_factory();
+    let backend = factory.create(&config).expect("gvproxy backend");
+    let spec = backend.spec();
+    assert_eq!(
+        spec.rate_limit,
+        Some(NetworkIoRateLimit {
+            upload_bytes_per_sec: Some(1_000_000),
+            download_bytes_per_sec: Some(2_000_000),
+        })
+    );
 }
 
 #[test]

--- a/src/cli/src/cli.rs
+++ b/src/cli/src/cli.rs
@@ -11,7 +11,7 @@ use boxlite::runtime::options::{
 };
 use boxlite::{
     BoxCommand, BoxOptions, BoxliteOptions, BoxliteRestOptions, BoxliteRuntime, ImageRegistry,
-    NetworkSpec,
+    NetworkIoRateLimit, NetworkSpec,
 };
 use clap::{Args, Command, Parser, Subcommand, ValueEnum};
 use clap_complete::shells::{Bash, Fish, Zsh};
@@ -314,6 +314,18 @@ impl GlobalFlags {
                 self.create_runtime_with_options(options)
             }
         }
+    }
+
+    /// True when a REST endpoint is configured (`--url` / `BOXLITE_REST_URL` /
+    /// stored profile), i.e. the CLI will talk to a remote server rather than
+    /// the local runtime. Used to reject local-only flags like the net-io rate
+    /// limits, which the REST wire silently drops.
+    pub fn is_rest_mode(&self) -> bool {
+        let stored = crate::credentials::load_named(&self.resolved_profile())
+            .ok()
+            .flatten();
+        let env_api_key = std::env::var("BOXLITE_API_KEY").ok();
+        self.resolve_rest_options(stored, env_api_key).is_some()
     }
 
     /// Build REST connection options from the selected credential profile and
@@ -655,6 +667,52 @@ impl NetworkFlags {
             mode,
             allow_net: self.allow_net.clone(),
         })?;
+        Ok(())
+    }
+}
+
+// ============================================================================
+// NETWORK I/O RATE LIMIT FLAGS (advanced, local-only)
+// ============================================================================
+
+#[derive(Args, Debug, Clone, Default)]
+pub struct NetworkRateLimitFlags {
+    /// Upload (guest → internet) rate limit, bytes/sec. 0 = unlimited.
+    /// Local boxes only — rejected when a REST URL is configured.
+    #[arg(long = "net-upload-limit", value_name = "BYTES_PER_SEC")]
+    pub upload: Option<u64>,
+
+    /// Download (internet → guest) rate limit, bytes/sec. 0 = unlimited.
+    /// Local boxes only — rejected when a REST URL is configured.
+    #[arg(long = "net-download-limit", value_name = "BYTES_PER_SEC")]
+    pub download: Option<u64>,
+}
+
+impl NetworkRateLimitFlags {
+    fn is_set(&self) -> bool {
+        self.upload.is_some() || self.download.is_some()
+    }
+
+    pub fn apply_to(&self, opts: &mut BoxOptions) {
+        if !self.is_set() {
+            return;
+        }
+        opts.advanced.net_io_rate_limit = Some(NetworkIoRateLimit {
+            upload_bytes_per_sec: self.upload,
+            download_bytes_per_sec: self.download,
+        });
+    }
+
+    /// Rate limits are local-only. In REST mode the field is dropped on the
+    /// wire (cloud always uses the default), so reject it loudly instead of
+    /// silently ignoring the flag.
+    pub fn reject_in_rest_mode(&self, is_rest: bool) -> anyhow::Result<()> {
+        if is_rest && self.is_set() {
+            anyhow::bail!(
+                "--net-upload-limit/--net-download-limit are only supported for local boxes, \
+                 not REST endpoints"
+            );
+        }
         Ok(())
     }
 }

--- a/src/cli/src/commands/create.rs
+++ b/src/cli/src/commands/create.rs
@@ -1,6 +1,6 @@
 use crate::cli::{
-    CapabilityFlags, GlobalFlags, KernelFlags, NetworkFlags, PublishFlags, ResourceFlags,
-    VolumeFlags,
+    CapabilityFlags, GlobalFlags, KernelFlags, NetworkFlags, NetworkRateLimitFlags, PublishFlags,
+    ResourceFlags, VolumeFlags,
 };
 use boxlite::{BoxOptions, RootfsSpec};
 use clap::Args;
@@ -52,11 +52,15 @@ pub struct CreateArgs {
     #[arg(index = 2, trailing_var_arg = true)]
     pub command: Vec<String>,
 
+    #[command(flatten, next_help_heading = "Advanced options")]
+    pub rate_limit: NetworkRateLimitFlags,
+
     #[command(flatten, next_help_heading = "Advanced boot options")]
     pub boot: KernelFlags,
 }
 
 pub async fn execute(args: CreateArgs, global: &GlobalFlags) -> anyhow::Result<()> {
+    args.rate_limit.reject_in_rest_mode(global.is_rest_mode())?;
     let box_options = args.to_box_options(global)?;
     let rt = global.create_runtime()?;
 
@@ -79,6 +83,7 @@ impl CreateArgs {
         self.publish.apply_to(&mut options)?;
         self.volume.apply_to(&mut options, global.home.as_deref())?;
         self.network.apply_to(&mut options)?;
+        self.rate_limit.apply_to(&mut options);
 
         // A `create`d box is a background box: `create` then `start`/`exec` runs
         // its main command detached (docker's create → start), so the launching
@@ -188,5 +193,29 @@ mod tests {
             .expect("options should build");
         assert_eq!(opts.advanced.capabilities.add, vec!["SYS_ADMIN"]);
         assert_eq!(opts.advanced.capabilities.drop, vec!["CAP_NET_RAW"]);
+    }
+
+    #[test]
+    fn create_net_rate_limit_flags_reach_box_options() {
+        let cli = Cli::try_parse_from([
+            "boxlite",
+            "create",
+            "--net-upload-limit",
+            "1000000",
+            "--net-download-limit",
+            "2000000",
+            "alpine",
+        ])
+        .expect("rate-limit flags should parse");
+        let Commands::Create(args) = cli.command else {
+            panic!("expected create command");
+        };
+
+        let opts = args
+            .to_box_options(&cli.global)
+            .expect("options should build");
+        let limit = opts.advanced.net_io_rate_limit.expect("rate limit set");
+        assert_eq!(limit.upload_bytes_per_sec, Some(1_000_000));
+        assert_eq!(limit.download_bytes_per_sec, Some(2_000_000));
     }
 }

--- a/src/cli/src/commands/run.rs
+++ b/src/cli/src/commands/run.rs
@@ -1,6 +1,6 @@
 use crate::cli::{
-    CapabilityFlags, GlobalFlags, KernelFlags, ManagementFlags, NetworkFlags, ProcessFlags,
-    PublishFlags, ResourceFlags, VolumeFlags,
+    CapabilityFlags, GlobalFlags, KernelFlags, ManagementFlags, NetworkFlags,
+    NetworkRateLimitFlags, ProcessFlags, PublishFlags, ResourceFlags, VolumeFlags,
 };
 use crate::terminal::StreamManager;
 use crate::util::to_shell_exit_code;
@@ -39,6 +39,9 @@ pub struct RunArgs {
     #[arg(index = 1, trailing_var_arg = true, value_name = "IMAGE|COMMAND")]
     pub args: Vec<String>,
 
+    #[command(flatten, next_help_heading = "Advanced options")]
+    pub rate_limit: NetworkRateLimitFlags,
+
     #[command(flatten, next_help_heading = "Advanced boot options")]
     pub boot: KernelFlags,
 }
@@ -55,6 +58,7 @@ pub async fn execute(args: RunArgs, global: &GlobalFlags) -> anyhow::Result<i32>
     args.boot.require_enabled(global.experimental_features())?;
     args.management
         .require_enabled(global.experimental_features())?;
+    args.rate_limit.reject_in_rest_mode(global.is_rest_mode())?;
     let (rootfs, command_args) = args.rootfs_and_command()?;
     let command_args = command_args.to_vec();
     let mut runner = BoxRunner::new(args, global)?;
@@ -138,6 +142,7 @@ impl BoxRunner {
             .volume
             .apply_to(&mut options, self.home.as_deref())?;
         self.args.network.apply_to(&mut options)?;
+        self.args.rate_limit.apply_to(&mut options);
         self.args.process.apply_to(&mut options)?;
 
         // Detached boxes keep manual lifecycle control: detach silently

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/forked_network.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/forked_network.go
@@ -40,6 +40,7 @@ func installAllowNetHandlers(
 	filter *AllowNetFilter,
 	ca *BoxCA,
 	secretMatcher *SecretHostMatcher,
+	rateLimiter *netRateLimiter,
 ) error {
 	s, err := stackOf(vn)
 	if err != nil {
@@ -51,11 +52,11 @@ func installAllowNetHandlers(
 	nat := natTable(config)
 	var natLock sync.Mutex
 
-	tcpFwd := TCPWithFilter(s, nat, &natLock, ec2MetadataAccess, filter, ca, secretMatcher)
+	tcpFwd := TCPWithFilter(s, nat, &natLock, ec2MetadataAccess, filter, ca, secretMatcher, rateLimiter)
 	s.SetTransportProtocolHandler(tcp.ProtocolNumber, tcpFwd.HandlePacket)
 	logrus.Info("allowNet TCP: handler overridden with SNI-inspecting forwarder")
 
-	s.SetTransportProtocolHandler(udp.ProtocolNumber, UDPWithFilter(s, nat, &natLock, filter))
+	s.SetTransportProtocolHandler(udp.ProtocolNumber, UDPWithFilter(s, nat, &natLock, filter, rateLimiter))
 	logrus.Info("allowNet UDP: handler overridden with allowlist-checking forwarder")
 
 	return nil

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/forked_tcp.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/forked_tcp.go
@@ -97,7 +97,7 @@ func resolveTCPDestination(localAddress tcpip.Address, nat map[tcpip.Address]tcp
 
 func TCPWithFilter(s *stack.Stack, nat map[tcpip.Address]tcpip.Address,
 	natLock *sync.Mutex, ec2MetadataAccess bool, filter *AllowNetFilter,
-	ca *BoxCA, secretMatcher *SecretHostMatcher) *tcp.Forwarder {
+	ca *BoxCA, secretMatcher *SecretHostMatcher, rl *netRateLimiter) *tcp.Forwarder {
 
 	return tcp.NewForwarder(s, 0, 10, func(r *tcp.ForwarderRequest) {
 		localAddress := r.ID().LocalAddress
@@ -115,10 +115,10 @@ func TCPWithFilter(s *stack.Stack, nat map[tcpip.Address]tcpip.Address,
 
 		switch decideTCPRoute(destIP, destPort, filter, secretMatcher) {
 		case tcpRouteStandardForward:
-			standardForward(r, destAddr)
+			standardForward(r, destAddr, rl)
 			return
 		case tcpRouteInspect:
-			inspectAndForward(r, destAddr, destPort, filter, ca, secretMatcher)
+			inspectAndForward(r, destAddr, destPort, filter, ca, secretMatcher, rl)
 			return
 		default:
 			// No matching rule: block
@@ -132,14 +132,13 @@ func TCPWithFilter(s *stack.Stack, nat map[tcpip.Address]tcpip.Address,
 }
 
 // standardForward is the upstream flow: Dial → CreateEndpoint → relay.
-func standardForward(r *tcp.ForwarderRequest, destAddr string) {
+func standardForward(r *tcp.ForwarderRequest, destAddr string, rl *netRateLimiter) {
 	outbound, err := net.Dial("tcp", destAddr)
 	if err != nil {
 		logrus.Tracef("net.Dial() = %v", err)
 		r.Complete(true)
 		return
 	}
-
 	var wq waiter.Queue
 	ep, tcpErr := r.CreateEndpoint(&wq)
 	r.Complete(false)
@@ -158,13 +157,15 @@ func standardForward(r *tcp.ForwarderRequest, destAddr string) {
 			return outbound, nil
 		},
 	}
-	remote.HandleConn(gonet.NewTCPConn(&wq, ep))
+	// Shape the guest-side conn: reads (upload) and writes (download). Nil rl =
+	// no limit. Wrapping here keeps `outbound` a bare *net.TCPConn for tcpproxy.
+	remote.HandleConn(rl.throttleInbound(gonet.NewTCPConn(&wq, ep)))
 }
 
 // inspectAndForward: Accept → Peek SNI/Host → check allowlist → Dial → relay.
 // The flow is reversed from upstream because we need to read from the guest
 // before deciding whether to connect to the upstream server.
-func inspectAndForward(r *tcp.ForwarderRequest, destAddr string, destPort uint16, filter *AllowNetFilter, ca *BoxCA, secretMatcher *SecretHostMatcher) {
+func inspectAndForward(r *tcp.ForwarderRequest, destAddr string, destPort uint16, filter *AllowNetFilter, ca *BoxCA, secretMatcher *SecretHostMatcher, rl *netRateLimiter) {
 	// Step 1: Accept TCP from guest first (reversed from upstream)
 	var wq waiter.Queue
 	ep, tcpErr := r.CreateEndpoint(&wq)
@@ -177,7 +178,10 @@ func inspectAndForward(r *tcp.ForwarderRequest, destAddr string, destPort uint16
 		}
 		return
 	}
-	guestConn := gonet.NewTCPConn(&wq, ep)
+	// Shape the guest-side conn up front so every downstream path — allowlist
+	// relay, MITM secret substitution, and WebSocket upgrade — reads/writes the
+	// same throttled conn. Reads are upload, writes are download. Nil rl = no-op.
+	guestConn := rl.throttleInbound(gonet.NewTCPConn(&wq, ep))
 
 	// Step 2: Peek to extract hostname (non-consuming read via bufio.Reader)
 	br := bufio.NewReaderSize(guestConn, 16384)
@@ -222,7 +226,6 @@ func inspectAndForward(r *tcp.ForwarderRequest, destAddr string, destPort uint16
 		guestConn.Close()
 		return
 	}
-
 	// Step 5: Relay using tcpproxy.DialProxy (same as standardForward).
 	// Wrap guestConn with the bufio.Reader so peeked bytes are replayed
 	// automatically when DialProxy copies guest→server.

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/forked_udp.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/forked_udp.go
@@ -1,11 +1,12 @@
 package main
 
-// forked_udp.go — UDP forwarding gated by the allow_net allowlist.
+// forked_udp.go — UDP forwarding gated by the allow_net allowlist + egress
+// rate limiting.
 //
-// Unlike the TCP path, this is not a fork of upstream's forwarder. The policy
-// check runs at the protocol-handler level, before upstream's forwarder
-// creates an endpoint, and allowed datagrams are handed to that forwarder
-// untouched — same shape as Tailscale's wrapUDPProtocolHandler.
+// The policy check runs at the protocol-handler level, before the forwarder
+// creates an endpoint, and allowed datagrams are handed to that forwarder —
+// same shape as Tailscale's wrapUDPProtocolHandler. The forwarder itself is a
+// fork (UDPWithRateLimit in forked_udp_forwarder.go) that shapes ingress.
 //
 // Traffic that never reaches here: the gateway DNS resolver (bound to
 // GatewayIP:53, services.go:62) and DHCP (bound to :67, dhcp.go:93) are
@@ -16,8 +17,8 @@ package main
 import (
 	"net"
 	"sync"
+	"time"
 
-	"github.com/containers/gvisor-tap-vsock/pkg/services/forwarder"
 	logrus "github.com/sirupsen/logrus"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/header"
@@ -28,26 +29,46 @@ import (
 // destination is outside the allowlist and forwards the rest through
 // upstream's forwarder. A nil filter forwards everything.
 func UDPWithFilter(s *stack.Stack, nat map[tcpip.Address]tcpip.Address,
-	natLock *sync.Mutex, filter *AllowNetFilter) func(stack.TransportEndpointID, *stack.PacketBuffer) bool {
+	natLock *sync.Mutex, filter *AllowNetFilter, rl *netRateLimiter) func(stack.TransportEndpointID, *stack.PacketBuffer) bool {
 
-	upstream := forwarder.UDP(s, nat, natLock)
+	upstream := UDPWithRateLimit(s, nat, natLock, rl)
+
+	var handler func(stack.TransportEndpointID, *stack.PacketBuffer) bool
 	if filter == nil {
-		return upstream.HandlePacket
+		handler = upstream.HandlePacket
+	} else {
+		blocked := newBlockedDestinationLog()
+		handler = func(id stack.TransportEndpointID, pkt *stack.PacketBuffer) bool {
+			// Policy sees the pre-NAT destination, matching the TCP path
+			// (resolveTCPDestination, forked_tcp.go:83). Upstream applies NAT
+			// itself once the datagram is allowed through.
+			if !udpDestinationAllowed(id.LocalAddress, filter) {
+				blocked.note(id.LocalAddress, id.LocalPort)
+				// Consumed: a silent drop. Returning false would make gVisor
+				// emit ICMP port-unreachable, handing the guest a probe oracle.
+				return true
+			}
+			return upstream.HandlePacket(id, pkt)
+		}
 	}
 
-	blocked := newBlockedDestinationLog()
-	return func(id stack.TransportEndpointID, pkt *stack.PacketBuffer) bool {
-		// Policy sees the pre-NAT destination, matching the TCP path
-		// (resolveTCPDestination, forked_tcp.go:83). Upstream applies NAT
-		// itself once the datagram is allowed through.
-		if !udpDestinationAllowed(id.LocalAddress, filter) {
-			blocked.note(id.LocalAddress, id.LocalPort)
-			// Consumed: a silent drop. Returning false would make gVisor
-			// emit ICMP port-unreachable, handing the guest a probe oracle.
-			return true
+	// UDP egress rate limiting: police the guest → internet datagrams before
+	// they reach the forwarder. UDP has no flow control, so over-limit
+	// datagrams are dropped rather than buffered — this also keeps the gVisor
+	// packet-processing path from blocking (which would stall TCP on the same
+	// NIC). Ingress (host → guest) is shaped in the forked UDPWithRateLimit
+	// (forked_udp_forwarder.go) by throttling the dialed conn's reads.
+	if rl != nil && rl.upload != nil {
+		upload := rl.upload
+		return func(id stack.TransportEndpointID, pkt *stack.PacketBuffer) bool {
+			if !upload.AllowN(time.Now(), pkt.Size()) {
+				return true // over-limit: drop the datagram
+			}
+			return handler(id, pkt)
 		}
-		return upstream.HandlePacket(id, pkt)
 	}
+
+	return handler
 }
 
 // udpDestinationAllowed applies the same link-local and broadcast guards as

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/forked_udp_forwarder.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/forked_udp_forwarder.go
@@ -1,0 +1,107 @@
+package main
+
+// forked_udp_forwarder.go — Fork of gvisor-tap-vsock's forwarder.UDP that
+// rate-limits the ingress (host → guest) direction.
+//
+// forwarder.UDP (pkg/services/forwarder/udp.go) dials the real host UDP socket
+// internally with no injection point, so shaping the download direction means
+// forking that one function and wrapping the dialed conn's reads. NewUDPProxy,
+// Run, and the buffer/timeout constants are all exported, so only the ~20-line
+// autoStoppingListener (unexported upstream) is copied too.
+
+import (
+	"net"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/containers/gvisor-tap-vsock/pkg/services/forwarder"
+	logrus "github.com/sirupsen/logrus"
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"
+	"gvisor.dev/gvisor/pkg/tcpip/header"
+	"gvisor.dev/gvisor/pkg/tcpip/stack"
+	"gvisor.dev/gvisor/pkg/tcpip/transport/udp"
+	"gvisor.dev/gvisor/pkg/waiter"
+)
+
+// UDPWithRateLimit mirrors forwarder.UDP but wraps the dialed host-side conn so
+// its reads (host → guest, the download direction) are shaped by the download
+// token bucket. Egress (guest → host) stays policed in UDPWithFilter
+// (forked_udp.go) — UDP has no flow control, so over-limit egress is dropped
+// rather than delayed.
+func UDPWithRateLimit(s *stack.Stack, nat map[tcpip.Address]tcpip.Address,
+	natLock *sync.Mutex, rl *netRateLimiter) *udp.Forwarder {
+	return udp.NewForwarder(s, func(r *udp.ForwarderRequest) {
+		localAddress := r.ID().LocalAddress
+
+		if linkLocalSubnet.Contains(localAddress) || localAddress == header.IPv4Broadcast {
+			return
+		}
+
+		natLock.Lock()
+		if replaced, ok := nat[localAddress]; ok {
+			localAddress = replaced
+		}
+		natLock.Unlock()
+
+		var wq waiter.Queue
+		ep, tcpErr := r.CreateEndpoint(&wq)
+		if tcpErr != nil {
+			if _, ok := tcpErr.(*tcpip.ErrConnectionRefused); ok {
+				// transient error
+				logrus.Debugf("r.CreateEndpoint() = %v", tcpErr)
+			} else {
+				logrus.Errorf("r.CreateEndpoint() = %v", tcpErr)
+			}
+			return
+		}
+
+		p, _ := forwarder.NewUDPProxy(&autoStoppingListener{underlying: gonet.NewUDPConn(&wq, ep)}, func() (net.Conn, error) {
+			hostPort := net.JoinHostPort(localAddress.String(), strconv.Itoa(int(r.ID().LocalPort)))
+			conn, err := net.Dial("udp", hostPort)
+			if err != nil {
+				return nil, err
+			}
+			if rl != nil {
+				// Shape only the download (read) direction. Egress is policed
+				// in UDPWithFilter, so the write direction stays unthrottled.
+				conn = throttleConn(conn, rl.download, nil)
+			}
+			return conn, nil
+		})
+		go func() {
+			p.Run()
+
+			// note that at this point packets that are sent to the current forwarder session
+			// will be dropped. We will start processing the packets again when we get a new
+			// forwarder request.
+			ep.Close()
+		}()
+	})
+}
+
+// autoStoppingListener mirrors forwarder's unexported autoStoppingListener: it
+// refreshes the guest-side conn's read deadline on every ReadFrom/WriteTo so an
+// idle UDP session stops after forwarder.UDPConnTrackTimeout instead of leaking.
+type autoStoppingListener struct {
+	underlying *gonet.UDPConn
+}
+
+func (l *autoStoppingListener) ReadFrom(b []byte) (int, net.Addr, error) {
+	_ = l.underlying.SetReadDeadline(time.Now().Add(forwarder.UDPConnTrackTimeout))
+	return l.underlying.ReadFrom(b)
+}
+
+func (l *autoStoppingListener) WriteTo(b []byte, addr net.Addr) (int, error) {
+	_ = l.underlying.SetReadDeadline(time.Now().Add(forwarder.UDPConnTrackTimeout))
+	return l.underlying.WriteTo(b, addr)
+}
+
+func (l *autoStoppingListener) SetReadDeadline(t time.Time) error {
+	return l.underlying.SetReadDeadline(t)
+}
+
+func (l *autoStoppingListener) Close() error {
+	return l.underlying.Close()
+}

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/go.mod
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	golang.org/x/net v0.57.0
 	golang.org/x/sync v0.22.0
+	golang.org/x/time v0.12.0
 	gvisor.dev/gvisor v0.0.0-20240916094835-a174eb65023f
 )
 
@@ -27,6 +28,5 @@ require (
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
-	golang.org/x/time v0.12.0 // indirect
 	golang.org/x/tools v0.47.0 // indirect
 )

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
@@ -174,6 +174,14 @@ type DNSZone struct {
 	DefaultIP string      `json:"default_ip"`        // Default IP for unmatched queries in this zone
 }
 
+// RateLimitConfig mirrors the Rust NetworkIoRateLimit (must stay in sync!).
+// Pointers distinguish "unset" (nil) from an explicit value; 0 also means
+// unlimited and is normalized to nil by newNetRateLimiter.
+type RateLimitConfig struct {
+	UploadBytesPerSec   *uint64 `json:"upload_bytes_per_sec,omitempty"`
+	DownloadBytesPerSec *uint64 `json:"download_bytes_per_sec,omitempty"`
+}
+
 // GvproxyConfig matches the Rust structure (must stay in sync!)
 type GvproxyConfig struct {
 	SocketPath       string         `json:"socket_path"`
@@ -196,6 +204,9 @@ type GvproxyConfig struct {
 	// forwarding / DNS / DHCP leases / stats / cam) to a host unix socket the
 	// boxlite core dials. Empty => the services API is not exposed.
 	ControlSocketPath string `json:"control_socket_path,omitempty"`
+	// RateLimit is the per-direction network I/O rate limit (upload/download,
+	// bytes/sec). nil => no limit.
+	RateLimit *RateLimitConfig `json:"rate_limit,omitempty"`
 }
 
 // GvproxyInstance tracks a running gvisor-tap-vsock instance
@@ -210,6 +221,7 @@ type GvproxyInstance struct {
 	vnMu          sync.RWMutex                   // Protects vn field
 	ca            *BoxCA                         // Ephemeral MITM CA (nil if no secrets)
 	secretMatcher *SecretHostMatcher             // Hostname→secrets lookup (nil if no secrets)
+	rateLimiter   *netRateLimiter                // Per-direction I/O rate limit (nil if unlimited)
 }
 
 func buildDNSZones(config GvproxyConfig) []types.Zone {
@@ -400,6 +412,10 @@ func gvproxy_create(configJSON *C.char, errOut **C.char) C.longlong {
 		logrus.WithField("num_secrets", len(config.Secrets)).Info("MITM: loaded CA from Rust config")
 	}
 
+	// Per-direction network I/O rate limit (token buckets). A nil config yields
+	// a nil limiter and the transport relay runs unthrottled.
+	instance.rateLimiter = newNetRateLimiter(config.RateLimit)
+
 	instancesMu.Lock()
 	instances[id] = instance
 	instancesMu.Unlock()
@@ -445,16 +461,17 @@ func gvproxy_create(configJSON *C.char, errOut **C.char) C.longlong {
 		}
 
 		// Override the TCP and UDP handlers with the AllowNet filter and/or
-		// MITM secret substitution
-		if len(config.AllowNet) > 0 || instance.secretMatcher != nil {
+		// MITM secret substitution and/or per-direction I/O rate limiting.
+		if len(config.AllowNet) > 0 || instance.secretMatcher != nil || instance.rateLimiter != nil {
 			var allowNetFilter *AllowNetFilter
 			if len(config.AllowNet) > 0 {
 				allowNetFilter = newAllowNetFilter(config)
 			}
 			// Fatal on purpose: the handlers left behind are upstream's
 			// unfiltered forwarders, so a box that starts anyway would carry
-			// an allow_net the caller believes in and the network ignores.
-			if err := installAllowNetHandlers(vn, tapConfig, tapConfig.Ec2MetadataAccess, allowNetFilter, instance.ca, instance.secretMatcher); err != nil {
+			// an allow_net / rate limit the caller believes in and the network
+			// ignores.
+			if err := installAllowNetHandlers(vn, tapConfig, tapConfig.Ec2MetadataAccess, allowNetFilter, instance.ca, instance.secretMatcher, instance.rateLimiter); err != nil {
 				logrus.WithFields(logrus.Fields{"error": err, "id": id}).Error("allowNet: failed to install transport handlers")
 				initErr <- fmt.Errorf("failed to install allow_net transport handlers: %w", err)
 				return

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/rate_limit.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/rate_limit.go
@@ -1,0 +1,127 @@
+package main
+
+// rate_limit.go — per-direction network I/O rate limiting (token buckets).
+//
+// Enforced in the gvproxy transport relay, mirroring Firecracker/cloud-hypervisor's
+// userspace token bucket at the virtio boundary. Two independent buckets:
+//   - upload   (guest → internet)
+//   - download (internet → guest)
+//
+// `golang.org/x/time/rate.Limiter` is the battle-tested token bucket. A nil
+// bucket (or a nil/zero config) means "no limit" for that direction.
+
+import (
+	"context"
+	"net"
+
+	"golang.org/x/time/rate"
+)
+
+// minBurstBytes is the token-bucket burst floor. io.Copy relays in ~32 KiB
+// chunks, so a burst must never fall below that or a single chunk would exceed
+// the bucket and fail to forward. Sustained rate is still the configured limit;
+// burst only bounds how much may go out instantly before throttling kicks in.
+const minBurstBytes = 64 * 1024
+
+// netRateLimiter holds the two independent token buckets for a box's network
+// I/O. Created once per gvproxy instance from the box's config.
+type netRateLimiter struct {
+	upload   *rate.Limiter // guest → internet
+	download *rate.Limiter // internet → guest
+}
+
+// newNetRateLimiter builds the limiter from config, or returns nil when neither
+// direction is limited.
+func newNetRateLimiter(cfg *RateLimitConfig) *netRateLimiter {
+	if cfg == nil {
+		return nil
+	}
+	up := limiterFor(cfg.UploadBytesPerSec)
+	down := limiterFor(cfg.DownloadBytesPerSec)
+	if up == nil && down == nil {
+		return nil
+	}
+	return &netRateLimiter{upload: up, download: down}
+}
+
+// limiterFor returns a token bucket for a bytes/sec rate, or nil for unlimited
+// (nil pointer or 0). Burst is one second of tokens (the standard default),
+// floored at minBurstBytes.
+func limiterFor(bytesPerSec *uint64) *rate.Limiter {
+	if bytesPerSec == nil || *bytesPerSec == 0 {
+		return nil
+	}
+	burst := int(*bytesPerSec)
+	if burst < minBurstBytes {
+		burst = minBurstBytes
+	}
+	return rate.NewLimiter(rate.Limit(*bytesPerSec), burst)
+}
+
+// throttleInbound wraps the guest-side conn so that reads (upload, guest →
+// internet) and writes (download, internet → guest) are shaped by the matching
+// bucket. A nil receiver is a no-op; a nil bucket in one direction leaves that
+// direction unthrottled.
+//
+// This is the single choke point that covers every TCP relay path — standard
+// forward, allowlist inspection, and MITM/WebSocket secret substitution —
+// because all of them read/write the same guest conn. Wrapping here (instead of
+// the internet-side conn) keeps `outbound` a bare *net.TCPConn, so tcpproxy's
+// keep-alive / splice optimizations keep working.
+func (rl *netRateLimiter) throttleInbound(c net.Conn) net.Conn {
+	if rl == nil {
+		return c
+	}
+	return throttleConn(c, rl.upload, rl.download)
+}
+
+// throttleConn wraps a net.Conn, throttling reads through `readLimiter`
+// (download) and writes through `writeLimiter` (upload). Nil limiters pass
+// through untouched.
+func throttleConn(c net.Conn, readLimiter, writeLimiter *rate.Limiter) net.Conn {
+	if readLimiter == nil && writeLimiter == nil {
+		return c
+	}
+	return &throttledConn{Conn: c, readLimiter: readLimiter, writeLimiter: writeLimiter}
+}
+
+// waitN consumes n tokens from the limiter, chunking so a single call never
+// exceeds the bucket burst (rate.Limiter.WaitN errors when n > burst, e.g. a
+// 2 MiB write against a 1 MiB burst).
+func waitN(l *rate.Limiter, n int) error {
+	for n > 0 {
+		chunk := n
+		if chunk > minBurstBytes {
+			chunk = minBurstBytes
+		}
+		if err := l.WaitN(context.Background(), chunk); err != nil {
+			return err
+		}
+		n -= chunk
+	}
+	return nil
+}
+
+type throttledConn struct {
+	net.Conn
+	readLimiter  *rate.Limiter
+	writeLimiter *rate.Limiter
+}
+
+func (c *throttledConn) Read(p []byte) (int, error) {
+	n, err := c.Conn.Read(p)
+	if n > 0 && c.readLimiter != nil {
+		// Best-effort: never fail the conn on a limiter error.
+		_ = waitN(c.readLimiter, n)
+	}
+	return n, err
+}
+
+func (c *throttledConn) Write(p []byte) (int, error) {
+	if c.writeLimiter != nil {
+		if err := waitN(c.writeLimiter, len(p)); err != nil {
+			return 0, err
+		}
+	}
+	return c.Conn.Write(p)
+}

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/rate_limit_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/rate_limit_test.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+func u64ptr(v uint64) *uint64 { return &v }
+
+func TestNewNetRateLimiter(t *testing.T) {
+	if newNetRateLimiter(nil) != nil {
+		t.Fatal("nil config should yield a nil limiter")
+	}
+	zero := uint64(0)
+	if newNetRateLimiter(&RateLimitConfig{UploadBytesPerSec: &zero, DownloadBytesPerSec: &zero}) != nil {
+		t.Fatal("all-zero config should yield a nil limiter")
+	}
+	if newNetRateLimiter(&RateLimitConfig{UploadBytesPerSec: u64ptr(1000)}) == nil {
+		t.Fatal("upload-only config should yield a limiter")
+	}
+	if newNetRateLimiter(&RateLimitConfig{DownloadBytesPerSec: u64ptr(1000)}) == nil {
+		t.Fatal("download-only config should yield a limiter")
+	}
+}
+
+func TestLimiterFor(t *testing.T) {
+	if limiterFor(nil) != nil {
+		t.Fatal("nil rate should be unlimited")
+	}
+	zero := uint64(0)
+	if limiterFor(&zero) != nil {
+		t.Fatal("0 rate should be unlimited")
+	}
+	if limiterFor(u64ptr(1000)) == nil {
+		t.Fatal("positive rate should yield a limiter")
+	}
+}
+
+// TestThrottledConnShapesRead proves the download (read) bucket actually shapes
+// traffic: net.Pipe is in-memory and effectively unbounded, so the limiter is
+// the only bottleneck. 2 MiB at 1 MiB/s with a 1 MiB burst ≈ 1 s.
+func TestThrottledConnShapesRead(t *testing.T) {
+	const bytesPerSec = 1 << 20 // 1 MiB/s
+	const total = 2 << 20       // 2 MiB
+
+	client, server := net.Pipe()
+	defer server.Close()
+	limited := throttleConn(server, limiterFor(u64ptr(bytesPerSec)), nil)
+
+	go func() {
+		defer client.Close()
+		_, _ = io.CopyN(client, bytes.NewReader(make([]byte, total)), int64(total))
+	}()
+
+	start := time.Now()
+	n, err := io.Copy(io.Discard, limited)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+	if n != total {
+		t.Fatalf("copied %d bytes, want %d", n, total)
+	}
+	if elapsed < 500*time.Millisecond {
+		t.Fatalf("read was not throttled: %d bytes in %v", n, elapsed)
+	}
+}
+
+// TestThrottledConnShapesWrite proves the upload (write) bucket actually shapes
+// traffic, independently of the read direction.
+func TestThrottledConnShapesWrite(t *testing.T) {
+	const bytesPerSec = 1 << 20
+	const total = 2 << 20
+
+	client, server := net.Pipe()
+	defer server.Close()
+	limited := throttleConn(client, nil, limiterFor(u64ptr(bytesPerSec)))
+
+	go func() {
+		defer server.Close()
+		_, _ = io.Copy(io.Discard, server)
+	}()
+
+	start := time.Now()
+	n, err := io.Copy(limited, bytes.NewReader(make([]byte, total)))
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+	if n != total {
+		t.Fatalf("copied %d bytes, want %d", n, total)
+	}
+	if elapsed < 500*time.Millisecond {
+		t.Fatalf("write was not throttled: %d bytes in %v", n, elapsed)
+	}
+}
+
+// TestThrottledConnUnlimitedPassesThrough guards the no-op path: with no limit,
+// the same transfer completes at in-memory speed.
+func TestThrottledConnUnlimitedPassesThrough(t *testing.T) {
+	const total = 1 << 20 // 1 MiB
+
+	client, server := net.Pipe()
+	defer server.Close()
+	limited := throttleConn(server, nil, nil)
+
+	go func() {
+		defer client.Close()
+		_, _ = io.CopyN(client, bytes.NewReader(make([]byte, total)), int64(total))
+	}()
+
+	start := time.Now()
+	n, err := io.Copy(io.Discard, limited)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+	if n != total {
+		t.Fatalf("copied %d bytes, want %d", n, total)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("unlimited transfer should be fast, took %v", elapsed)
+	}
+}
+
+// TestThrottleInboundShapesReadAsUpload proves throttleInbound maps upload to
+// the read direction: with only the upload bucket set, reads are throttled
+// while writes pass through. If the mapping were inverted (upload → write),
+// this test would not throttle.
+func TestThrottleInboundShapesReadAsUpload(t *testing.T) {
+	const bytesPerSec = 1 << 20 // 1 MiB/s
+	const total = 2 << 20       // 2 MiB
+
+	rl := &netRateLimiter{upload: limiterFor(u64ptr(bytesPerSec))}
+	client, server := net.Pipe()
+	defer server.Close()
+	limited := rl.throttleInbound(server)
+
+	go func() {
+		defer client.Close()
+		_, _ = io.CopyN(client, bytes.NewReader(make([]byte, total)), int64(total))
+	}()
+
+	start := time.Now()
+	n, err := io.Copy(io.Discard, limited)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+	if n != total {
+		t.Fatalf("copied %d bytes, want %d", n, total)
+	}
+	if elapsed < 500*time.Millisecond {
+		t.Fatalf("read was not throttled by the upload bucket: %d bytes in %v", n, elapsed)
+	}
+}
+
+// TestThrottleInboundShapesWriteAsDownload proves throttleInbound maps download
+// to the write direction: with only the download bucket set, writes are
+// throttled while reads pass through.
+func TestThrottleInboundShapesWriteAsDownload(t *testing.T) {
+	const bytesPerSec = 1 << 20
+	const total = 2 << 20
+
+	rl := &netRateLimiter{download: limiterFor(u64ptr(bytesPerSec))}
+	client, server := net.Pipe()
+	defer server.Close()
+	limited := rl.throttleInbound(client)
+
+	go func() {
+		defer server.Close()
+		_, _ = io.Copy(io.Discard, server)
+	}()
+
+	start := time.Now()
+	n, err := io.Copy(limited, bytes.NewReader(make([]byte, total)))
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+	if n != total {
+		t.Fatalf("copied %d bytes, want %d", n, total)
+	}
+	if elapsed < 500*time.Millisecond {
+		t.Fatalf("write was not throttled by the download bucket: %d bytes in %v", n, elapsed)
+	}
+}

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/udp_filter_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/udp_filter_test.go
@@ -70,7 +70,7 @@ func startNetwork(t *testing.T, allowNet []string) *guestTap {
 
 	if len(cfg.AllowNet) > 0 {
 		filter := newAllowNetFilter(cfg)
-		if err := installAllowNetHandlers(vn, tapConfig, tapConfig.Ec2MetadataAccess, filter, nil, nil); err != nil {
+		if err := installAllowNetHandlers(vn, tapConfig, tapConfig.Ec2MetadataAccess, filter, nil, nil, nil); err != nil {
 			t.Fatalf("installAllowNetHandlers: %v", err)
 		}
 	}


### PR DESCRIPTION
## Summary
Add per-direction network I/O rate limits (upload/download, bytes/sec) to box advanced options, enforced host-side in the gvproxy transport relay. Local-only: the field never reaches the REST wire, so cloud boxes stay unlimited. Closes POL-232 (`net io rate limit`).

## Call graph

Before
  build_network_backend   (InitTask · src/boxlite/src/litebox/init/tasks/vmm_spawn.rs:353)  — builds NetworkBackendConfig { allow_net, secrets }, no rate limit
    └─ GvproxyBackend::spec (GvproxyBackend · src/boxlite/src/net/gvproxy/services.rs:336)  — NetworkBackendSpec → gvproxy
         └─ gvproxy_create  (FFI · src/deps/libgvproxy-sys/gvproxy-bridge/main.go:309)       — allowlist-only TCP/UDP handlers

After
  build_network_backend   (InitTask · src/boxlite/src/litebox/init/tasks/vmm_spawn.rs:353)  — + rate_limit from options.advanced.net_io_rate_limit
    └─ GvproxyBackend::spec (GvproxyBackend · src/boxlite/src/net/gvproxy/services.rs:336)  — + rate_limit on NetworkBackendSpec
         └─ gvproxy_create  (FFI · src/deps/libgvproxy-sys/gvproxy-bridge/main.go:309)       — RateLimit → netRateLimiter
              ├─ TCPWithFilter → standardForward/inspectAndForward (forked_tcp.go:98)        — throttleInbound(guestConn, upload, download)
              └─ UDPWithRateLimit → UDPProxy.replyLoop (forked_udp_forwarder.go:33)          — throttleConn(dial, download)

## Changes
- Add `NetworkIoRateLimit { upload_bytes_per_sec, download_bytes_per_sec }` to `AdvancedBoxOptions`; REST projection drops it (local-only, cloud default unlimited).
- Thread the limit through `NetworkBackendConfig` → `NetworkBackendSpec` → `GvproxyConfig` → Go `GvproxyConfig` (same path as `allow_net`/`secrets`).
- Token-bucket enforcement in gvproxy (reuses vendored `golang.org/x/time/rate`): TCP shaped both directions at the guest-side conn — one choke point covering standard forward / allowlist inspection / MITM & WebSocket, and `outbound` stays a bare `*net.TCPConn` so tcpproxy keep-alive survives; UDP egress policed (drop over-limit), UDP ingress shaped via a fork of `forwarder.UDP`.
- CLI flags `--net-upload-limit` / `--net-download-limit` (bytes/sec, "Advanced options"), rejected in REST mode.

## How to verify
- `make cli`, then `boxlite --profile local run --net-download-limit 131072 alpine sh -c 'time wget -q -O /dev/null http://host.boxlite.internal:8000/<4MB-file>'` → ~31 s; without the flag → ~0.02 s. Upload: same shape with `nc`. UDP download: received byte count drops vs unlimited.
- Unit tests: `go test ./...` in `src/deps/libgvproxy-sys/gvproxy-bridge` (`rate_limit_test.go`), plus `cargo test -p boxlite` / `-p boxlite-cli`.

## Risks / rollout
- Cloud boxes unaffected (field absent from REST DTOs / OpenAPI / NestJS).
- UDP egress uses policing (drop) rather than shaping — UDP has no flow control; TCP and UDP ingress shape.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable network upload and download rate limits.
  * Added `--net-upload-limit` and `--net-download-limit` options to box creation and run commands.
  * Applied rate limiting to TCP and UDP traffic, with unlimited behavior when unset or zero.
* **Bug Fixes**
  * Preserved existing network rate-limit settings when reattaching to a running box.
* **Tests**
  * Added coverage for configuration serialization, CLI handling, propagation, and throttling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->