### PR TITLE
feat(dashboard): confirm plan changes on a page and show what is queued

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -40,6 +40,7 @@ import Boxes from './pages/Boxes'
 const Keys = React.lazy(() => import('./pages/Keys'))
 // Billing pulls in the plan/wallet/usage sections (and recharts) behind this one chunk.
 const Billing = React.lazy(() => import('./pages/Billing'))
+const BillingPlanChange = React.lazy(() => import('./pages/BillingPlanChange'))
 const Volumes = React.lazy(() => import('./pages/Volumes'))
 const EmailVerify = React.lazy(() => import('./pages/EmailVerify'))
 const OrganizationSettings = React.lazy(() => import('@/pages/OrganizationSettings'))
@@ -190,6 +191,10 @@ function App() {
             hooks/queries/billingQueries.ts, and the plan-switching surface is gated
             on the owner role inside components/billing/PlanSection.tsx. */}
         <Route path={getRouteSubPath(RoutePath.BILLING)} element={<Billing />} />
+        <Route path={getRouteSubPath(RoutePath.BILLING_PLAN_CHANGE)} element={<BillingPlanChange />} />
+        {/* Without this the bare path falls past the dashboard shell to the
+            top-level NotFound instead of the plan grid it is missing an id for. */}
+        <Route path={getRouteSubPath(RoutePath.BILLING_PLAN)} element={<Navigate to={RoutePath.BILLING} replace />} />
         <Route
           path={getRouteSubPath(RoutePath.BILLING_SPENDING)}
           element={<Navigate to={RoutePath.BILLING} replace />}

--- a/apps/dashboard/src/components/billing/CycleOverview.tsx
+++ b/apps/dashboard/src/components/billing/CycleOverview.tsx
@@ -4,10 +4,15 @@
  */
 
 import { OrganizationPlan, OrganizationWallet, Plan } from '@/billing-api'
-import { BRAND, Metric, Panel, PanelNote, SectionTitle, SegmentedBar } from '@/components/ascii'
+import { AsciiButton, BRAND, Metric, Panel, PanelNote, SectionTitle, SegmentedBar } from '@/components/ascii'
+import { ScheduledChange, scheduledChange } from '@/components/billing/planChange'
+import { Spinner } from '@/components/ui/spinner'
+import { useKeepPlanMutation } from '@/hooks/mutations/useKeepPlanMutation'
 import { useUsagePricesQuery } from '@/hooks/queries/useUsagePricesQuery'
 import { formatPriceCents } from '@/lib/box-price'
+import { handleApiError } from '@/lib/error-handling'
 import { formatAmount, formatWholeDollars } from '@/lib/utils'
+import { toast } from 'sonner'
 
 /**
  * How this organization is being billed right now, and the figures that follow
@@ -57,16 +62,22 @@ export function CycleOverview({
   organizationPlan,
   catalogPlan,
   catalogIndex,
+  catalog = [],
+  organizationId,
   plansAnchorId,
 }: {
   wallet: OrganizationWallet
   organizationPlan?: OrganizationPlan | null
   catalogPlan?: Plan
   catalogIndex?: number
+  /** The whole catalog, so a queued plan can be named rather than shown as an id. */
+  catalog?: Plan[]
+  organizationId?: string
   plansAnchorId?: string
 }) {
   const mode = billingMode(wallet, organizationPlan)
   const tierLabel = catalogIndex === undefined ? 'Plan' : `T${catalogIndex + 1}`
+  const scheduled = scheduledChange({ plan: organizationPlan, catalog })
 
   return (
     <section>
@@ -107,8 +118,66 @@ export function CycleOverview({
         )}
 
         {mode.kind !== 'plan' && <UnsubscribedNote mode={mode} plansAnchorId={plansAnchorId} />}
+        {scheduled && organizationPlan && (
+          <ScheduledChangeNote scheduled={scheduled} organizationId={organizationId} planId={organizationPlan.planId} />
+        )}
       </Panel>
     </section>
+  )
+}
+
+/**
+ * States what is already queued against this cycle, and offers the way out.
+ *
+ * Deliberately asymmetric with the plan-change confirmation page: committing a
+ * downgrade costs capacity and gets a full page, while keeping the plan you
+ * already have restores the status quo, changes nothing today, and can be
+ * re-queued from the grid at no cost. So this one commits on a single click.
+ */
+function ScheduledChangeNote({
+  scheduled,
+  organizationId,
+  planId,
+}: {
+  scheduled: ScheduledChange
+  /** Absent while the organization is still resolving — the note still states what is queued. */
+  organizationId?: string
+  planId: string
+}) {
+  const keepPlan = useKeepPlanMutation()
+
+  const handleKeep = async () => {
+    if (!organizationId) {
+      return
+    }
+    try {
+      const checkoutUrl = await keepPlan.mutateAsync({ organizationId, planId })
+      if (checkoutUrl) {
+        // Not expected while a subscription is live, but the upgrade path can
+        // always answer with one — following it beats silently reporting done.
+        window.location.href = checkoutUrl
+        return
+      }
+      toast.success(scheduled.keptLabel)
+    } catch (error) {
+      handleApiError(error, 'Failed to cancel the scheduled plan change')
+    }
+  }
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border px-[22px] py-4">
+      <PanelNote>{scheduled.text}</PanelNote>
+      {organizationId && (
+        <AsciiButton
+          disabled={keepPlan.isPending}
+          onClick={handleKeep}
+          className="inline-flex shrink-0 items-center gap-2"
+        >
+          {keepPlan.isPending && <Spinner className="size-3.5" />}
+          {scheduled.keepLabel}
+        </AsciiButton>
+      )}
+    </div>
   )
 }
 

--- a/apps/dashboard/src/components/billing/PlanCards.tsx
+++ b/apps/dashboard/src/components/billing/PlanCards.tsx
@@ -5,23 +5,11 @@
 
 import { OrganizationPlan, Plan } from '@/billing-api'
 import { AsciiButton, BRAND } from '@/components/ascii'
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog'
+import { planCardCta } from '@/components/billing/planChange'
 import { Skeleton } from '@/components/ui/skeleton'
-import { useDowngradePlanMutation } from '@/hooks/mutations/useDowngradePlanMutation'
-import { useUpgradePlanMutation } from '@/hooks/mutations/useUpgradePlanMutation'
-import { handleApiError } from '@/lib/error-handling'
+import { RoutePath } from '@/enums/RoutePath'
 import { formatWholeDollars } from '@/lib/utils'
-import { useState } from 'react'
-import { toast } from 'sonner'
+import { generatePath, useNavigate } from 'react-router-dom'
 
 const CUSTOM_PLAN_CONTACT_URL =
   'mailto:sales@boxlite.ai?subject=Custom%20Plan%20Inquiry&body=Hi%20BoxLite%20Team%2C%0A%0AI%27m%20interested%20in%20a%20custom%20plan%20and%20would%20like%20to%20learn%20more%20about%20your%20options.%0A%0AHere%27s%20some%20context%3A%0A%0A-%20Your%20use%20case%3A%20%0A-%20Current%20technology%3A%20%0A-%20Requirements%3A%20%0A-%20Typical%20box%20size%3A%20%0A-%20Peak%20concurrent%20boxes%3A%20%0A%0AThanks.'
@@ -54,28 +42,21 @@ export function planCardDisplay(plan: Plan, catalogIndex: number): { tierLabel: 
   return { tierLabel: `T${catalogIndex + 1}`, leverage }
 }
 
-/** With no plan yet, $0/mo is the floor — every real plan is an upgrade. */
-function isUpgradeTo(plan: Plan, currentPriceCents: number | null): boolean {
-  return (plan.priceMonthlyCents ?? 0) > (currentPriceCents ?? 0)
-}
-
 function PlanCard({
   plan,
-  currentPlanId,
+  organizationPlan,
   currentPriceCents,
   catalogIndex,
   onSwitch,
-  pending,
 }: {
   plan: Plan
-  currentPlanId?: string
+  organizationPlan?: OrganizationPlan | null
   currentPriceCents: number | null
   catalogIndex: number
   onSwitch: (plan: Plan) => void
-  pending: boolean
 }) {
-  const isActive = plan.id === currentPlanId
-  const isUpgrade = isUpgradeTo(plan, currentPriceCents)
+  const cta = planCardCta({ plan, organizationPlan, currentPriceCents })
+  const isActive = cta.kind === 'current'
   const display = planCardDisplay(plan, catalogIndex)
 
   return (
@@ -91,6 +72,13 @@ function PlanCard({
         {isActive && (
           <span className="bg-foreground px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[1px] text-background">
             current
+          </span>
+        )}
+        {/* Outlined, not filled: this plan is coming, not active — the same
+            distinction CustomPlanCard's "by request" badge draws. */}
+        {cta.kind === 'scheduled' && (
+          <span className="border border-brand/30 px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[1px] text-brand">
+            scheduled
           </span>
         )}
       </div>
@@ -113,17 +101,17 @@ function PlanCard({
         />
       </div>
 
-      {isActive ? (
+      {cta.disabled ? (
         <AsciiButton disabled className="w-full text-muted-foreground">
-          Current plan
-        </AsciiButton>
-      ) : isUpgrade ? (
-        <AsciiButton variant="primary" className="w-full" disabled={pending} onClick={() => onSwitch(plan)}>
-          Upgrade →
+          {cta.label}
         </AsciiButton>
       ) : (
-        <AsciiButton className="w-full" disabled={pending} onClick={() => onSwitch(plan)}>
-          Downgrade
+        <AsciiButton
+          variant={cta.kind === 'upgrade' ? 'primary' : 'secondary'}
+          className="w-full"
+          onClick={() => onSwitch(plan)}
+        >
+          {cta.label}
         </AsciiButton>
       )}
     </div>
@@ -185,85 +173,31 @@ export function PlanCardsSkeleton({ count = 3 }: { count?: number }) {
   )
 }
 
-export function PlanCards({
-  plans,
-  organizationPlan,
-  organizationId,
-}: {
-  plans: Plan[]
-  organizationPlan?: OrganizationPlan | null
-  organizationId: string
-}) {
-  const [confirmPlan, setConfirmPlan] = useState<Plan | null>(null)
-  const upgradePlan = useUpgradePlanMutation()
-  const downgradePlan = useDowngradePlanMutation()
-  const pending = upgradePlan.isPending || downgradePlan.isPending
-  const currentPlanId = organizationPlan?.planId
+export function PlanCards({ plans, organizationPlan }: { plans: Plan[]; organizationPlan?: OrganizationPlan | null }) {
+  const navigate = useNavigate()
+  // A lapsed subscription still names its old plan, but that plan no longer
+  // prices anything — planCardCta ignores it too, and the two must agree or a
+  // card reads "Downgrade" for a move the confirmation page calls "Subscribe".
+  const currentPlanId = organizationPlan?.status === 'canceled' ? undefined : organizationPlan?.planId
   // A plan not in this (self-serve-only) catalog is a managed/custom deal —
   // there is no price to compare against, so every self-serve plan reads as
-  // an upgrade. The server is the one that actually knows and will refuse a
-  // self-serve switch away from managed billing with its own error.
+  // an upgrade. The confirmation page says so, and the server is the one that
+  // actually knows and will refuse a self-serve switch away from managed billing.
   const currentPriceCents = plans.find((plan) => plan.id === currentPlanId)?.priceMonthlyCents ?? null
 
-  const isUpgrade = !!confirmPlan && isUpgradeTo(confirmPlan, currentPriceCents)
-
-  const handleConfirm = async () => {
-    if (!confirmPlan) {
-      return
-    }
-    const target = confirmPlan
-    const upgrading = isUpgradeTo(confirmPlan, currentPriceCents)
-    setConfirmPlan(null)
-    try {
-      if (upgrading) {
-        const checkoutUrl = await upgradePlan.mutateAsync({ organizationId, planId: target.id })
-        if (checkoutUrl) {
-          window.location.href = checkoutUrl
-          return
-        }
-        toast.success('Plan upgraded successfully')
-      } else {
-        await downgradePlan.mutateAsync({ organizationId, planId: target.id })
-        toast.success('Plan will change at the next billing cycle')
-      }
-    } catch (error) {
-      handleApiError(error, `Failed to ${upgrading ? 'upgrade' : 'downgrade'} organization plan`)
-    }
-  }
-
   return (
-    <>
-      <div className="grid grid-cols-1 gap-[14px] md:grid-cols-2 xl:grid-cols-4">
-        {plans.map((plan, catalogIndex) => (
-          <PlanCard
-            key={plan.id}
-            plan={plan}
-            currentPlanId={currentPlanId}
-            currentPriceCents={currentPriceCents}
-            catalogIndex={catalogIndex}
-            onSwitch={setConfirmPlan}
-            pending={pending}
-          />
-        ))}
-        <CustomPlanCard catalogIndex={plans.length} />
-      </div>
-
-      <AlertDialog open={!!confirmPlan} onOpenChange={(open) => !open && setConfirmPlan(null)}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{isUpgrade ? 'Upgrade plan' : 'Downgrade plan'}</AlertDialogTitle>
-            <AlertDialogDescription>
-              {isUpgrade
-                ? `Switch to ${confirmPlan?.name} now. An existing subscription is charged the prorated difference immediately; a first subscribe continues to a secure Stripe checkout to confirm payment.`
-                : `Switch to ${confirmPlan?.name} at the next billing cycle. Your current plan's quota stays available until then.`}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={handleConfirm}>Confirm</AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </>
+    <div className="grid grid-cols-1 gap-[14px] md:grid-cols-2 xl:grid-cols-4">
+      {plans.map((plan, catalogIndex) => (
+        <PlanCard
+          key={plan.id}
+          plan={plan}
+          organizationPlan={organizationPlan}
+          currentPriceCents={currentPriceCents}
+          catalogIndex={catalogIndex}
+          onSwitch={(target) => navigate(generatePath(RoutePath.BILLING_PLAN_CHANGE, { planId: target.id }))}
+        />
+      ))}
+      <CustomPlanCard catalogIndex={plans.length} />
+    </div>
   )
 }

--- a/apps/dashboard/src/components/billing/PlanSection.tsx
+++ b/apps/dashboard/src/components/billing/PlanSection.tsx
@@ -65,6 +65,10 @@ export function PlanSection() {
               organizationPlan={organizationPlan}
               catalogPlan={activeCatalogPlan}
               catalogIndex={activeCatalogIndex >= 0 ? activeCatalogIndex : undefined}
+              // Unfiltered: a queued plan should still be named even when it is
+              // not one the organization could have picked itself.
+              catalog={plansQuery.data}
+              organizationId={selectedOrganization?.id}
               plansAnchorId={ALL_PLANS_ANCHOR}
             />
           )}
@@ -75,11 +79,7 @@ export function PlanSection() {
               {isLoading ? (
                 <PlanCardsSkeleton count={4} />
               ) : (
-                <PlanCards
-                  plans={plans || []}
-                  organizationPlan={organizationPlan}
-                  organizationId={selectedOrganization.id}
-                />
+                <PlanCards plans={plans || []} organizationPlan={organizationPlan} />
               )}
             </section>
           )}

--- a/apps/dashboard/src/components/billing/ThisCycleCard.test.ts
+++ b/apps/dashboard/src/components/billing/ThisCycleCard.test.ts
@@ -14,6 +14,16 @@ const plan: OrganizationPlan = {
   quotaRemainingCents: 18750,
 }
 const now = new Date('2026-08-14T12:00:00.000Z')
+const catalog = [
+  {
+    id: 'starter',
+    name: 'Starter',
+    priceMonthlyCents: 1_900,
+    includedQuotaCents: 3_000,
+    concurrencyLimit: 20,
+    selfServe: true,
+  },
+]
 
 describe('cycleFacts', () => {
   it('counts the days to the roll and states the window', () => {
@@ -37,9 +47,19 @@ describe('cycleFacts', () => {
   })
 
   it('notes a queued downgrade with the roll date, cancellation taking precedence', () => {
-    expect(cycleFacts({ ...plan, pendingPlanId: 'starter' }, now).note).toBe(
-      'Downgrades to starter when the cycle rolls on Sep 5',
+    expect(cycleFacts({ ...plan, pendingPlanId: 'starter' }, now, catalog).note).toBe(
+      'Downgrades to Starter when the cycle rolls on Sep 5',
     )
-    expect(cycleFacts({ ...plan, status: 'canceled', pendingPlanId: 'starter' }, now).note).toMatch(/^Canceled/)
+    expect(cycleFacts({ ...plan, status: 'canceled', pendingPlanId: 'starter' }, now, catalog).note).toMatch(
+      /^Canceled/,
+    )
+  })
+
+  // A negotiated plan never appears in the public catalog, so there is no name
+  // to resolve — but the note still has to say something.
+  it('falls back to the id only when the catalog cannot name the queued plan', () => {
+    expect(cycleFacts({ ...plan, pendingPlanId: 'negotiated' }, now, catalog).note).toBe(
+      'Downgrades to negotiated when the cycle rolls on Sep 5',
+    )
   })
 })

--- a/apps/dashboard/src/components/billing/ThisCycleCard.tsx
+++ b/apps/dashboard/src/components/billing/ThisCycleCard.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { OrganizationPlan } from '@/billing-api'
+import { OrganizationPlan, Plan } from '@/billing-api'
 import { Metric, Panel, PanelNote, SectionTitle, SegmentedBar } from '@/components/ascii'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useOwnerPlanQuery, useOwnerWalletQuery } from '@/hooks/queries/billingQueries'
@@ -18,9 +18,14 @@ import { differenceInCalendarDays, format } from 'date-fns'
  * (plan, now) so the unlimited/canceled/downgrade branching is
  * testable without a DOM.
  */
-export function cycleFacts(plan: OrganizationPlan, now: Date) {
+export function cycleFacts(plan: OrganizationPlan, now: Date, catalog: Plan[] = []) {
   const daysLeft = Math.max(0, differenceInCalendarDays(plan.cycleTo, now))
   const rollDay = format(plan.cycleTo, 'MMM d')
+  // A plan id is not user-facing copy. Fall back to it only when the public
+  // catalog cannot name the queued plan — a negotiated one never appears there.
+  const queuedName = plan.pendingPlanId
+    ? (catalog.find((entry) => entry.id === plan.pendingPlanId)?.name ?? plan.pendingPlanId)
+    : null
   return {
     unlimited: plan.includedQuotaCents === null,
     daysLeft,
@@ -28,8 +33,8 @@ export function cycleFacts(plan: OrganizationPlan, now: Date) {
     note:
       plan.status === 'canceled'
         ? `Canceled — quota stays usable until ${rollDay}, then pay-as-you-go from the wallet`
-        : plan.pendingPlanId
-          ? `Downgrades to ${plan.pendingPlanId} when the cycle rolls on ${rollDay}`
+        : queuedName
+          ? `Downgrades to ${queuedName} when the cycle rolls on ${rollDay}`
           : null,
   }
 }
@@ -69,7 +74,7 @@ export function ThisCycleCard() {
   }
   if (!plan) return null
 
-  const { unlimited, daysLeft, window, note } = cycleFacts(plan, new Date())
+  const { unlimited, daysLeft, window, note } = cycleFacts(plan, new Date(), plans ?? [])
 
   return (
     <section>

--- a/apps/dashboard/src/components/billing/billingLayout.ts
+++ b/apps/dashboard/src/components/billing/billingLayout.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+/**
+ * The billing surface sets its own page width rather than using the shared
+ * PageLayout shell. Shared so the plan-change confirmation lines up with the
+ * billing page it is reached from and returns to.
+ */
+export const BILLING_PAGE_CONTAINER = 'mx-auto w-full max-w-[1440px] px-4 sm:px-5 2xl:px-0'

--- a/apps/dashboard/src/components/billing/planChange.test.ts
+++ b/apps/dashboard/src/components/billing/planChange.test.ts
@@ -1,0 +1,390 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { OrganizationPlan, Plan } from '@/billing-api'
+import { describe, expect, it } from 'vitest'
+import { isUpgradeTo, planCardCta, planChangeSummary, scheduledChange } from './planChange'
+
+const CATALOG: Plan[] = [
+  {
+    id: 'starter',
+    name: 'Starter',
+    priceMonthlyCents: 1_900,
+    includedQuotaCents: 3_000,
+    concurrencyLimit: 20,
+    selfServe: true,
+  },
+  {
+    id: 'pro',
+    name: 'Pro',
+    priceMonthlyCents: 14_900,
+    includedQuotaCents: 25_000,
+    concurrencyLimit: 100,
+    selfServe: true,
+  },
+  {
+    id: 'max',
+    name: 'Max',
+    priceMonthlyCents: 49_900,
+    includedQuotaCents: 90_000,
+    concurrencyLimit: 1_000,
+    selfServe: true,
+  },
+  {
+    id: 'enterprise',
+    name: 'Enterprise',
+    priceMonthlyCents: null,
+    includedQuotaCents: null,
+    concurrencyLimit: null,
+    selfServe: false,
+  },
+]
+
+const LIVE_PRO: OrganizationPlan = {
+  planId: 'pro',
+  planName: 'Pro',
+  status: 'active',
+  cycleFrom: new Date(Date.UTC(2026, 7, 5)),
+  cycleTo: new Date(Date.UTC(2026, 8, 5)),
+  includedQuotaCents: 25_000,
+  quotaConsumedCents: 6_250,
+  quotaRemainingCents: 18_750,
+}
+
+const summarize = (
+  planId: string,
+  plan: OrganizationPlan | null,
+  wallet?: Parameters<typeof planChangeSummary>[0]['wallet'],
+) => planChangeSummary({ planId, catalog: CATALOG, plan, wallet })
+
+describe('isUpgradeTo', () => {
+  it('treats an unpriced current plan as the $0 floor', () => {
+    expect(isUpgradeTo(CATALOG[0], null)).toBe(true)
+    expect(isUpgradeTo(CATALOG[1], 14_900)).toBe(false)
+  })
+})
+
+describe('direction and the endpoint it maps to', () => {
+  it('reads a costlier plan as an upgrade that applies in place', () => {
+    const summary = summarize('max', LIVE_PRO)
+
+    expect(summary.direction).toBe('upgrade')
+    expect(summary.action).toBe('upgrade')
+    expect(summary.title).toBe('Upgrade plan')
+  })
+
+  it('reads a cheaper plan as a downgrade that defers', () => {
+    const summary = summarize('starter', LIVE_PRO)
+
+    expect(summary.direction).toBe('downgrade')
+    expect(summary.action).toBe('downgrade')
+  })
+
+  it('calls a first subscribe a subscribe, not an upgrade from zero', () => {
+    const summary = summarize('pro', null)
+
+    expect(summary.direction).toBe('subscribe')
+    expect(summary.action).toBe('upgrade')
+    expect(summary.confirmLabel).toBe('Subscribe')
+  })
+
+  // A canceled subscription has no next cycle, so routing a cheaper plan to the
+  // downgrade endpoint would promise a roll that never happens.
+  it('treats a cheaper plan after cancellation as a resubscribe, not a downgrade', () => {
+    const summary = summarize('starter', { ...LIVE_PRO, status: 'canceled' })
+
+    expect(summary.direction).toBe('subscribe')
+    expect(summary.action).toBe('upgrade')
+    expect(summary.effect).toContain('has ended')
+  })
+
+  it('claims no direction when the live plan is off-catalog', () => {
+    const managed: OrganizationPlan = { ...LIVE_PRO, planId: 'managed', planName: 'Managed' }
+    const summary = summarize('pro', managed)
+
+    expect(summary.direction).toBe('unknown')
+    expect(summary.action).toBe('upgrade')
+  })
+})
+
+describe('comparisons', () => {
+  it('lays the catalog specs side by side', () => {
+    expect(summarize('max', LIVE_PRO).comparisons).toEqual([
+      { label: 'Price', from: '$149/mo', to: '$499/mo' },
+      { label: 'Included quota', from: '$250', to: '$900' },
+      { label: 'Concurrency', from: '100 boxes', to: '1000 boxes' },
+    ])
+  })
+
+  it('shows no subscription rather than $0 when there is no plan', () => {
+    expect(summarize('pro', null).comparisons.map((row) => row.from)).toEqual([
+      'No subscription',
+      'No subscription',
+      'No subscription',
+    ])
+  })
+
+  it('shows a negotiated plan as Custom rather than inventing a price', () => {
+    const managed: OrganizationPlan = { ...LIVE_PRO, planId: 'managed', planName: 'Managed' }
+
+    expect(summarize('pro', managed).comparisons.map((row) => row.from)).toEqual(['Custom', 'Custom', 'Custom'])
+  })
+})
+
+describe('effect', () => {
+  it('warns a first subscribe that confirming leaves the dashboard', () => {
+    const summary = summarize('pro', null)
+
+    expect(summary.effect).toContain('Stripe')
+    expect(summary.effect).toContain('leave the dashboard')
+  })
+
+  it('charges an upgrade on a live subscription immediately and prorated', () => {
+    const summary = summarize('max', LIVE_PRO)
+
+    expect(summary.effect).toContain('immediately')
+    expect(summary.effect).toContain('prorated')
+  })
+
+  it('names the day a downgrade lands and says nothing is charged', () => {
+    const summary = summarize('starter', LIVE_PRO)
+
+    expect(summary.effect).toContain('Sep 5, 2026')
+    expect(summary.effect).toContain('Nothing is charged today')
+  })
+})
+
+describe('quota and wallet', () => {
+  it('frames the unused quota a downgrade keeps, not loses', () => {
+    const summary = summarize('starter', LIVE_PRO)
+
+    expect(summary.quotaNote).toContain('$187.50')
+    expect(summary.quotaNote).toContain('Sep 5, 2026')
+  })
+
+  it('says nothing about quota when upgrading', () => {
+    expect(summarize('max', LIVE_PRO).quotaNote).toBeNull()
+  })
+
+  it('says nothing about quota on an unlimited plan', () => {
+    expect(summarize('starter', { ...LIVE_PRO, quotaRemainingCents: null }).quotaNote).toBeNull()
+  })
+
+  it('names the wallet balance that funds overage', () => {
+    const summary = summarize('starter', LIVE_PRO, {
+      balanceCents: 1_000,
+      ongoingBalanceCents: 1_000,
+      name: 'Wallet',
+      creditCardConnected: false,
+    })
+
+    expect(summary.walletNote).toContain('$10.00')
+  })
+
+  it('omits the wallet note before the wallet loads', () => {
+    expect(summarize('starter', LIVE_PRO).walletNote).toBeNull()
+  })
+})
+
+describe('caveats', () => {
+  it('warns that a negotiated plan may refuse a self-serve switch', () => {
+    const managed: OrganizationPlan = { ...LIVE_PRO, planId: 'managed', planName: 'Managed' }
+
+    expect(summarize('pro', managed).caveats[0].text).toContain('negotiated plan')
+  })
+
+  // ThisCycleCard printed the raw id here; user-facing copy should not.
+  it('names a queued change by its plan name, not its id', () => {
+    const queued: OrganizationPlan = { ...LIVE_PRO, pendingPlanId: 'starter' }
+    const caveat = summarize('max', queued).caveats[0]
+
+    expect(caveat.text).toContain('Starter')
+    expect(caveat.text).not.toContain('starter')
+  })
+
+  it('lets a scheduled cancellation take precedence over a queued downgrade', () => {
+    const canceling: OrganizationPlan = { ...LIVE_PRO, pendingPlanId: 'starter', cancelAtPeriodEnd: true }
+
+    expect(summarize('max', canceling).caveats[0].text).toContain('set to end')
+  })
+
+  it('stays quiet on an ordinary switch', () => {
+    expect(summarize('max', LIVE_PRO).caveats).toEqual([])
+  })
+})
+
+describe('blocked', () => {
+  it('redirects a plan id the catalog does not carry', () => {
+    expect(summarize('bogus', LIVE_PRO).blocked).toEqual({ kind: 'not-in-catalog', redirect: true })
+  })
+
+  it('redirects a plan that is not self-serve', () => {
+    expect(summarize('enterprise', LIVE_PRO).blocked).toEqual({ kind: 'not-in-catalog', redirect: true })
+  })
+
+  // Back after a successful upgrade lands here; without this it is a dead page.
+  it('redirects when the target is already the live plan', () => {
+    expect(summarize('pro', LIVE_PRO).blocked).toEqual({ kind: 'same-plan', redirect: true })
+  })
+
+  it('lets a canceled subscription resubscribe to the same plan', () => {
+    expect(summarize('pro', { ...LIVE_PRO, status: 'canceled' }).blocked).toBeNull()
+  })
+
+  it('explains rather than redirects when the target is already queued', () => {
+    const queued: OrganizationPlan = { ...LIVE_PRO, pendingPlanId: 'starter' }
+    const blocked = summarize('starter', queued).blocked
+
+    expect(blocked?.kind).toBe('already-queued')
+    expect(blocked?.redirect).toBe(false)
+  })
+
+  it('does not block an ordinary switch', () => {
+    expect(summarize('max', LIVE_PRO).blocked).toBeNull()
+  })
+
+  // `blocked` already says there is nothing to confirm; a caveat saying
+  // "confirming replaces it" renders right beside it and contradicts it.
+  it('drops the queued-change caveat when the queued plan is the one being viewed', () => {
+    const queued: OrganizationPlan = { ...LIVE_PRO, pendingPlanId: 'starter' }
+    const summary = summarize('starter', queued)
+
+    expect(summary.blocked?.kind).toBe('already-queued')
+    expect(summary.caveats).toEqual([])
+  })
+
+  it('keeps the caveat when switching to a different plan than the queued one', () => {
+    const queued: OrganizationPlan = { ...LIVE_PRO, pendingPlanId: 'starter' }
+
+    expect(summarize('max', queued).caveats[0].text).toContain('already queued')
+  })
+
+  // A lapsed cycle can still carry the id it was going to roll into. Calling
+  // that "already scheduled" contradicts the effect line, which says the
+  // subscription has ended and this starts a new one — and leaves the page
+  // with no Confirm button and no way to act.
+  it('does not call a lapsed plan queued, so resubscribing to it stays possible', () => {
+    const lapsed: OrganizationPlan = { ...LIVE_PRO, status: 'canceled', pendingPlanId: 'starter' }
+    const summary = summarize('starter', lapsed)
+
+    expect(summary.blocked).toBeNull()
+    expect(summary.direction).toBe('subscribe')
+  })
+})
+
+describe('caveats after the cycle lapsed', () => {
+  it('does not claim a change is queued against a cycle that already ended', () => {
+    const lapsed: OrganizationPlan = { ...LIVE_PRO, status: 'canceled', pendingPlanId: 'starter' }
+
+    expect(summarize('max', lapsed).caveats).toEqual([])
+  })
+
+  it('does not claim a subscription is about to end once it already has', () => {
+    const lapsed: OrganizationPlan = { ...LIVE_PRO, status: 'canceled', cancelAtPeriodEnd: true }
+
+    expect(summarize('max', lapsed).caveats).toEqual([])
+  })
+})
+
+describe('scheduledChange', () => {
+  const queued = (extra: Partial<OrganizationPlan>) =>
+    scheduledChange({ plan: { ...LIVE_PRO, ...extra }, catalog: CATALOG })
+
+  it('says nothing when nothing is queued', () => {
+    expect(scheduledChange({ plan: LIVE_PRO, catalog: CATALOG })).toBeNull()
+    expect(scheduledChange({ plan: null, catalog: CATALOG })).toBeNull()
+  })
+
+  it('names the queued plan and the day it starts', () => {
+    const change = queued({ pendingPlanId: 'starter' })
+
+    expect(change?.kind).toBe('downgrade')
+    expect(change?.text).toContain('Starter')
+    expect(change?.text).toContain('Sep 5, 2026')
+  })
+
+  it('reassures that the current plan holds until then', () => {
+    expect(queued({ pendingPlanId: 'starter' })?.text).toContain("Pro's quota and concurrency stay yours")
+  })
+
+  // ThisCycleCard printed the raw id here; user-facing copy should not.
+  it('never prints a raw plan id', () => {
+    expect(queued({ pendingPlanId: 'starter' })?.text).not.toContain('starter')
+  })
+
+  it('says what happens without inventing a name for an off-catalog queued plan', () => {
+    const change = queued({ pendingPlanId: 'negotiated' })
+
+    expect(change?.text).toContain('Sep 5, 2026')
+    expect(change?.text).not.toContain('negotiated')
+  })
+
+  it('reads a scheduled cancellation as an ending, not a downgrade', () => {
+    const change = queued({ cancelAtPeriodEnd: true })
+
+    expect(change?.kind).toBe('cancel')
+    expect(change?.text).toContain('subscription ends')
+  })
+
+  it('lets a cancellation outrank a queued downgrade', () => {
+    expect(queued({ pendingPlanId: 'starter', cancelAtPeriodEnd: true })?.kind).toBe('cancel')
+  })
+
+  it('offers to keep the plan by name', () => {
+    expect(queued({ pendingPlanId: 'starter' })?.keepLabel).toBe('Keep Pro')
+    expect(queued({ cancelAtPeriodEnd: true })?.keepLabel).toBe('Keep Pro')
+  })
+
+  // The cycle already lapsed, so there is no roll left to schedule against.
+  it('has nothing to keep once the subscription has ended', () => {
+    expect(queued({ status: 'canceled', pendingPlanId: 'starter' })).toBeNull()
+  })
+})
+
+describe('planCardCta', () => {
+  const catalogEntry = (planId: string): Plan => {
+    const entry = CATALOG.find((plan) => plan.id === planId)
+    if (!entry) {
+      throw new Error(`no catalog entry for ${planId}`)
+    }
+    return entry
+  }
+  const cta = (planId: string, plan: OrganizationPlan | null) =>
+    planCardCta({
+      plan: catalogEntry(planId),
+      organizationPlan: plan,
+      currentPriceCents: plan ? (CATALOG.find((entry) => entry.id === plan.planId)?.priceMonthlyCents ?? null) : null,
+    })
+
+  it('marks the live plan as current and offers nothing to click', () => {
+    expect(cta('pro', LIVE_PRO)).toEqual({ kind: 'current', label: 'Current plan', disabled: true })
+  })
+
+  it('offers an upgrade above the current price and a downgrade below it', () => {
+    expect(cta('max', LIVE_PRO).kind).toBe('upgrade')
+    expect(cta('starter', LIVE_PRO).kind).toBe('downgrade')
+  })
+
+  // Without this the card invites a click that dead-ends on the confirmation
+  // page's already-queued notice.
+  it('shows a queued plan as scheduled with its start date, not as a downgrade', () => {
+    const scheduled = cta('starter', { ...LIVE_PRO, pendingPlanId: 'starter' })
+
+    expect(scheduled).toEqual({ kind: 'scheduled', label: 'Starts Sep 5', disabled: true })
+  })
+
+  it('does not call a plan scheduled when a cancellation will replace it', () => {
+    expect(cta('starter', { ...LIVE_PRO, pendingPlanId: 'starter', cancelAtPeriodEnd: true }).kind).toBe('downgrade')
+  })
+
+  // Otherwise the resubscribe path the confirmation page accepts is unreachable.
+  it('lets a canceled subscription act on its own former plan', () => {
+    expect(cta('pro', { ...LIVE_PRO, status: 'canceled' }).disabled).toBe(false)
+  })
+
+  it('reads every plan as an upgrade when there is no subscription', () => {
+    expect(cta('starter', null).kind).toBe('upgrade')
+  })
+})

--- a/apps/dashboard/src/components/billing/planChange.ts
+++ b/apps/dashboard/src/components/billing/planChange.ts
@@ -1,0 +1,380 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { OrganizationPlan, OrganizationWallet, Plan } from '@/billing-api'
+import { formatAmount, formatWholeDollars } from '@/lib/utils'
+import { format } from 'date-fns'
+
+/**
+ * What kind of move this is, for the words on the page. Separate from `action`
+ * because the two do not line up: a resubscribe and a switch away from a
+ * negotiated deal both run the *upgrade* endpoint whatever their price says.
+ */
+export type PlanChangeDirection = 'upgrade' | 'downgrade' | 'subscribe' | 'unknown'
+
+export interface PlanComparison {
+  label: string
+  from: string
+  to: string
+}
+
+export interface PlanChangeNote {
+  tone: 'info' | 'warn'
+  text: string
+}
+
+/** Why Confirm cannot run. `redirect` cases the caller turns into a <Navigate replace>. */
+export type PlanChangeBlock =
+  | { kind: 'not-in-catalog'; redirect: true }
+  | { kind: 'same-plan'; redirect: true }
+  | { kind: 'already-queued'; redirect: false; text: string }
+
+/**
+ * Everything the confirmation states, as plain values — pure in
+ * (planId, catalog, plan, wallet) so the subscribe/canceled/queued/unlimited
+ * branching is testable without a DOM.
+ */
+export interface PlanChangeSummary {
+  /** The catalog row for `planId`, or null when it names nothing switchable. */
+  target: Plan | null
+  direction: PlanChangeDirection
+  /** Which mutation Confirm runs. Not derivable from `direction`. */
+  action: 'upgrade' | 'downgrade'
+  title: string
+  confirmLabel: string
+  /** Price, included quota and concurrency, already formatted for display. */
+  comparisons: PlanComparison[]
+  /** When the change lands and what it costs. */
+  effect: string
+  /** Downgrade only: the quota this cycle already paid for. */
+  quotaNote: string | null
+  /** The wallet that absorbs usage beyond the included quota. */
+  walletNote: string | null
+  /** Conditions worth stating before confirming — a negotiated plan, a queued change. */
+  caveats: PlanChangeNote[]
+  blocked: PlanChangeBlock | null
+}
+
+/** With no plan yet, $0/mo is the floor — every real plan is an upgrade. */
+export function isUpgradeTo(plan: Plan, currentPriceCents: number | null): boolean {
+  return (plan.priceMonthlyCents ?? 0) > (currentPriceCents ?? 0)
+}
+
+/** `null` price means negotiated outside the catalog, not free. */
+function price(plan: Plan | undefined, fallback: string): string {
+  if (!plan) {
+    return fallback
+  }
+  return plan.priceMonthlyCents != null ? `${formatWholeDollars(plan.priceMonthlyCents)}/mo` : 'Custom'
+}
+
+/** `null` quota/concurrency means unlimited, not zero. */
+function quota(plan: Plan | undefined, fallback: string): string {
+  if (!plan) {
+    return fallback
+  }
+  return plan.includedQuotaCents != null ? formatWholeDollars(plan.includedQuotaCents) : 'Unlimited'
+}
+
+function concurrency(plan: Plan | undefined, fallback: string): string {
+  if (!plan) {
+    return fallback
+  }
+  return plan.concurrencyLimit != null ? `${plan.concurrencyLimit} boxes` : 'Unlimited'
+}
+
+/** A plan id is not user-facing copy — resolve it, and only fall back when the catalog cannot. */
+function planName(planId: string, catalog: Plan[]): string {
+  return catalog.find((plan) => plan.id === planId)?.name ?? planId
+}
+
+export function planChangeSummary({
+  planId,
+  catalog,
+  plan,
+  wallet,
+}: {
+  planId: string
+  /** The public catalog as served; `selfServe` is enforced here, not by the caller. */
+  catalog: Plan[]
+  /** `null` means no live subscription. The caller waits for the query to succeed first. */
+  plan: OrganizationPlan | null
+  wallet?: OrganizationWallet
+}): PlanChangeSummary {
+  const target = catalog.find((entry) => entry.id === planId && entry.selfServe) ?? null
+  // The catalog row for the live plan. Missing means a negotiated deal that
+  // never appears in the public catalog (Plan.ts), not a loading gap.
+  const current = plan ? catalog.find((entry) => entry.id === plan.planId) : undefined
+  const rollDay = plan ? format(plan.cycleTo, 'MMM d, yyyy') : null
+  // A canceled subscription has no next cycle to roll into, so nothing can be
+  // "queued" against it — it restarts instead (OrganizationPlan.ts:20-25).
+  const ended = plan?.status === 'canceled'
+
+  const direction = directionFor({ target, plan, current, ended })
+  // Only a plain downgrade on a live cycle defers; everything else takes the
+  // upgrade endpoint, which applies in place or hands back a Checkout URL.
+  const action = direction === 'downgrade' ? 'downgrade' : 'upgrade'
+  const noPlanLabel = 'No subscription'
+
+  return {
+    target,
+    direction,
+    action,
+    title: { upgrade: 'Upgrade plan', downgrade: 'Downgrade plan', subscribe: 'Subscribe', unknown: 'Change plan' }[
+      direction
+    ],
+    confirmLabel: {
+      upgrade: 'Confirm upgrade',
+      downgrade: 'Confirm downgrade',
+      subscribe: 'Subscribe',
+      unknown: 'Confirm change',
+    }[direction],
+    comparisons: [
+      { label: 'Price', from: price(current, plan ? 'Custom' : noPlanLabel), to: price(target ?? undefined, '—') },
+      {
+        label: 'Included quota',
+        from: quota(current, plan ? 'Custom' : noPlanLabel),
+        to: quota(target ?? undefined, '—'),
+      },
+      {
+        label: 'Concurrency',
+        from: concurrency(current, plan ? 'Custom' : noPlanLabel),
+        to: concurrency(target ?? undefined, '—'),
+      },
+    ],
+    effect: effectFor({ direction, targetName: target?.name ?? planId, ended, rollDay }),
+    quotaNote:
+      direction === 'downgrade' && plan?.quotaRemainingCents != null && rollDay
+        ? `You keep ${formatAmount(plan.quotaRemainingCents)} of unused quota until ${rollDay}.`
+        : null,
+    walletNote: wallet
+      ? `Usage beyond the included quota draws on the wallet, which holds ${formatAmount(wallet.balanceCents)}.`
+      : null,
+    caveats: caveatsFor({ planId, plan, current, catalog, rollDay, ended }),
+    blocked: blockFor({ planId, target, plan, ended, rollDay }),
+  }
+}
+
+function directionFor({
+  target,
+  plan,
+  current,
+  ended,
+}: {
+  target: Plan | null
+  plan: OrganizationPlan | null
+  current: Plan | undefined
+  ended: boolean
+}): PlanChangeDirection {
+  // Nothing live to change from — a first subscribe, or a restart after the
+  // paid cycle ran out. Either way there is no cycle to defer into.
+  if (!plan || ended) {
+    return 'subscribe'
+  }
+  // No catalog row for the live plan, or none for the target: no two prices to
+  // compare, so claiming a direction would be a guess.
+  if (!current || !target) {
+    return 'unknown'
+  }
+  return isUpgradeTo(target, current.priceMonthlyCents) ? 'upgrade' : 'downgrade'
+}
+
+/**
+ * The sentence read immediately before money moves. The live-subscription cases
+ * carry over the wording the confirm dialog already shipped; the subscribe and
+ * resubscribe cases are new, and say plainly that confirming may leave the app.
+ */
+function effectFor({
+  direction,
+  targetName,
+  ended,
+  rollDay,
+}: {
+  direction: PlanChangeDirection
+  targetName: string
+  ended: boolean
+  rollDay: string | null
+}): string {
+  if (direction === 'subscribe') {
+    return ended
+      ? `Your subscription has ended, so this starts a new one on ${targetName}. You may be sent to Stripe to confirm payment.`
+      : `Starts as soon as payment is confirmed. Continuing opens a secure Stripe checkout to enter your card — you will leave the dashboard.`
+  }
+  if (direction === 'unknown') {
+    return `Switches you to ${targetName}. Because your current plan is negotiated, the terms and any charge are settled by billing rather than shown here.`
+  }
+  if (direction === 'upgrade') {
+    return `Applies immediately. Your subscription is charged the prorated difference today, and ${targetName}'s quota is available right away.`
+  }
+  return rollDay
+    ? `Applies on ${rollDay}, when the current cycle rolls. Nothing is charged today.`
+    : `Applies at the next billing cycle. Nothing is charged today.`
+}
+
+function caveatsFor({
+  planId,
+  plan,
+  current,
+  catalog,
+  rollDay,
+  ended,
+}: {
+  planId: string
+  plan: OrganizationPlan | null
+  current: Plan | undefined
+  catalog: Plan[]
+  rollDay: string | null
+  ended: boolean
+}): PlanChangeNote[] {
+  const caveats: PlanChangeNote[] = []
+  // A live plan with no catalog row is a negotiated deal: there is no public
+  // price to compare against, and billing refuses the self-serve switch with
+  // its own error rather than the dashboard guessing the terms.
+  if (plan && !current) {
+    caveats.push({
+      tone: 'warn',
+      text: `${plan.planName} is a negotiated plan, so there is no catalog price to compare against. Switching to a standard plan may be refused — talk to sales first.`,
+    })
+  }
+  if (plan?.cancelAtPeriodEnd && !ended) {
+    caveats.push({
+      tone: 'warn',
+      text: `Your subscription is set to end${rollDay ? ` on ${rollDay}` : ''}. Confirming replaces that with this change.`,
+    })
+    // Two suppressions. Nothing is queued against a cycle that already lapsed,
+    // whatever id the plan still carries. And when the queued plan IS the one
+    // being viewed, `blocked` already says there is nothing to confirm — adding
+    // "confirming replaces it" beside that contradicts it.
+  } else if (plan?.pendingPlanId && !ended && plan.pendingPlanId !== planId) {
+    caveats.push({
+      tone: 'info',
+      text: `A change to ${planName(plan.pendingPlanId, catalog)} is already queued${
+        rollDay ? ` for ${rollDay}` : ''
+      }. Confirming replaces it.`,
+    })
+  }
+  return caveats
+}
+
+function blockFor({
+  planId,
+  target,
+  plan,
+  ended,
+  rollDay,
+}: {
+  planId: string
+  target: Plan | null
+  plan: OrganizationPlan | null
+  ended: boolean
+  rollDay: string | null
+}): PlanChangeBlock | null {
+  if (!target) {
+    return { kind: 'not-in-catalog', redirect: true }
+  }
+  // A canceled subscription still names its old plan, and resubscribing to it
+  // is a real change — only a live plan makes this a no-op.
+  if (plan && !ended && plan.planId === planId) {
+    return { kind: 'same-plan', redirect: true }
+  }
+  // A lapsed cycle can still carry the id it was going to roll into, but that
+  // change will never happen — resubscribing to it is a real action, not a
+  // no-op, and calling it "already scheduled" would contradict the effect line.
+  if (!ended && plan?.pendingPlanId === planId) {
+    return {
+      kind: 'already-queued',
+      redirect: false,
+      text: `${target.name} is already scheduled to start${rollDay ? ` on ${rollDay}` : ''}. There is nothing to confirm.`,
+    }
+  }
+  return null
+}
+
+/** A change already queued against the live cycle, and the control that discards it. */
+export interface ScheduledChange {
+  kind: 'downgrade' | 'cancel'
+  /** What the panel states. */
+  text: string
+  /** Label for the control that discards it — names the plan being kept. */
+  keepLabel: string
+  /** Confirmation once it is discarded. Stated outright rather than derived from keepLabel. */
+  keptLabel: string
+}
+
+/**
+ * What is queued against this cycle, if anything. `null` once the cycle has
+ * already lapsed (`status: 'canceled'`): there is no roll left to schedule
+ * against, so nothing to keep.
+ *
+ * A cancellation outranks a queued downgrade — the same precedence
+ * `cycleFacts` uses, so the two surfaces never disagree about what happens.
+ */
+export function scheduledChange({
+  plan,
+  catalog,
+}: {
+  plan: OrganizationPlan | null | undefined
+  catalog: Plan[]
+}): ScheduledChange | null {
+  if (!plan || plan.status === 'canceled') {
+    return null
+  }
+  const on = format(plan.cycleTo, 'MMM d, yyyy')
+  const keeps = `${plan.planName}'s quota and concurrency stay yours until then.`
+  const keepLabel = `Keep ${plan.planName}`
+  const keptLabel = `Staying on ${plan.planName}`
+
+  if (plan.cancelAtPeriodEnd) {
+    return { kind: 'cancel', text: `Your subscription ends ${on} — ${keeps}`, keepLabel, keptLabel }
+  }
+  if (plan.pendingPlanId) {
+    // An id is not user-facing copy. A queued plan the public catalog cannot
+    // name is a negotiated one; say what happens without inventing a name.
+    const queued = catalog.find((entry) => entry.id === plan.pendingPlanId)
+    return {
+      kind: 'downgrade',
+      text: queued
+        ? `Your downgrade to ${queued.name} is scheduled for ${on} — ${keeps}`
+        : `Your plan changes on ${on} — ${keeps}`,
+      keepLabel,
+      keptLabel,
+    }
+  }
+  return null
+}
+
+/** What a plan's card offers. `disabled` covers both "already yours" and "already queued". */
+export type PlanCardCta =
+  | { kind: 'current'; label: string; disabled: true }
+  | { kind: 'scheduled'; label: string; disabled: true }
+  | { kind: 'upgrade'; label: string; disabled: false }
+  | { kind: 'downgrade'; label: string; disabled: false }
+
+export function planCardCta({
+  plan,
+  organizationPlan,
+  currentPriceCents,
+}: {
+  plan: Plan
+  organizationPlan: OrganizationPlan | null | undefined
+  currentPriceCents: number | null
+}): PlanCardCta {
+  // A canceled subscription still names its old plan, but that plan is no
+  // longer yours to be "current" on — resubscribing to it is a real action,
+  // and the confirmation page accepts it.
+  const live = organizationPlan && organizationPlan.status !== 'canceled' ? organizationPlan : null
+
+  if (live?.planId === plan.id) {
+    return { kind: 'current', label: 'Current plan', disabled: true }
+  }
+  // A pending cancel replaces any queued downgrade, so the card is only
+  // "scheduled" while that cancel is not what is actually coming.
+  if (live?.pendingPlanId === plan.id && !live.cancelAtPeriodEnd) {
+    return { kind: 'scheduled', label: `Starts ${format(live.cycleTo, 'MMM d')}`, disabled: true }
+  }
+  return isUpgradeTo(plan, currentPriceCents)
+    ? { kind: 'upgrade', label: 'Upgrade →', disabled: false }
+    : { kind: 'downgrade', label: 'Downgrade', disabled: false }
+}

--- a/apps/dashboard/src/enums/RoutePath.ts
+++ b/apps/dashboard/src/enums/RoutePath.ts
@@ -25,6 +25,11 @@ export enum RoutePath {
   VOLUMES = '/dashboard/volumes',
   LIMITS = '/dashboard/limits',
   BILLING_SPENDING = '/dashboard/billing/spending',
+  /** Parent of BILLING_PLAN_CHANGE. Carries no id of its own, so it only redirects. */
+  BILLING_PLAN = '/dashboard/billing/plan',
+  /** Confirming a switch to `:planId`. Cancelling a subscription outright is not
+   *  reachable here — it takes a null plan id, which this segment cannot carry. */
+  BILLING_PLAN_CHANGE = '/dashboard/billing/plan/:planId',
   BILLING_WALLET = '/dashboard/billing/wallet',
   MEMBERS = '/dashboard/members',
   ROLES = '/dashboard/roles',

--- a/apps/dashboard/src/hooks/mutations/useKeepPlanMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useKeepPlanMutation.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { queryKeys } from '../queries/queryKeys'
+import { useApi } from '../useApi'
+
+interface KeepPlanParams {
+  organizationId: string
+  /** The plan the organization is already on — the one being kept. */
+  planId: string
+}
+
+/**
+ * Discards whatever is queued against the current cycle (a downgrade, or a
+ * cancellation) and stays on the live plan.
+ *
+ * Commerce exposes no "clear the pending change" route, so this re-asserts the
+ * plan the organization already holds and relies on the upgrade path treating
+ * that as "cancel what is scheduled". That is the only expression the current
+ * contract allows:
+ *
+ *   - `downgradePlan(id, planId)` would queue a change *to the current plan*
+ *     rather than clear one.
+ *   - `downgradePlan(id, null)` cancels the subscription outright — the exact
+ *     opposite of this action, and the reason this lives behind its own hook
+ *     rather than being spelled out at the call site.
+ *
+ * If commerce ever grows an explicit route (`DELETE .../plan/pending`), this
+ * hook is the only thing that changes.
+ */
+export const useKeepPlanMutation = () => {
+  const { billingApi } = useApi()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ organizationId, planId }: KeepPlanParams) => billingApi.upgradePlan(organizationId, planId),
+    onSuccess: async (_data, { organizationId }) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.organization.plan(organizationId) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.organization.usage.overview(organizationId) }),
+      ])
+    },
+  })
+}

--- a/apps/dashboard/src/hooks/useSuspensionBanner.tsx
+++ b/apps/dashboard/src/hooks/useSuspensionBanner.tsx
@@ -65,13 +65,12 @@ export function useSuspensionBanner(suspension?: Suspension | null) {
           title: 'Setup Required',
           description: 'Add a payment method to start creating Boxes.',
           icon: <CreditCardIcon className="h-4 w-4 flex-shrink-0 text-current" />,
-          action:
-            path !== RoutePath.BILLING
-              ? {
-                  label: 'Go to Billing',
-                  onClick: () => navigate(RoutePath.BILLING),
-                }
-              : undefined,
+          action: !path?.startsWith(RoutePath.BILLING)
+            ? {
+                label: 'Go to Billing',
+                onClick: () => navigate(RoutePath.BILLING),
+              }
+            : undefined,
           isDismissible: false,
         })
       } else if (reason === VERIFY_EMAIL_REASON) {
@@ -106,13 +105,12 @@ export function useSuspensionBanner(suspension?: Suspension | null) {
         variant: 'error',
         title: 'Credits depleted',
         description: cleanupText,
-        action:
-          path !== RoutePath.BILLING
-            ? {
-                label: 'Go to Billing',
-                onClick: () => navigate(RoutePath.BILLING),
-              }
-            : undefined,
+        action: !path?.startsWith(RoutePath.BILLING)
+          ? {
+              label: 'Go to Billing',
+              onClick: () => navigate(RoutePath.BILLING),
+            }
+          : undefined,
         isDismissible: false,
       })
       return

--- a/apps/dashboard/src/pages/Billing.tsx
+++ b/apps/dashboard/src/pages/Billing.tsx
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
+import { BILLING_PAGE_CONTAINER } from '@/components/billing/billingLayout'
 import { BillingAlerts } from '@/components/billing/BillingAlerts'
 import { PlanSection } from '@/components/billing/PlanSection'
 import { UsageSection } from '@/components/billing/UsageSection'
@@ -18,7 +19,6 @@ import { Link } from 'react-router-dom'
 // Verbatim from the design: square segments, right-divided, accent fill when active.
 const TAB_TRIGGER =
   'h-full gap-1.5 rounded-none border-0 border-r border-border px-5 text-xs text-muted-foreground transition-colors hover:text-foreground data-[state=active]:bg-accent data-[state=active]:font-semibold data-[state=active]:text-foreground data-[state=active]:shadow-none'
-const BILLING_PAGE_CONTAINER = 'mx-auto w-full max-w-[1440px] px-4 sm:px-5 2xl:px-0'
 const TAB_PANE = 'py-6'
 const TAB_TRIGGER_LAST =
   'h-full gap-1.5 rounded-none border-0 px-5 text-xs text-muted-foreground transition-colors hover:text-foreground data-[state=active]:bg-accent data-[state=active]:font-semibold data-[state=active]:text-foreground data-[state=active]:shadow-none'

--- a/apps/dashboard/src/pages/BillingPlanChange.tsx
+++ b/apps/dashboard/src/pages/BillingPlanChange.tsx
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { AsciiButton, Panel, PanelNote, SectionTitle } from '@/components/ascii'
+import { BILLING_PAGE_CONTAINER } from '@/components/billing/billingLayout'
+import { PlanChangeNote, PlanComparison, planChangeSummary } from '@/components/billing/planChange'
+import { ArrowLeft, RefreshCcw } from '@/components/ui/icon'
+import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Spinner } from '@/components/ui/spinner'
+import { RoutePath } from '@/enums/RoutePath'
+import { useDowngradePlanMutation } from '@/hooks/mutations/useDowngradePlanMutation'
+import { useUpgradePlanMutation } from '@/hooks/mutations/useUpgradePlanMutation'
+import { useOwnerPlanQuery, useOwnerWalletQuery } from '@/hooks/queries/billingQueries'
+import { usePlansQuery } from '@/hooks/queries/usePlansQuery'
+import { useConfig } from '@/hooks/useConfig'
+import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
+import { handleApiError } from '@/lib/error-handling'
+import { OrganizationUserRoleEnum } from '@boxlite-ai/api-client'
+import { format } from 'date-fns'
+import { useState } from 'react'
+import { Navigate, useNavigate, useParams } from 'react-router-dom'
+import { toast } from 'sonner'
+
+/**
+ * The confirmation step for a plan switch. Reached from a plan card, but also
+ * by deep link, reload and Back — so unlike the dialog it replaced, it has to
+ * establish for itself that billing is available, that the viewer owns the
+ * organization, and that `:planId` names a change worth making.
+ */
+function BillingPlanChange() {
+  const { planId = '' } = useParams<{ planId: string }>()
+  const navigate = useNavigate()
+  const config = useConfig()
+  const { selectedOrganization, organizationMembers, authenticatedUserOrganizationMember } = useSelectedOrganization()
+
+  const planQuery = useOwnerPlanQuery()
+  const walletQuery = useOwnerWalletQuery()
+  const plansQuery = usePlansQuery()
+  const upgradePlan = useUpgradePlanMutation()
+  const downgradePlan = useDowngradePlanMutation()
+  const [leaving, setLeaving] = useState(false)
+
+  // Members load in the background from an empty list
+  // (SelectedOrganizationProvider.tsx:97-113), so a missing member means
+  // "not resolved yet" just as often as "not an owner". Redirecting on it
+  // would bounce a real owner off their own deep link on every refresh.
+  const membersResolved = organizationMembers.length > 0
+  const isOwner = authenticatedUserOrganizationMember?.role === OrganizationUserRoleEnum.OWNER
+
+  if (!config.billingApiUrl) {
+    return <Navigate to={RoutePath.BILLING} replace />
+  }
+  if (!selectedOrganization || !membersResolved) {
+    return <PlanChangeShell>{<Skeleton className="h-[320px] w-full" />}</PlanChangeShell>
+  }
+  if (!isOwner) {
+    return (
+      <PlanChangeShell>
+        <Notice title="Plan changes are owner-only">
+          Ask an owner of {selectedOrganization.name} to change the subscription.
+        </Notice>
+      </PlanChangeShell>
+    )
+  }
+
+  const isError = planQuery.isError || plansQuery.isError || walletQuery.isError
+  if (isError) {
+    return (
+      <PlanChangeShell>
+        <Panel className="flex flex-col items-center gap-3 px-[22px] py-10">
+          <span className="font-mono text-[13px] text-foreground">Oops, something went wrong</span>
+          <span className="font-mono text-[11px] text-muted-foreground">There was an error loading billing data.</span>
+          <Button
+            variant="outline"
+            className="mt-1 font-mono text-[12px]"
+            onClick={() => {
+              planQuery.refetch()
+              plansQuery.refetch()
+              walletQuery.refetch()
+            }}
+          >
+            <RefreshCcw className="mr-2 size-4" />
+            Retry
+          </Button>
+        </Panel>
+      </PlanChangeShell>
+    )
+  }
+
+  // A confirmation that briefly states the wrong price is worse than one that
+  // states nothing, so nothing renders until both the catalog and the live plan
+  // have actually landed — no zero-value fallbacks.
+  if (!plansQuery.isSuccess || !planQuery.isSuccess) {
+    return <PlanChangeShell>{<Skeleton className="h-[320px] w-full" />}</PlanChangeShell>
+  }
+
+  const summary = planChangeSummary({
+    planId,
+    catalog: plansQuery.data,
+    plan: planQuery.data,
+    wallet: walletQuery.data,
+  })
+
+  // An unknown plan id, or one the viewer already has, has no confirmation to
+  // show. `replace` keeps Back from bouncing straight back into the redirect.
+  if (summary.blocked?.redirect) {
+    return <Navigate to={RoutePath.BILLING} replace />
+  }
+
+  const pending = upgradePlan.isPending || downgradePlan.isPending || leaving
+  // Only a downgrade defers, and a downgrade always has a live cycle to defer
+  // into — but read it defensively rather than asserting the branch.
+  const rollDay = planQuery.data ? format(planQuery.data.cycleTo, 'MMM d, yyyy') : 'the next billing cycle'
+
+  const handleConfirm = async () => {
+    try {
+      if (summary.action === 'upgrade') {
+        const checkoutUrl = await upgradePlan.mutateAsync({ organizationId: selectedOrganization.id, planId })
+        if (checkoutUrl) {
+          // Hold the pending state through the hand-off: the browser takes a
+          // moment to leave, and an idle-looking button invites a second click.
+          setLeaving(true)
+          window.location.href = checkoutUrl
+          return
+        }
+        toast.success('Plan upgraded successfully')
+      } else {
+        await downgradePlan.mutateAsync({ organizationId: selectedOrganization.id, planId })
+        // Name the plan and the day: "at the next billing cycle" left the user
+        // to go looking for when that is.
+        toast.success(`${summary.target?.name ?? 'Your new plan'} starts ${rollDay}`)
+      }
+      // `replace` so Back does not return to a confirmation for a plan the
+      // organization now holds.
+      navigate(RoutePath.BILLING, { replace: true })
+    } catch (error) {
+      handleApiError(error, `Failed to ${summary.action} organization plan`)
+    }
+  }
+
+  return (
+    <PlanChangeShell title={summary.title}>
+      <div className="flex flex-col gap-6">
+        <section>
+          <SectionTitle title={summary.target?.name ?? planId} />
+          <Panel className="px-[22px] py-2">
+            {summary.comparisons.map((comparison) => (
+              <ComparisonRow key={comparison.label} comparison={comparison} />
+            ))}
+          </Panel>
+          <PanelNote>{summary.effect}</PanelNote>
+        </section>
+
+        {(summary.quotaNote || summary.walletNote || summary.caveats.length > 0) && (
+          <section className="flex flex-col gap-2">
+            {summary.caveats.map((caveat) => (
+              <NoteLine key={caveat.text} note={caveat} />
+            ))}
+            {summary.quotaNote && <NoteLine note={{ tone: 'info', text: summary.quotaNote }} />}
+            {summary.walletNote && <NoteLine note={{ tone: 'info', text: summary.walletNote }} />}
+          </section>
+        )}
+
+        {summary.blocked?.kind === 'already-queued' ? (
+          <Notice title="Already scheduled">{summary.blocked.text}</Notice>
+        ) : (
+          <div className="flex items-center gap-3">
+            <AsciiButton
+              variant="primary"
+              disabled={pending}
+              onClick={handleConfirm}
+              className="inline-flex items-center gap-2"
+            >
+              {pending && <Spinner className="size-3.5" />}
+              {leaving ? 'Redirecting to Stripe…' : summary.confirmLabel}
+            </AsciiButton>
+            {/* Cancelling mid-request would leave the user unsure whether the
+                change went through, so it waits with the confirm button. */}
+            <AsciiButton disabled={pending} onClick={() => navigate(RoutePath.BILLING)}>
+              Cancel
+            </AsciiButton>
+          </div>
+        )}
+      </div>
+    </PlanChangeShell>
+  )
+}
+
+function PlanChangeShell({ title = 'Change plan', children }: { title?: string; children: React.ReactNode }) {
+  const navigate = useNavigate()
+
+  return (
+    <div className={BILLING_PAGE_CONTAINER}>
+      <div className="flex flex-col gap-6 py-6">
+        <div className="flex items-center gap-3">
+          <Button variant="ghost" size="icon-sm" className="shrink-0" onClick={() => navigate(RoutePath.BILLING)}>
+            <ArrowLeft className="size-4" />
+          </Button>
+          <h1 className="font-display text-2xl font-semibold leading-none tracking-tight">{title}</h1>
+        </div>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function ComparisonRow({ comparison }: { comparison: PlanComparison }) {
+  return (
+    <div className="flex items-baseline justify-between gap-3 border-b border-border/40 py-3 font-mono text-[12px] last:border-b-0">
+      <span className="uppercase tracking-[0.5px] text-muted-foreground">{comparison.label}</span>
+      <span className="flex items-baseline gap-2 tabular-nums">
+        <span className="text-muted-foreground line-through decoration-muted-foreground/40">{comparison.from}</span>
+        <span className="text-muted-foreground">→</span>
+        <span className="font-semibold text-foreground">{comparison.to}</span>
+      </span>
+    </div>
+  )
+}
+
+function NoteLine({ note }: { note: PlanChangeNote }) {
+  return (
+    <p
+      className={`font-mono text-[11px] leading-relaxed ${
+        note.tone === 'warn' ? 'text-warning' : 'text-muted-foreground'
+      }`}
+    >
+      {note.text}
+    </p>
+  )
+}
+
+function Notice({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <Panel className="flex flex-col gap-2 px-[22px] py-6">
+      <span className="font-mono text-[13px] text-foreground">{title}</span>
+      <span className="font-mono text-[11px] leading-relaxed text-muted-foreground">{children}</span>
+    </Panel>
+  )
+}
+
+export default BillingPlanChange


### PR DESCRIPTION
Changing a plan moves money, but it was confirmed by a two-line `AlertDialog` that named
neither the price you were leaving nor the one you were taking, and closed *before* firing the
mutation — so a slow upgrade showed nothing until a toast or a full-page redirect. And once a
downgrade was queued, the only surface rendering `pendingPlanId` sat on the Usage tab, while
confirming returns you to Overview: after the toast faded, the scheduled change was invisible.

Confirmation now happens on `/dashboard/billing/plan/:planId`, and the Active Plan panel states
what is queued with a control to discard it.

## Before

```
PlanSection.tsx:20        PlanSection()                                   ~100 LOC
  └─ PlanCards.tsx:188    PlanCards({plans, organizationPlan, orgId})
       ├─ PlanCard        "Upgrade →" / "Downgrade" → setConfirmPlan(plan)
       └─ AlertDialog     one generic sentence per direction
            └─ :210       handleConfirm()
                 ├─ :216  setConfirmPlan(null)        ← BUG: closes before the request fires,
                 │                                      so a slow upgrade shows nothing at all
                 ├─ :219  upgradePlan.mutateAsync()  → window.location.href = checkoutUrl
                 └─ :226  downgradePlan.mutateAsync() → toast "at the next billing cycle"
                                                        ← BUG: never says when; nothing persists it

CycleOverview.tsx:55      CycleOverview()            ← BUG: renders no note for pendingPlanId,
                                                        so a queued downgrade is invisible here
ThisCycleCard.tsx:21      cycleFacts(plan, now)      ← BUG: prints the raw plan id in user copy
                                                        ("Downgrades to starter"), Usage tab only
```

## After

```
PlanCards.tsx:176         PlanCards({plans, organizationPlan})            no mutations, no dialog
  └─ PlanCard             planCardCta() → current | scheduled | upgrade | downgrade
       └─ navigate(generatePath(RoutePath.BILLING_PLAN_CHANGE, {planId}))

BillingPlanChange.tsx:33  BillingPlanChange()                             ~245 LOC, new route
  ├─ guards               billingApiUrl · owner · catalog+plan resolved · blocked?.redirect
  ├─ planChange.ts:95     planChangeSummary({planId, catalog, plan, wallet})   pure
  │    ├─ :163            directionFor()   upgrade | downgrade | subscribe | unknown
  │    ├─ :192            effectFor()      when it lands, and the Stripe hand-off
  │    └─ :260            blockFor()       not-in-catalog | same-plan | already-queued
  └─ handleConfirm()      pending state held through the request, then
                          navigate(BILLING, {replace: true})

CycleOverview.tsx:60      CycleOverview({..., catalog, organizationId})
  └─ :137                 ScheduledChangeNote()
       ├─ planChange.ts:311  scheduledChange({plan, catalog})             pure
       │                     "Your downgrade to Starter is scheduled for Sep 5, 2026 —
       │                      Pro's quota and concurrency stay yours until then."
       └─ useKeepPlanMutation()   [ Keep Pro ] discards it

ThisCycleCard.tsx:21      cycleFacts(plan, now, catalog)   resolves the id to a name
```

## Notes

**Why a route, not a richer dialog.** The four things worth stating — before/after specs, when
it lands, the Stripe hand-off, and the quota the cycle keeps — would turn a dialog into a
scrolling modal. A route is refresh-safe, linkable, and back-safe, and it fixes the
close-before-request problem for free. This does not undo #1166: that merged four *duplicate
views of the same billing data* into tabs; a transactional confirm step is not a fifth view.

**Why no success screen.** An upgrade may redirect off-site to Stripe, so a success state is
reachable on only one branch. The billing page already *is* the outcome — `cycleFacts` renders
the queued change from `pendingPlanId`, and the new card marks itself `current`. Returning
there shows server-derived state instead of a synthetic congratulation.

**Ownership is read as unresolved, not denied.** `organizationMembers` loads in the background
from an empty list (`SelectedOrganizationProvider.tsx:97-113`), so `!isOwner` means "still
loading" as often as "not an owner". Redirecting on it would bounce a real owner off their own
deep link on every refresh; the page skeletons until members resolve. Related: `useOwnerPlanQuery`
is `enabled`-gated, and a disabled react-query v5 query reports `isLoading === false` with
`data === undefined` — which would otherwise read as "no subscription" and show a non-owner the
first-subscribe Stripe flow.

**One-line fix in `useSuspensionBanner`.** It compared `path !== RoutePath.BILLING` exactly, so
a suspended org on the new route would get a "Go to Billing" button navigating away
mid-confirmation. Scoped to `startsWith` — a regression this PR introduces, so it is fixed here.

## Verification

- `vitest run` (apps/dashboard): **183 passed, 26 files** — 47 new cases across
  `isUpgradeTo`, `planChangeSummary`, `scheduledChange`, `planCardCta`
- `tsc -p tsconfig.app.json --noEmit`: exit 0
- lint: 24 problems / 4 errors — **identical to the HEAD baseline**, verified by re-running
  against `git show HEAD:App.tsx`
- Mutation-checked each non-obvious guard: reverting the `canceled` handling, the caveat
  suppression, and the `ended` guards each fails exactly the tests written for them
- Driven in `yarn start:mock`: upgrade and downgrade pages, deep-link refresh, Back after
  confirm, `/plan/bogus` · `/plan/pro` · `/plan/enterprise` · `/plan` all redirecting, the
  Stripe checkout branch, and both `pendingPlanId` and `cancelAtPeriodEnd` states

## Known gaps

- **`Keep Pro` rests on an unverified server behavior.** No route clears a pending change, so
  it re-asserts the current plan via `plan/upgrade` and depends on boxlite-commerce treating
  that as "discard what is queued". A 2xx that does not clear `pendingPlanId` would toast
  "Staying on Pro" while the panel still shows the downgrade. Isolated in
  `useKeepPlanMutation` — the single seam if a `DELETE .../plan/pending` route appears.
- **`pendingPlanId` population is likewise assumed.** If commerce does not set it after a
  downgrade, all three scheduled-change surfaces silently render nothing.
- `BillingPlanChange` skeletons indefinitely if the members fetch fails —
  `SelectedOrganizationProvider` swallows that error. A proper fix needs a `membersLoading`
  flag on `ISelectedOrganizationContext`.
- No DOM test for the page or the `Keep` click path; only the pure logic is pinned.
- Cancelling a subscription outright (`planId: null`) remains unreachable from the UI, as before.

https://claude.ai/code/session_01WcBSS7RKkMWziPtmc3jk9d


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a billing plan-change confirmation page with plan comparisons, pricing and quota details, caveats, and confirmation controls.
  * Added support for scheduled downgrades and cancellations, including options to keep the current plan.
  * Improved plan cards with clearer actions for upgrades, downgrades, subscriptions, and resubscriptions.
  * Added readable names and dates for pending plan changes.
  * Added billing navigation and redirect handling for plan-change routes.

* **Bug Fixes**
  * Canceled subscriptions are now correctly treated as eligible for resubscription.
  * Billing actions are hidden consistently throughout billing pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->