### PR TITLE
feat: Public status page

### DIFF
--- a/apps/dashboard/src/components/Sidebar.test.tsx
+++ b/apps/dashboard/src/components/Sidebar.test.tsx
@@ -53,7 +53,10 @@ describe('Sidebar primary navigation', () => {
     document.body.innerHTML = ''
   })
 
-  it('keeps Volumes in primary navigation', () => {
+  it.each([
+    ['Volumes', '/dashboard/volumes'],
+    ['Status', '/status'],
+  ])('keeps %s in primary navigation', (label, href) => {
     const host = document.createElement('div')
     document.body.appendChild(host)
 
@@ -66,11 +69,11 @@ describe('Sidebar primary navigation', () => {
       )
     })
 
-    const volumeLinks = Array.from(document.querySelectorAll<HTMLAnchorElement>('a')).filter(
-      (link) => link.getAttribute('href') === '/dashboard/volumes',
+    const links = Array.from(document.querySelectorAll<HTMLAnchorElement>('a')).filter(
+      (link) => link.getAttribute('href') === href,
     )
 
-    expect(volumeLinks.length).toBeGreaterThan(0)
-    expect(volumeLinks.every((link) => link.textContent === 'Volumes')).toBe(true)
+    expect(links.length).toBeGreaterThan(0)
+    expect(links.every((link) => link.textContent === label)).toBe(true)
   })
 })

--- a/apps/dashboard/src/components/Sidebar.tsx
+++ b/apps/dashboard/src/components/Sidebar.tsx
@@ -65,6 +65,7 @@ const PRIMARY_NAV_ITEMS: NavItem[] = [
   { label: 'Boxes', path: RoutePath.BOXES },
   { label: 'Volumes', path: RoutePath.VOLUMES },
   { label: 'Billing', path: RoutePath.BILLING },
+  { label: 'Status', path: RoutePath.STATUS },
 ]
 
 const themeOptions: { value: Theme; label: string; icon: React.ReactElement }[] = [

--- a/apps/dashboard/src/enums/RoutePath.ts
+++ b/apps/dashboard/src/enums/RoutePath.ts
@@ -15,6 +15,7 @@ export enum RoutePath {
   DASHBOARD = '/dashboard',
   DOCS = '/docs',
   SLACK = '/slack',
+  STATUS = '/status',
 
   // Dashboard sub-routes
   KEYS = '/dashboard/keys',

--- a/apps/dashboard/src/lib/status-snapshot.test.ts
+++ b/apps/dashboard/src/lib/status-snapshot.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseStatusSnapshot, StaleStatusSnapshotError } from './status-snapshot'
+
+const generatedAt = '2026-08-24T04:00:00.000Z'
+
+function snapshot() {
+  return {
+    schemaVersion: 1,
+    generatedAt,
+    regions: [
+      {
+        id: 'ap-southeast-1',
+        name: 'Asia Pacific (Singapore)',
+        status: 'operational',
+        services: [{ id: 'api', name: 'API', status: 'operational' }],
+      },
+    ],
+  }
+}
+
+describe('parseStatusSnapshot', () => {
+  it('accepts a fresh version 1 snapshot', () => {
+    expect(parseStatusSnapshot(snapshot(), Date.parse(generatedAt) + 60_000)).toMatchObject({
+      schemaVersion: 1,
+      regions: [{ id: 'ap-southeast-1' }],
+    })
+  })
+
+  it('rejects a stale snapshot instead of leaving an operational status visible', () => {
+    expect(() => parseStatusSnapshot(snapshot(), Date.parse(generatedAt) + 5 * 60_000 + 1)).toThrow(
+      StaleStatusSnapshotError,
+    )
+  })
+
+  it('rejects unknown statuses at the public-data boundary', () => {
+    const input = snapshot()
+    input.regions[0].services[0].status = 'healthy'
+
+    expect(() => parseStatusSnapshot(input, Date.parse(generatedAt))).toThrow()
+  })
+})

--- a/apps/dashboard/src/lib/status-snapshot.test.ts
+++ b/apps/dashboard/src/lib/status-snapshot.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { parseStatusSnapshot, StaleStatusSnapshotError } from './status-snapshot'
+import { FutureStatusSnapshotError, parseStatusSnapshot, StaleStatusSnapshotError } from './status-snapshot'
 
 const generatedAt = '2026-08-24T04:00:00.000Z'
 
@@ -30,6 +30,13 @@ describe('parseStatusSnapshot', () => {
   it('rejects a stale snapshot instead of leaving an operational status visible', () => {
     expect(() => parseStatusSnapshot(snapshot(), Date.parse(generatedAt) + 5 * 60_000 + 1)).toThrow(
       StaleStatusSnapshotError,
+    )
+  })
+
+  it('rejects a snapshot generated beyond the allowed clock skew', () => {
+    expect(() => parseStatusSnapshot(snapshot(), Date.parse(generatedAt) - 60_000)).not.toThrow()
+    expect(() => parseStatusSnapshot(snapshot(), Date.parse(generatedAt) - 60_000 - 1)).toThrow(
+      FutureStatusSnapshotError,
     )
   })
 

--- a/apps/dashboard/src/lib/status-snapshot.ts
+++ b/apps/dashboard/src/lib/status-snapshot.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod'
+
+export const STATUS_SNAPSHOT_MAX_AGE_MS = 5 * 60 * 1000
+
+const serviceStatusSchema = z.enum(['operational', 'disruption', 'partial_outage', 'outage', 'maintenance'])
+
+const statusSnapshotSchema = z.object({
+  schemaVersion: z.literal(1),
+  generatedAt: z.string().datetime(),
+  regions: z
+    .array(
+      z.object({
+        id: z.string().min(1),
+        name: z.string().min(1),
+        status: serviceStatusSchema,
+        services: z
+          .array(
+            z.object({
+              id: z.string().min(1),
+              name: z.string().min(1),
+              status: serviceStatusSchema,
+            }),
+          )
+          .min(1),
+      }),
+    )
+    .min(1),
+})
+
+export type ServiceStatus = z.infer<typeof serviceStatusSchema>
+export type StatusSnapshot = z.infer<typeof statusSnapshotSchema>
+
+export class StaleStatusSnapshotError extends Error {
+  constructor() {
+    super('The public status snapshot is stale')
+    this.name = 'StaleStatusSnapshotError'
+  }
+}
+
+export function parseStatusSnapshot(
+  input: unknown,
+  now = Date.now(),
+  maxAgeMs = STATUS_SNAPSHOT_MAX_AGE_MS,
+): StatusSnapshot {
+  const snapshot = statusSnapshotSchema.parse(input)
+  const generatedAt = Date.parse(snapshot.generatedAt)
+
+  if (now - generatedAt > maxAgeMs) {
+    throw new StaleStatusSnapshotError()
+  }
+
+  return snapshot
+}
+
+export async function fetchStatusSnapshot(url: string, signal?: AbortSignal): Promise<StatusSnapshot> {
+  const response = await fetch(url, { cache: 'no-store', signal })
+
+  if (!response.ok) {
+    throw new Error(`Unable to fetch public status snapshot: HTTP ${response.status}`)
+  }
+
+  return parseStatusSnapshot(await response.json())
+}

--- a/apps/dashboard/src/lib/status-snapshot.ts
+++ b/apps/dashboard/src/lib/status-snapshot.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 export const STATUS_SNAPSHOT_MAX_AGE_MS = 5 * 60 * 1000
+const STATUS_SNAPSHOT_MAX_FUTURE_SKEW_MS = 60 * 1000
 
 const serviceStatusSchema = z.enum(['operational', 'disruption', 'partial_outage', 'outage', 'maintenance'])
 
@@ -37,6 +38,13 @@ export class StaleStatusSnapshotError extends Error {
   }
 }
 
+export class FutureStatusSnapshotError extends Error {
+  constructor() {
+    super('The public status snapshot timestamp is too far in the future')
+    this.name = 'FutureStatusSnapshotError'
+  }
+}
+
 export function parseStatusSnapshot(
   input: unknown,
   now = Date.now(),
@@ -44,12 +52,22 @@ export function parseStatusSnapshot(
 ): StatusSnapshot {
   const snapshot = statusSnapshotSchema.parse(input)
   const generatedAt = Date.parse(snapshot.generatedAt)
+  const ageMs = now - generatedAt
 
-  if (now - generatedAt > maxAgeMs) {
+  if (ageMs < -STATUS_SNAPSHOT_MAX_FUTURE_SKEW_MS) {
+    throw new FutureStatusSnapshotError()
+  }
+
+  if (ageMs > maxAgeMs) {
     throw new StaleStatusSnapshotError()
   }
 
   return snapshot
+}
+
+export function isStatusSnapshotFresh(snapshot: StatusSnapshot, now = Date.now()): boolean {
+  const ageMs = now - Date.parse(snapshot.generatedAt)
+  return ageMs >= -STATUS_SNAPSHOT_MAX_FUTURE_SKEW_MS && ageMs <= STATUS_SNAPSHOT_MAX_AGE_MS
 }
 
 export async function fetchStatusSnapshot(url: string, signal?: AbortSignal): Promise<StatusSnapshot> {

--- a/apps/dashboard/src/main.test.tsx
+++ b/apps/dashboard/src/main.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+
+import { act, type ReactNode } from 'react'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+
+function PassThrough({ children }: { children: ReactNode }) {
+  return children
+}
+
+vi.mock('nuqs/adapters/react-router/v6', () => ({ NuqsAdapter: PassThrough }))
+vi.mock('./App', () => ({ default: () => <div>Dashboard application</div> }))
+vi.mock('./components/PostHogProviderWrapper', () => ({ PostHogProviderWrapper: PassThrough }))
+vi.mock('./contexts/ThemeContext', () => ({ ThemeProvider: PassThrough }))
+vi.mock('./pages/Status', () => ({ default: () => <div>Public status page</div> }))
+vi.mock('./providers/ConfigProvider', () => ({ ConfigProvider: PassThrough }))
+vi.mock('./providers/QueryProvider', () => ({ QueryProvider: PassThrough }))
+
+describe('public status routing', () => {
+  beforeAll(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  })
+
+  it('serves the public status page when the URL has a trailing slash', async () => {
+    document.body.innerHTML = '<div id="root"></div>'
+    window.history.replaceState({}, '', '/status/')
+
+    await act(async () => {
+      await import('./main')
+    })
+
+    expect(document.body.textContent).toContain('Public status page')
+    expect(document.body.textContent).not.toContain('Dashboard application')
+  })
+})

--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -8,17 +8,39 @@ import { NuqsAdapter } from 'nuqs/adapters/react-router/v6'
 import React, { Suspense } from 'react'
 import ReactDOM from 'react-dom/client'
 import { ErrorBoundary } from 'react-error-boundary'
-import { BrowserRouter } from 'react-router-dom'
+import { BrowserRouter, useLocation } from 'react-router-dom'
 import App from './App'
 import { ErrorBoundaryFallback } from './components/ErrorBoundaryFallback'
 import LoadingFallback from './components/LoadingFallback'
 import { PostHogProviderWrapper } from './components/PostHogProviderWrapper'
 import { ThemeProvider } from './contexts/ThemeContext'
+import { RoutePath } from './enums/RoutePath'
 import './index.css'
+import Status from './pages/Status'
 import { ConfigProvider } from './providers/ConfigProvider'
 import { QueryProvider } from './providers/QueryProvider'
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
+
+function Application() {
+  const location = useLocation()
+
+  if (location.pathname === RoutePath.STATUS) {
+    return <Status />
+  }
+
+  return (
+    <Suspense fallback={<LoadingFallback />}>
+      <ConfigProvider>
+        <PostHogProviderWrapper>
+          <NuqsAdapter>
+            <App />
+          </NuqsAdapter>
+        </PostHogProviderWrapper>
+      </ConfigProvider>
+    </Suspense>
+  )
+}
 
 async function enableMocking() {
   if (import.meta.env.VITE_ENABLE_MOCKING !== 'true') {
@@ -35,17 +57,9 @@ enableMocking().then(() =>
       <ErrorBoundary FallbackComponent={ErrorBoundaryFallback}>
         <QueryProvider>
           <ThemeProvider>
-            <Suspense fallback={<LoadingFallback />}>
-              <ConfigProvider>
-                <BrowserRouter>
-                  <PostHogProviderWrapper>
-                    <NuqsAdapter>
-                      <App />
-                    </NuqsAdapter>
-                  </PostHogProviderWrapper>
-                </BrowserRouter>
-              </ConfigProvider>
-            </Suspense>
+            <BrowserRouter>
+              <Application />
+            </BrowserRouter>
           </ThemeProvider>
         </QueryProvider>
       </ErrorBoundary>

--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -25,7 +25,7 @@ const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 function Application() {
   const location = useLocation()
 
-  if (location.pathname === RoutePath.STATUS) {
+  if (location.pathname === RoutePath.STATUS || location.pathname === `${RoutePath.STATUS}/`) {
     return <Status />
   }
 

--- a/apps/dashboard/src/pages/Status.test.tsx
+++ b/apps/dashboard/src/pages/Status.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import Status from './Status'
+
+const queryState = vi.hoisted(() => ({
+  data: undefined as
+    | {
+        schemaVersion: 1
+        generatedAt: string
+        regions: Array<{
+          id: string
+          name: string
+          status: 'operational'
+          services: Array<{ id: string; name: string; status: 'operational' }>
+        }>
+      }
+    | undefined,
+  isPending: false,
+  isError: false,
+}))
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: () => queryState,
+}))
+
+describe('Status', () => {
+  let root: Root | null = null
+
+  beforeAll(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  })
+
+  afterEach(() => {
+    act(() => root?.unmount())
+    root = null
+    document.body.innerHTML = ''
+    queryState.data = undefined
+    queryState.isPending = false
+    queryState.isError = false
+  })
+
+  it('hides retained operational data when a refresh fails', () => {
+    queryState.data = {
+      schemaVersion: 1,
+      generatedAt: '2026-08-24T04:00:00.000Z',
+      regions: [
+        {
+          id: 'ap-southeast-1',
+          name: 'Asia Pacific (Singapore)',
+          status: 'operational',
+          services: [{ id: 'api', name: 'API', status: 'operational' }],
+        },
+      ],
+    }
+
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    root = createRoot(host)
+
+    act(() => root?.render(<Status />))
+    expect(document.body.textContent).toContain('Operational')
+
+    queryState.isError = true
+    act(() => root?.render(<Status />))
+
+    expect(document.body.textContent).toContain('Status unavailable')
+    expect(document.body.textContent).not.toContain('Operational')
+  })
+})

--- a/apps/dashboard/src/pages/Status.test.tsx
+++ b/apps/dashboard/src/pages/Status.test.tsx
@@ -2,7 +2,7 @@
 
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
-import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import Status from './Status'
 
@@ -29,15 +29,22 @@ vi.mock('@tanstack/react-query', () => ({
 
 describe('Status', () => {
   let root: Root | null = null
+  const generatedAt = Date.parse('2026-08-24T04:00:00.000Z')
 
   beforeAll(() => {
     globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  })
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(generatedAt + 60_000)
   })
 
   afterEach(() => {
     act(() => root?.unmount())
     root = null
     document.body.innerHTML = ''
+    vi.useRealTimers()
     queryState.data = undefined
     queryState.isPending = false
     queryState.isError = false
@@ -66,6 +73,33 @@ describe('Status', () => {
 
     queryState.isError = true
     act(() => root?.render(<Status />))
+
+    expect(document.body.textContent).toContain('Status unavailable')
+    expect(document.body.textContent).not.toContain('Operational')
+  })
+
+  it('hides operational data when the cached snapshot expires without a refetch', () => {
+    queryState.data = {
+      schemaVersion: 1,
+      generatedAt: new Date(generatedAt).toISOString(),
+      regions: [
+        {
+          id: 'ap-southeast-1',
+          name: 'Asia Pacific (Singapore)',
+          status: 'operational',
+          services: [{ id: 'api', name: 'API', status: 'operational' }],
+        },
+      ],
+    }
+
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    root = createRoot(host)
+
+    act(() => root?.render(<Status />))
+    expect(document.body.textContent).toContain('Operational')
+
+    act(() => vi.advanceTimersByTime(4 * 60_000 + 1))
 
     expect(document.body.textContent).toContain('Status unavailable')
     expect(document.body.textContent).not.toContain('Operational')

--- a/apps/dashboard/src/pages/Status.test.tsx
+++ b/apps/dashboard/src/pages/Status.test.tsx
@@ -70,4 +70,40 @@ describe('Status', () => {
     expect(document.body.textContent).toContain('Status unavailable')
     expect(document.body.textContent).not.toContain('Operational')
   })
+
+  it('expands and collapses the services within a region', () => {
+    queryState.data = {
+      schemaVersion: 1,
+      generatedAt: '2026-08-24T04:00:00.000Z',
+      regions: [
+        {
+          id: 'ap-southeast-1',
+          name: 'Asia Pacific (Singapore)',
+          status: 'operational',
+          services: [{ id: 'api', name: 'Api', status: 'operational' }],
+        },
+      ],
+    }
+
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    root = createRoot(host)
+    act(() => root?.render(<Status />))
+
+    const regionToggle = document.querySelector<HTMLButtonElement>(
+      'button[aria-controls="region-services-ap-southeast-1"]',
+    )
+    const serviceList = document.getElementById('region-services-ap-southeast-1') as HTMLUListElement
+
+    expect(regionToggle?.getAttribute('aria-expanded')).toBe('true')
+    expect(serviceList.hidden).toBe(false)
+
+    act(() => regionToggle?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+    expect(regionToggle?.getAttribute('aria-expanded')).toBe('false')
+    expect(serviceList.hidden).toBe(true)
+
+    act(() => regionToggle?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+    expect(regionToggle?.getAttribute('aria-expanded')).toBe('true')
+    expect(serviceList.hidden).toBe(false)
+  })
 })

--- a/apps/dashboard/src/pages/Status.tsx
+++ b/apps/dashboard/src/pages/Status.tsx
@@ -1,5 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
+import { useState } from 'react'
 
+import { ChevronDown } from '@/components/ui/icon'
 import { fetchStatusSnapshot, type ServiceStatus } from '@/lib/status-snapshot'
 import { cn } from '@/lib/utils'
 
@@ -45,6 +47,59 @@ function StatusUnavailable() {
   )
 }
 
+function RegionStatus({
+  region,
+}: {
+  region: {
+    id: string
+    name: string
+    status: ServiceStatus
+    services: Array<{ id: string; name: string; status: ServiceStatus }>
+  }
+}) {
+  const [isExpanded, setIsExpanded] = useState(true)
+  const serviceListId = `region-services-${region.id}`
+
+  return (
+    <section className="border border-border bg-card">
+      <header>
+        <h2>
+          <button
+            type="button"
+            aria-controls={serviceListId}
+            aria-expanded={isExpanded}
+            onClick={() => setIsExpanded((expanded) => !expanded)}
+            className="flex w-full items-center justify-between gap-4 border-b border-border px-5 py-4 text-left transition-colors hover:bg-accent/40"
+          >
+            <span className="flex min-w-0 items-center gap-3">
+              <ChevronDown
+                className={cn(
+                  'size-4 shrink-0 text-muted-foreground transition-transform',
+                  !isExpanded && '-rotate-90',
+                )}
+                aria-hidden="true"
+              />
+              <span className="min-w-0">
+                <span className="block truncate font-mono text-base font-medium">{region.id}</span>
+                <span className="mt-1 block truncate text-xs font-normal text-muted-foreground">{region.name}</span>
+              </span>
+            </span>
+            <StatusLabel status={region.status} />
+          </button>
+        </h2>
+      </header>
+      <ul id={serviceListId} hidden={!isExpanded} className="ml-8 divide-y divide-border border-l border-border">
+        {region.services.map((service) => (
+          <li key={service.id} className="flex items-center justify-between gap-4 px-5 py-4 pl-7">
+            <span className="text-sm font-medium">{service.name}</span>
+            <StatusLabel status={service.status} />
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
 export default function Status() {
   const statusQuery = useQuery({
     queryKey: ['public-status-snapshot'],
@@ -87,23 +142,7 @@ export default function Status() {
           </div>
 
           {snapshot.regions.map((region) => (
-            <section key={region.id} className="border border-border bg-card">
-              <header className="flex flex-wrap items-center justify-between gap-3 border-b border-border px-5 py-4">
-                <div>
-                  <h2 className="font-mono text-base font-medium">{region.id}</h2>
-                  <p className="mt-1 text-xs text-muted-foreground">{region.name}</p>
-                </div>
-                <StatusLabel status={region.status} />
-              </header>
-              <ul className="divide-y divide-border">
-                {region.services.map((service) => (
-                  <li key={service.id} className="flex items-center justify-between gap-4 px-5 py-4">
-                    <span className="text-sm font-medium">{service.name}</span>
-                    <StatusLabel status={service.status} />
-                  </li>
-                ))}
-              </ul>
-            </section>
+            <RegionStatus key={region.id} region={region} />
           ))}
         </div>
       )}

--- a/apps/dashboard/src/pages/Status.tsx
+++ b/apps/dashboard/src/pages/Status.tsx
@@ -1,0 +1,112 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { fetchStatusSnapshot, type ServiceStatus } from '@/lib/status-snapshot'
+import { cn } from '@/lib/utils'
+
+const PUBLIC_STATUS_SNAPSHOT_PATH = '/public-status.json'
+
+const statusLabels: Record<ServiceStatus, string> = {
+  operational: 'Operational',
+  disruption: 'Disruption',
+  partial_outage: 'Partial outage',
+  outage: 'Outage',
+  maintenance: 'Under maintenance',
+}
+
+const statusClasses: Record<ServiceStatus, string> = {
+  operational: 'bg-emerald-500',
+  disruption: 'bg-amber-400',
+  partial_outage: 'bg-orange-500',
+  outage: 'bg-red-500',
+  maintenance: 'bg-blue-500',
+}
+
+function StatusLabel({ status }: { status: ServiceStatus }) {
+  return (
+    <span className="inline-flex items-center gap-2 font-mono text-xs text-muted-foreground">
+      <span className={cn('size-2 shrink-0 rounded-full', statusClasses[status])} aria-hidden="true" />
+      {statusLabels[status]}
+    </span>
+  )
+}
+
+function StatusUnavailable() {
+  return (
+    <div className="border border-border bg-card px-5 py-8" role="status">
+      <div className="flex items-center gap-3">
+        <span className="size-2 rounded-full bg-muted-foreground" aria-hidden="true" />
+        <h2 className="font-mono text-base font-medium">Status unavailable</h2>
+      </div>
+      <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+        The public status snapshot could not be verified. No operational claim is being made until a fresh snapshot is
+        available.
+      </p>
+    </div>
+  )
+}
+
+export default function Status() {
+  const statusQuery = useQuery({
+    queryKey: ['public-status-snapshot'],
+    queryFn: ({ signal }) => fetchStatusSnapshot(PUBLIC_STATUS_SNAPSHOT_PATH, signal),
+    refetchInterval: 60_000,
+    retry: false,
+  })
+
+  const snapshot = statusQuery.data
+
+  return (
+    <main className="mx-auto w-full max-w-5xl p-4 sm:p-5 lg:p-8">
+      <div className="mb-8">
+        <p className="mb-2 font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+          Platform availability
+        </p>
+        <h1 className="font-mono text-[22px] font-medium leading-none tracking-[-0.5px]">Status</h1>
+        <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+          Current availability of BoxLite services by AWS region. This view contains public, aggregated service state
+          only.
+        </p>
+      </div>
+
+      {statusQuery.isPending ? (
+        <div className="border border-border bg-card px-5 py-8 font-mono text-sm text-muted-foreground" role="status">
+          Loading current status…
+        </div>
+      ) : statusQuery.isError || !snapshot ? (
+        <StatusUnavailable />
+      ) : (
+        <div className="space-y-5">
+          <div className="flex flex-wrap items-center justify-between gap-3 border border-border bg-card px-5 py-4">
+            <div>
+              <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">Last updated</p>
+              <time className="mt-1 block font-mono text-sm" dateTime={snapshot.generatedAt}>
+                {new Date(snapshot.generatedAt).toLocaleString()}
+              </time>
+            </div>
+            <span className="font-mono text-xs text-muted-foreground">AWS</span>
+          </div>
+
+          {snapshot.regions.map((region) => (
+            <section key={region.id} className="border border-border bg-card">
+              <header className="flex flex-wrap items-center justify-between gap-3 border-b border-border px-5 py-4">
+                <div>
+                  <h2 className="font-mono text-base font-medium">{region.id}</h2>
+                  <p className="mt-1 text-xs text-muted-foreground">{region.name}</p>
+                </div>
+                <StatusLabel status={region.status} />
+              </header>
+              <ul className="divide-y divide-border">
+                {region.services.map((service) => (
+                  <li key={service.id} className="flex items-center justify-between gap-4 px-5 py-4">
+                    <span className="text-sm font-medium">{service.name}</span>
+                    <StatusLabel status={service.status} />
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+      )}
+    </main>
+  )
+}

--- a/apps/dashboard/src/pages/Status.tsx
+++ b/apps/dashboard/src/pages/Status.tsx
@@ -1,8 +1,13 @@
 import { useQuery } from '@tanstack/react-query'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { ChevronDown } from '@/components/ui/icon'
-import { fetchStatusSnapshot, type ServiceStatus } from '@/lib/status-snapshot'
+import {
+  fetchStatusSnapshot,
+  isStatusSnapshotFresh,
+  type ServiceStatus,
+  STATUS_SNAPSHOT_MAX_AGE_MS,
+} from '@/lib/status-snapshot'
 import { cn } from '@/lib/utils'
 
 const PUBLIC_STATUS_SNAPSHOT_PATH = '/public-status.json'
@@ -101,6 +106,7 @@ function RegionStatus({
 }
 
 export default function Status() {
+  const [freshnessNow, setFreshnessNow] = useState(() => Date.now())
   const statusQuery = useQuery({
     queryKey: ['public-status-snapshot'],
     queryFn: ({ signal }) => fetchStatusSnapshot(PUBLIC_STATUS_SNAPSHOT_PATH, signal),
@@ -109,6 +115,26 @@ export default function Status() {
   })
 
   const snapshot = statusQuery.data
+  const snapshotGeneratedAt = snapshot?.generatedAt
+  const snapshotIsFresh = snapshot ? isStatusSnapshotFresh(snapshot, freshnessNow) : false
+
+  useEffect(() => {
+    setFreshnessNow(Date.now())
+
+    if (!snapshotGeneratedAt) {
+      return
+    }
+
+    const expiresAt = Date.parse(snapshotGeneratedAt) + STATUS_SNAPSHOT_MAX_AGE_MS
+    const refreshFreshness = () => setFreshnessNow(Date.now())
+    const timeoutId = window.setTimeout(refreshFreshness, Math.max(0, expiresAt - Date.now() + 1))
+
+    document.addEventListener('visibilitychange', refreshFreshness)
+    return () => {
+      window.clearTimeout(timeoutId)
+      document.removeEventListener('visibilitychange', refreshFreshness)
+    }
+  }, [snapshotGeneratedAt])
 
   return (
     <main className="mx-auto w-full max-w-5xl p-4 sm:p-5 lg:p-8">
@@ -127,7 +153,7 @@ export default function Status() {
         <div className="border border-border bg-card px-5 py-8 font-mono text-sm text-muted-foreground" role="status">
           Loading current status…
         </div>
-      ) : statusQuery.isError || !snapshot ? (
+      ) : statusQuery.isError || !snapshot || !snapshotIsFresh ? (
         <StatusUnavailable />
       ) : (
         <div className="space-y-5">

--- a/apps/infra/.env.example
+++ b/apps/infra/.env.example
@@ -42,6 +42,11 @@ IAM_PERMISSIONS_BOUNDARY_STAGE=dev
 # Subdomain for this stack (e.g. dev.boxlite.ai, staging.boxlite.ai)
 STACK_DOMAIN=dev.example.com
 
+# [required] Exact publicStatusSnapshotUrl output from the matching Backoffice
+# stage. Deploy Backoffice and wait for its first Cron snapshot before deploying
+# BoxLite so /public-status.json can be served immediately.
+BACKOFFICE_PUBLIC_STATUS_SNAPSHOT_URL=https://d1234567890.cloudfront.net/public-status.json
+
 # Cloudflare credentials — create an ACCOUNT-owned token with Zone:Read +
 # DNS:Edit. apps/infra/README.md#cloudflare-api-token has a link that pre-fills
 # those permissions in the dashboard form; the link carries no zone parameter,

--- a/apps/infra/deployment/environment.test.ts
+++ b/apps/infra/deployment/environment.test.ts
@@ -11,6 +11,7 @@ import {
   loadDeploymentEnvironment,
   optionalPublicOidcIssuer,
   readWorkspaceVersion,
+  requireBackofficePublicStatusSnapshotUrl,
   requireIamPermissionsBoundaryStage,
   requireOidcIssuer,
   resolveAwsRegion,
@@ -90,6 +91,35 @@ test('rejects non-stable or whitespace-normalized release identities', () => {
   }
   for (const version of [' 0.9.8 ', 'latest', '0.9.8+build.1', '0.9.8-rc.1', '1.02.3']) {
     assert.throws(() => resolveReleaseVersion('0.9.7', { VERSION: version }), /stable semantic version/)
+  }
+})
+
+test('requires the exact Backoffice public status snapshot URL', () => {
+  assert.equal(
+    requireBackofficePublicStatusSnapshotUrl({
+      BACKOFFICE_PUBLIC_STATUS_SNAPSHOT_URL: 'https://d123.cloudfront.net/public-status.json',
+    }),
+    'https://d123.cloudfront.net',
+  )
+
+  assert.throws(() => requireBackofficePublicStatusSnapshotUrl({}), /BACKOFFICE_PUBLIC_STATUS_SNAPSHOT_URL is required/)
+  for (const value of [
+    'http://d123.cloudfront.net/public-status.json',
+    ' https://d123.cloudfront.net/public-status.json',
+    'https://user@d123.cloudfront.net/public-status.json',
+    'https://d123.cloudfront.net:8443/public-status.json',
+    'https://d123.cloudfront.net/other.json',
+    'https://d123.cloudfront.net/public-status.json/',
+    'https://d123.cloudfront.net/public-status.json?cache=false',
+    'https://d123.cloudfront.net/public-status.json#latest',
+  ]) {
+    assert.throws(
+      () =>
+        requireBackofficePublicStatusSnapshotUrl({
+          BACKOFFICE_PUBLIC_STATUS_SNAPSHOT_URL: value,
+        }),
+      /BACKOFFICE_PUBLIC_STATUS_SNAPSHOT_URL/,
+    )
   }
 })
 

--- a/apps/infra/deployment/environment.ts
+++ b/apps/infra/deployment/environment.ts
@@ -180,6 +180,42 @@ export function optionalPublicOidcIssuer(environment = process.env) {
   return validateOidcIssuer('PUBLIC_OIDC_DOMAIN', value)
 }
 
+export function requireBackofficePublicStatusSnapshotUrl(environment = process.env) {
+  const value = environment.BACKOFFICE_PUBLIC_STATUS_SNAPSHOT_URL
+  if (!value) {
+    throw new Error(
+      'BACKOFFICE_PUBLIC_STATUS_SNAPSHOT_URL is required (copy publicStatusSnapshotUrl from the matching Backoffice stage)',
+    )
+  }
+  if (value !== value.trim()) {
+    throw new Error('BACKOFFICE_PUBLIC_STATUS_SNAPSHOT_URL must not contain leading or trailing whitespace')
+  }
+
+  let snapshotUrl
+  try {
+    snapshotUrl = new URL(value)
+  } catch {
+    throw new Error('BACKOFFICE_PUBLIC_STATUS_SNAPSHOT_URL must be a valid absolute HTTPS URL')
+  }
+  if (snapshotUrl.protocol !== 'https:') {
+    throw new Error('BACKOFFICE_PUBLIC_STATUS_SNAPSHOT_URL must use HTTPS')
+  }
+  if (snapshotUrl.username || snapshotUrl.password) {
+    throw new Error('BACKOFFICE_PUBLIC_STATUS_SNAPSHOT_URL must not include credentials')
+  }
+  if (snapshotUrl.port) {
+    throw new Error('BACKOFFICE_PUBLIC_STATUS_SNAPSHOT_URL must not include a port')
+  }
+  if (snapshotUrl.pathname !== '/public-status.json') {
+    throw new Error('BACKOFFICE_PUBLIC_STATUS_SNAPSHOT_URL path must be exactly /public-status.json')
+  }
+  if (snapshotUrl.search || snapshotUrl.hash) {
+    throw new Error('BACKOFFICE_PUBLIC_STATUS_SNAPSHOT_URL must not include a query string or fragment')
+  }
+
+  return snapshotUrl.origin
+}
+
 export function resolveReleaseVersion(workspaceVersion: any, environment = process.env) {
   if (typeof workspaceVersion !== 'string' || workspaceVersion.trim() === '') {
     throw new Error('The workspace release version is missing')

--- a/apps/infra/deployment/key-policy.test.ts
+++ b/apps/infra/deployment/key-policy.test.ts
@@ -108,7 +108,13 @@ test('nothing the deploy never reads can be hydrated', () => {
 test('the configuration a stage actually needs is storable', () => {
   // The other half: an allowlist that refused real configuration would be useless. These are the keys
   // .env.example marks required.
-  for (const key of ['STACK_DOMAIN', 'OIDC_AUDIENCE', 'OIDC_ISSUER_BASE_URL', 'IAM_PERMISSIONS_BOUNDARY_STAGE']) {
+  for (const key of [
+    'BACKOFFICE_PUBLIC_STATUS_SNAPSHOT_URL',
+    'STACK_DOMAIN',
+    'OIDC_AUDIENCE',
+    'OIDC_ISSUER_BASE_URL',
+    'IAM_PERMISSIONS_BOUNDARY_STAGE',
+  ]) {
     assert.equal(isStorableStageConfigKey(key), true, `${key} must be storable`)
   }
 })

--- a/apps/infra/deployment/key-policy.ts
+++ b/apps/infra/deployment/key-policy.ts
@@ -37,6 +37,7 @@ import { CLICKHOUSE_STAGE_CONFIG_KEYS } from './clickhouse.js'
 export const STORABLE_STAGE_CONFIG_KEYS: readonly string[] = [
   'ADMIN_API_KEY',
   'APP_URL',
+  'BACKOFFICE_PUBLIC_STATUS_SNAPSHOT_URL',
   'BILLING_API_URL',
   'BOXLITE_API_KEY',
   'BOXLITE_API_URL',

--- a/apps/infra/docs/deployment.md
+++ b/apps/infra/docs/deployment.md
@@ -18,6 +18,7 @@ flowchart TB
     sdk(["SDK / CLI"])
     idp(["OIDC IdP<br/>Auth0 · Okta · Keycloak · Dex"])
     ghcr(["ghcr.io"])
+    publicStatus(["Backoffice PublicStatusCdn"])
 
     subgraph edge["public edge"]
         cf["CloudFront<br/>STACK_DOMAIN"]
@@ -47,6 +48,7 @@ flowchart TB
 
     browser -->|"dashboard SPA"| cf
     cf --> alb
+    cf -->|"/public-status.json"| publicStatus
     browser -->|"/api/* · WS · SSE"| alb
     sdk -->|"/api/*"| alb
     browser -->|"port preview"| nlb
@@ -87,7 +89,7 @@ only when the dispatch explicitly names it — see [scaling out](#scaling-runner
 ```bash
 cd apps/infra
 npm install
-cp .env.example .env && $EDITOR .env   # STACK_DOMAIN, OIDC_ISSUER_BASE_URL, OIDC_AUDIENCE
+cp .env.example .env && $EDITOR .env   # STACK_DOMAIN, OIDC_*, BACKOFFICE_PUBLIC_STATUS_SNAPSHOT_URL
 
 npm run login                          # browser sign-in: AWS, GitHub, Auth0
 npm run bootstrap -- --stage dev       # IAM role, GitHub Environment, secrets
@@ -110,6 +112,19 @@ full flag list is in the script's header comment.
 
 A deploy takes 10–15 minutes and prints the service URLs. On a transient
 registry error, just rerun — SST resumes from the failed step.
+
+The public status route has a cross-stack dependency. For each stage, deploy in
+this order:
+
+1. Deploy the matching Backoffice stage and copy its `publicStatusSnapshotUrl`
+   output into `BACKOFFICE_PUBLIC_STATUS_SNAPSHOT_URL` in BoxLite's `.env`.
+2. Wait for the Backoffice Cron to publish the first `public-status.json`.
+3. Rerun `npm run bootstrap -- --stage <stage>` so the value enters that stage's
+   configuration store, then deploy BoxLite.
+
+BoxLite validates that the configured URL is HTTPS and has the exact
+`/public-status.json` path. Its Router forwards only that same-origin path to
+the Backoffice CDN; all other paths continue to use the BoxLite API origin.
 
 **Adding a stage:** run `npm run bootstrap -- --stage <name>`, then add `<name>`
 to the `options` of whichever Environment-selecting inputs should reach it —

--- a/apps/infra/stack/contract.test.ts
+++ b/apps/infra/stack/contract.test.ts
@@ -341,6 +341,18 @@ test('enables Proxy OTLP logging in hosted and local deployments', () => {
   )
 })
 
+test('routes only the exact public status snapshot path to the configured Backoffice origin', () => {
+  const deploy = configSection('export async function deployStack()')
+  const edge = configSection('// ─── 9. CDN ROUTES')
+
+  assert.match(deploy, /requireBackofficePublicStatusSnapshotUrl/)
+  assert.match(deploy, /const publicStatusOrigin = requireBackofficePublicStatusSnapshotUrl\(\)/)
+  assert.match(deploy, /buildEdge\(\{[\s\S]*publicStatusOrigin,/)
+  assert.match(edge, /router\.route\('\/public-status\.json\/', api\.url\)/)
+  assert.match(edge, /router\.route\('\/public-status\.json', publicStatusOrigin\)/)
+  assert.match(edge, /router\.route\('\/', api\.url\)/)
+})
+
 test('requires the OIDC client ID through the SST secret store', () => {
   assert.match(liveConfig, /new sst\.Secret\('OIDC_CLIENT_ID'\)/)
   assert.doesNotMatch(liveConfig, /new sst\.Secret\('OIDC_CLIENT_ID',/)

--- a/apps/infra/stack/deploy.ts
+++ b/apps/infra/stack/deploy.ts
@@ -17,6 +17,7 @@ export async function deployStack() {
     const {
       optionalPublicOidcIssuer,
       readWorkspaceVersion,
+      requireBackofficePublicStatusSnapshotUrl,
       requireIamPermissionsBoundaryStage,
       requireOidcIssuer,
       resolveAwsRegion,
@@ -29,6 +30,7 @@ export async function deployStack() {
     const workspaceVersion = readWorkspaceVersion()
     const deploymentConfig = resolvePublicDeploymentConfig(process.env, workspaceVersion)
     const { stackDomain, proxyDomain, proxyProtocol, proxyTemplateUrl, releaseVersion } = deploymentConfig
+    const publicStatusOrigin = requireBackofficePublicStatusSnapshotUrl()
     const runnerInventory = resolveRunnerInventory(process.env)
     const oidcIssuer = requireOidcIssuer()
     const publicOidcIssuer = optionalPublicOidcIssuer()
@@ -261,6 +263,7 @@ export async function deployStack() {
       foundation,
       api,
       router,
+      publicStatusOrigin,
       proxyDomain,
       proxyProtocol,
       cloudflareDns,

--- a/apps/infra/stack/edge.ts
+++ b/apps/infra/stack/edge.ts
@@ -11,6 +11,7 @@ export interface EdgeInputs {
   foundation: FoundationResources
   api: ApiResources['api']
   router: sst.aws.Router
+  publicStatusOrigin: string
   proxyDomain: string
   proxyProtocol: string
   cloudflareDns: ReturnType<typeof sst.cloudflare.dns>
@@ -28,6 +29,7 @@ export function buildEdge(input: EdgeInputs): void {
     foundation: { cluster },
     api,
     router,
+    publicStatusOrigin,
     proxyDomain,
     proxyProtocol,
     cloudflareDns,
@@ -157,5 +159,9 @@ new sst.aws.Service('MailDev', {
 
 // ─── 9. CDN ROUTES ───────────────────────────────────────────────────────
 // Router (declared in section 4) fronts the Api with HTTPS.
+// SST path routes match segment prefixes. A longer Api route catches descendants,
+// so only the exact snapshot path reaches Backoffice.
+router.route('/public-status.json/', api.url)
+router.route('/public-status.json', publicStatusOrigin)
 router.route('/', api.url)
 }


### PR DESCRIPTION
## Summary

Adds a public, unauthenticated `/status` page that displays Backoffice-produced AWS service availability by region and fails closed when the snapshot cannot be verified. Routes only the exact same-origin `/public-status.json` request to the configured Backoffice PublicStatusCdn.

## Changes

- Adds a standalone public status route, sidebar navigation, and collapsible region/service hierarchy.
- Validates the versioned snapshot contract and rejects missing, malformed, stale, future-dated, or failed refresh data.
- Actively expires retained query data after five minutes so stale operational state cannot remain visible.
- Requires the matching Backoffice snapshot URL in stage configuration and routes only the exact snapshot path to that origin.
- Documents the Backoffice-first deployment order and initial Cron snapshot prerequisite.

## How to verify

- Run the focused dashboard tests:
  `cd apps && corepack yarn vitest run --config dashboard/vite.config.mts src/lib/status-snapshot.test.ts src/pages/Status.test.tsx src/main.test.tsx`
- Run `make test:apps:infra`.
- Run `make test:apps:infra-config`.
- Run `make lint:apps`.
- Serve a fresh local `/public-status.json`, open `/status` and `/status/`, and verify region expand/collapse behavior. Then return an error or stale snapshot and verify the page shows `Status unavailable`.
- The focused suites pass. The canonical full `make test:apps` target was not completed locally because the VM/libkrun prerequisites were unavailable.

