### PR TITLE
fix(dashboard): make the wallet warn, and name the unsubscribed modes

### DIFF
--- a/apps/dashboard/src/components/billing/BalanceLowBanner.test.ts
+++ b/apps/dashboard/src/components/billing/BalanceLowBanner.test.ts
@@ -1,29 +1,56 @@
 import { describe, expect, it } from 'vitest'
-import { lowBalance } from './BalanceLowBanner'
+import { balanceWarning } from './BalanceLowBanner'
 
 const autoTopUp = { thresholdAmount: 20, targetAmount: 100 }
+const spentQuota = { quotaRemainingCents: 0 }
 
-describe('lowBalance', () => {
+describe('balanceWarning', () => {
   it('fires below the configured threshold (dollars) against the balance (cents)', () => {
-    expect(lowBalance({ ongoingBalanceCents: 1_999, automaticTopUp: autoTopUp })).toEqual({
+    expect(balanceWarning({ ongoingBalanceCents: 1_999, automaticTopUp: autoTopUp })).toEqual({
+      level: 'below-threshold',
       thresholdDollars: 20,
       targetDollars: 100,
     })
   })
 
   it('stays silent at or above the threshold', () => {
-    expect(lowBalance({ ongoingBalanceCents: 2_000, automaticTopUp: autoTopUp })).toBeNull()
-    expect(lowBalance({ ongoingBalanceCents: 8_750, automaticTopUp: autoTopUp })).toBeNull()
+    expect(balanceWarning({ ongoingBalanceCents: 2_000, automaticTopUp: autoTopUp })).toBeNull()
+    expect(balanceWarning({ ongoingBalanceCents: 8_750, automaticTopUp: autoTopUp })).toBeNull()
   })
 
-  it('stays silent with no auto-reload configured — there is no threshold to compare', () => {
-    expect(lowBalance({ ongoingBalanceCents: -500 })).toBeNull()
-    expect(lowBalance(undefined)).toBeNull()
-  })
-
-  it('treats a zeroed threshold as disabled, the WalletSection convention', () => {
+  it('warns on a negative balance even with no auto-reload to compare against', () => {
+    // The reload threshold lives behind a linked card, so requiring one here is
+    // what let an unlinked account run negative in silence.
+    expect(balanceWarning({ ongoingBalanceCents: -3 })).toEqual({ level: 'overdrawn' })
     expect(
-      lowBalance({ ongoingBalanceCents: -500, automaticTopUp: { thresholdAmount: 0, targetAmount: 0 } }),
-    ).toBeNull()
+      balanceWarning({ ongoingBalanceCents: -500, automaticTopUp: { thresholdAmount: 0, targetAmount: 0 } }),
+    ).toEqual({ level: 'overdrawn' })
+  })
+
+  it('warns on an empty wallet once quota is spent', () => {
+    expect(balanceWarning({ ongoingBalanceCents: 0 }, spentQuota)).toEqual({ level: 'empty' })
+  })
+
+  it('stays quiet on an empty wallet that quota still stands in front of', () => {
+    // A funded plan is *expected* to sit at $0 wallet; warning there is noise.
+    expect(balanceWarning({ ongoingBalanceCents: 0 }, { quotaRemainingCents: 18_750 })).toBeNull()
+  })
+
+  it('reads a null quota remaining as an unlimited grant, not an exhausted one', () => {
+    expect(balanceWarning({ ongoingBalanceCents: 0 }, { quotaRemainingCents: null })).toBeNull()
+  })
+
+  it('warns on an empty wallet when there is no plan at all', () => {
+    expect(balanceWarning({ ongoingBalanceCents: 0 })).toEqual({ level: 'empty' })
+  })
+
+  it('does not let leftover quota excuse a draw that already happened', () => {
+    expect(balanceWarning({ ongoingBalanceCents: -3 }, { quotaRemainingCents: 18_750 })).toEqual({
+      level: 'overdrawn',
+    })
+  })
+
+  it('stays silent without a wallet', () => {
+    expect(balanceWarning(undefined)).toBeNull()
   })
 })

--- a/apps/dashboard/src/components/billing/BalanceLowBanner.tsx
+++ b/apps/dashboard/src/components/billing/BalanceLowBanner.tsx
@@ -3,50 +3,114 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { OrganizationWallet } from '@/billing-api'
-import { useOwnerWalletQuery } from '@/hooks/queries/billingQueries'
+import { OrganizationPlan, OrganizationWallet } from '@/billing-api'
+import { useOwnerPlanQuery, useOwnerWalletQuery } from '@/hooks/queries/billingQueries'
 import { formatAmount } from '@/lib/utils'
+import { cn } from '@/lib/utils'
+
+type WalletFacts = Pick<OrganizationWallet, 'ongoingBalanceCents' | 'automaticTopUp'>
+type PlanFacts = Pick<OrganizationPlan, 'quotaRemainingCents'>
+
+export type BalanceWarning =
+  /** Usage has drawn past the balance. Wrong under every plan, so it always fires. */
+  | { level: 'overdrawn' }
+  /** Nothing left to draw on, and no quota standing in front of the wallet. */
+  | { level: 'empty' }
+  /** Still funded, but under the reload point the user set for themselves. */
+  | { level: 'below-threshold'; thresholdDollars: number; targetDollars: number }
 
 /**
- * The banner fires only against the auto-reload threshold the user set —
- * the one honest low-balance line that exists. A zeroed threshold means
- * auto-reload is disabled (WalletSection's own convention), not "warn below
- * $0". Thresholds are wire dollars; the balance is cents.
+ * Which low-balance warning the wallet has earned, if any.
+ *
+ * The threshold tier alone used to be the whole rule, which made the banner
+ * unreachable in the case that needs it most: the reload threshold lives behind
+ * a linked card, so an account that never linked one could run its balance
+ * negative in silence. Overdrawn and empty are therefore judged on the balance
+ * itself, with no configuration to opt into.
+ *
+ * Quota matters only for `empty`: a plan with quota left is *expected* to sit at
+ * a $0 wallet, and warning there would be noise on a healthy account. Overdrawn
+ * is not excused by quota — the draw already happened.
+ *
+ * Thresholds are wire dollars; balances are cents.
  */
-export function lowBalance(
-  wallet: Pick<OrganizationWallet, 'ongoingBalanceCents' | 'automaticTopUp'> | undefined,
-): { thresholdDollars: number; targetDollars: number } | null {
-  const threshold = wallet?.automaticTopUp?.thresholdAmount
-  const target = wallet?.automaticTopUp?.targetAmount
-  if (!wallet || !threshold || !target) return null
-  if (wallet.ongoingBalanceCents / 100 >= threshold) return null
-  return { thresholdDollars: threshold, targetDollars: target }
+export function balanceWarning(wallet: WalletFacts | undefined, plan?: PlanFacts | null): BalanceWarning | null {
+  if (!wallet) return null
+
+  const balanceCents = wallet.ongoingBalanceCents
+  if (balanceCents < 0) return { level: 'overdrawn' }
+
+  // `null` remaining is an unlimited/negotiated grant, not an exhausted one.
+  const quotaRemainingCents = plan?.quotaRemainingCents
+  const quotaCovers = quotaRemainingCents === null || (quotaRemainingCents ?? 0) > 0
+  if (balanceCents === 0 && !quotaCovers) return { level: 'empty' }
+
+  const thresholdDollars = wallet.automaticTopUp?.thresholdAmount
+  const targetDollars = wallet.automaticTopUp?.targetAmount
+  // A zeroed threshold means auto-reload is off (WalletSection's convention),
+  // not "warn below $0" — that case is already covered above.
+  if (!thresholdDollars || !targetDollars) return null
+  if (balanceCents / 100 >= thresholdDollars) return null
+
+  return { level: 'below-threshold', thresholdDollars, targetDollars }
+}
+
+const COPY: Record<BalanceWarning['level'], { title: (balance: string) => string; destructive: boolean }> = {
+  overdrawn: { title: (balance) => `Wallet overdrawn — ${balance}`, destructive: true },
+  empty: { title: () => 'Wallet empty — $0.00 remaining', destructive: false },
+  'below-threshold': { title: (balance) => `Wallet balance low — ${balance} remaining`, destructive: false },
+}
+
+function detail(warning: BalanceWarning): string {
+  switch (warning.level) {
+    case 'overdrawn':
+      return 'Usage has already drawn past your balance. Top up to settle it.'
+    case 'empty':
+      return 'Your included quota is spent, so further usage draws on the wallet. Top up to keep going.'
+    case 'below-threshold':
+      return `Auto-reload brings the balance to $${warning.targetDollars.toFixed(2)} when it drops below $${warning.thresholdDollars.toFixed(2)}.`
+  }
 }
 
 /**
- * Warns when the wallet has fallen below the user's own auto-reload
- * threshold. Suspension states are the global banner's job
- * (useSuspensionBanner), not repeated here.
+ * Warns on a wallet that cannot fund what comes next. Suspension states are the
+ * global banner's job (useSuspensionBanner), not repeated here.
  */
 export function BalanceLowBanner({ onGoToWallet }: { onGoToWallet: () => void }) {
   const { data: wallet } = useOwnerWalletQuery()
-  const low = lowBalance(wallet)
-  if (!wallet || !low) return null
+  const { data: plan } = useOwnerPlanQuery()
+  const warning = balanceWarning(wallet, plan)
+  if (!wallet || !warning) return null
+
+  const { title, destructive } = COPY[warning.level]
+  const tone = destructive ? 'destructive' : 'warning'
 
   return (
-    <div className="flex flex-wrap items-center justify-between gap-4 border border-warning/60 bg-warning/10 px-[22px] py-4">
+    <div
+      className={cn(
+        'flex flex-wrap items-center justify-between gap-4 border px-[22px] py-4',
+        destructive ? 'border-destructive/60 bg-destructive/10' : 'border-warning/60 bg-warning/10',
+      )}
+    >
       <div className="flex flex-col gap-1">
-        <span className="flex items-center gap-2 font-mono text-[12px] font-semibold text-warning">
-          <span className="size-[9px]" style={{ background: 'hsl(var(--warning))' }} />
-          Wallet balance low — {formatAmount(wallet.ongoingBalanceCents)} remaining
+        <span
+          className={cn(
+            'flex items-center gap-2 font-mono text-[12px] font-semibold',
+            destructive ? 'text-destructive' : 'text-warning',
+          )}
+        >
+          <span className="size-[9px]" style={{ background: `hsl(var(--${tone}))` }} />
+          {title(formatAmount(wallet.ongoingBalanceCents))}
         </span>
-        <span className="font-mono text-[11px] text-muted-foreground">
-          Auto-reload brings the balance to ${low.targetDollars.toFixed(2)} when it drops below $
-          {low.thresholdDollars.toFixed(2)}.
-        </span>
+        <span className="font-mono text-[11px] text-muted-foreground">{detail(warning)}</span>
       </div>
       <button
-        className="border border-warning/60 px-4 py-2 font-mono text-[12px] text-warning transition-colors hover:bg-warning/10"
+        className={cn(
+          'border px-4 py-2 font-mono text-[12px] transition-colors',
+          destructive
+            ? 'border-destructive/60 text-destructive hover:bg-destructive/10'
+            : 'border-warning/60 text-warning hover:bg-warning/10',
+        )}
         onClick={onGoToWallet}
       >
         Top up →

--- a/apps/dashboard/src/components/billing/CycleOverview.test.ts
+++ b/apps/dashboard/src/components/billing/CycleOverview.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { OrganizationPlan } from '@/billing-api'
+import { billingMode } from './CycleOverview'
+
+const plan: OrganizationPlan = {
+  planId: 'pro',
+  planName: 'Pro',
+  status: 'active',
+  cycleFrom: new Date('2026-08-05T12:00:00.000Z'),
+  cycleTo: new Date('2026-09-05T12:00:00.000Z'),
+  includedQuotaCents: 25_000,
+  quotaConsumedCents: 6_250,
+  quotaRemainingCents: 18_750,
+}
+
+describe('billingMode', () => {
+  it('reads a live plan as the plan mode, whatever credit sits behind it', () => {
+    expect(billingMode({ creditGrantedCents: 10_000, creditRemainingCents: 10_000 }, plan)).toEqual({
+      kind: 'plan',
+      plan,
+    })
+  })
+
+  it('reads an unsubscribed account with a grant as a free trial', () => {
+    expect(billingMode({ creditGrantedCents: 10_000, creditRemainingCents: 6_230 })).toEqual({
+      kind: 'free-trial',
+      grantedCents: 10_000,
+      remainingCents: 6_230,
+    })
+  })
+
+  it('stays a free trial once the grant is spent — the account is still on one', () => {
+    expect(billingMode({ creditGrantedCents: 10_000, creditRemainingCents: 0 })).toEqual({
+      kind: 'free-trial',
+      grantedCents: 10_000,
+      remainingCents: 0,
+    })
+  })
+
+  it('is pay-as-you-go when Commerce has granted nothing', () => {
+    // The state a fresh account is in today: the grant is not implemented, so
+    // claiming a free trial would promise credit the wallet does not hold.
+    expect(billingMode({ creditGrantedCents: 0, creditRemainingCents: 0 })).toEqual({ kind: 'payg' })
+  })
+
+  it('is pay-as-you-go when Commerce reports no credit fields at all', () => {
+    expect(billingMode({})).toEqual({ kind: 'payg' })
+  })
+
+  it('treats a granted-but-unreported remainder as fully spent rather than inventing one', () => {
+    expect(billingMode({ creditGrantedCents: 10_000 })).toEqual({
+      kind: 'free-trial',
+      grantedCents: 10_000,
+      remainingCents: 0,
+    })
+  })
+})

--- a/apps/dashboard/src/components/billing/CycleOverview.tsx
+++ b/apps/dashboard/src/components/billing/CycleOverview.tsx
@@ -4,80 +4,221 @@
  */
 
 import { OrganizationPlan, OrganizationWallet, Plan } from '@/billing-api'
-import { BRAND, Metric, Panel } from '@/components/ascii'
+import { BRAND, Metric, Panel, PanelNote, SectionTitle, SegmentedBar } from '@/components/ascii'
+import { useUsagePricesQuery } from '@/hooks/queries/useUsagePricesQuery'
+import { formatPriceCents } from '@/lib/box-price'
 import { formatAmount, formatWholeDollars } from '@/lib/utils'
 
 /**
- * Active-plan banner: a header strip naming the current plan, then the cycle
- * figures from the organization plan and wallet. Catalog data is joined by
- * plan id for the self-serve price and cosmetic tier label; negotiated plans
- * remain honest when they have no public catalog row.
+ * How this organization is being billed right now, and the figures that follow
+ * from it.
+ *
+ * Three modes, because "no subscription" is not one state. An account on free
+ * credits and an account paying its own way both lack a plan, but they are
+ * reading for different numbers — how much of the grant is left, versus what
+ * the wallet is funding. Rendering both as the word "No plan" told neither of
+ * them anything, and labelled the panel "Active plan" while saying there wasn't
+ * one.
  */
+export type BillingMode =
+  | { kind: 'plan'; plan: OrganizationPlan }
+  /** No subscription, still spending a grant. Credit is what they watch. */
+  | { kind: 'free-trial'; grantedCents: number; remainingCents: number }
+  /** No subscription and no grant: usage is charged to the wallet, per hour. */
+  | { kind: 'payg' }
+
+const TITLE: Record<BillingMode['kind'], string> = {
+  plan: 'Active Plan',
+  'free-trial': 'Free Credits',
+  payg: 'Billing',
+}
+
+/**
+ * A grant that was never issued is not a free trial — `creditGrantedCents` is
+ * absent (Commerce does not track one) or zero (tracked, none given). Both read
+ * as pay-as-you-go, which is what the account actually is until the grant lands.
+ */
+export function billingMode(
+  wallet: Pick<OrganizationWallet, 'creditGrantedCents' | 'creditRemainingCents'>,
+  plan?: OrganizationPlan | null,
+): BillingMode {
+  if (plan) {
+    return { kind: 'plan', plan }
+  }
+  const grantedCents = wallet.creditGrantedCents ?? 0
+  if (grantedCents > 0) {
+    return { kind: 'free-trial', grantedCents, remainingCents: wallet.creditRemainingCents ?? 0 }
+  }
+  return { kind: 'payg' }
+}
 
 export function CycleOverview({
   wallet,
   organizationPlan,
   catalogPlan,
   catalogIndex,
+  plansAnchorId,
 }: {
   wallet: OrganizationWallet
   organizationPlan?: OrganizationPlan | null
   catalogPlan?: Plan
   catalogIndex?: number
+  plansAnchorId?: string
 }) {
+  const mode = billingMode(wallet, organizationPlan)
   const tierLabel = catalogIndex === undefined ? 'Plan' : `T${catalogIndex + 1}`
 
   return (
-    <Panel>
-      {/* Header strip */}
-      <div className="flex flex-wrap items-center gap-4 px-[22px] py-5">
-        <div className="flex items-center gap-3">
-          {organizationPlan && (
-            <span className="font-mono text-[10px] uppercase tracking-[1.5px] text-muted-foreground">
-              <span style={{ color: BRAND }}>▸</span> {tierLabel}
+    <section>
+      <SectionTitle title={TITLE[mode.kind]} />
+      <Panel>
+        <div className="flex flex-wrap items-center gap-4 px-[22px] py-5">
+          <div className="flex items-center gap-3">
+            {mode.kind === 'plan' && (
+              <span className="font-mono text-[10px] uppercase tracking-[1.5px] text-muted-foreground">
+                <span style={{ color: BRAND }}>▸</span> {tierLabel}
+              </span>
+            )}
+            <span className="font-mono text-[18px] font-semibold tracking-tight text-foreground">
+              {mode.kind === 'plan' ? mode.plan.planName : mode.kind === 'free-trial' ? 'Free trial' : 'Pay as you go'}
+              <span className="ml-1 animate-pulse text-muted-foreground">▮</span>
             </span>
-          )}
-          <span className="font-mono text-[18px] font-semibold tracking-tight text-foreground">
-            {organizationPlan ? organizationPlan.planName : 'No plan'}
-            <span className="ml-1 animate-pulse text-muted-foreground">▮</span>
-          </span>
-          {organizationPlan && (
-            <span className="bg-foreground px-2 py-0.5 font-mono text-[10px] uppercase tracking-[1px] text-background">
-              {organizationPlan.status}
+            {mode.kind === 'plan' && (
+              <span className="bg-foreground px-2 py-0.5 font-mono text-[10px] uppercase tracking-[1px] text-background">
+                {mode.plan.status}
+              </span>
+            )}
+          </div>
+          {mode.kind === 'plan' && catalogPlan?.priceMonthlyCents != null ? (
+            <span className="ml-auto font-mono text-[11px] text-muted-foreground">
+              {formatWholeDollars(catalogPlan.priceMonthlyCents)}/mo
             </span>
-          )}
+          ) : mode.kind !== 'plan' ? (
+            <span className="ml-auto font-mono text-[11px] text-muted-foreground">no subscription</span>
+          ) : null}
         </div>
-        {catalogPlan?.priceMonthlyCents != null && (
-          <span className="ml-auto font-mono text-[11px] text-muted-foreground">
-            {formatWholeDollars(catalogPlan.priceMonthlyCents)}/mo
-          </span>
-        )}
-      </div>
 
-      {/* Cycle figures */}
-      <div className="grid grid-cols-2 gap-5 border-t border-border px-[22px] py-5 sm:flex sm:flex-row sm:gap-14">
-        <Metric
-          label="Subscription"
-          value={organizationPlan?.planName ?? 'No plan'}
-          sub={
-            catalogPlan?.priceMonthlyCents != null
-              ? `${formatWholeDollars(catalogPlan.priceMonthlyCents)}/mo`
-              : undefined
-          }
-        />
-        <Metric label="Wallet balance" value={formatAmount(wallet.ongoingBalanceCents)} />
-        {organizationPlan && (
-          <Metric
-            label="Quota consumed"
-            value={formatAmount(organizationPlan.quotaConsumedCents)}
-            sub={
-              organizationPlan.includedQuotaCents == null
-                ? 'unlimited quota'
-                : `/ ${formatAmount(organizationPlan.includedQuotaCents)}`
-            }
-          />
+        {mode.kind === 'plan' ? (
+          <PlanFigures plan={mode.plan} wallet={wallet} catalogPlan={catalogPlan} />
+        ) : mode.kind === 'free-trial' ? (
+          <FreeTrialFigures mode={mode} wallet={wallet} />
+        ) : (
+          <PaygFigures wallet={wallet} />
         )}
+
+        {mode.kind !== 'plan' && <UnsubscribedNote mode={mode} plansAnchorId={plansAnchorId} />}
+      </Panel>
+    </section>
+  )
+}
+
+const FIGURES = 'grid grid-cols-2 gap-5 border-t border-border px-[22px] py-5 sm:flex sm:flex-row sm:gap-14'
+
+function PlanFigures({
+  plan,
+  wallet,
+  catalogPlan,
+}: {
+  plan: OrganizationPlan
+  wallet: OrganizationWallet
+  catalogPlan?: Plan
+}) {
+  return (
+    <div className={FIGURES}>
+      <Metric
+        label="Subscription"
+        value={plan.planName}
+        sub={
+          catalogPlan?.priceMonthlyCents != null ? `${formatWholeDollars(catalogPlan.priceMonthlyCents)}/mo` : undefined
+        }
+      />
+      <Metric label="Wallet balance" value={formatAmount(wallet.ongoingBalanceCents)} />
+      <Metric
+        label="Quota consumed"
+        value={formatAmount(plan.quotaConsumedCents)}
+        sub={plan.includedQuotaCents == null ? 'unlimited quota' : `/ ${formatAmount(plan.includedQuotaCents)}`}
+      />
+    </div>
+  )
+}
+
+function FreeTrialFigures({
+  mode,
+  wallet,
+}: {
+  mode: Extract<BillingMode, { kind: 'free-trial' }>
+  wallet: OrganizationWallet
+}) {
+  const spentCents = Math.max(0, mode.grantedCents - mode.remainingCents)
+  return (
+    <>
+      <div className={FIGURES}>
+        <Metric
+          label="Free credits left"
+          value={formatAmount(mode.remainingCents)}
+          sub={`of ${formatAmount(mode.grantedCents)} granted`}
+        />
+        <Metric label="Wallet balance" value={formatAmount(wallet.ongoingBalanceCents)} sub="used after credits" />
       </div>
-    </Panel>
+      <div className="border-t border-border px-[22px] py-4">
+        <div className="flex items-center gap-4 font-mono text-[12px]">
+          <span className="w-[100px] shrink-0 uppercase tracking-[0.5px] text-muted-foreground">Credits used</span>
+          <span className="w-[140px] shrink-0 tabular-nums text-foreground">
+            {formatAmount(spentCents)} / {formatAmount(mode.grantedCents)}
+          </span>
+          {/* Fills as the grant is spent — the bar's warning colours only read
+              correctly when the filled part is the part that is gone. */}
+          <SegmentedBar used={spentCents} limit={mode.grantedCents} />
+        </div>
+      </div>
+    </>
+  )
+}
+
+function PaygFigures({ wallet }: { wallet: OrganizationWallet }) {
+  // Commerce's ongoing balance is the wallet minus usage it has metered but not
+  // yet invoiced, so the gap is exactly what this period has drawn. Naming it
+  // "this month" would be a guess: without a subscription there is no cycle.
+  const uninvoicedCents = Math.max(0, wallet.balanceCents - wallet.ongoingBalanceCents)
+  return (
+    <div className={FIGURES}>
+      <Metric label="Wallet balance" value={formatAmount(wallet.ongoingBalanceCents)} sub="funds every box" />
+      {uninvoicedCents > 0 && (
+        <Metric label="Uninvoiced usage" value={formatAmount(uninvoicedCents)} sub="drawn, not yet billed" />
+      )}
+    </div>
+  )
+}
+
+/** Says what happens next, and points at the grid that changes it. */
+function UnsubscribedNote({
+  mode,
+  plansAnchorId,
+}: {
+  mode: Extract<BillingMode, { kind: 'free-trial' | 'payg' }>
+  plansAnchorId?: string
+}) {
+  const { data: prices } = useUsagePricesQuery()
+  const cpu = prices?.prices.find((price) => price.code === 'cpu')
+  const fromRate = cpu ? ` — from ${formatPriceCents(cpu.unitPriceCents, 6)}/vCPU·hr` : ''
+  const howItIsCharged =
+    mode.kind === 'free-trial'
+      ? 'Usage draws on your free credits first, then on the wallet.'
+      : `Usage is charged to your wallet at the published rates${fromRate}.`
+
+  return (
+    <div className="border-t border-border px-[22px] py-4">
+      <PanelNote>
+        {howItIsCharged} A plan adds included quota at a lower effective rate.
+        {plansAnchorId && (
+          <>
+            {' '}
+            <a href={`#${plansAnchorId}`} className="text-foreground underline underline-offset-2">
+              Compare plans ↓
+            </a>
+          </>
+        )}
+      </PanelNote>
+    </div>
   )
 }

--- a/apps/dashboard/src/components/billing/PlanSection.tsx
+++ b/apps/dashboard/src/components/billing/PlanSection.tsx
@@ -15,6 +15,8 @@ import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { OrganizationUserRoleEnum } from '@boxlite-ai/api-client'
 import { RefreshCcw } from '@/components/ui/icon'
 
+const ALL_PLANS_ANCHOR = 'all-plans'
+
 export function PlanSection() {
   const { selectedOrganization, authenticatedUserOrganizationMember } = useSelectedOrganization()
   const organizationPlanQuery = useOwnerPlanQuery()
@@ -58,19 +60,17 @@ export function PlanSection() {
       ) : (
         <div className="flex flex-col gap-8">
           {config.billingApiUrl && isOwner && wallet && (
-            <section>
-              <SectionTitle title="Active Plan" />
-              <CycleOverview
-                wallet={wallet}
-                organizationPlan={organizationPlan}
-                catalogPlan={activeCatalogPlan}
-                catalogIndex={activeCatalogIndex >= 0 ? activeCatalogIndex : undefined}
-              />
-            </section>
+            <CycleOverview
+              wallet={wallet}
+              organizationPlan={organizationPlan}
+              catalogPlan={activeCatalogPlan}
+              catalogIndex={activeCatalogIndex >= 0 ? activeCatalogIndex : undefined}
+              plansAnchorId={ALL_PLANS_ANCHOR}
+            />
           )}
 
           {config.billingApiUrl && isOwner && selectedOrganization && (
-            <section>
+            <section id={ALL_PLANS_ANCHOR} className="scroll-mt-6">
               <SectionTitle title="All Plans" count={plans ? `${plans.length + 1} tiers` : undefined} />
               {isLoading ? (
                 <PlanCardsSkeleton count={4} />

--- a/apps/dashboard/src/components/billing/WalletSection.test.ts
+++ b/apps/dashboard/src/components/billing/WalletSection.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { MIN_TOP_UP_DOLLARS, topUpGate } from './WalletSection'
+
+describe('topUpGate', () => {
+  it('names the missing card rather than leaving the button dead and unexplained', () => {
+    expect(topUpGate(false, 100)).toEqual({
+      enabled: false,
+      reason: 'Connect a payment method above to add funds.',
+    })
+  })
+
+  it('stays quiet with nothing chosen yet — a disabled button needs no excuse there', () => {
+    expect(topUpGate(true, undefined)).toEqual({ enabled: false, reason: null })
+    expect(topUpGate(true, 0)).toEqual({ enabled: false, reason: null })
+  })
+
+  it('states the minimum instead of letting Commerce reject the round trip', () => {
+    expect(topUpGate(true, 5)).toEqual({ enabled: false, reason: 'Minimum top-up is $10.' })
+    expect(topUpGate(true, MIN_TOP_UP_DOLLARS - 0.01).reason).toBe('Minimum top-up is $10.')
+  })
+
+  it('allows the minimum itself and anything above it', () => {
+    expect(topUpGate(true, MIN_TOP_UP_DOLLARS)).toEqual({ enabled: true, reason: null })
+    expect(topUpGate(true, 25)).toEqual({ enabled: true, reason: null })
+  })
+
+  it('reports the card before the amount — fixing the amount would not unblock anything', () => {
+    expect(topUpGate(false, 5).reason).toBe('Connect a payment method above to add funds.')
+  })
+})

--- a/apps/dashboard/src/components/billing/WalletSection.tsx
+++ b/apps/dashboard/src/components/billing/WalletSection.tsx
@@ -30,6 +30,38 @@ import { toast } from 'sonner'
 
 const DEFAULT_PAGE_SIZE = 10
 
+/** Commerce rejects anything smaller, so the form says so before the round trip. */
+export const MIN_TOP_UP_DOLLARS = 10
+
+/**
+ * What an unconfigured auto-reload starts at, so switching it on is one click
+ * rather than a policy decision the user has to invent.
+ */
+const DEFAULT_AUTO_RELOAD: AutomaticTopUp = { thresholdAmount: 20, targetAmount: 100 }
+
+/**
+ * Whether Top up can run, and why not when it cannot.
+ *
+ * A silently disabled button was the whole problem here: the real blocker is a
+ * missing card, which the control itself never said. `reason` is null only when
+ * there is nothing to say yet — no amount picked — which needs no explanation.
+ */
+export function topUpGate(
+  creditCardConnected: boolean,
+  amountDollars: number | undefined,
+): { enabled: boolean; reason: string | null } {
+  if (!creditCardConnected) {
+    return { enabled: false, reason: 'Connect a payment method above to add funds.' }
+  }
+  if (!amountDollars) {
+    return { enabled: false, reason: null }
+  }
+  if (amountDollars < MIN_TOP_UP_DOLLARS) {
+    return { enabled: false, reason: `Minimum top-up is $${MIN_TOP_UP_DOLLARS}.` }
+  }
+  return { enabled: true, reason: null }
+}
+
 export function WalletSection() {
   const { selectedOrganization } = useSelectedOrganization()
   const { user } = useAuth()
@@ -39,6 +71,10 @@ export function WalletSection() {
   const [redeemCouponSuccess, setRedeemCouponSuccess] = useState<string | null>(null)
   const [oneTimeTopUpAmount, setOneTimeTopUpAmount] = useState<number | undefined>(undefined)
   const [selectedPreset, setSelectedPreset] = useState<number | null>(100)
+  // Both are folded by default: one is a setting you touch once, the other a
+  // one-shot action. Neither earns six rows of the panel on every visit.
+  const [autoReloadOpen, setAutoReloadOpen] = useState(false)
+  const [couponOpen, setCouponOpen] = useState(false)
   const [invoicesPagination, setInvoicesPagination] = useState({
     pageIndex: 0,
     pageSize: DEFAULT_PAGE_SIZE,
@@ -56,9 +92,10 @@ export function WalletSection() {
   const topUpWalletMutation = useTopUpWalletMutation()
 
   useEffect(() => {
-    if (wallet?.automaticTopUp) {
-      setAutomaticTopUp(wallet.automaticTopUp)
+    if (!wallet) {
+      return
     }
+    setAutomaticTopUp(wallet.automaticTopUp ?? DEFAULT_AUTO_RELOAD)
   }, [wallet])
 
   const handleUpdatePaymentMethod = useCallback(async () => {
@@ -173,9 +210,12 @@ export function WalletSection() {
   }, [selectedOrganization, selectedPreset, oneTimeTopUpAmount, topUpWalletMutation])
 
   const isBillingLoading = walletQuery.isLoading && billingPortalUrlQuery.isLoading
-  const topUpEnabled =
-    wallet?.creditCardConnected && !topUpWalletMutation.isPending && (selectedPreset || oneTimeTopUpAmount)
-  const autoReloadEnabled = (automaticTopUp?.thresholdAmount ?? 0) > 0 || (automaticTopUp?.targetAmount ?? 0) > 0
+  const cardConnected = Boolean(wallet?.creditCardConnected)
+  const topUp = topUpGate(cardConnected, selectedPreset ?? oneTimeTopUpAmount)
+  // Read the indicator off the saved wallet, not the form: the form is
+  // pre-filled with defaults, which would otherwise read as already on.
+  const autoReloadActive =
+    (wallet?.automaticTopUp?.thresholdAmount ?? 0) > 0 || (wallet?.automaticTopUp?.targetAmount ?? 0) > 0
 
   return (
     <div className="flex flex-col gap-8">
@@ -205,6 +245,30 @@ export function WalletSection() {
         <div className="flex flex-col gap-8">
           {/* Wallet balance — one panel of divided rows: balance, add funds, auto-reload, coupon */}
           <section>
+            <SectionTitle title="Payment Method" />
+            <Panel className="px-[22px] py-4">
+              <div className="flex flex-wrap items-center justify-between gap-4">
+                {!wallet.creditCardConnected ? (
+                  <span className="font-mono text-[13px] text-muted-foreground">Payment method not connected</span>
+                ) : (
+                  <span className="flex items-center gap-2 font-mono text-[13px] text-foreground">
+                    <CheckCircleIcon className="size-4 shrink-0" /> Credit card connected
+                  </span>
+                )}
+                <AsciiButton
+                  variant={wallet.creditCardConnected ? 'secondary' : 'primary'}
+                  onClick={handleUpdatePaymentMethod}
+                  disabled={isCheckoutUrlLoading}
+                  className="inline-flex items-center gap-2"
+                >
+                  {isCheckoutUrlLoading && <Spinner />} {wallet.creditCardConnected ? 'Update card' : 'Connect'}
+                </AsciiButton>
+              </div>
+              <PanelNote>Used for top-up charges · card details are held by Stripe</PanelNote>
+            </Panel>
+          </section>
+
+          <section>
             <SectionTitle title="Wallet Balance" />
             <Panel className="px-[22px] py-5">
               <div className="flex items-baseline gap-3">
@@ -215,15 +279,24 @@ export function WalletSection() {
               </div>
 
               <div className="mt-4">
-                {wallet.creditGrantedCents !== undefined && wallet.creditRemainingCents !== undefined && (
+                {/* Only when a grant exists. A $0.00 / $0.00 row is not a fact
+                    about promotional credit, it is the absence of one. */}
+                {(wallet.creditGrantedCents ?? 0) > 0 && (
                   <>
                     <div className="mb-1.5 flex items-center justify-between font-mono text-[10px] uppercase tracking-[1px] text-muted-foreground">
                       <span>Promotional credit remaining</span>
                       <span className="tabular-nums">
-                        {formatAmount(wallet.creditRemainingCents)} / {formatAmount(wallet.creditGrantedCents)}
+                        {formatAmount(wallet.creditRemainingCents ?? 0)} /{' '}
+                        {formatAmount(wallet.creditGrantedCents ?? 0)}
                       </span>
                     </div>
-                    <SegmentedBar used={wallet.creditRemainingCents} limit={wallet.creditGrantedCents} />
+                    {/* Fill the spent part, not the remaining one: SegmentedBar
+                        turns amber past 80% and red past 90%, so passing the
+                        remainder painted a freshly granted, untouched credit red. */}
+                    <SegmentedBar
+                      used={Math.max(0, (wallet.creditGrantedCents ?? 0) - (wallet.creditRemainingCents ?? 0))}
+                      limit={wallet.creditGrantedCents ?? 0}
+                    />
                   </>
                 )}
                 {billingPortalUrlQuery.isLoading ? (
@@ -283,36 +356,58 @@ export function WalletSection() {
                 <AsciiButton
                   variant="primary"
                   onClick={handleTopUpWallet}
-                  disabled={!topUpEnabled}
+                  disabled={!topUp.enabled || topUpWalletMutation.isPending}
                   className="inline-flex w-full items-center justify-center gap-2 sm:ml-auto sm:w-auto"
                 >
                   {topUpWalletMutation.isPending && <Spinner />}
                   Top up →
                 </AsciiButton>
               </div>
-              <PanelNote>You will be redirected to Stripe to complete the payment.</PanelNote>
+              {topUp.reason && (
+                <p className="mt-3 font-mono text-[11px] leading-relaxed text-warning">{topUp.reason}</p>
+              )}
+              <PanelNote>
+                Minimum ${MIN_TOP_UP_DOLLARS} · you will be redirected to Stripe to complete the payment.
+              </PanelNote>
 
-              {wallet.creditCardConnected && (
-                <>
-                  <div className="my-5 h-px bg-border" />
+              {/* Auto-reload stays on the page without a card, disabled and
+                  labelled: hiding it is why nobody knew it existed, and it is
+                  also the only thing that arms the low-balance warning. */}
+              <>
+                <div className="my-5 h-px bg-border" />
 
-                  {/* Auto-reload — one row. Both API fields stay inline: the endpoint takes a
-                      threshold and a target, not a top-up amount. */}
-                  <div className="flex flex-wrap items-center justify-between gap-3">
+                <button
+                  type="button"
+                  aria-expanded={autoReloadOpen}
+                  aria-controls="auto-reload-settings"
+                  onClick={() => setAutoReloadOpen((wasOpen) => !wasOpen)}
+                  className="flex w-full items-center gap-2 font-mono text-[10px] uppercase tracking-[1.5px] text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  <span style={{ color: BRAND }}>{autoReloadOpen ? '▾' : '▸'}</span>
+                  Auto-reload
+                  <span
+                    className="size-[6px] rounded-full"
+                    style={{ background: autoReloadActive ? BRAND : 'hsl(var(--muted-foreground))' }}
+                  />
+                  {/* Folded, the row still answers the only question it is asked:
+                      is it on, and at what numbers. */}
+                  <span className="ml-auto normal-case tracking-normal">
+                    {autoReloadActive && wallet.automaticTopUp
+                      ? `Below $${wallet.automaticTopUp.thresholdAmount.toFixed(2)} → $${wallet.automaticTopUp.targetAmount.toFixed(2)}`
+                      : 'Off'}
+                  </span>
+                </button>
+
+                {autoReloadOpen && (
+                  <div id="auto-reload-settings" className="mt-3 flex flex-wrap items-center justify-between gap-3">
                     <div className="flex flex-col gap-1.5">
-                      <span className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-[1.5px] text-muted-foreground">
-                        Auto-reload
-                        <span
-                          className="size-[6px] rounded-full"
-                          style={{ background: autoReloadEnabled ? BRAND : 'hsl(var(--muted-foreground))' }}
-                        />
-                      </span>
                       <div className="flex flex-wrap items-center gap-2 font-mono text-[13px] text-foreground">
                         <span>when balance &lt;</span>
                         <span className="inline-flex items-center border border-border px-2 py-1 transition-colors focus-within:border-brand">
                           <span className="text-muted-foreground">$</span>
                           <NumericFormat
                             id="thresholdAmount"
+                            disabled={!cardConnected}
                             placeholder="0.00"
                             inputMode="decimal"
                             thousandSeparator
@@ -339,6 +434,7 @@ export function WalletSection() {
                           <span className="text-muted-foreground">$</span>
                           <NumericFormat
                             id="targetAmount"
+                            disabled={!cardConnected}
                             placeholder="0.00"
                             inputMode="decimal"
                             thousandSeparator
@@ -369,77 +465,73 @@ export function WalletSection() {
                     </div>
                     <AsciiButton
                       onClick={handleSetAutomaticTopUp}
-                      disabled={saveAutomaticTopUpDisabled || walletQuery.isLoading || !wallet}
+                      disabled={!cardConnected || saveAutomaticTopUpDisabled || walletQuery.isLoading || !wallet}
                       className="inline-flex items-center gap-2"
                     >
                       {setAutomaticTopUpMutation.isPending && <Spinner />} Save
                     </AsciiButton>
                   </div>
-                  <PanelNote>Target must be at least $10 above the threshold · set both to 0 to disable</PanelNote>
-                </>
-              )}
+                )}
+                {autoReloadOpen &&
+                  (cardConnected ? (
+                    <PanelNote>Target must be at least $10 above the threshold · set both to 0 to disable</PanelNote>
+                  ) : (
+                    <p className="mt-3 font-mono text-[11px] leading-relaxed text-warning">
+                      Connect a payment method above to turn auto-reload on. Until it is set, nothing warns you before
+                      the balance runs out.
+                    </p>
+                  ))}
+              </>
 
               {user?.profile.email_verified && (
                 <>
                   <div className="my-5 h-px bg-border" />
 
-                  <div className="flex flex-wrap items-center justify-between gap-3">
-                    <div className="flex flex-col gap-1.5">
-                      <span className="font-mono text-[10px] uppercase tracking-[1.5px] text-muted-foreground">
-                        Redeem coupon
-                      </span>
-                      {redeemCouponError ? (
-                        <span className="font-mono text-[12px] text-destructive">{redeemCouponError}</span>
-                      ) : redeemCouponSuccess ? (
-                        <span className="font-mono text-[12px] text-success">{redeemCouponSuccess}</span>
-                      ) : (
-                        <span className="font-mono text-[12px] text-muted-foreground">
-                          Enter a coupon code to redeem your credits.
+                  {/* A one-shot action with no state to summarise, so it gets a
+                      link rather than a settings row — the checkout convention. */}
+                  {!couponOpen ? (
+                    <button
+                      type="button"
+                      onClick={() => setCouponOpen(true)}
+                      className="font-mono text-[11px] text-muted-foreground underline underline-offset-2 transition-colors hover:text-foreground"
+                    >
+                      Have a coupon code?
+                    </button>
+                  ) : (
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <div className="flex flex-col gap-1.5">
+                        <span className="font-mono text-[10px] uppercase tracking-[1.5px] text-muted-foreground">
+                          Redeem coupon
                         </span>
-                      )}
+                        {redeemCouponError ? (
+                          <span className="font-mono text-[12px] text-destructive">{redeemCouponError}</span>
+                        ) : redeemCouponSuccess ? (
+                          <span className="font-mono text-[12px] text-success">{redeemCouponSuccess}</span>
+                        ) : (
+                          <span className="font-mono text-[12px] text-muted-foreground">
+                            Enter a coupon code to redeem your credits.
+                          </span>
+                        )}
+                      </div>
+                      <div className="flex w-full items-center gap-2 sm:w-auto">
+                        <Input
+                          placeholder="Enter coupon code"
+                          value={couponCode}
+                          onChange={(e) => setCouponCode(e.target.value)}
+                          className="h-9 w-full font-mono text-[13px] sm:w-[200px]"
+                        />
+                        <AsciiButton
+                          onClick={handleRedeemCoupon}
+                          disabled={redeemCouponMutation.isPending}
+                          className="inline-flex shrink-0 items-center gap-2"
+                        >
+                          {redeemCouponMutation.isPending && <Spinner />} Redeem
+                        </AsciiButton>
+                      </div>
                     </div>
-                    <div className="flex w-full items-center gap-2 sm:w-auto">
-                      <Input
-                        placeholder="Enter coupon code"
-                        value={couponCode}
-                        onChange={(e) => setCouponCode(e.target.value)}
-                        className="h-9 w-full font-mono text-[13px] sm:w-[200px]"
-                      />
-                      <AsciiButton
-                        onClick={handleRedeemCoupon}
-                        disabled={redeemCouponMutation.isPending}
-                        className="inline-flex shrink-0 items-center gap-2"
-                      >
-                        {redeemCouponMutation.isPending && <Spinner />} Redeem
-                      </AsciiButton>
-                    </div>
-                  </div>
+                  )}
                 </>
               )}
-            </Panel>
-          </section>
-
-          <section>
-            <SectionTitle title="Payment Method" />
-            <Panel className="px-[22px] py-4">
-              <div className="flex flex-wrap items-center justify-between gap-4">
-                {!wallet.creditCardConnected ? (
-                  <span className="font-mono text-[13px] text-muted-foreground">Payment method not connected</span>
-                ) : (
-                  <span className="flex items-center gap-2 font-mono text-[13px] text-foreground">
-                    <CheckCircleIcon className="size-4 shrink-0" /> Credit card connected
-                  </span>
-                )}
-                <AsciiButton
-                  variant={wallet.creditCardConnected ? 'secondary' : 'primary'}
-                  onClick={handleUpdatePaymentMethod}
-                  disabled={isCheckoutUrlLoading}
-                  className="inline-flex items-center gap-2"
-                >
-                  {isCheckoutUrlLoading && <Spinner />} {wallet.creditCardConnected ? 'Update card' : 'Connect'}
-                </AsciiButton>
-              </div>
-              <PanelNote>Used for top-up charges · card details are held by Stripe</PanelNote>
             </Panel>
           </section>
 

--- a/apps/dashboard/src/pages/Volumes.tsx
+++ b/apps/dashboard/src/pages/Volumes.tsx
@@ -16,7 +16,7 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
-import { Plus, Search, Trash } from '@/components/ui/icon'
+import { Database, Plus, Search, Trash } from '@/components/ui/icon'
 import { RoutePath } from '@/enums/RoutePath'
 import { useCreateVolumeMutation } from '@/hooks/mutations/useCreateVolumeMutation'
 import { useDeleteVolumeMutation } from '@/hooks/mutations/useDeleteVolumeMutation'
@@ -436,7 +436,12 @@ const Volumes: React.FC = () => {
 function EmptyState({ canCreate, onCreate }: { canCreate: boolean; onCreate: () => void }) {
   return (
     <div className="flex flex-1 flex-col items-center justify-center gap-[16px] px-6 text-center">
-      <span className="size-[10px]" style={{ background: 'hsl(var(--brand))' }} />
+      {/* A bordered tile with the disk glyph, matching BillingComingSoon's
+          treatment. The bare 10px brand square this replaces read as a stray
+          artifact rather than an icon, with nothing around it to give it scale. */}
+      <div className="flex size-11 items-center justify-center border border-border bg-card">
+        <Database className="size-5 text-muted-foreground" strokeWidth={1.6} />
+      </div>
       <div className="font-mono text-[17px] font-semibold">No volumes yet</div>
       <p className="max-w-[420px] font-mono text-[12.5px] leading-relaxed text-muted-foreground">
         A box loses everything on its disk when it is destroyed. A volume does not — mount one into a box and the data


### PR DESCRIPTION
## Summary

Three console gaps POL-261 found, plus the free-trial surface behind the $100 grant.

The low-balance banner could not fire for the account that needed it: it only compared against the auto-reload threshold, and the auto-reload form only rendered once a card was linked. No card meant no threshold meant no warning — POL-261 sat at **-$0.03 with three clean tabs**. Alongside that, a Top up button that never said why it was disabled, and an overview that said "No plan" twice without saying what having no plan means.

## Call graph

**Before**

```
Billing (page)
├─ UsageSection → BalanceLowBanner (BalanceLowBanner.tsx:16)
│  └─ lowBalance(wallet)            ← BUG: returns null unless automaticTopUp is set,
│                                     and that form is gated on a linked card, so an
│                                     unlinked account runs negative in silence
├─ PlanSection → SectionTitle "Active Plan" + CycleOverview
│  └─ organizationPlan ? planName : 'No plan'
│                                   ← BUG: titled "Active plan" while saying there is none,
│                                     and repeats the word in a Subscription metric
└─ WalletSection                    Wallet Balance ▸ … ▸ Payment Method
   ├─ topUpEnabled = card && amount ← BUG: disabled with no reason, no $10 minimum
   └─ SegmentedBar(used=creditRemaining)
                                    ← BUG: bar reddens past 90%, so a full grant renders red
```

**After**

```
Billing (page)
├─ UsageSection → BalanceLowBanner (BalanceLowBanner.tsx:41)
│  └─ balanceWarning(wallet, plan) → overdrawn | empty | below-threshold | null
│                                    balance-driven; quota excuses empty, never overdrawn
├─ PlanSection → CycleOverview (CycleOverview.tsx:41)
│  └─ billingMode(wallet, plan) → plan | free-trial | payg
│     ├─ PlanFigures        subscription, wallet, quota
│     ├─ FreeTrialFigures   credits left of the grant + spend bar
│     ├─ PaygFigures        wallet, uninvoiced usage
│     └─ UnsubscribedNote   the rate (from GET /usage-prices) + link to the plan grid
└─ WalletSection            Payment Method ▸ Wallet Balance ▸ Invoices
   ├─ topUpGate(card, amount) → { enabled, reason }   (WalletSection.tsx:50)
   ├─ auto-reload   always rendered, folds to one row, defaults $20 → $100
   └─ coupon        folds behind "Have a coupon code?"
```

## Screenshots

Driven by `start:mock`.

**Overview, no subscription and no grant** — "Pay as you go" instead of "No plan", with the rate read live from `GET /usage-prices`.

![Pay as you go](https://raw.githubusercontent.com/Mandalorian-Wang/boxlite/assets/billing-wallet-guardrails/01-payg.png)

**Overview, free trial** — reads the wallet's own `creditGranted`/`creditRemaining`.

![Free trial](https://raw.githubusercontent.com/Mandalorian-Wang/boxlite/assets/billing-wallet-guardrails/04-free-trial.png)

**Usage, overdrawn** — fires with no auto-reload configured, and despite $187.50 of quota still remaining.

![Overdrawn](https://raw.githubusercontent.com/Mandalorian-Wang/boxlite/assets/billing-wallet-guardrails/05-overdrawn.png)

**Wallet** — Payment Method first; auto-reload and coupon folded.

![Wallet collapsed](https://raw.githubusercontent.com/Mandalorian-Wang/boxlite/assets/billing-wallet-guardrails/02-wallet-collapsed.png)

**Wallet, expanded** — Top up names its blocker and states the minimum.

![Wallet expanded](https://raw.githubusercontent.com/Mandalorian-Wang/boxlite/assets/billing-wallet-guardrails/03-wallet-expanded.png)

**Volumes, empty** — the bare 10px square replaced with the disk glyph.

![Volumes empty](https://raw.githubusercontent.com/Mandalorian-Wang/boxlite/assets/billing-wallet-guardrails/06-volumes-empty.png)

## On the $100 free trial

Commerce does not issue the signup grant yet. Rather than hardcode it, `free-trial` is driven by the wallet's existing `creditGrantedCents` / `creditRemainingCents` — the same pair the Wallet tab already renders. With no grant the mode stays dark and the account reads as pay-as-you-go, which is what it is. When Commerce starts granting, this lights up with no further frontend change and **never shows credit the wallet does not hold**.

## Note on scope

The third commit (`fix(dashboard): give the empty volumes state a real icon`) is unrelated to billing — it was spotted while reviewing these screens. Happy to split it into its own PR if preferred.

## Validation

- `yarn vitest run src/` — 25 files, 135 passed (20 new across `BalanceLowBanner`, `WalletSection`, `CycleOverview`)
- `yarn eslint` / `yarn prettier --check` on every touched file — clean
- `yarn tsc -p tsconfig.app.json --noEmit` — 158 errors, unchanged from `origin/main`; all pre-existing, 90 of them the ungenerated `@boxlite-ai/api-client`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer billing views for subscriptions, free trials, and pay-as-you-go accounts.
  * Added billing warnings for low, depleted, and overdrawn balances.
  * Improved wallet management with top-up minimums, payment status, auto-reload guidance, and usage tracking.
  * Added easier navigation to plan comparisons and simplified coupon redemption.
  * Updated the Volumes empty state with a clearer database illustration.

* **Bug Fixes**
  * Corrected balance warnings for overdrawn wallets and exhausted credits.
  * Improved handling of missing or incomplete billing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->