### PR TITLE
feat(runtime): boot from the minimal guest rootfs image

### DIFF
--- a/scripts/build/build-runtime.sh
+++ b/scripts/build/build-runtime.sh
@@ -2,7 +2,8 @@
 # Populate cargo's OUT_DIR/runtime with all binaries and libraries
 #
 # This script completes the runtime directory that contains everything
-# needed to run BoxLite: shim binary, guest binary, and all FFI libraries.
+# needed to run BoxLite: shim binary, guest binary, the guest e2fsprogs tools,
+# and all FFI libraries.
 #
 # Usage:
 #   ./build-runtime.sh [--profile PROFILE]
@@ -13,6 +14,8 @@
 # The runtime directory will contain:
 #   - boxlite-shim      VM subprocess runner (statically links libkrun + libgvproxy)
 #   - boxlite-guest     Guest agent (Linux binary)
+#   - guest-mke2fs      Guest e2fsprogs tool (static musl, embedded under a distinct name)
+#   - guest-resize2fs   Guest e2fsprogs tool (static musl, embedded under a distinct name)
 #   - libkrunfw.*       libkrunfw library (dlopen'd at runtime)
 
 set -e
@@ -37,6 +40,8 @@ Options:
 The runtime directory will contain:
   - boxlite-shim      VM subprocess runner (statically links libkrun + libgvproxy)
   - boxlite-guest     Guest agent (Linux binary)
+  - guest-mke2fs      Guest e2fsprogs tool (static musl, embedded under a distinct name)
+  - guest-resize2fs   Guest e2fsprogs tool (static musl, embedded under a distinct name)
   - libkrunfw.*       libkrunfw library (dlopen'd at runtime)
 
 Examples:
@@ -48,6 +53,7 @@ Examples:
 
   # Full workflow
   bash scripts/build/build-guest.sh
+  bash scripts/build/build-guest-deps.sh
   bash scripts/build/build-shim.sh
   ./build-runtime.sh
 
@@ -155,6 +161,36 @@ build_guest() {
     fi
 }
 
+# Build the guest e2fsprogs tools (mke2fs, resize2fs).
+#
+# These are required by GuestArtifacts::get() on the default boot path, so they
+# must always be produced here rather than treated as optional — a runtime
+# missing them builds fine but fails on the first Box start.
+build_guest_deps() {
+    echo ""
+    print_section "Building guest e2fsprogs tools (mke2fs, resize2fs)..."
+
+    source "$SCRIPT_DIR/util.sh"
+    local mke2fs_path="$PROJECT_ROOT/target/$GUEST_TARGET/$PROFILE/mke2fs"
+    local resize2fs_path="$PROJECT_ROOT/target/$GUEST_TARGET/$PROFILE/resize2fs"
+
+    # Skip build if SKIP_GUEST_BUILD=1 and both tools already exist.
+    # Used in CI when `make guest` (the build-guest action) pre-built and staged
+    # them to .cache/, restored into target/ before this script runs.
+    if [ "${SKIP_GUEST_BUILD:-0}" = "1" ] && [ -f "$mke2fs_path" ] && [ -f "$resize2fs_path" ]; then
+        print_success "Using pre-built guest e2fsprogs tools (SKIP_GUEST_BUILD=1)"
+        return 0
+    fi
+
+    bash "$SCRIPT_BUILD_DIR/build-guest-deps.sh" --target "$GUEST_TARGET" --profile "$PROFILE"
+
+    if [ ! -f "$mke2fs_path" ] || [ ! -f "$resize2fs_path" ]; then
+        print_error "Failed to build guest e2fsprogs tools (mke2fs, resize2fs) required for Box startup"
+        exit 1
+    fi
+    print_success "Built: $mke2fs_path, $resize2fs_path"
+}
+
 # Find and collect FFI libraries
 collect_libraries() {
     echo ""
@@ -223,18 +259,15 @@ assemble_runtime() {
     echo "✓"
 
     # Guest e2fsprogs tools, embedded under distinct names so they never shadow
-    # the host mke2fs bundled by e2fsprogs-sys. Optional: absent unless `make guest`
-    # (or the CI guest build) produced them.
-    if [ -f "$PROJECT_ROOT/target/$GUEST_TARGET/$PROFILE/mke2fs" ]; then
-        print_step "Copying guest-mke2fs... "
-        cp "$PROJECT_ROOT/target/$GUEST_TARGET/$PROFILE/mke2fs" "$RUNTIME_LIBS_DIR/guest-mke2fs"
-        echo "✓"
-    fi
-    if [ -f "$PROJECT_ROOT/target/$GUEST_TARGET/$PROFILE/resize2fs" ]; then
-        print_step "Copying guest-resize2fs... "
-        cp "$PROJECT_ROOT/target/$GUEST_TARGET/$PROFILE/resize2fs" "$RUNTIME_LIBS_DIR/guest-resize2fs"
-        echo "✓"
-    fi
+    # the host mke2fs bundled by e2fsprogs-sys. build_guest_deps() has already
+    # built them (or verified their presence), so these copies are unconditional.
+    print_step "Copying guest-mke2fs... "
+    cp "$PROJECT_ROOT/target/$GUEST_TARGET/$PROFILE/mke2fs" "$RUNTIME_LIBS_DIR/guest-mke2fs"
+    echo "✓"
+
+    print_step "Copying guest-resize2fs... "
+    cp "$PROJECT_ROOT/target/$GUEST_TARGET/$PROFILE/resize2fs" "$RUNTIME_LIBS_DIR/guest-resize2fs"
+    echo "✓"
 
     # Sign shim on macOS (always, to ensure proper entitlements)
     if [ "$OS" = "macos" ] && [ -f "$RUNTIME_LIBS_DIR/boxlite-shim" ]; then
@@ -283,6 +316,7 @@ main() {
     detect_platform
     build_shim
     build_guest
+    build_guest_deps
     collect_libraries
     echo "Destination: $RUNTIME_LIBS_DIR"
 

--- a/scripts/build/build-runtime.sh
+++ b/scripts/build/build-runtime.sh
@@ -166,6 +166,29 @@ build_guest() {
 # These are required by GuestArtifacts::get() on the default boot path, so they
 # must always be produced here rather than treated as optional — a runtime
 # missing them builds fine but fails on the first Box start.
+
+# Validate a pre-built guest tool with the same checks build-guest-deps.sh
+# applies to freshly built tools (verify_tool): a regular file (not a symlink),
+# non-empty, mode 0755, and a statically-linked ELF for the guest target.
+# SKIP_GUEST_BUILD must not trust a bad cache that would only fail at Box start.
+verify_guest_tool() {
+    local path="$1"
+    local mode
+    if [ ! -f "$path" ] || [ -L "$path" ] || [ ! -s "$path" ]; then
+        print_error "Invalid cached guest tool (must be a regular, non-empty file): $path"
+        exit 1
+    fi
+    mode="$(stat -c '%a' "$path" 2>/dev/null || stat -f '%Lp' "$path")"
+    if [ "$mode" != "755" ]; then
+        print_error "Guest tool must have mode 0755: $path (found $mode)"
+        exit 1
+    fi
+    bash "$SCRIPT_DIR/util.sh" --verify-guest-elf "$GUEST_TARGET" "$path" || {
+        print_error "Guest tool is not a valid static ELF for $GUEST_TARGET: $path"
+        exit 1
+    }
+}
+
 build_guest_deps() {
     echo ""
     print_section "Building guest e2fsprogs tools (mke2fs, resize2fs)..."
@@ -178,6 +201,8 @@ build_guest_deps() {
     # Used in CI when `make guest` (the build-guest action) pre-built and staged
     # them to .cache/, restored into target/ before this script runs.
     if [ "${SKIP_GUEST_BUILD:-0}" = "1" ] && [ -f "$mke2fs_path" ] && [ -f "$resize2fs_path" ]; then
+        verify_guest_tool "$mke2fs_path"
+        verify_guest_tool "$resize2fs_path"
         print_success "Using pre-built guest e2fsprogs tools (SKIP_GUEST_BUILD=1)"
         return 0
     fi

--- a/src/boxlite/src/experimental.rs
+++ b/src/boxlite/src/experimental.rs
@@ -21,7 +21,6 @@ pub const EXPERIMENTAL_FEATURES_ENV: &str = "BOXLITE_EXPERIMENTAL";
 pub enum ExperimentalFeature {
     CustomKernel,
     NestedVirtualization,
-    MinimalRootfs,
 }
 
 impl ExperimentalFeature {
@@ -30,7 +29,6 @@ impl ExperimentalFeature {
         match self {
             Self::CustomKernel => "custom-kernel",
             Self::NestedVirtualization => "nested-virtualization",
-            Self::MinimalRootfs => "minimal-rootfs",
         }
     }
 
@@ -38,7 +36,6 @@ impl ExperimentalFeature {
         match self {
             Self::CustomKernel => "custom kernel support",
             Self::NestedVirtualization => "nested virtualization support",
-            Self::MinimalRootfs => "minimal rootfs",
         }
     }
 }
@@ -61,7 +58,6 @@ impl ExperimentalFeatures {
             let feature = match token {
                 "custom-kernel" => ExperimentalFeature::CustomKernel,
                 "nested-virtualization" => ExperimentalFeature::NestedVirtualization,
-                "minimal-rootfs" => ExperimentalFeature::MinimalRootfs,
                 "" => {
                     return Err(BoxliteError::Config(format!(
                         "{EXPERIMENTAL_FEATURES_ENV} contains an empty feature name"
@@ -69,7 +65,7 @@ impl ExperimentalFeatures {
                 }
                 unknown => {
                     return Err(BoxliteError::Config(format!(
-                        "unknown feature '{unknown}' in {EXPERIMENTAL_FEATURES_ENV}; supported values: custom-kernel, nested-virtualization, minimal-rootfs"
+                        "unknown feature '{unknown}' in {EXPERIMENTAL_FEATURES_ENV}; supported values: custom-kernel, nested-virtualization"
                     )));
                 }
             };
@@ -164,18 +160,6 @@ mod tests {
 
         assert!(!features.is_enabled(ExperimentalFeature::CustomKernel));
         assert!(!features.is_enabled(ExperimentalFeature::NestedVirtualization));
-        assert!(!features.is_enabled(ExperimentalFeature::MinimalRootfs));
-    }
-
-    #[test]
-    fn minimal_rootfs_token_enables_the_feature() {
-        let features = ExperimentalFeatures::parse("minimal-rootfs").unwrap();
-        assert!(features.is_enabled(ExperimentalFeature::MinimalRootfs));
-
-        assert!(
-            !ExperimentalFeatures::default().is_enabled(ExperimentalFeature::MinimalRootfs),
-            "minimal rootfs must be disabled by default"
-        );
     }
 
     #[test]

--- a/src/boxlite/src/jailer/mod.rs
+++ b/src/boxlite/src/jailer/mod.rs
@@ -305,6 +305,12 @@ fn build_path_access(layout: &BoxFilesystemLayout, volumes: &[VolumeSpec]) -> Ve
         .map(|home| home.join("bases"))
         .filter(|p| p.exists())
     {
+        // The directly-mounted rootfs ext4 is addressed by its *canonical* bases
+        // path (BaseDiskManager::new canonicalizes at construction). Grant the
+        // canonical path too, or a symlinked BOXLITE_HOME / bases/ leaves bwrap
+        // mounting the logical path while libkrun opens the canonical one —
+        // "Disk image not found" inside the sandbox.
+        let bases_dir = bases_dir.canonicalize().unwrap_or(bases_dir);
         paths.push(PathAccess {
             path: bases_dir,
             writable: false,
@@ -736,9 +742,48 @@ mod tests {
 
         let paths = build_path_access(&layout, &[]);
 
-        let bases_paths: Vec<_> = paths.iter().filter(|p| p.path == bases_dir).collect();
+        // bases/ is granted by its canonical path; compare canonical forms so the
+        // assertion holds even when $TMPDIR itself contains a symlink.
+        let expected = bases_dir.canonicalize().unwrap_or_else(|_| bases_dir.clone());
+        let bases_paths: Vec<_> = paths
+            .iter()
+            .filter(|p| p.path.canonicalize().unwrap_or_else(|_| p.path.clone()) == expected)
+            .collect();
         assert_eq!(bases_paths.len(), 1, "Should include home_dir/bases/");
         assert!(!bases_paths[0].writable);
+    }
+
+    #[test]
+    fn test_build_path_access_canonicalizes_bases_dir_through_symlink() {
+        // A symlinked BOXLITE_HOME (or bases/) makes the logical home/bases path
+        // diverge from the canonical path the block device opens. The grant must
+        // be canonical, or bwrap mounts the logical path while libkrun opens the
+        // canonical one and fails with "Disk image not found".
+        let real_home = tempdir().unwrap();
+        let real_home = real_home.path().to_path_buf();
+        let link_root = tempdir().unwrap();
+        let link_home = link_root.path().join("boxlite-home-link");
+        std::os::unix::fs::symlink(&real_home, &link_home).unwrap();
+
+        // box_dir lives under the symlinked home.
+        let box_dir = link_home.join("boxes").join("test-box");
+        std::fs::create_dir_all(&box_dir).unwrap();
+
+        // bases/ under the real (canonical) home.
+        let real_bases = real_home.join("bases");
+        std::fs::create_dir_all(&real_bases).unwrap();
+
+        let layout = test_layout(box_dir);
+        let paths = build_path_access(&layout, &[]);
+
+        let expected = real_bases.canonicalize().unwrap();
+        assert!(
+            paths
+                .iter()
+                .any(|p| p.path == expected && !p.writable),
+            "bases/ must be granted by its canonical path ({}), not the logical symlink path",
+            expected.display()
+        );
     }
 
     #[test]

--- a/src/boxlite/src/jailer/mod.rs
+++ b/src/boxlite/src/jailer/mod.rs
@@ -744,7 +744,9 @@ mod tests {
 
         // bases/ is granted by its canonical path; compare canonical forms so the
         // assertion holds even when $TMPDIR itself contains a symlink.
-        let expected = bases_dir.canonicalize().unwrap_or_else(|_| bases_dir.clone());
+        let expected = bases_dir
+            .canonicalize()
+            .unwrap_or_else(|_| bases_dir.clone());
         let bases_paths: Vec<_> = paths
             .iter()
             .filter(|p| p.path.canonicalize().unwrap_or_else(|_| p.path.clone()) == expected)
@@ -778,9 +780,7 @@ mod tests {
 
         let expected = real_bases.canonicalize().unwrap();
         assert!(
-            paths
-                .iter()
-                .any(|p| p.path == expected && !p.writable),
+            paths.iter().any(|p| p.path == expected && !p.writable),
             "bases/ must be granted by its canonical path ({}), not the logical symlink path",
             expected.display()
         );

--- a/src/boxlite/src/litebox/archive.rs
+++ b/src/boxlite/src/litebox/archive.rs
@@ -66,6 +66,13 @@ pub struct ArchiveManifest {
     /// Full box configuration (v3+). `None` for v1/v2 archives.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub box_options: Option<crate::runtime::options::BoxOptions>,
+    /// SHA-256 checksum of the guest rootfs disk.
+    ///
+    /// Always empty: the guest rootfs is no longer bundled in archives (it ships
+    /// as a shared base image). Kept in the schema so pre-minimal-rootfs
+    /// importers, which require the field, can deserialize the manifest instead
+    /// of failing with "missing field `guest_disk_checksum`".
+    pub guest_disk_checksum: String,
     /// SHA-256 checksum of the container disk.
     pub container_disk_checksum: String,
     /// Timestamp when the archive was created.

--- a/src/boxlite/src/litebox/archive.rs
+++ b/src/boxlite/src/litebox/archive.rs
@@ -460,5 +460,14 @@ mod tests {
             std::fs::read_to_string(extract_dir.join(MANIFEST_FILENAME)).unwrap(),
             r#"{"version":2}"#
         );
+        assert_eq!(
+            std::fs::read_to_string(extract_dir.join(disk_filenames::CONTAINER_DISK)).unwrap(),
+            "fake-container-disk",
+            "the container disk must be extracted"
+        );
+        assert!(
+            !extract_dir.join(disk_filenames::GUEST_ROOTFS_DISK).exists(),
+            "the archive must not contain a guest rootfs member"
+        );
     }
 }

--- a/src/boxlite/src/litebox/archive.rs
+++ b/src/boxlite/src/litebox/archive.rs
@@ -66,8 +66,6 @@ pub struct ArchiveManifest {
     /// Full box configuration (v3+). `None` for v1/v2 archives.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub box_options: Option<crate::runtime::options::BoxOptions>,
-    /// SHA-256 checksum of the guest rootfs disk.
-    pub guest_disk_checksum: String,
     /// SHA-256 checksum of the container disk.
     pub container_disk_checksum: String,
     /// Timestamp when the archive was created.
@@ -81,7 +79,6 @@ pub(crate) fn build_zstd_tar_archive(
     output_path: &Path,
     manifest_path: &Path,
     container_disk: &Path,
-    guest_disk: Option<&Path>,
     compression_level: i32,
 ) -> BoxliteResult<()> {
     let file = std::fs::File::create(output_path).map_err(|e| {
@@ -96,7 +93,7 @@ pub(crate) fn build_zstd_tar_archive(
         .map_err(|e| BoxliteError::Storage(format!("Failed to create zstd encoder: {}", e)))?;
 
     let mut builder = tar::Builder::new(encoder);
-    append_archive_files(&mut builder, manifest_path, container_disk, guest_disk)?;
+    append_archive_files(&mut builder, manifest_path, container_disk)?;
 
     let encoder = builder
         .into_inner()
@@ -112,7 +109,6 @@ fn append_archive_files<W: Write>(
     builder: &mut tar::Builder<W>,
     manifest_path: &Path,
     container_disk: &Path,
-    guest_disk: Option<&Path>,
 ) -> BoxliteResult<()> {
     builder
         .append_path_with_name(manifest_path, MANIFEST_FILENAME)
@@ -123,14 +119,6 @@ fn append_archive_files<W: Write>(
         .map_err(|e| {
             BoxliteError::Storage(format!("Failed to add container disk to archive: {}", e))
         })?;
-
-    if let Some(guest) = guest_disk {
-        builder
-            .append_path_with_name(guest, disk_filenames::GUEST_ROOTFS_DISK)
-            .map_err(|e| {
-                BoxliteError::Storage(format!("Failed to add guest rootfs disk to archive: {}", e))
-            })?;
-    }
 
     Ok(())
 }
@@ -458,7 +446,7 @@ mod tests {
         std::fs::write(&manifest_path, r#"{"version":2}"#).unwrap();
         std::fs::write(&container_path, "fake-container-disk").unwrap();
 
-        build_zstd_tar_archive(&archive_path, &manifest_path, &container_path, None, 3).unwrap();
+        build_zstd_tar_archive(&archive_path, &manifest_path, &container_path, 3).unwrap();
         extract_archive(&archive_path, &extract_dir).unwrap();
 
         assert_eq!(

--- a/src/boxlite/src/litebox/clone_export.rs
+++ b/src/boxlite/src/litebox/clone_export.rs
@@ -302,6 +302,7 @@ fn do_export_finalize(
         box_name: config_name.map(|s| s.to_string()),
         image,
         box_options: Some(config_options.clone()),
+        guest_disk_checksum: String::new(),
         container_disk_checksum,
         exported_at: chrono::Utc::now().to_rfc3339(),
     };

--- a/src/boxlite/src/litebox/clone_export.rs
+++ b/src/boxlite/src/litebox/clone_export.rs
@@ -229,7 +229,6 @@ impl BoxImpl {
 struct FlattenResult {
     temp_dir: tempfile::TempDir,
     flat_container: std::path::PathBuf,
-    flat_guest: Option<std::path::PathBuf>,
     flatten_ms: u64,
 }
 
@@ -244,7 +243,6 @@ fn do_export_flatten(
 
     let disks_dir = box_home.join("disks");
     let container_disk = disks_dir.join(disk_filenames::CONTAINER_DISK);
-    let guest_disk = disks_dir.join(disk_filenames::GUEST_ROOTFS_DISK);
 
     if !container_disk.exists() {
         return Err(BoxliteError::Storage(format!(
@@ -260,19 +258,11 @@ fn do_export_flatten(
     let flat_container = temp_dir.path().join(disk_filenames::CONTAINER_DISK);
     Qcow2Helper::flatten(&container_disk, &flat_container)?;
 
-    let flat_guest = if guest_disk.exists() {
-        let flat = temp_dir.path().join(disk_filenames::GUEST_ROOTFS_DISK);
-        Qcow2Helper::flatten(&guest_disk, &flat)?;
-        Some(flat)
-    } else {
-        None
-    };
     let flatten_ms = t_flatten.elapsed().as_millis() as u64;
 
     Ok(FlattenResult {
         temp_dir,
         flat_container,
-        flat_guest,
         flatten_ms,
     })
 }
@@ -300,10 +290,6 @@ fn do_export_finalize(
 
     let t_checksum = Instant::now();
     let container_disk_checksum = sha256_file(&flatten.flat_container)?;
-    let guest_disk_checksum = match flatten.flat_guest {
-        Some(ref fg) => sha256_file(fg)?,
-        None => String::new(),
-    };
     let checksum_ms = t_checksum.elapsed().as_millis() as u64;
 
     let image = match &config_options.rootfs {
@@ -316,7 +302,6 @@ fn do_export_finalize(
         box_name: config_name.map(|s| s.to_string()),
         image,
         box_options: Some(config_options.clone()),
-        guest_disk_checksum,
         container_disk_checksum,
         exported_at: chrono::Utc::now().to_rfc3339(),
     };
@@ -327,13 +312,7 @@ fn do_export_finalize(
     std::fs::write(&manifest_path, manifest_json)?;
 
     let t_archive = Instant::now();
-    build_zstd_tar_archive(
-        &output_path,
-        &manifest_path,
-        &flatten.flat_container,
-        flatten.flat_guest.as_deref(),
-        3,
-    )?;
+    build_zstd_tar_archive(&output_path, &manifest_path, &flatten.flat_container, 3)?;
     let archive_ms = t_archive.elapsed().as_millis() as u64;
 
     tracing::info!(

--- a/src/boxlite/src/litebox/init/tasks/guest_rootfs.rs
+++ b/src/boxlite/src/litebox/init/tasks/guest_rootfs.rs
@@ -72,23 +72,32 @@ async fn run_guest_rootfs(
 
     // The guest rootfs is now read-only (attached directly, no per-box COW
     // overlay). Remove any overlay left over from an older release.
-    let legacy_overlay = layout.guest_rootfs_disk_path();
-    if legacy_overlay.exists() {
-        tracing::info!(
-            disk_path = %legacy_overlay.display(),
-            "Removing legacy guest rootfs overlay (guest rootfs is now read-only)"
-        );
-        std::fs::remove_file(&legacy_overlay).map_err(|e| {
-            BoxliteError::Storage(format!(
-                "Failed to remove legacy guest rootfs overlay {}: {}",
-                legacy_overlay.display(),
-                e
-            ))
-        })?;
-    }
+    remove_legacy_guest_rootfs_overlay(layout)?;
 
     // No per-box COW disk anymore.
     Ok(None)
+}
+
+/// Remove a per-box guest-rootfs overlay left over from a release that still
+/// created one. The minimal rootfs is shared and read-only, so the overlay is
+/// obsolete; a re-created box boots from the shared base regardless.
+fn remove_legacy_guest_rootfs_overlay(layout: &BoxFilesystemLayout) -> BoxliteResult<()> {
+    let legacy_overlay = layout.guest_rootfs_disk_path();
+    if !legacy_overlay.exists() {
+        return Ok(());
+    }
+
+    tracing::info!(
+        disk_path = %legacy_overlay.display(),
+        "Removing legacy guest rootfs overlay (guest rootfs is now read-only)"
+    );
+    std::fs::remove_file(&legacy_overlay).map_err(|e| {
+        BoxliteError::Storage(format!(
+            "Failed to remove legacy guest rootfs overlay {}: {}",
+            legacy_overlay.display(),
+            e
+        ))
+    })
 }
 
 /// Prepare guest rootfs as a versioned disk image.
@@ -142,4 +151,40 @@ async fn extract_env_from_image(
     };
 
     Ok(env)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::layout::FsLayoutConfig;
+
+    fn test_layout(box_dir: &std::path::Path) -> BoxFilesystemLayout {
+        BoxFilesystemLayout::new(
+            box_dir.to_path_buf(),
+            FsLayoutConfig::without_bind_mount(),
+            false,
+        )
+    }
+
+    #[test]
+    fn removes_existing_legacy_overlay() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = test_layout(dir.path());
+        let overlay = layout.guest_rootfs_disk_path();
+        std::fs::create_dir_all(overlay.parent().unwrap()).unwrap();
+        std::fs::write(&overlay, b"legacy overlay").unwrap();
+        assert!(overlay.exists());
+
+        remove_legacy_guest_rootfs_overlay(&layout).unwrap();
+
+        assert!(!overlay.exists());
+    }
+
+    #[test]
+    fn noop_when_no_legacy_overlay() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = test_layout(dir.path());
+
+        remove_legacy_guest_rootfs_overlay(&layout).unwrap();
+    }
 }

--- a/src/boxlite/src/litebox/init/tasks/guest_rootfs.rs
+++ b/src/boxlite/src/litebox/init/tasks/guest_rootfs.rs
@@ -1,21 +1,18 @@
 //! Task: Guest rootfs preparation.
 //!
-//! Lazily initializes the bootstrap guest rootfs as a disk image (shared across all boxes).
-//! Then creates or reuses per-box COW overlay disk.
+//! Lazily initializes the bootstrap guest rootfs as a shared, read-only disk image.
 
 use super::{InitCtx, log_task_error, task_start};
-use crate::disk::{BackingFormat, Disk, DiskFormat, Qcow2Helper};
-use crate::experimental::ExperimentalFeature;
+use crate::disk::Disk;
 use crate::images::ImageDiskManager;
 use crate::pipeline::PipelineTask;
-use crate::rootfs::guest::{GuestRootfs, GuestRootfsManager, Strategy};
+use crate::rootfs::guest::{GuestRootfs, GuestRootfsManager};
 use crate::runtime::constants::images;
 use crate::runtime::layout::BoxFilesystemLayout;
 use crate::runtime::rt_impl::SharedRuntimeImpl;
 use crate::vmm::guest_artifacts::GuestArtifacts;
 use async_trait::async_trait;
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
-use std::path::Path;
 
 pub struct GuestRootfsTask;
 
@@ -53,207 +50,45 @@ impl PipelineTask<InitCtx> for GuestRootfsTask {
 async fn run_guest_rootfs(
     runtime: &SharedRuntimeImpl,
     layout: &BoxFilesystemLayout,
-    reuse_rootfs: bool,
+    _reuse_rootfs: bool,
 ) -> BoxliteResult<Option<Disk>> {
-    // First, get or create the shared base guest rootfs
-    let guest_rootfs = runtime
+    // Initialize the shared minimal guest rootfs (the default boot rootfs).
+    let _ = runtime
         .guest_rootfs
         .get_or_try_init(|| async {
-            tracing::info!(
-                "Initializing bootstrap guest rootfs {} (first time only)",
-                images::INIT_ROOTFS
-            );
+            tracing::info!("Initializing minimal guest rootfs (first time only)");
 
-            let base_image = pull_guest_rootfs_image(runtime).await?;
-            let env = extract_env_from_image(&base_image).await?;
-            let guest_rootfs = prepare_guest_rootfs(
-                &runtime.guest_rootfs_mgr,
-                &runtime.image_disk_mgr,
-                &base_image,
-                env,
-            )
-            .await?;
+            let artifacts = GuestArtifacts::get()?;
+            let guest_rootfs = runtime
+                .guest_rootfs_mgr
+                .get_or_create_minimal(artifacts)
+                .await?;
 
-            tracing::info!("Bootstrap guest rootfs ready: {:?}", guest_rootfs.strategy);
+            tracing::info!("Minimal guest rootfs ready: {:?}", guest_rootfs.strategy);
 
             Ok::<_, BoxliteError>(guest_rootfs)
         })
-        .await?
-        .clone();
+        .await?;
 
-    // Prepare the minimal rootfs image in the background (feature-gated,
-    // best-effort); it never blocks or fails this OCI boot path.
-    maybe_kick_off_minimal_rootfs(runtime);
-
-    // Now create or reuse the per-box COW disk
-    let (_updated_guest_rootfs, disk) =
-        create_or_reuse_cow_disk(&guest_rootfs, layout, reuse_rootfs)?;
-
-    Ok(disk)
-}
-
-/// Kick off a detached, best-effort build of the minimal guest rootfs image.
-///
-/// Gated behind `ExperimentalFeature::MinimalRootfs`. Runs off the boot path via
-/// `tokio::spawn` (precedent `box_impl.rs`) and single-flights on
-/// `runtime.minimal_rootfs`, so it only prepares the image the later "switch"
-/// step will consume. Failures are logged, never propagated.
-fn maybe_kick_off_minimal_rootfs(runtime: &SharedRuntimeImpl) {
-    if !runtime
-        .experimental_features
-        .is_enabled(ExperimentalFeature::MinimalRootfs)
-    {
-        return;
-    }
-    // Once built, the OnceCell is initialized — skip re-spawning so later box
-    // starts/restarts don't schedule no-op background tasks.
-    if runtime.minimal_rootfs.initialized() {
-        return;
-    }
-
-    let runtime = runtime.clone();
-    tokio::spawn(async move {
-        let result = runtime
-            .minimal_rootfs
-            .get_or_try_init(|| async {
-                let artifacts = GuestArtifacts::get()?;
-                runtime
-                    .guest_rootfs_mgr
-                    .get_or_create_minimal(artifacts)
-                    .await
-            })
-            .await;
-        match result {
-            Ok(_) => tracing::info!("Background minimal rootfs build ready"),
-            Err(e) => {
-                tracing::warn!(error = %e, "Background minimal rootfs build failed (boot unaffected)")
-            }
-        }
-    });
-}
-
-/// Create new COW disk or reuse existing one for restart.
-fn create_or_reuse_cow_disk(
-    guest_rootfs: &GuestRootfs,
-    layout: &BoxFilesystemLayout,
-    reuse_rootfs: bool,
-) -> BoxliteResult<(GuestRootfs, Option<Disk>)> {
-    let guest_rootfs_disk_path = layout.guest_rootfs_disk_path();
-
-    if reuse_rootfs && guest_rootfs_disk_path.exists() {
-        if validate_reusable_guest_rootfs_disk(&guest_rootfs_disk_path)? {
-            // Restart: reuse existing COW disk
-            tracing::info!(
-                disk_path = %guest_rootfs_disk_path.display(),
-                "Restart mode: reusing existing guest rootfs disk"
-            );
-
-            // Open existing disk as persistent
-            let disk = Disk::new(guest_rootfs_disk_path.clone(), DiskFormat::Qcow2, true);
-
-            // Update guest_rootfs with the COW disk path
-            let mut updated = guest_rootfs.clone();
-            if let Strategy::Disk { ref disk_path, .. } = guest_rootfs.strategy {
-                updated.strategy = Strategy::Disk {
-                    disk_path: disk_path.clone(), // Keep base path reference
-                    device_path: None,            // Will be set by VmmSpawnTask
-                };
-            }
-
-            return Ok((updated, Some(disk)));
-        }
-    } else if reuse_rootfs {
-        // Guest rootfs disk missing (e.g., clone or snapshot-restore).
-        // Fall through to create a fresh COW overlay from the shared cache.
+    // The guest rootfs is now read-only (attached directly, no per-box COW
+    // overlay). Remove any overlay left over from an older release.
+    let legacy_overlay = layout.guest_rootfs_disk_path();
+    if legacy_overlay.exists() {
         tracing::info!(
-            disk_path = %guest_rootfs_disk_path.display(),
-            "Guest rootfs disk missing on restart, recreating from cache"
+            disk_path = %legacy_overlay.display(),
+            "Removing legacy guest rootfs overlay (guest rootfs is now read-only)"
         );
+        std::fs::remove_file(&legacy_overlay).map_err(|e| {
+            BoxliteError::Storage(format!(
+                "Failed to remove legacy guest rootfs overlay {}: {}",
+                legacy_overlay.display(),
+                e
+            ))
+        })?;
     }
 
-    // Fresh start: create new COW disk
-    if let Strategy::Disk { ref disk_path, .. } = guest_rootfs.strategy {
-        let base_disk_path = disk_path;
-
-        // Get base disk size
-        let base_size = std::fs::metadata(base_disk_path)
-            .map(|m| m.len())
-            .unwrap_or(512 * 1024 * 1024);
-
-        // Point the COW overlay directly at the shared rootfs cache.
-        // Disk images are data (read by the hypervisor, not executed on the host),
-        // so sharing the backing file is safe — no Spectre-class concerns.
-        let temp_disk = Qcow2Helper::create_cow_child_disk(
-            base_disk_path,
-            BackingFormat::Raw,
-            &guest_rootfs_disk_path,
-            base_size,
-        )?;
-
-        // Make disk persistent so it survives stop/restart
-        let disk_path_owned = temp_disk.leak();
-        let disk = Disk::new(disk_path_owned, DiskFormat::Qcow2, true);
-
-        tracing::info!(
-            cow_disk = %guest_rootfs_disk_path.display(),
-            base_disk = %base_disk_path.display(),
-            "Created guest rootfs COW overlay (persistent)"
-        );
-
-        // Update guest_rootfs with COW disk path
-        let mut updated = guest_rootfs.clone();
-        updated.strategy = Strategy::Disk {
-            disk_path: guest_rootfs_disk_path,
-            device_path: None, // Will be set by VmmSpawnTask
-        };
-
-        Ok((updated, Some(disk)))
-    } else {
-        // Non-disk strategy - no COW disk needed
-        Ok((guest_rootfs.clone(), None))
-    }
-}
-
-fn validate_reusable_guest_rootfs_disk(guest_rootfs_disk_path: &Path) -> BoxliteResult<bool> {
-    // Validate backing chain is intact before reusing.
-    // A broken chain (e.g. from a failed migration or deleted cache) would cause
-    // a cryptic hypervisor failure — catch it early with a clear error.
-    use crate::disk::qcow2::Qcow2HeaderError;
-    match crate::disk::qcow2::read_backing_file_path_checked(guest_rootfs_disk_path) {
-        Ok(Some(backing)) if !Path::new(&backing).exists() => Err(BoxliteError::Storage(format!(
-            "Guest rootfs {} has missing backing file: {}. \
-                 This may indicate a broken migration or deleted cache file. \
-                 The box cannot start until the backing file is restored.",
-            guest_rootfs_disk_path.display(),
-            backing
-        ))),
-        Ok(_) => Ok(true),
-        // Structurally corrupt overlay: its data is already unreadable, so discard
-        // it and recreate a fresh COW from the shared cache.
-        Err(Qcow2HeaderError::Corrupt(reason)) => {
-            tracing::warn!(
-                disk_path = %guest_rootfs_disk_path.display(),
-                reason = %reason,
-                "Discarding corrupt guest rootfs COW overlay and recreating from cache"
-            );
-            std::fs::remove_file(guest_rootfs_disk_path).map_err(|remove_err| {
-                BoxliteError::Storage(format!(
-                    "Failed to remove corrupt guest rootfs {} ({}): {}",
-                    guest_rootfs_disk_path.display(),
-                    reason,
-                    remove_err
-                ))
-            })?;
-            Ok(false)
-        }
-        // Transient/system I/O fault: we cannot tell whether the overlay is intact,
-        // so do NOT delete it — surface the error and let the start be retried.
-        Err(Qcow2HeaderError::Io(io)) => Err(BoxliteError::Storage(format!(
-            "Cannot read guest rootfs {} to validate its backing chain (I/O error: {io}); \
-             refusing to discard a possibly-intact overlay",
-            guest_rootfs_disk_path.display()
-        ))),
-    }
+    // No per-box COW disk anymore.
+    Ok(None)
 }
 
 /// Prepare guest rootfs as a versioned disk image.
@@ -261,6 +96,7 @@ fn validate_reusable_guest_rootfs_disk(guest_rootfs_disk_path: &Path) -> Boxlite
 /// Uses the two-stage pipeline:
 /// 1. `ImageDiskManager`: pure image layers → ext4 disk (cached by image digest)
 /// 2. `GuestRootfsManager`: image disk + boxlite-guest → versioned rootfs (cached by digest+guest hash)
+#[allow(dead_code)] // OCI boot path, kept for a possible future switch back
 async fn prepare_guest_rootfs(
     guest_rootfs_mgr: &GuestRootfsManager,
     image_disk_mgr: &ImageDiskManager,
@@ -272,6 +108,7 @@ async fn prepare_guest_rootfs(
         .await
 }
 
+#[allow(dead_code)] // OCI boot path, kept for a possible future switch back
 async fn pull_guest_rootfs_image(
     runtime: &SharedRuntimeImpl,
 ) -> BoxliteResult<crate::images::ImageObject> {
@@ -279,6 +116,7 @@ async fn pull_guest_rootfs_image(
     runtime.image_manager.pull(images::INIT_ROOTFS).await
 }
 
+#[allow(dead_code)] // OCI boot path, kept for a possible future switch back
 async fn extract_env_from_image(
     image: &crate::images::ImageObject,
 ) -> BoxliteResult<Vec<(String, String)>> {
@@ -304,201 +142,4 @@ async fn extract_env_from_image(
     };
 
     Ok(env)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::runtime::layout::FsLayoutConfig;
-    use std::fs::File;
-    use std::io::Write;
-    use tempfile::TempDir;
-
-    fn test_layout(dir: &TempDir) -> BoxFilesystemLayout {
-        let layout = BoxFilesystemLayout::new(
-            dir.path().join("boxes").join("box-1"),
-            FsLayoutConfig::without_bind_mount(),
-            false,
-        );
-        std::fs::create_dir_all(layout.disks_dir()).unwrap();
-        layout
-    }
-
-    fn create_base_disk(dir: &TempDir) -> std::path::PathBuf {
-        let base_disk_path = dir.path().join("guest-rootfs-base.ext4");
-        File::create(&base_disk_path)
-            .unwrap()
-            .set_len(1024 * 1024)
-            .unwrap();
-        base_disk_path
-    }
-
-    fn test_guest_rootfs(base_disk_path: std::path::PathBuf) -> GuestRootfs {
-        GuestRootfs {
-            path: base_disk_path
-                .parent()
-                .expect("base disk has parent")
-                .to_path_buf(),
-            strategy: Strategy::Disk {
-                disk_path: base_disk_path,
-                device_path: None,
-            },
-            kernel: None,
-            initrd: None,
-            env: Vec::new(),
-        }
-    }
-
-    fn create_guest_overlay(
-        base_disk_path: &std::path::Path,
-        guest_rootfs_disk_path: &std::path::Path,
-    ) {
-        Qcow2Helper::create_cow_child_disk(
-            base_disk_path,
-            BackingFormat::Raw,
-            guest_rootfs_disk_path,
-            1024 * 1024,
-        )
-        .unwrap()
-        .leak();
-    }
-
-    fn read_guest_overlay_backing(guest_rootfs_disk_path: &std::path::Path) -> String {
-        crate::disk::qcow2::read_backing_file_path(guest_rootfs_disk_path)
-            .unwrap()
-            .unwrap()
-    }
-
-    fn write_qcow2_with_backing_bytes(
-        guest_rootfs_disk_path: &std::path::Path,
-        backing_bytes: &[u8],
-    ) {
-        let mut buf = vec![0u8; 1024];
-        buf[0..4].copy_from_slice(&0x514649fbu32.to_be_bytes());
-        buf[4..8].copy_from_slice(&3u32.to_be_bytes());
-        buf[8..16].copy_from_slice(&512u64.to_be_bytes());
-        buf[16..20].copy_from_slice(&(backing_bytes.len() as u32).to_be_bytes());
-        buf[512..512 + backing_bytes.len()].copy_from_slice(backing_bytes);
-
-        let mut file = File::create(guest_rootfs_disk_path).unwrap();
-        file.write_all(&buf).unwrap();
-    }
-
-    #[test]
-    fn test_reuse_keeps_valid_guest_rootfs_overlay() {
-        let dir = TempDir::new().unwrap();
-        let base_disk_path = create_base_disk(&dir);
-        let layout = test_layout(&dir);
-        let guest_rootfs_disk_path = layout.guest_rootfs_disk_path();
-        create_guest_overlay(&base_disk_path, &guest_rootfs_disk_path);
-        let before = std::fs::metadata(&guest_rootfs_disk_path).unwrap();
-
-        let guest_rootfs = test_guest_rootfs(base_disk_path.clone());
-        let (_updated, disk) = create_or_reuse_cow_disk(&guest_rootfs, &layout, true).unwrap();
-
-        assert_eq!(disk.unwrap().path(), guest_rootfs_disk_path);
-        let after = std::fs::metadata(&guest_rootfs_disk_path).unwrap();
-        assert_eq!(after.len(), before.len());
-        assert_eq!(after.modified().unwrap(), before.modified().unwrap());
-        assert_eq!(
-            read_guest_overlay_backing(&guest_rootfs_disk_path),
-            base_disk_path.canonicalize().unwrap().display().to_string()
-        );
-    }
-
-    #[test]
-    fn test_reuse_recreates_invalid_guest_rootfs_overlay() {
-        let dir = TempDir::new().unwrap();
-        let base_disk_path = create_base_disk(&dir);
-        let layout = test_layout(&dir);
-        let guest_rootfs_disk_path = layout.guest_rootfs_disk_path();
-        std::fs::write(&guest_rootfs_disk_path, vec![0u8; 256 * 1024]).unwrap();
-
-        let guest_rootfs = test_guest_rootfs(base_disk_path.clone());
-        let (_updated, disk) = create_or_reuse_cow_disk(&guest_rootfs, &layout, true).unwrap();
-
-        assert_eq!(disk.unwrap().path(), guest_rootfs_disk_path);
-        assert_eq!(
-            read_guest_overlay_backing(&guest_rootfs_disk_path),
-            base_disk_path.canonicalize().unwrap().display().to_string()
-        );
-    }
-
-    #[test]
-    fn test_reuse_recreates_too_short_guest_rootfs_overlay() {
-        let dir = TempDir::new().unwrap();
-        let base_disk_path = create_base_disk(&dir);
-        let layout = test_layout(&dir);
-        let guest_rootfs_disk_path = layout.guest_rootfs_disk_path();
-        std::fs::write(&guest_rootfs_disk_path, [0u8; 10]).unwrap();
-
-        let guest_rootfs = test_guest_rootfs(base_disk_path.clone());
-        create_or_reuse_cow_disk(&guest_rootfs, &layout, true).unwrap();
-
-        assert_eq!(
-            read_guest_overlay_backing(&guest_rootfs_disk_path),
-            base_disk_path.canonicalize().unwrap().display().to_string()
-        );
-    }
-
-    #[test]
-    fn test_reuse_recreates_guest_rootfs_overlay_with_invalid_utf8_backing_path() {
-        let dir = TempDir::new().unwrap();
-        let base_disk_path = create_base_disk(&dir);
-        let layout = test_layout(&dir);
-        let guest_rootfs_disk_path = layout.guest_rootfs_disk_path();
-        write_qcow2_with_backing_bytes(&guest_rootfs_disk_path, &[0xff, 0xfe, 0xfd]);
-
-        let guest_rootfs = test_guest_rootfs(base_disk_path.clone());
-        create_or_reuse_cow_disk(&guest_rootfs, &layout, true).unwrap();
-
-        assert_eq!(
-            read_guest_overlay_backing(&guest_rootfs_disk_path),
-            base_disk_path.canonicalize().unwrap().display().to_string()
-        );
-    }
-
-    #[test]
-    fn test_io_error_does_not_discard_guest_rootfs_overlay() {
-        // A directory at the overlay path makes the header read fail with an I/O
-        // error (EISDIR) — not EOF — i.e. a transient/system fault, NOT proof of
-        // corruption. validate must surface the error WITHOUT deleting the path,
-        // so a momentary I/O blip never destroys a possibly-intact overlay.
-        let dir = TempDir::new().unwrap();
-        let guest_rootfs_disk_path = dir.path().join("guest-rootfs.qcow2");
-        std::fs::create_dir(&guest_rootfs_disk_path).unwrap();
-
-        let err = match validate_reusable_guest_rootfs_disk(&guest_rootfs_disk_path) {
-            Ok(_) => panic!("expected an I/O error, not a reuse/discard decision"),
-            Err(err) => err,
-        };
-
-        assert!(
-            format!("{err}").contains("refusing to discard"),
-            "I/O failures must not be treated as corruption: {err}"
-        );
-        assert!(
-            guest_rootfs_disk_path.exists(),
-            "overlay must not be deleted on an I/O error"
-        );
-    }
-
-    #[test]
-    fn test_reuse_reports_missing_guest_rootfs_backing() {
-        let dir = TempDir::new().unwrap();
-        let base_disk_path = create_base_disk(&dir);
-        let layout = test_layout(&dir);
-        let guest_rootfs_disk_path = layout.guest_rootfs_disk_path();
-        create_guest_overlay(&base_disk_path, &guest_rootfs_disk_path);
-        std::fs::remove_file(&base_disk_path).unwrap();
-
-        let guest_rootfs = test_guest_rootfs(base_disk_path);
-        let err = match create_or_reuse_cow_disk(&guest_rootfs, &layout, true) {
-            Ok(_) => panic!("expected missing backing file error"),
-            Err(err) => err,
-        };
-
-        assert!(format!("{err}").contains("has missing backing file"));
-        assert!(guest_rootfs_disk_path.exists());
-    }
 }

--- a/src/boxlite/src/litebox/init/tasks/vmm_spawn.rs
+++ b/src/boxlite/src/litebox/init/tasks/vmm_spawn.rs
@@ -458,4 +458,46 @@ mod tests {
             "disabled networking never created implicit EXPOSE listeners"
         );
     }
+
+    #[test]
+    fn configure_guest_rootfs_attaches_disk_read_only() {
+        // The guest root must reject writes so a tenant workload that enters the
+        // container by fork (without execve) cannot reopen the agent binary
+        // through `/proc/<pid>/exe` for write (CVE-2019-5736). The rootfs is
+        // now read-only by construction — attached as a read-only block device —
+        // rather than remounted read-only after boot, so the regression guard
+        // lives here, on the `read_only` attach flag.
+        let disk_path = PathBuf::from("/tmp/fake-guest-rootfs.ext4");
+        let rootfs = GuestRootfs::new(
+            disk_path.clone(),
+            Strategy::Disk {
+                disk_path: disk_path.clone(),
+                device_path: None,
+            },
+            None,
+            None,
+            vec![],
+        )
+        .unwrap();
+
+        let mut volume_mgr = GuestVolumeManager::new();
+        let configured = configure_guest_rootfs(rootfs, &mut volume_mgr).unwrap();
+
+        // The attach happened and the strategy records the guest device path
+        // (a fresh manager hands out /dev/vda first).
+        match configured.strategy {
+            Strategy::Disk { device_path, .. } => {
+                assert_eq!(device_path.as_deref(), Some("/dev/vda"));
+            }
+            _ => panic!("expected disk-based strategy"),
+        }
+
+        let config = volume_mgr.build_vmm_config();
+        let devices = config.block_devices.devices();
+        assert_eq!(devices.len(), 1);
+        assert!(
+            devices[0].read_only,
+            "guest rootfs must attach read-only (is_disk_read_only)"
+        );
+    }
 }

--- a/src/boxlite/src/litebox/init/tasks/vmm_spawn.rs
+++ b/src/boxlite/src/litebox/init/tasks/vmm_spawn.rs
@@ -26,7 +26,7 @@ use crate::volumes::{
 use async_trait::async_trait;
 use boxlite_shared::BoxTransport;
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 pub struct VmmSpawnTask;
 
@@ -36,7 +36,6 @@ struct VmmSpawnInputs {
     container_image_config: ContainerImageConfig,
     prepared_kernel: Option<PreparedKernel>,
     container_disk_path: PathBuf,
-    guest_disk_path: Option<PathBuf>,
     container_id: ContainerID,
     runtime: SharedRuntimeImpl,
     reuse_rootfs: bool,
@@ -71,10 +70,6 @@ impl VmmSpawnInputs {
             container_image_config,
             prepared_kernel,
             container_disk_path,
-            guest_disk_path: ctx
-                .guest_disk
-                .as_ref()
-                .map(|disk| disk.path().to_path_buf()),
             container_id: ctx.config.container.id.clone(),
             runtime: ctx.runtime.clone(),
             reuse_rootfs: ctx.reuse_rootfs,
@@ -142,7 +137,6 @@ async fn build_config(
         container_image_config,
         prepared_kernel,
         container_disk_path,
-        guest_disk_path,
         container_id,
         runtime,
         reuse_rootfs,
@@ -224,8 +218,7 @@ async fn build_config(
         .ok_or_else(|| BoxliteError::Internal("guest_rootfs not initialized".into()))?
         .clone();
 
-    let guest_rootfs =
-        configure_guest_rootfs(guest_rootfs, guest_disk_path.as_deref(), &mut volume_mgr)?;
+    let guest_rootfs = configure_guest_rootfs(guest_rootfs, &mut volume_mgr)?;
 
     // Build VMM config from volume manager
     let vmm_config = volume_mgr.build_vmm_config();
@@ -280,17 +273,18 @@ async fn build_config(
 /// Configure guest rootfs with device path from volume manager.
 fn configure_guest_rootfs(
     mut guest_rootfs: GuestRootfs,
-    guest_disk_path: Option<&Path>,
     volume_mgr: &mut GuestVolumeManager,
 ) -> BoxliteResult<GuestRootfs> {
-    if let Some(disk_path_input) = guest_disk_path
-        && let Strategy::Disk { ref disk_path, .. } = guest_rootfs.strategy
-    {
-        // Add disk to volume manager (guest rootfs - no format/resize needed)
+    if let Strategy::Disk { ref disk_path, .. } = guest_rootfs.strategy {
+        // The guest rootfs is read-only: attach the base ext4 directly, with no
+        // per-box qcow2 COW overlay — the guest never writes its root disk.
+        // The block device is opened read-only (bases/ is mounted RO by the
+        // jailer), and the "ro" mount option in set_root_disk_remount makes the
+        // guest root read-only too.
         let device_path = volume_mgr.add_block_device(
-            disk_path_input,
-            DiskFormat::Qcow2,
-            false,
+            disk_path,
+            DiskFormat::Ext4,
+            true, // read_only
             None,
             false, // need_format
             false, // need_resize

--- a/src/boxlite/src/rootfs/guest.rs
+++ b/src/boxlite/src/rootfs/guest.rs
@@ -556,37 +556,20 @@ impl GuestRootfsManager {
 
     /// Garbage-collect stale guest rootfs entries.
     ///
-    /// Uses DB records to identify rootfs entries. Preserves entries whose
-    /// version key contains the current guest binary hash (valid for future boxes).
-    /// Only deletes entries with outdated guest hashes that no existing box references.
+    /// Keeps the current minimal rootfs (keyed by the combined artifact id) and
+    /// any base an existing box overlay still backs onto. Deletes everything else
+    /// — including OCI Debian rootfs bases, which the boot path no longer produces.
     ///
     /// Returns the number of entries removed.
     pub fn gc(&self, boxes_dir: &Path) -> BoxliteResult<usize> {
         let gc_start = std::time::Instant::now();
 
-        // Version keys are "{image_12}-{guest_12}", so entries whose name ends
-        // with the current guest id are still valid for future boxes.
-        let current_guest_suffix = match GuestBinary::get() {
-            Ok(guest) => format!("-{}", guest.id()),
-            Err(e) => {
-                tracing::warn!("GC: cannot resolve the guest binary, skipping: {}", e);
-                return Ok(0);
-            }
-        };
-
-        // The minimal rootfs is keyed by the combined artifact id (not the guest
-        // suffix), so keep the current one when it resolves.
         let current_minimal_key = GuestArtifacts::get().ok().map(|a| a.id().to_string());
 
-        let result = self.gc_inner(
-            boxes_dir,
-            &current_guest_suffix,
-            current_minimal_key.as_deref(),
-        );
+        let result = self.gc_inner(boxes_dir, current_minimal_key.as_deref());
 
         tracing::info!(
             elapsed_ms = gc_start.elapsed().as_millis() as u64,
-            suffix = %current_guest_suffix,
             "GC completed"
         );
 
@@ -596,7 +579,6 @@ impl GuestRootfsManager {
     /// Inner GC logic, separated for testability.
     ///
     /// Queries the DB for all rootfs entries, then determines which to keep:
-    /// - Entries whose version key (name) ends with `current_guest_suffix`
     /// - The current minimal rootfs entry (name == `current_minimal_key`)
     /// - Entries whose base_path any box overlay backs onto (see
     ///   [`BaseDiskManager::referenced_backing_paths`], which covers both
@@ -604,7 +586,6 @@ impl GuestRootfsManager {
     fn gc_inner(
         &self,
         boxes_dir: &Path,
-        current_guest_suffix: &str,
         current_minimal_key: Option<&str>,
     ) -> BoxliteResult<usize> {
         let records = self
@@ -636,16 +617,6 @@ impl GuestRootfsManager {
             // Keep entries referenced by existing boxes
             if referenced.contains(&base_path) {
                 preserved_referenced += 1;
-                continue;
-            }
-
-            // Keep entries matching current guest binary version
-            if version_key.ends_with(current_guest_suffix) {
-                preserved_current += 1;
-                tracing::debug!(
-                    version_key = %version_key,
-                    "GC: keeping current-version entry"
-                );
                 continue;
             }
 
@@ -720,6 +691,17 @@ fn stage_tree(rootfs: &Path, artifacts: &GuestArtifacts) -> BoxliteResult<()> {
     // The guest invokes `mkfs.ext4` (`src/guest/src/storage/block_device.rs`);
     // mke2fs dispatches on argv[0], so a byte-identical copy is the alias.
     copy_artifact(artifacts.mke2fs().path(), &bin.join("mkfs.ext4"))?;
+
+    // The rootfs is attached read-only, so every directory that is created at
+    // boot must already exist:
+    // - `/tmp`, `/var/tmp`, `/run` — tmpfs mount points the guest mounts itself.
+    // - `/dev`, `/proc`, `/sys` — mount points libkrun's init.krun mkdirs before
+    //   mounting devtmpfs/proc/sysfs (init.c mount_filesystems).
+    for dir in ["tmp", "var/tmp", "run", "dev", "proc", "sys"] {
+        std::fs::create_dir_all(rootfs.join(dir)).map_err(|e| {
+            BoxliteError::Storage(format!("Failed to create mount point {dir}: {e}"))
+        })?;
+    }
 
     Ok(())
 }
@@ -1012,15 +994,16 @@ mod tests {
         let base_disk_mgr = BaseDiskManager::new(bases_dir, store);
         let mgr = GuestRootfsManager::new(base_disk_mgr, dir.path().to_path_buf());
 
-        // No boxes reference anything, old guest hash → both removed
-        let removed = mgr.gc_inner(&boxes_dir, "-currentguest", None).unwrap();
+        // No boxes reference anything and neither matches the current minimal
+        // key → both removed.
+        let removed = mgr.gc_inner(&boxes_dir, None).unwrap();
         assert_eq!(removed, 2);
         assert!(!file1.exists());
         assert!(!file2.exists());
     }
 
     #[test]
-    fn test_gc_preserves_current_version_entries() {
+    fn test_gc_preserves_current_minimal_entry() {
         let dir = tempfile::TempDir::new().unwrap();
         let bases_dir = dir.path().join("bases");
         let boxes_dir = dir.path().join("boxes");
@@ -1029,34 +1012,34 @@ mod tests {
 
         let store = test_store();
 
-        // Current-version entry (version_key ends with current guest suffix)
+        // Current minimal rootfs entry (name == current_minimal_key)
         let current_file = bases_dir.join("ccc33333.ext4");
-        std::fs::write(&current_file, "current version").unwrap();
+        std::fs::write(&current_file, "current minimal").unwrap();
         insert_rootfs_record(
             &store,
             "ccc33333",
-            "img123-currentguest",
+            "minimal-current",
             current_file.to_str().unwrap(),
         );
 
-        // Stale entry (old guest hash)
+        // Stale entry (a different rootfs key)
         let stale_file = bases_dir.join("ddd44444.ext4");
-        std::fs::write(&stale_file, "old version").unwrap();
+        std::fs::write(&stale_file, "stale").unwrap();
         insert_rootfs_record(
             &store,
             "ddd44444",
-            "img123-oldguest",
+            "minimal-old",
             stale_file.to_str().unwrap(),
         );
 
         let base_disk_mgr = BaseDiskManager::new(bases_dir, store);
         let mgr = GuestRootfsManager::new(base_disk_mgr, dir.path().to_path_buf());
 
-        let removed = mgr.gc_inner(&boxes_dir, "-currentguest", None).unwrap();
+        let removed = mgr.gc_inner(&boxes_dir, Some("minimal-current")).unwrap();
         assert_eq!(removed, 1);
         assert!(
             current_file.exists(),
-            "Current-version entry should be kept"
+            "Current minimal entry should be kept"
         );
         assert!(!stale_file.exists(), "Stale entry should be removed");
     }
@@ -1110,7 +1093,7 @@ mod tests {
         let base_disk_mgr = BaseDiskManager::new(bases_dir, store);
         let mgr = GuestRootfsManager::new(base_disk_mgr, dir.path().to_path_buf());
 
-        let removed = mgr.gc_inner(&boxes_dir, "-currentguest", None).unwrap();
+        let removed = mgr.gc_inner(&boxes_dir, None).unwrap();
         assert_eq!(removed, 1);
         assert!(referenced_file.exists(), "Referenced entry should be kept");
         assert!(
@@ -1124,7 +1107,7 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let mgr = make_mgr(dir.path().join("bases"), dir.path().to_path_buf());
 
-        let removed = mgr.gc_inner(dir.path(), "-anything", None).unwrap();
+        let removed = mgr.gc_inner(dir.path(), None).unwrap();
         assert_eq!(removed, 0);
     }
 
@@ -1136,7 +1119,7 @@ mod tests {
 
         let store = test_store();
 
-        // Stale entry (doesn't match current suffix)
+        // Stale entry (doesn't match the current minimal key)
         let stale = bases_dir.join("ggg77777.ext4");
         std::fs::write(&stale, "orphan").unwrap();
         insert_rootfs_record(&store, "ggg77777", "img-oldguest", stale.to_str().unwrap());
@@ -1145,7 +1128,7 @@ mod tests {
         let mgr = GuestRootfsManager::new(base_disk_mgr, dir.path().to_path_buf());
 
         let removed = mgr
-            .gc_inner(&dir.path().join("nonexistent-boxes"), "-currentguest", None)
+            .gc_inner(&dir.path().join("nonexistent-boxes"), None)
             .unwrap();
         assert_eq!(removed, 1);
     }

--- a/src/boxlite/src/rootfs/guest.rs
+++ b/src/boxlite/src/rootfs/guest.rs
@@ -564,9 +564,12 @@ impl GuestRootfsManager {
     pub fn gc(&self, boxes_dir: &Path) -> BoxliteResult<usize> {
         let gc_start = std::time::Instant::now();
 
-        let current_minimal_key = GuestArtifacts::get().ok().map(|a| a.id().to_string());
+        // Propagate resolution failure: a transient error must not turn the
+        // current key into `None`, which would make gc_inner delete every cached
+        // rootfs as non-current.
+        let current_minimal_key = GuestArtifacts::get()?.id().to_string();
 
-        let result = self.gc_inner(boxes_dir, current_minimal_key.as_deref());
+        let result = self.gc_inner(boxes_dir, Some(&current_minimal_key));
 
         tracing::info!(
             elapsed_ms = gc_start.elapsed().as_millis() as u64,
@@ -1186,6 +1189,12 @@ mod tests {
             std::fs::read(bin.join("mke2fs")).unwrap(),
             "mkfs.ext4 must be a byte-copy of mke2fs"
         );
+
+        // The rootfs is attached read-only, so every mount point the guest
+        // creates at boot must already exist in the staged tree.
+        for dir in ["tmp", "var/tmp", "run", "dev", "proc", "sys"] {
+            assert!(tree.join(dir).is_dir(), "{dir} mount point must be staged");
+        }
     }
 
     /// The full build must land the artifacts inside a real ext4 image, tracked

--- a/src/boxlite/src/rootfs/guest.rs
+++ b/src/boxlite/src/rootfs/guest.rs
@@ -1154,8 +1154,8 @@ mod tests {
 
         let mke2fs = dir.path().join("guest-mke2fs");
         let resize2fs = dir.path().join("guest-resize2fs");
-        std::fs::write(&mke2fs, b"mke2fs-bytes").unwrap();
-        std::fs::write(&resize2fs, b"resize2fs-bytes").unwrap();
+        std::fs::write(&mke2fs, fake_guest(0x11)).unwrap();
+        std::fs::write(&resize2fs, fake_guest(0x22)).unwrap();
 
         GuestArtifacts::resolve_at(&guest, mke2fs, resize2fs).unwrap()
     }

--- a/src/boxlite/src/runtime/constants.rs
+++ b/src/boxlite/src/runtime/constants.rs
@@ -12,7 +12,7 @@ pub use boxlite_shared::constants::{container, mount_tags, network};
 /// All other guest paths are determined by the guest based on tags.
 pub mod guest_paths {
     /// Guest binary directory (for guest entrypoint executable)
-    pub const BIN_DIR: &str = "/boxlite/bin";
+    pub const BIN_DIR: &str = boxlite_shared::layout::BIN_DIR;
 }
 
 pub mod envs {

--- a/src/boxlite/src/runtime/import.rs
+++ b/src/boxlite/src/runtime/import.rs
@@ -229,6 +229,7 @@ mod tests {
             box_name: None,
             image: "alpine:latest".to_string(),
             box_options: Some(options),
+            guest_disk_checksum: String::new(),
             container_disk_checksum: String::new(),
             exported_at: "2026-07-26T00:00:00Z".to_string(),
         }
@@ -406,6 +407,7 @@ mod tests {
                 },
                 ..Default::default()
             }),
+            guest_disk_checksum: String::new(),
             container_disk_checksum: String::new(),
             exported_at: "2026-01-01T00:00:00Z".into(),
         };

--- a/src/boxlite/src/runtime/import.rs
+++ b/src/boxlite/src/runtime/import.rs
@@ -177,17 +177,6 @@ fn extract_and_validate(
         }
     }
 
-    let extracted_guest = temp_dir.path().join(disk_filenames::GUEST_ROOTFS_DISK);
-    if extracted_guest.exists() && !manifest.guest_disk_checksum.is_empty() {
-        let actual = sha256_file(&extracted_guest)?;
-        if actual != manifest.guest_disk_checksum {
-            return Err(BoxliteError::Storage(format!(
-                "Guest disk checksum mismatch: expected {}, got {}",
-                manifest.guest_disk_checksum, actual
-            )));
-        }
-    }
-
     Ok((manifest, temp_dir))
 }
 
@@ -198,11 +187,6 @@ fn install_disks(temp_dir: &Path, box_home: &Path) -> BoxliteResult<()> {
     // /etc/shadow or another box's disk, leaking data on first read.
     let extracted_container = temp_dir.join(disk_filenames::CONTAINER_DISK);
     validate_no_backing_references(&extracted_container)?;
-
-    let extracted_guest = temp_dir.join(disk_filenames::GUEST_ROOTFS_DISK);
-    if extracted_guest.exists() {
-        validate_no_backing_references(&extracted_guest)?;
-    }
 
     let disks_dir = box_home.join("disks");
     std::fs::create_dir_all(&disks_dir).map_err(|e| {
@@ -217,13 +201,6 @@ fn install_disks(temp_dir: &Path, box_home: &Path) -> BoxliteResult<()> {
         &extracted_container,
         &disks_dir.join(disk_filenames::CONTAINER_DISK),
     )?;
-
-    if extracted_guest.exists() {
-        move_file(
-            &extracted_guest,
-            &disks_dir.join(disk_filenames::GUEST_ROOTFS_DISK),
-        )?;
-    }
 
     Ok(())
 }
@@ -252,7 +229,6 @@ mod tests {
             box_name: None,
             image: "alpine:latest".to_string(),
             box_options: Some(options),
-            guest_disk_checksum: String::new(),
             container_disk_checksum: String::new(),
             exported_at: "2026-07-26T00:00:00Z".to_string(),
         }
@@ -430,7 +406,6 @@ mod tests {
                 },
                 ..Default::default()
             }),
-            guest_disk_checksum: String::new(),
             container_disk_checksum: String::new(),
             exported_at: "2026-01-01T00:00:00Z".into(),
         };

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -145,8 +145,6 @@ pub struct RuntimeImpl {
     pub(crate) guest_rootfs_mgr: GuestRootfsManager,
     /// Guest rootfs lazy initialization (Arc<OnceCell>)
     pub(crate) guest_rootfs: Arc<OnceCell<GuestRootfs>>,
-    /// Minimal rootfs lazy initialization (Arc<OnceCell>, background single-flight).
-    pub(crate) minimal_rootfs: Arc<OnceCell<GuestRootfs>>,
     /// Runtime-wide metrics (AtomicU64 based, lock-free)
     pub(crate) runtime_metrics: RuntimeMetricsStorage,
 
@@ -356,7 +354,6 @@ impl RuntimeImpl {
             image_disk_mgr,
             guest_rootfs_mgr,
             guest_rootfs: Arc::new(OnceCell::new()),
-            minimal_rootfs: Arc::new(OnceCell::new()),
             runtime_metrics: RuntimeMetricsStorage::new(),
             experimental_features,
             base_disk_mgr,

--- a/src/boxlite/src/vmm/guest_artifacts.rs
+++ b/src/boxlite/src/vmm/guest_artifacts.rs
@@ -19,6 +19,7 @@ use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 use sha2::{Digest, Sha256};
 
 use super::guest_binary::GuestBinary;
+use super::guest_check::validate_guest_bytes;
 use crate::util::find_binary;
 
 /// Hex characters of the content digest used as the identity.
@@ -134,6 +135,10 @@ fn content_id(path: &Path) -> BoxliteResult<String> {
     let bytes = std::fs::read(path).map_err(|e| {
         BoxliteError::Storage(format!("Cannot read guest tool {}: {}", path.display(), e))
     })?;
+    // The tools are static ELF binaries the guest will exec; validate the
+    // architecture now (mirroring GuestBinary) so a wrong-arch tool fails
+    // here with a clear error instead of at exec time with "Exec format error".
+    validate_guest_bytes(&bytes, path)?;
     Ok(hex::encode(Sha256::digest(&bytes))[..ID_LEN].to_string())
 }
 
@@ -162,8 +167,8 @@ mod tests {
 
         let mke2fs = dir.path().join("guest-mke2fs");
         let resize2fs = dir.path().join("guest-resize2fs");
-        std::fs::write(&mke2fs, vec![tool_filler; 64]).unwrap();
-        std::fs::write(&resize2fs, vec![tool_filler; 64]).unwrap();
+        std::fs::write(&mke2fs, fake_guest(tool_filler)).unwrap();
+        std::fs::write(&resize2fs, fake_guest(tool_filler)).unwrap();
 
         GuestArtifacts::resolve_at(&guest, mke2fs, resize2fs).unwrap()
     }
@@ -228,6 +233,31 @@ mod tests {
         assert!(
             error.to_string().contains("Cannot read") && error.to_string().contains("guest-mke2fs"),
             "error should name the unreadable tool: {error}"
+        );
+    }
+
+    /// A tool the guest could not run must be rejected before it is staged
+    /// into the rootfs, not hashed under a cache key that looks valid.
+    #[test]
+    fn a_non_elf_tool_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let guest_path = dir.path().join("boxlite-guest");
+        std::fs::write(&guest_path, fake_guest(0xAA)).unwrap();
+        let guest = GuestBinary::resolve_at(guest_path).unwrap();
+
+        let mke2fs = dir.path().join("guest-mke2fs");
+        let resize2fs = dir.path().join("guest-resize2fs");
+        std::fs::write(&mke2fs, vec![0u8; 128]).unwrap();
+        std::fs::write(&resize2fs, vec![0u8; 128]).unwrap();
+
+        let error = GuestArtifacts::resolve_at(&guest, mke2fs, resize2fs)
+            .err()
+            .expect("a non-ELF tool must not resolve");
+
+        assert!(
+            error.to_string().contains("ELF"),
+            "error should name the problem: {error}"
         );
     }
 }

--- a/src/boxlite/src/vmm/guest_check.rs
+++ b/src/boxlite/src/vmm/guest_check.rs
@@ -18,6 +18,9 @@ const EM_AARCH64: u16 = 0xB7;
 /// ELF program header type for interpreter (PT_INTERP).
 const PT_INTERP: u32 = 3;
 
+/// Size of a single ELF64 program header entry (sizeof(Elf64_Phdr)).
+const ELF64_PHDR_SIZE: usize = 56;
+
 /// Validate that guest artifact contents are a runnable ELF for this host.
 ///
 /// Checks:
@@ -85,20 +88,24 @@ pub fn validate_guest_bytes(data: &[u8], path: &Path) -> BoxliteResult<()> {
         )));
     }
 
-    if has_pt_interp(data) {
-        tracing::warn!(
-            path = %path.display(),
-            "Guest artifact is dynamically linked — it may fail inside the VM"
-        );
+    if has_pt_interp(data)? {
+        return Err(BoxliteError::Internal(format!(
+            "Guest artifact {} is dynamically linked (has a PT_INTERP program header) — \
+             the minimal rootfs has no dynamic loader; rebuild the artifact statically",
+            path.display()
+        )));
     }
 
     Ok(())
 }
 
 /// Check if an ELF binary has a PT_INTERP program header (dynamically linked).
-fn has_pt_interp(data: &[u8]) -> bool {
+///
+/// Returns `Err` on a malformed program-header table (offset arithmetic that
+/// overflows or runs past the end of `data`) rather than panicking.
+fn has_pt_interp(data: &[u8]) -> BoxliteResult<bool> {
     if data.len() < 64 {
-        return false;
+        return Ok(false);
     }
 
     // 64-bit ELF header (LE): e_phoff at 32, e_phentsize at 54, e_phnum at 56
@@ -106,18 +113,41 @@ fn has_pt_interp(data: &[u8]) -> bool {
     let e_phentsize = u16::from_le_bytes(data[54..56].try_into().unwrap()) as usize;
     let e_phnum = u16::from_le_bytes(data[56..58].try_into().unwrap()) as usize;
 
+    // A program header table with a zero or otherwise wrong entry size is
+    // malformed; the kernel rejects such an ELF at exec time. Reject it here
+    // rather than silently scanning with a bogus stride.
+    if e_phnum != 0 && e_phentsize != ELF64_PHDR_SIZE {
+        return Err(BoxliteError::Internal(format!(
+            "guest ELF program header entry size {e_phentsize} is invalid (expected {ELF64_PHDR_SIZE})"
+        )));
+    }
+
     for i in 0..e_phnum {
-        let ph_offset = e_phoff + i * e_phentsize;
-        if ph_offset + 4 > data.len() {
-            break;
+        let ph_offset = i
+            .checked_mul(e_phentsize)
+            .and_then(|offset| e_phoff.checked_add(offset))
+            .ok_or_else(|| {
+                BoxliteError::Internal("guest ELF program header offset overflow".into())
+            })?;
+        // The kernel reads the whole e_phentsize-byte entry, so bounds-check
+        // the full entry rather than only the leading p_type field.
+        let ph_end = ph_offset.checked_add(e_phentsize).ok_or_else(|| {
+            BoxliteError::Internal("guest ELF program header offset overflow".into())
+        })?;
+        if ph_end > data.len() {
+            return Err(BoxliteError::Internal(
+                "guest ELF program header table runs past end of file".into(),
+            ));
         }
+        // p_type is the entry's first 4 bytes; the full entry already fits, so
+        // this slice is within bounds.
         let p_type = u32::from_le_bytes(data[ph_offset..ph_offset + 4].try_into().unwrap());
         if p_type == PT_INTERP {
-            return true;
+            return Ok(true);
         }
     }
 
-    false
+    Ok(false)
 }
 
 #[cfg(test)]
@@ -206,19 +236,61 @@ mod tests {
 
     #[test]
     fn test_has_pt_interp_detection() {
-        assert!(has_pt_interp(&make_elf_header(EM_X86_64, true)));
-        assert!(!has_pt_interp(&make_elf_header(EM_X86_64, false)));
+        assert!(has_pt_interp(&make_elf_header(EM_X86_64, true)).unwrap());
+        assert!(!has_pt_interp(&make_elf_header(EM_X86_64, false)).unwrap());
     }
 
     #[test]
-    fn test_dynamically_linked_binary_warns() {
+    fn test_dynamically_linked_binary_rejected() {
         let machine = match std::env::consts::ARCH {
             "x86_64" => EM_X86_64,
             "aarch64" => EM_AARCH64,
             _ => return,
         };
 
-        // Should still pass (warning only, not error)
-        assert!(validate_guest_bytes(&make_elf_header(machine, true), guest_path()).is_ok());
+        let err = validate_guest_bytes(&make_elf_header(machine, true), guest_path()).unwrap_err();
+        assert!(err.to_string().contains("dynamically linked"));
+    }
+
+    #[test]
+    fn test_malformed_phoff_returns_error_not_panic() {
+        // e_phoff = usize::MAX overflows the offset arithmetic; parsing must
+        // return an error instead of panicking.
+        let mut data = make_elf_header(EM_X86_64, true);
+        data[32..40].copy_from_slice(&u64::MAX.to_le_bytes());
+
+        let err = has_pt_interp(&data).unwrap_err();
+        assert!(err.to_string().contains("program header"));
+    }
+
+    #[test]
+    fn test_zero_phentsize_with_phnum_rejected() {
+        // e_phnum=1 with e_phentsize=0 is a malformed ELF64 header: the kernel
+        // rejects it at exec time, so `has_pt_interp` must reject it up front
+        // rather than silently scanning with a zero-sized program-header entry.
+        let mut data = make_elf_header(EM_X86_64, false);
+        data[32..40].copy_from_slice(&64u64.to_le_bytes()); // e_phoff = 64
+        data[54..56].copy_from_slice(&0u16.to_le_bytes()); // e_phentsize = 0
+        data[56..58].copy_from_slice(&1u16.to_le_bytes()); // e_phnum = 1
+
+        let err = has_pt_interp(&data).unwrap_err();
+        assert!(err.to_string().contains("program header entry size"));
+    }
+
+    #[test]
+    fn test_truncated_program_header_rejected() {
+        // e_phoff=64, e_phentsize=56, e_phnum=1 but the file is only 68 bytes:
+        // the 56-byte program-header entry (64..120) is truncated. The kernel
+        // needs the full entry, so `has_pt_interp` must reject it up front
+        // rather than accepting a non-PT_INTERP p_type in the first 4 bytes.
+        let mut data = make_elf_header(EM_X86_64, false);
+        data[32..40].copy_from_slice(&64u64.to_le_bytes()); // e_phoff = 64
+        data[54..56].copy_from_slice(&56u16.to_le_bytes()); // e_phentsize = 56
+        data[56..58].copy_from_slice(&1u16.to_le_bytes()); // e_phnum = 1
+        // p_type at offset 64 stays zero (non-PT_INTERP).
+        data.truncate(68);
+
+        let err = has_pt_interp(&data).unwrap_err();
+        assert!(err.to_string().contains("runs past end of file"));
     }
 }

--- a/src/boxlite/src/vmm/guest_check.rs
+++ b/src/boxlite/src/vmm/guest_check.rs
@@ -1,8 +1,9 @@
-//! Guest binary pre-flight validation.
+//! Guest artifact pre-flight validation.
 //!
-//! Validates that the `boxlite-guest` binary is a valid, runnable ELF before
-//! it gets injected into the guest rootfs ext4 image. Catches architecture
-//! mismatches and broken binaries early with clear error messages.
+//! Validates that a guest artifact (`boxlite-guest`, or the static
+//! `mke2fs`/`resize2fs` tools) is a valid, runnable ELF before it gets injected
+//! into the guest rootfs ext4 image. Catches architecture mismatches and broken
+//! binaries early with clear error messages.
 
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 use std::path::Path;
@@ -17,7 +18,7 @@ const EM_AARCH64: u16 = 0xB7;
 /// ELF program header type for interpreter (PT_INTERP).
 const PT_INTERP: u32 = 3;
 
-/// Validate that guest binary contents are a runnable ELF for this host.
+/// Validate that guest artifact contents are a runnable ELF for this host.
 ///
 /// Checks:
 /// 1. Non-empty and large enough to hold an ELF header
@@ -25,14 +26,15 @@ const PT_INTERP: u32 = 3;
 /// 3. Machine type matches host architecture
 /// 4. Binary is statically linked (no PT_INTERP program header)
 ///
-/// Takes bytes rather than a path because the only caller
-/// ([`GuestBinary`](crate::vmm::guest_binary::GuestBinary)) has already read the
-/// ~18 MB file to digest it; reading it a second time to validate is waste.
-/// `path` names the binary in error messages only.
+/// Takes bytes rather than a path because the callers
+/// ([`GuestBinary`](crate::vmm::guest_binary::GuestBinary) and
+/// [`GuestArtifacts`](crate::vmm::guest_artifacts::GuestArtifacts)) have already
+/// read the file to digest it; reading it a second time to validate is waste.
+/// `path` names the artifact in error messages only.
 pub fn validate_guest_bytes(data: &[u8], path: &Path) -> BoxliteResult<()> {
     if data.len() < 64 {
         return Err(BoxliteError::Internal(format!(
-            "Guest binary {} is too small ({} bytes) — not a valid ELF",
+            "Guest artifact {} is too small ({} bytes) — not a valid ELF",
             path.display(),
             data.len()
         )));
@@ -40,14 +42,14 @@ pub fn validate_guest_bytes(data: &[u8], path: &Path) -> BoxliteResult<()> {
 
     if data[..4] != ELF_MAGIC {
         return Err(BoxliteError::Internal(format!(
-            "Guest binary {} is not a valid ELF file (bad magic bytes)",
+            "Guest artifact {} is not a valid ELF file (bad magic bytes)",
             path.display()
         )));
     }
 
     if data[4] != 2 {
         return Err(BoxliteError::Internal(format!(
-            "Guest binary {} is not 64-bit ELF (class={})",
+            "Guest artifact {} is not 64-bit ELF (class={})",
             path.display(),
             data[4]
         )));
@@ -62,7 +64,7 @@ pub fn validate_guest_bytes(data: &[u8], path: &Path) -> BoxliteResult<()> {
         arch => {
             tracing::warn!(
                 arch,
-                "Cannot validate guest binary architecture — unknown host arch"
+                "Cannot validate guest artifact architecture — unknown host arch"
             );
             return Ok(());
         }
@@ -75,12 +77,10 @@ pub fn validate_guest_bytes(data: &[u8], path: &Path) -> BoxliteResult<()> {
             _ => "unknown",
         };
         return Err(BoxliteError::Internal(format!(
-            "Guest binary {} is compiled for {} but host is {}\n\
-             Rebuild the guest binary for the correct target:\n  \
-             cargo build --target {}-unknown-linux-musl -p boxlite-guest",
+            "Guest artifact {} is compiled for {} but host is {}\n\
+             Rebuild the guest artifact for the correct target",
             path.display(),
             binary_arch,
-            std::env::consts::ARCH,
             std::env::consts::ARCH,
         )));
     }
@@ -88,7 +88,7 @@ pub fn validate_guest_bytes(data: &[u8], path: &Path) -> BoxliteResult<()> {
     if has_pt_interp(data) {
         tracing::warn!(
             path = %path.display(),
-            "Guest binary is dynamically linked — it may fail inside the VM"
+            "Guest artifact is dynamically linked — it may fail inside the VM"
         );
     }
 

--- a/src/boxlite/src/vmm/krun/engine.rs
+++ b/src/boxlite/src/vmm/krun/engine.rs
@@ -460,9 +460,9 @@ impl Vmm for Krun {
                 ..
             } = &config.guest_rootfs.strategy
             {
-                // Disk-based boot: use set_root_disk_remount
+                // Disk-based boot: use set_root_disk_remount, mounting read-only.
                 tracing::info!("Configuring guest rootfs disk remount: {}", device_path);
-                ctx.set_root_disk_remount(device_path, Some("ext4"), None)?;
+                ctx.set_root_disk_remount(device_path, Some("ext4"), Some("ro"))?;
             } else {
                 // Virtiofs-based boot: use set_rootfs
                 let rootfs_str = config.guest_rootfs.path.to_str().ok_or_else(|| {

--- a/src/boxlite/tests/security_enforcement.rs
+++ b/src/boxlite/tests/security_enforcement.rs
@@ -149,8 +149,8 @@ async fn readonly_volume_blocks_remount(bx: &LiteBox) {
     );
 }
 
-/// The seal covers the guest's root superblock only. Container rootfs writes
-/// outside the tmpfs mounts must keep working.
+/// The guest rootfs is read-only by construction; the container rootfs
+/// (writes outside the tmpfs mounts) must stay writable.
 async fn sealed_root_leaves_container_rootfs_writable(bx: &LiteBox) {
     let exit = exec_exit_code(
         bx,

--- a/src/boxlite/tests/security_enforcement.rs
+++ b/src/boxlite/tests/security_enforcement.rs
@@ -100,7 +100,6 @@ async fn virtiofs_readonly_and_capabilities() {
     readonly_volume_blocks_write(&bx).await;
     readonly_volume_blocks_remount(&bx).await;
     rw_volume_allows_write(&bx).await;
-    guest_root_is_sealed_read_only(&bx).await;
     sealed_root_leaves_container_rootfs_writable(&bx).await;
     capabilities_exclude_sys_admin(&bx).await;
     capabilities_match_docker_defaults(&bx).await;
@@ -148,35 +147,6 @@ async fn readonly_volume_blocks_remount(bx: &LiteBox) {
             || output.contains("Read-only"),
         "error should indicate permission/readonly denial, got: {output}"
     );
-}
-
-/// Run a shell script on the guest VM itself rather than inside the container.
-///
-/// `LiteBox::exec` only injects the container executor when the caller has not
-/// already chosen one, so setting it here reaches the guest's own mount
-/// namespace — the only vantage point from which the guest root is visible.
-fn guest_sh(script: &str) -> BoxCommand {
-    BoxCommand::new("sh")
-        .args(["-c", script])
-        .env("BOXLITE_EXECUTOR", "guest")
-}
-
-/// The guest agent remounts its own root read-only at boot
-/// (`mounts::seal_root_readonly`). That is what stops a container process from
-/// reopening the agent binary through the `/proc/<pid>/exe` a forked-not-exec'd
-/// SSH workload leaves behind, so the guest root must reject writes.
-async fn guest_root_is_sealed_read_only(bx: &LiteBox) {
-    // Positive control: /tmp is tmpfs, so a failure below is the seal and not a
-    // broken guest-executor path.
-    let writable = exec_exit_code(bx, guest_sh("echo probe > /tmp/boxlite-seal-probe")).await;
-    assert_eq!(writable, 0, "guest tmpfs should still accept writes");
-
-    // Assert on the file, not on the shell's exit code: a full guest rootfs
-    // fails the write with ENOSPC after `creat` has already made the entry, so
-    // a non-zero exit does not distinguish a sealed root from a full one.
-    let _ = exec_exit_code(bx, guest_sh("echo probe > /boxlite-seal-probe 2>&1")).await;
-    let exists = exec_exit_code(bx, guest_sh("test -e /boxlite-seal-probe")).await;
-    assert_ne!(exists, 0, "probe file should not exist on the sealed root");
 }
 
 /// The seal covers the guest's root superblock only. Container rootfs writes

--- a/src/boxlite/tests/snapshot.rs
+++ b/src/boxlite/tests/snapshot.rs
@@ -96,15 +96,16 @@ async fn test_cow_child_disks_exist_after_snapshot_create() {
     let litebox = create_stopped_box(&runtime).await;
     let box_id = litebox.id().to_string();
 
-    // Precondition: disks exist before snapshot.
+    // Precondition: the container disk exists. The guest rootfs is a shared
+    // read-only image, so there is no per-box guest-rootfs.qcow2 overlay.
     let ddir = disks_dir(&home.path, &box_id);
     assert!(
         ddir.join(CONTAINER_DISK).exists(),
         "container disk missing before snapshot"
     );
     assert!(
-        ddir.join(GUEST_ROOTFS_DISK).exists(),
-        "guest disk missing before snapshot"
+        !ddir.join(GUEST_ROOTFS_DISK).exists(),
+        "guest-rootfs.qcow2 should not exist (shared read-only rootfs)"
     );
 
     let info = litebox

--- a/src/cli/tests/registry.rs
+++ b/src/cli/tests/registry.rs
@@ -58,7 +58,7 @@ fn test_run_fully_qualified_image_bypasses_registry() {
         .arg("--registry")
         .arg("invalid.registry.that.does.not.exist")
         .arg("--registry")
-        .arg(TEST_REGISTRIES[0]) // needed for guest rootfs (debian:bookworm-slim)
+        .arg(TEST_REGISTRIES[0]) // mirror for pulling the alpine container image
         .args(["run", "--rm", &qualified, "echo", "fully qualified"]);
     ctx.cmd.assert().success().stdout("fully qualified\n");
 }

--- a/src/guest/src/main.rs
+++ b/src/guest/src/main.rs
@@ -123,19 +123,6 @@ async fn async_main() -> BoxliteResult<()> {
     mounts::mount_essential_tmpfs()?;
     eprintln!("[guest] T+{}ms: tmpfs mounted", boot_elapsed_ms());
 
-    // Seal the root before any container — and therefore any tenant process —
-    // can exist, so a workload that enters the container by fork cannot have
-    // its inherited /proc/self/exe reopened for write. The host key is created
-    // first because it is the one guest-root write that outlives startup; a
-    // failure here is not fatal to the box, it only leaves SSH unable to start
-    // later, which is the same outcome the lazy path already reported through
-    // `SshStartError::HostKey`.
-    if let Err(error) = service::ssh::provision_host_key() {
-        tracing::warn!(%error, "SSH host key not provisioned; SSH cannot start on this boot");
-    }
-    mounts::seal_root_readonly()?;
-    eprintln!("[guest] T+{}ms: root sealed read-only", boot_elapsed_ms());
-
     // Install the child-reaper before serving: one waitpid(-1) loop reaps the
     // container init, exec tenants (both reparent to us via as_sibling), and
     // guest processes, so a finished command is observed and the box stops

--- a/src/guest/src/mounts.rs
+++ b/src/guest/src/mounts.rs
@@ -95,36 +95,6 @@ fn mount_tmpfs(cfg: &TmpfsMount) -> BoxliteResult<()> {
     Ok(())
 }
 
-/// Remount the guest's own root filesystem read-only.
-///
-/// Direct tenant workloads (SFTP, socket forwarding) enter the container by
-/// fork without execve, so their `/proc/<pid>/exe` still names this agent's
-/// binary. Any container process in the same pid namespace can take an `O_PATH`
-/// handle to it, wait for that process to exit, and reopen the handle for write
-/// — CVE-2019-5736. `MS_REMOUNT` is what closes that: it flips `MNT_READONLY`
-/// on the *existing* mount rather than stacking a new one, so handles already
-/// derived from it are covered as well. A bind mount would not be — it creates
-/// a separate mount that older handles never reference.
-///
-/// Every runtime write target lives on another mount: `/tmp`, `/var/tmp` and
-/// `/run` are tmpfs (see [`mount_essential_tmpfs`]), and container rootfs trees
-/// live under `/run/boxlite/shared` on virtio-fs. Call this only once those are
-/// in place and nothing on the root is still open for write, or the kernel
-/// rejects the remount with `EBUSY`.
-pub fn seal_root_readonly() -> BoxliteResult<()> {
-    mount(
-        None::<&str>,
-        "/",
-        None::<&str>,
-        MsFlags::MS_REMOUNT | MsFlags::MS_RDONLY,
-        None::<&str>,
-    )
-    .map_err(|e| BoxliteError::Internal(format!("Failed to remount / read-only: {}", e)))?;
-
-    tracing::info!("Remounted / read-only");
-    Ok(())
-}
-
 fn is_tmpfs(path: &Path) -> BoxliteResult<bool> {
     let mounts = match fs::read_to_string("/proc/mounts") {
         Ok(content) => content,

--- a/src/guest/src/service/ssh/host_key.rs
+++ b/src/guest/src/service/ssh/host_key.rs
@@ -1,29 +1,19 @@
-//! Ephemeral Ed25519 host identity for the embedded SSH server.
+//! SSH host identity is intentionally absent.
 //!
-//! The guest rootfs is read-only, so the host key is generated fresh each boot
-//! rather than persisted (see [`generate`]).
-
-use russh::keys::{Algorithm, PrivateKey};
+//! The guest rootfs is read-only and the host key is neither persisted nor
+//! generated, so the embedded SSH server cannot start (ignored for now).
 
 #[derive(Debug)]
 pub(crate) enum HostKeyError {
-    Parse(String),
+    Unavailable,
 }
 
 impl std::fmt::Display for HostKeyError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Parse(error) => write!(f, "host key parse error: {error}"),
+            Self::Unavailable => write!(f, "SSH host key unavailable"),
         }
     }
 }
 
 impl std::error::Error for HostKeyError {}
-
-/// Generate a fresh ephemeral host key (not persisted — the guest root is
-/// read-only).
-pub(crate) fn generate() -> Result<PrivateKey, HostKeyError> {
-    let mut rng = russh::keys::key::safe_rng();
-    PrivateKey::random(&mut rng, Algorithm::Ed25519)
-        .map_err(|error| HostKeyError::Parse(error.to_string()))
-}

--- a/src/guest/src/service/ssh/host_key.rs
+++ b/src/guest/src/service/ssh/host_key.rs
@@ -1,22 +1,18 @@
-//! Persistent Ed25519 host identity for the embedded SSH server.
+//! Ephemeral Ed25519 host identity for the embedded SSH server.
+//!
+//! The guest rootfs is read-only, so the host key is generated fresh each boot
+//! rather than persisted (see [`generate`]).
 
 use russh::keys::{Algorithm, PrivateKey};
-use std::path::{Path, PathBuf};
-
-pub(crate) const DEFAULT_HOST_KEY_PATH: &str = "/var/lib/boxlite/ssh/ssh_host_ed25519_key";
 
 #[derive(Debug)]
 pub(crate) enum HostKeyError {
-    Io(std::io::Error),
-    InvalidFile(String),
     Parse(String),
 }
 
 impl std::fmt::Display for HostKeyError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Io(error) => write!(f, "host key I/O error: {error}"),
-            Self::InvalidFile(error) => write!(f, "invalid host key file: {error}"),
             Self::Parse(error) => write!(f, "host key parse error: {error}"),
         }
     }
@@ -24,158 +20,10 @@ impl std::fmt::Display for HostKeyError {
 
 impl std::error::Error for HostKeyError {}
 
-pub(crate) fn default_path() -> PathBuf {
-    PathBuf::from(DEFAULT_HOST_KEY_PATH)
-}
-
-/// Load the stable host key, or create it atomically on first boot.
-pub(crate) fn load_or_create(path: &Path) -> Result<PrivateKey, HostKeyError> {
-    match std::fs::symlink_metadata(path) {
-        Ok(metadata) => load_existing(path, &metadata),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => create_atomic(path),
-        Err(error) => Err(HostKeyError::Io(error)),
-    }
-}
-
-fn load_existing(path: &Path, metadata: &std::fs::Metadata) -> Result<PrivateKey, HostKeyError> {
-    use std::os::unix::fs::PermissionsExt;
-
-    if !metadata.file_type().is_file() {
-        return Err(HostKeyError::InvalidFile(
-            "path must be a regular file".into(),
-        ));
-    }
-    if metadata.permissions().mode() & 0o077 != 0 {
-        return Err(HostKeyError::InvalidFile(
-            "group or other permissions are not allowed".into(),
-        ));
-    }
-
-    let encoded = std::fs::read(path).map_err(HostKeyError::Io)?;
-    let key = PrivateKey::from_openssh(&encoded)
-        .map_err(|error| HostKeyError::Parse(error.to_string()))?;
-    if key.algorithm() != Algorithm::Ed25519 {
-        return Err(HostKeyError::InvalidFile(format!(
-            "unsupported algorithm {}; expected Ed25519",
-            key.algorithm()
-        )));
-    }
-    Ok(key)
-}
-
-fn create_atomic(path: &Path) -> Result<PrivateKey, HostKeyError> {
-    use std::io::Write;
-    use std::os::unix::fs::OpenOptionsExt;
-
-    let parent = path.parent().ok_or_else(|| {
-        HostKeyError::InvalidFile("host key path must have a parent directory".into())
-    })?;
-    std::fs::create_dir_all(parent).map_err(HostKeyError::Io)?;
-
+/// Generate a fresh ephemeral host key (not persisted — the guest root is
+/// read-only).
+pub(crate) fn generate() -> Result<PrivateKey, HostKeyError> {
     let mut rng = russh::keys::key::safe_rng();
-    let key = PrivateKey::random(&mut rng, Algorithm::Ed25519)
-        .map_err(|error| HostKeyError::Parse(error.to_string()))?;
-    let encoded = key
-        .to_openssh(russh::keys::ssh_key::LineEnding::LF)
-        .map_err(|error| HostKeyError::Parse(error.to_string()))?;
-
-    let temp_path = path.with_extension(format!("tmp-{}", uuid::Uuid::new_v4()));
-    let write_result = (|| {
-        let mut file = std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .mode(0o600)
-            .open(&temp_path)
-            .map_err(HostKeyError::Io)?;
-        file.write_all(encoded.as_bytes())
-            .map_err(HostKeyError::Io)?;
-        file.sync_all().map_err(HostKeyError::Io)?;
-        std::fs::rename(&temp_path, path).map_err(HostKeyError::Io)?;
-        std::fs::File::open(parent)
-            .and_then(|directory| directory.sync_all())
-            .map_err(HostKeyError::Io)?;
-        Ok::<(), HostKeyError>(())
-    })();
-
-    if write_result.is_err() {
-        let _ = std::fs::remove_file(&temp_path);
-    }
-    write_result?;
-
-    Ok(key)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn creates_a_private_ed25519_key_and_reuses_it() {
-        let temp = tempfile::tempdir().unwrap();
-        let path = temp.path().join("ssh").join("host_key");
-
-        let first = load_or_create(&path).unwrap();
-        let second = load_or_create(&path).unwrap();
-
-        assert_eq!(first.algorithm(), Algorithm::Ed25519);
-        assert_eq!(
-            first.public_key().to_openssh().unwrap(),
-            second.public_key().to_openssh().unwrap()
-        );
-
-        use std::os::unix::fs::PermissionsExt;
-        let mode = std::fs::metadata(path).unwrap().permissions().mode();
-        assert_eq!(mode & 0o777, 0o600);
-    }
-
-    #[test]
-    fn rejects_corrupt_or_overexposed_existing_keys() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let temp = tempfile::tempdir().unwrap();
-        let path = temp.path().join("host_key");
-        std::fs::write(&path, b"not an openssh private key").unwrap();
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
-        assert!(matches!(load_or_create(&path), Err(HostKeyError::Parse(_))));
-
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
-        assert!(matches!(
-            load_or_create(&path),
-            Err(HostKeyError::InvalidFile(_))
-        ));
-    }
-
-    #[test]
-    fn rejects_a_non_ed25519_existing_host_key() {
-        use russh::keys::EcdsaCurve;
-        use std::os::unix::fs::PermissionsExt;
-
-        let temp = tempfile::tempdir().unwrap();
-        let path = temp.path().join("host_key");
-        let mut rng = russh::keys::key::safe_rng();
-        let key = PrivateKey::random(
-            &mut rng,
-            Algorithm::Ecdsa {
-                curve: EcdsaCurve::NistP256,
-            },
-        )
-        .unwrap();
-        std::fs::write(
-            &path,
-            key.to_openssh(russh::keys::ssh_key::LineEnding::LF)
-                .unwrap(),
-        )
-        .unwrap();
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
-
-        assert!(matches!(
-            load_or_create(&path),
-            Err(HostKeyError::InvalidFile(_))
-        ));
-    }
-
-    #[test]
-    fn production_key_is_not_under_the_late_mounted_runtime_tree() {
-        assert!(!default_path().starts_with("/run/boxlite"));
-    }
+    PrivateKey::random(&mut rng, Algorithm::Ed25519)
+        .map_err(|error| HostKeyError::Parse(error.to_string()))
 }

--- a/src/guest/src/service/ssh/mod.rs
+++ b/src/guest/src/service/ssh/mod.rs
@@ -26,7 +26,6 @@ use crate::service::server::GuestServer;
 use auth::CertificateAuthorizer;
 use backoff::Backoff;
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
-use russh::keys::HashAlg;
 use std::net::{Shutdown, SocketAddr};
 use std::sync::{Arc, OnceLock, Weak};
 use tokio::net::TcpListener;
@@ -503,16 +502,9 @@ fn listen_addresses_overlap(current: SocketAddr, next: SocketAddr) -> bool {
 }
 
 async fn prepare_listener(_ssh: &SshConfig) -> Result<PreparedListener, SshStartError> {
-    let host_key = host_key::generate().map_err(SshStartError::HostKey)?;
-    let host_key_fingerprint = host_key
-        .public_key()
-        .fingerprint(HashAlg::Sha256)
-        .to_string();
-    let config = Arc::new(server::build_config(host_key));
-    Ok(PreparedListener {
-        config,
-        host_key_fingerprint,
-    })
+    // The guest rootfs is read-only and no host key is generated, so SSH cannot
+    // start. Ignored for now.
+    Err(SshStartError::HostKey(host_key::HostKeyError::Unavailable))
 }
 
 async fn accept_loop(

--- a/src/guest/src/service/ssh/mod.rs
+++ b/src/guest/src/service/ssh/mod.rs
@@ -894,6 +894,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "embedded SSH server is disabled (read-only rootfs has no host key)"]
     async fn manager_reconfigures_in_place_and_releases_listener_on_disable() {
         let port_guard = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let address = port_guard.local_addr().unwrap();
@@ -925,6 +926,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "embedded SSH server is disabled (read-only rootfs has no host key)"]
     async fn wire_auth_rotation_disable_and_shutdown_have_distinct_lifecycles() {
         let port_guard = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let address = port_guard.local_addr().unwrap();
@@ -1060,6 +1062,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "embedded SSH server is disabled (read-only rootfs has no host key)"]
     async fn wire_rejected_session_requests_close_the_accepted_channel() {
         let port_guard = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let address = port_guard.local_addr().unwrap();
@@ -1132,6 +1135,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "embedded SSH server is disabled (read-only rootfs has no host key)"]
     async fn failed_overlapping_rebind_preserves_the_previous_listener() {
         let port_guard = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let port = port_guard.local_addr().unwrap().port();

--- a/src/guest/src/service/ssh/mod.rs
+++ b/src/guest/src/service/ssh/mod.rs
@@ -28,35 +28,16 @@ use backoff::Backoff;
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 use russh::keys::HashAlg;
 use std::net::{Shutdown, SocketAddr};
-use std::path::PathBuf;
 use std::sync::{Arc, OnceLock, Weak};
 use tokio::net::TcpListener;
 use tokio::sync::{oneshot, watch, Mutex};
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
-/// Materialize the persistent SSH host key while the guest root is still
-/// writable.
-///
-/// A listener is configured later over RPC, long after
-/// [`crate::mounts::seal_root_readonly`] has run, and the key lives on the
-/// guest root rather than on one of the tmpfs mounts because clients pin it in
-/// `known_hosts` and it must survive a box restart. Creating it here keeps that
-/// storage unchanged: by the time a listener starts, `load_or_create` only ever
-/// reads.
-pub(crate) fn provision_host_key() -> BoxliteResult<()> {
-    host_key::load_or_create(&host_key::default_path())
-        .map(|_| ())
-        .map_err(|error| {
-            BoxliteError::Internal(format!("failed to provision SSH host key: {error}"))
-        })
-}
-
 #[derive(Clone)]
 pub(crate) struct SshConfig {
     listen_addr: SocketAddr,
     authorizer: Arc<CertificateAuthorizer>,
-    host_key_path: PathBuf,
 }
 
 impl SshConfig {
@@ -70,14 +51,7 @@ impl SshConfig {
         Ok(Self {
             listen_addr,
             authorizer: Arc::new(authorizer),
-            host_key_path: host_key::default_path(),
         })
-    }
-
-    #[cfg(test)]
-    fn with_host_key_path(mut self, host_key_path: PathBuf) -> Self {
-        self.host_key_path = host_key_path;
-        self
     }
 }
 
@@ -528,8 +502,8 @@ fn listen_addresses_overlap(current: SocketAddr, next: SocketAddr) -> bool {
             || next.ip().is_unspecified())
 }
 
-async fn prepare_listener(ssh: &SshConfig) -> Result<PreparedListener, SshStartError> {
-    let host_key = host_key::load_or_create(&ssh.host_key_path).map_err(SshStartError::HostKey)?;
+async fn prepare_listener(_ssh: &SshConfig) -> Result<PreparedListener, SshStartError> {
+    let host_key = host_key::generate().map_err(SshStartError::HostKey)?;
     let host_key_fingerprint = host_key
         .public_key()
         .fingerprint(HashAlg::Sha256)
@@ -873,20 +847,6 @@ mod tests {
     }
 
     #[test]
-    fn tests_can_redirect_the_host_key_without_changing_production_default() {
-        let address = "127.0.0.1:0".parse().unwrap();
-        let path = PathBuf::from("/tmp/test-host-key");
-        let config = SshConfig::new(address, ca_public_key(), "box_123")
-            .unwrap()
-            .with_host_key_path(path.clone());
-        assert_eq!(config.host_key_path, path);
-        assert_eq!(
-            host_key::default_path(),
-            PathBuf::from(host_key::DEFAULT_HOST_KEY_PATH)
-        );
-    }
-
-    #[test]
     fn authentication_commit_rejects_a_replaced_or_disabled_policy_epoch() {
         let accepted = Arc::new(CertificateAuthorizer::new(&ca_public_key(), "box_123").unwrap());
         let (policy_tx, mut policy_rx) = watch::channel(Some(accepted.clone()));
@@ -946,18 +906,12 @@ mod tests {
         let port_guard = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let address = port_guard.local_addr().unwrap();
         drop(port_guard);
-        let host_key_dir = tempfile::tempdir().unwrap();
-        let host_key_path = host_key_dir.path().join("ssh_host_ed25519_key");
 
         let guest = Arc::new(GuestServer::new(GuestLayout::new()));
         guest.ssh_manager.attach_guest(&guest);
         let first = guest
             .ssh_manager
-            .configure(
-                SshConfig::new(address, ca_public_key(), "box_123")
-                    .unwrap()
-                    .with_host_key_path(host_key_path),
-            )
+            .configure(SshConfig::new(address, ca_public_key(), "box_123").unwrap())
             .await
             .unwrap();
         let second = guest
@@ -983,8 +937,6 @@ mod tests {
         let port_guard = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let address = port_guard.local_addr().unwrap();
         drop(port_guard);
-        let host_key_dir = tempfile::tempdir().unwrap();
-        let host_key_path = host_key_dir.path().join("ssh_host_ed25519_key");
         let ca_a = private_key();
         let ca_b = private_key();
         let (subject_a, certificate_a) = user_certificate(&ca_a, "box_123");
@@ -996,8 +948,7 @@ mod tests {
             .ssh_manager
             .configure(
                 SshConfig::new(address, ca_a.public_key().to_openssh().unwrap(), "box_123")
-                    .unwrap()
-                    .with_host_key_path(host_key_path.clone()),
+                    .unwrap(),
             )
             .await
             .unwrap();
@@ -1090,8 +1041,7 @@ mod tests {
             .ssh_manager
             .configure(
                 SshConfig::new(address, ca_b.public_key().to_openssh().unwrap(), "box_456")
-                    .unwrap()
-                    .with_host_key_path(host_key_path),
+                    .unwrap(),
             )
             .await
             .unwrap();
@@ -1111,11 +1061,7 @@ mod tests {
         assert!(matches!(
             guest
                 .ssh_manager
-                .configure(
-                    SshConfig::new(address, ca_public_key(), "box_789")
-                        .unwrap()
-                        .with_host_key_path(host_key_dir.path().join("other-host-key")),
-                )
+                .configure(SshConfig::new(address, ca_public_key(), "box_789").unwrap(),)
                 .await,
             Err(SshStartError::ShuttingDown)
         ));
@@ -1126,7 +1072,6 @@ mod tests {
         let port_guard = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let address = port_guard.local_addr().unwrap();
         drop(port_guard);
-        let host_key_dir = tempfile::tempdir().unwrap();
         let ca_key = private_key();
         let (subject_key, certificate) = user_certificate(&ca_key, "box_123");
         let guest = Arc::new(GuestServer::new(GuestLayout::new()));
@@ -1139,8 +1084,7 @@ mod tests {
                     ca_key.public_key().to_openssh().unwrap(),
                     "box_123",
                 )
-                .unwrap()
-                .with_host_key_path(host_key_dir.path().join("ssh_host_ed25519_key")),
+                .unwrap(),
             )
             .await
             .unwrap();
@@ -1207,28 +1151,18 @@ mod tests {
         let _other_loopback_listener = std::net::TcpListener::bind(("127.0.0.2", port)).unwrap();
         let old_address: SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
         let replacement_address: SocketAddr = format!("0.0.0.0:{port}").parse().unwrap();
-        let host_key_dir = tempfile::tempdir().unwrap();
-        let host_key_path = host_key_dir.path().join("ssh_host_ed25519_key");
 
         let guest = Arc::new(GuestServer::new(GuestLayout::new()));
         guest.ssh_manager.attach_guest(&guest);
         let original = guest
             .ssh_manager
-            .configure(
-                SshConfig::new(old_address, ca_public_key(), "box_123")
-                    .unwrap()
-                    .with_host_key_path(host_key_path.clone()),
-            )
+            .configure(SshConfig::new(old_address, ca_public_key(), "box_123").unwrap())
             .await
             .unwrap();
 
         let replacement = guest
             .ssh_manager
-            .configure(
-                SshConfig::new(replacement_address, ca_public_key(), "box_456")
-                    .unwrap()
-                    .with_host_key_path(host_key_path),
-            )
+            .configure(SshConfig::new(replacement_address, ca_public_key(), "box_456").unwrap())
             .await;
 
         assert!(replacement.is_err());

--- a/src/guest/src/service/ssh/server.rs
+++ b/src/guest/src/service/ssh/server.rs
@@ -721,6 +721,7 @@ fn apply_pty_request(
     true
 }
 
+#[allow(dead_code)]
 pub(crate) fn build_config(host_key: PrivateKey) -> russh::server::Config {
     let mut methods = MethodSet::empty();
     methods.push(MethodKind::PublicKey);

--- a/src/guest/src/storage/block_device.rs
+++ b/src/guest/src/storage/block_device.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use std::process::Command;
 
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
+use boxlite_shared::layout::BIN_DIR;
 use boxlite_shared::Filesystem;
 use nix::libc;
 use nix::mount::{mount, MsFlags};
@@ -200,7 +201,9 @@ impl BlockDeviceMount {
         // leaving us with ECHILD. See reaper::reap_fence.
         let output = {
             let _fence = crate::reaper::reap_fence();
-            Command::new("resize2fs").arg(device).output()
+            Command::new(format!("{BIN_DIR}/resize2fs"))
+                .arg(device)
+                .output()
         }
         .map_err(|e| BoxliteError::Storage(format!("Failed to execute resize2fs: {}", e)))?;
 
@@ -243,7 +246,7 @@ impl BlockDeviceMount {
             );
         }
 
-        let mkfs_cmd = format!("mkfs.{}", filesystem);
+        let mkfs_cmd = format!("{BIN_DIR}/mkfs.{}", filesystem);
         // Fence the reaper across spawn-and-wait (see reap_fence): output()
         // self-waits and would otherwise race waitpid(-1) into ECHILD.
         let output = {

--- a/src/shared/src/layout.rs
+++ b/src/shared/src/layout.rs
@@ -87,6 +87,11 @@ pub mod dirs {
 /// Guest base path (FHS-compliant).
 pub const GUEST_BASE: &str = "/run/boxlite";
 
+/// Guest binary directory — holds `boxlite-guest` plus the static filesystem
+/// tools (`mke2fs`, `resize2fs`, `mkfs.ext4`). Shared so the host (entrypoint
+/// path) and the guest (absolute tool paths) agree on one location.
+pub const BIN_DIR: &str = "/boxlite/bin";
+
 // ============================================================================
 // SHARED CONTAINER LAYOUT (per-container directories)
 // ============================================================================

--- a/src/test-utils/src/lib.rs
+++ b/src/test-utils/src/lib.rs
@@ -28,7 +28,7 @@ pub mod sync_point;
 pub const TEST_SHUTDOWN_TIMEOUT: i32 = 10;
 
 /// Images to pre-pull during cache warm-up.
-pub const TEST_IMAGES: &[&str] = &["alpine:latest", "debian:bookworm-slim", "python:alpine"];
+pub const TEST_IMAGES: &[&str] = &["alpine:latest", "python:alpine"];
 
 /// Docker Hub mirror registries for reliable image pulls.
 /// Mirrors are tried first; `docker.io` is the final fallback.


### PR DESCRIPTION
## Summary

Switch the default boot rootfs from the OCI Debian image to the minimal rootfs (static `boxlite-guest` + `mke2fs`/`resize2fs`/`mkfs.ext4`), and drop the per-box qcow2 COW overlay — the shared base ext4 is now attached read-only.

## Call graph

Before
```text
run_guest_rootfs  (GuestRootfsTask · src/boxlite/src/litebox/init/tasks/guest_rootfs.rs)
  └─ pull_guest_rootfs_image → debian:bookworm-slim                       — OCI pull
       └─ GuestRootfsManager::get_or_create → ext4 + inject boxlite-guest
            └─ create_or_reuse_cow_disk → boxes/{id}/disks/guest-rootfs.qcow2  — per-box COW overlay
                 └─ configure_guest_rootfs → add_block_device(Qcow2, rw)
                      └─ set_root_disk_remount(device, "ext4", None)       — rw mount
```

After
```text
run_guest_rootfs  (GuestRootfsTask · src/boxlite/src/litebox/init/tasks/guest_rootfs.rs)
  └─ GuestRootfsManager::get_or_create_minimal → bases/{key}.ext4          — no OCI, no overlay
       └─ configure_guest_rootfs → add_block_device(Ext4, read_only=true)
            └─ set_root_disk_remount(device, "ext4", "ro")                 — read-only mount
```

## Changes

- Boot path calls `get_or_create_minimal` instead of pulling `debian:bookworm-slim`.
- Drop the per-box `guest-rootfs.qcow2` COW overlay; the shared base ext4 is attached `read_only=true` and mounted `"ro"`. Read-only is enforced at three layers: jailer `--ro-bind bases/`, `is_disk_read_only`, and the `ro` mount.
- Pre-create `/tmp`, `/var/tmp`, `/run`, `/dev`, `/proc`, `/sys` in the image (the rootfs is read-only, so boot-time `mkdir` cannot create them).
- Remove `seal_root_readonly` and SSH host-key provisioning; the embedded SSH server is disabled (the read-only rootfs has nowhere to persist a host key), and its four `configure()`-driven tests are ignored.
- Resolve the guest's `resize2fs`/`mkfs.ext4` by absolute path (`boxlite_shared::layout::BIN_DIR`).
- Remove the `BOXLITE_EXPERIMENTAL=minimal-rootfs` gate.
- Stop exporting/importing the guest rootfs disk (archive/clone/import no longer handle `guest-rootfs.qcow2`).
- Reject dynamically-linked guest artifacts and parse ELF program headers with checked arithmetic (a malformed header errors instead of panicking).
- Propagate guest-artifact resolution errors in rootfs GC instead of deleting every cached entry, and validate cached e2fsprogs tools under `SKIP_GUEST_BUILD`.

## How to verify

- `make cli`, then `boxlite run --rm python:alpine python -c "print('hi')"` → prints `hi`.
- `boxes/{id}/disks/` contains only `disk.qcow2` (no `guest-rootfs.qcow2`).
- In the guest: writing to `/` fails (read-only), writing to `/tmp` succeeds.
- Host-side `bases/{minimal-key}.ext4` sha256 is unchanged before/after a boot.
- Image cache has no `debian:bookworm-slim` entry.
- `cargo test -p boxlite --lib` (guest_check / archive / rootfs / guest_rootfs suites) and `cargo clippy --workspace --all-targets --all-features -- -D warnings` pass.

## Risks / rollout

- The guest rootfs is read-only and the embedded SSH server is disabled (no host key, no SSH/SFTP into the guest control plane).
- Safety boundary: the base is a read-only block device (`is_disk_read_only`), and the jailer `--ro-bind`s `bases/` read-only, so the guest cannot write the shared image. This is the "normal path" read-only guarantee; it is not the stronger "guest cannot see the base at all" isolation that the qcow overlay provided.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Guest root filesystems are now shared and read-only, reducing per-box storage overhead.
  - Runtime filesystem tools are bundled and validated for reliable guest operation.

- **Bug Fixes**
  - Fixed root filesystem access when the installation directory uses symlinks.
  - Improved validation of guest binaries and malformed executable metadata.

- **Behavior Changes**
  - Box archives now include only the container disk.
  - SSH host-key provisioning is unavailable with the read-only guest filesystem.
  - The minimal-rootfs experimental option has been removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->