### PR TITLE
feat(dashboard): make box names visible and copyable on boxes views

### DIFF
--- a/apps/dashboard/src/components/BoxTable/index.test.tsx
+++ b/apps/dashboard/src/components/BoxTable/index.test.tsx
@@ -126,6 +126,61 @@ describe('BoxTable pagination controls', () => {
     return props
   }
 
+  it('does not navigate when the click ends a text selection over a row', () => {
+    const onRowClick = vi.fn()
+    renderBoxTable({ onRowClick, data: [makeBox('1')] })
+
+    // Desktop row and mobile card both carry the row-navigation click handler.
+    const clickTargets = Array.from(document.querySelectorAll<HTMLElement>('div.cursor-pointer'))
+    expect(clickTargets.length).toBeGreaterThan(0)
+
+    const nameEl = Array.from(document.querySelectorAll('span')).find((el) => el.textContent === 'box-1')
+    if (!nameEl) throw new Error('Missing box name element')
+
+    // Simulate the tail end of a drag-to-copy: text is selected when the
+    // mouseup fires the row's click.
+    const selection = window.getSelection()
+    if (!selection) throw new Error('Missing selection API')
+    const range = document.createRange()
+    range.selectNodeContents(nameEl)
+    selection.removeAllRanges()
+    selection.addRange(range)
+    expect(selection.isCollapsed).toBe(false)
+
+    for (const target of clickTargets) {
+      act(() => {
+        target.click()
+      })
+    }
+    expect(onRowClick).not.toHaveBeenCalled()
+
+    // A plain click (no selection) still navigates.
+    selection.removeAllRanges()
+    act(() => {
+      clickTargets[0].click()
+    })
+    expect(onRowClick).toHaveBeenCalledWith(expect.objectContaining({ id: '1' }))
+  })
+
+  it('copies the box name without navigating when the copy button is clicked', () => {
+    const writeText = vi.fn()
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
+
+    const onRowClick = vi.fn()
+    renderBoxTable({ onRowClick, data: [makeBox('1')] })
+
+    const copyButtons = Array.from(document.querySelectorAll<HTMLButtonElement>('button[title="Copy name"]'))
+    // Desktop row and mobile card each render one.
+    expect(copyButtons.length).toBe(2)
+
+    act(() => {
+      copyButtons[0].click()
+    })
+
+    expect(writeText).toHaveBeenCalledWith('box-1')
+    expect(onRowClick).not.toHaveBeenCalled()
+  })
+
   it('lets the user choose how many boxes are shown per page', () => {
     const onPaginationChange = vi.fn()
     renderBoxTable({ onPaginationChange })

--- a/apps/dashboard/src/components/BoxTable/index.tsx
+++ b/apps/dashboard/src/components/BoxTable/index.tsx
@@ -11,11 +11,13 @@ import { cn, getRelativeTimeString } from '@/lib/utils'
 import { isRecoverable, isStartable, isStoppable, isTransitioning } from '@/lib/utils/box'
 import { OrganizationRolePermissionsEnum, Box, BoxState } from '@boxlite-ai/api-client'
 import {
+  Check,
   ChevronLeft,
   ChevronRight,
   ChevronsLeft,
   ChevronsRight,
   Container,
+  Copy,
   Loader2,
   MoreHorizontal,
   Pause,
@@ -23,7 +25,7 @@ import {
   RotateCcw,
   Trash2,
 } from '@/components/ui/icon'
-import { type ReactNode } from 'react'
+import { type ReactNode, useState } from 'react'
 import { BoxTableProps } from './types'
 import { PAGE_SIZE_OPTIONS } from '@/constants/Pagination'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
@@ -66,6 +68,38 @@ function statusOf(box: Box): { label: string; color: string } {
 // Proportional columns so the gaps stay even as the table widens, instead of
 // dumping all the slack into the Name column.
 const GRID = 'grid-cols-[2fr_1.3fr_1fr_120px] gap-x-4'
+
+// Releasing a drag-selection (e.g. selecting a box name to copy it) fires a
+// click on the row; navigating away then would discard the selection mid-copy.
+function isSelectingText(): boolean {
+  const selection = window.getSelection()
+  return selection != null && !selection.isCollapsed
+}
+
+// One-click name copy that must not trigger the row's navigation click.
+function CopyNameButton({ name, className }: { name: string; className?: string }) {
+  const [copied, setCopied] = useState(false)
+
+  return (
+    <button
+      type="button"
+      title="Copy name"
+      onClick={(e) => {
+        e.stopPropagation()
+        try {
+          navigator.clipboard?.writeText(name)
+        } catch {
+          /* clipboard may be unavailable */
+        }
+        setCopied(true)
+        setTimeout(() => setCopied(false), 1300)
+      }}
+      className={`shrink-0 text-muted-foreground transition-opacity hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none ${className ?? ''}`}
+    >
+      {copied ? <Check className="size-[13px]" style={{ color: STATUS.running }} /> : <Copy className="size-[13px]" />}
+    </button>
+  )
+}
 
 function IconButton({
   title,
@@ -252,17 +286,21 @@ export function BoxTable({
             return (
               <div
                 key={box.id}
-                onClick={() => onRowClick?.(box)}
-                className={`grid ${GRID} items-center border-b border-border px-[18px] py-3 text-[13px] transition-colors hover:bg-card ${
+                onClick={() => {
+                  if (isSelectingText()) return
+                  onRowClick?.(box)
+                }}
+                className={`group grid ${GRID} items-center border-b border-border px-[18px] py-3 text-[13px] transition-colors hover:bg-card ${
                   onRowClick ? 'cursor-pointer' : ''
                 } ${busy ? 'pointer-events-none opacity-70' : ''} ${transitioning ? 'animate-pulse' : ''}`}
               >
                 {/* name */}
-                <span className="inline-flex items-center gap-2 truncate font-semibold">
+                <span className="inline-flex min-w-0 items-center gap-2 font-semibold">
                   <span style={{ color: 'hsl(var(--brand))' }} className="text-[10px]">
                     ▸
                   </span>
                   <span className="truncate">{name}</span>
+                  <CopyNameButton name={name} className="opacity-0 group-hover:opacity-100" />
                 </span>
 
                 {/* box id */}
@@ -319,7 +357,10 @@ export function BoxTable({
                 key={box.id}
                 role={onRowClick ? 'button' : undefined}
                 tabIndex={onRowClick ? 0 : undefined}
-                onClick={() => onRowClick?.(box)}
+                onClick={() => {
+                  if (isSelectingText()) return
+                  onRowClick?.(box)
+                }}
                 onKeyDown={(e) => {
                   if (!onRowClick || (e.key !== 'Enter' && e.key !== ' ')) return
                   e.preventDefault()
@@ -336,6 +377,7 @@ export function BoxTable({
                         ▸
                       </span>
                       <span className="truncate">{name}</span>
+                      <CopyNameButton name={name} />
                     </span>
                     <span className="mt-1 block truncate font-mono text-[11px] text-muted-foreground">
                       {getBoxPublicIdLabel(box)}

--- a/apps/dashboard/src/components/boxes/BoxDetails.test.tsx
+++ b/apps/dashboard/src/components/boxes/BoxDetails.test.tsx
@@ -190,6 +190,14 @@ describe('BoxDetails refresh', () => {
     expect(document.querySelector('[data-testid="terminal-frame"]')).toBe(frameBeforeRefresh)
   })
 
+  // The list page navigates here by id, so the name the user gave the box must
+  // survive the transition — the id alone is not how they recognize it.
+  it('shows the box name in the identity strip', async () => {
+    await renderBoxDetails()
+
+    expect(document.body.textContent).toContain('box-one')
+  })
+
   // A box stores an opaque volume handle, so the mount list is only readable
   // once it is resolved back to the volume's name. The fallback matters just as
   // much: a volume deleted out from under a running box must still render its

--- a/apps/dashboard/src/components/boxes/BoxDetails.tsx
+++ b/apps/dashboard/src/components/boxes/BoxDetails.tsx
@@ -29,7 +29,7 @@ import { useConfig } from '@/hooks/useConfig'
 import { useRegions } from '@/hooks/useRegions'
 import { useBoxWsSync } from '@/hooks/useBoxWsSync'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
-import { getBoxPublicId, getBoxPublicIdLabel } from '@/lib/box-identity'
+import { getBoxDisplayName, getBoxPublicId, getBoxPublicIdLabel } from '@/lib/box-identity'
 import { handleApiError } from '@/lib/error-handling'
 import { setLocalStorageItem } from '@/lib/local-storage'
 import {
@@ -119,6 +119,7 @@ export default function BoxDetails() {
   const [showOnboardingDialog, setShowOnboardingDialog] = useState(false)
   const [onboardingProgress, setOnboardingProgress] = useState<OnboardingProgress>(() => readOnboardingProgress(userId))
   const [copied, setCopied] = useState(false)
+  const [copiedName, setCopiedName] = useState(false)
   const [terminalRefreshSignal, setTerminalRefreshSignal] = useState(0)
   const refreshRef = useRef<HTMLSpanElement>(null)
 
@@ -270,6 +271,17 @@ export default function BoxDetails() {
     setTimeout(() => setCopied(false), 1300)
   }
 
+  const copyName = () => {
+    if (!box) return
+    try {
+      navigator.clipboard?.writeText(getBoxDisplayName(box))
+    } catch {
+      /* clipboard may be unavailable */
+    }
+    setCopiedName(true)
+    setTimeout(() => setCopiedName(false), 1300)
+  }
+
   return (
     <div className="flex h-[calc(100svh-60px)] min-h-0 flex-col gap-[14px] px-4 pb-[22px] pt-4 font-mono text-[13px] sm:px-6 lg:px-[40px]">
       <OnboardingGuideDialog
@@ -322,8 +334,25 @@ export default function BoxDetails() {
           {/* identity strip */}
           <div className="flex flex-none flex-col gap-4 border-b border-dashed border-border pb-[14px] lg:flex-row lg:items-center lg:gap-[18px]">
             <div className="flex min-w-0 flex-1 flex-col gap-3 sm:flex-row sm:items-center sm:gap-[14px]">
-              <span className="max-w-full truncate text-[20px] font-medium tracking-[-0.4px] sm:max-w-[360px] sm:text-[22px]">
-                {getBoxPublicIdLabel(box)}
+              <span className="flex min-w-0 items-center gap-[9px]">
+                <span
+                  className="max-w-full truncate text-[20px] font-medium tracking-[-0.4px] sm:max-w-[360px] sm:text-[22px]"
+                  title={getBoxDisplayName(box)}
+                >
+                  {getBoxDisplayName(box)}
+                </span>
+                <button
+                  type="button"
+                  onClick={copyName}
+                  title="copy name"
+                  className="shrink-0 text-muted-foreground hover:text-foreground"
+                >
+                  {copiedName ? (
+                    <Check className="size-[15px]" style={{ color: STATUS.running }} />
+                  ) : (
+                    <Copy className="size-[15px]" />
+                  )}
+                </button>
               </span>
               <span className="flex flex-none items-center gap-2 text-[13px]">
                 <span


### PR DESCRIPTION
## Summary

Box names were effectively unreachable: the detail page rendered only the box id, and on the list page drag-selecting a name to copy it navigated away on mouseup. The name now survives the click into the detail page and is one click away from the clipboard on both views.

## Call graph

```text
Before
  BoxTable row onClick     (BoxTable · apps/dashboard/src/components/BoxTable/index.tsx:255)  — mouseup after drag-selecting a name still navigates, destroying the selection
    └─ onRowClick → navigate (Boxes · apps/dashboard/src/pages/Boxes.tsx:804)
         └─ identity strip   (BoxDetails · apps/dashboard/src/components/boxes/BoxDetails.tsx:326)  — renders getBoxPublicIdLabel; the name appears nowhere on the page

After
  BoxTable row onClick     (BoxTable · apps/dashboard/src/components/BoxTable/index.tsx:289)  — returns early while isSelectingText() (index.tsx:74)
    ├─ CopyNameButton       (BoxTable · apps/dashboard/src/components/BoxTable/index.tsx:80)  — one-click copy, stopPropagation keeps the row from navigating
    └─ onRowClick → navigate (Boxes · apps/dashboard/src/pages/Boxes.tsx:804)
         └─ identity strip   (BoxDetails · apps/dashboard/src/components/boxes/BoxDetails.tsx:342)  — renders getBoxDisplayName + copyName button (BoxDetails.tsx:274)
```

## Changes

- Box detail identity strip shows the display name (uuid-like names still fall back to the id via `getBoxDisplayName`); the id stays in the breadcrumb and the `box id` spec row.
- List rows skip navigation when the click ends a non-collapsed text selection, so drag-to-copy works on any cell.
- Copy-name buttons: hover-revealed on desktop table rows, always visible on mobile cards, and next to the detail title — all with the same green-check feedback as the existing `box id` copy.

## Screenshots

List row (hover reveals the copy icon next to the name):

![boxes list with copy-name button](https://raw.githubusercontent.com/Mandalorian-Wang/boxlite/assets/box-name-copy/boxes-list-hover-copy.png)

Box detail (name as the title, copy button beside it; id remains in breadcrumb + spec row):

![box detail showing the name](https://raw.githubusercontent.com/Mandalorian-Wang/boxlite/assets/box-name-copy/box-detail-name.png)

## How to verify

- `cd apps && npm run start:mock`, open `/dashboard/boxes`: drag-select a box name and release — the selection survives and no navigation happens; click the copy icon — clipboard gets the name, row does not navigate; click the row — detail page titles the box name.
- `cd apps/dashboard && ../node_modules/.bin/vitest run src/components/BoxTable/index.test.tsx src/components/boxes/BoxDetails.test.tsx` — 8 tests, including the selection-guard and copy-button cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added copy-name buttons for boxes in desktop and mobile views, with confirmation feedback.
  - Box detail headers now display the box name for easier identification.
- **Bug Fixes**
  - Copying a box name no longer opens the box accidentally.
  - Selecting text in a box row no longer triggers navigation, while regular clicks continue to open the box.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->