### PR TITLE
fix(dashboard): read one predicate for what a cycle rolls into

### DIFF
--- a/apps/dashboard/src/components/billing/ThisCycleCard.test.ts
+++ b/apps/dashboard/src/components/billing/ThisCycleCard.test.ts
@@ -55,6 +55,21 @@ describe('cycleFacts', () => {
     )
   })
 
+  // The Overview panel states the subscription is ending; this tab must not
+  // simultaneously promise the queued downgrade happens at the same roll.
+  it('lets a cancellation outrank the downgrade queued behind it', () => {
+    expect(cycleFacts({ ...plan, pendingPlanId: 'starter', cancelAtPeriodEnd: true }, now, catalog).note).toBe(
+      'Ends Sep 5 — quota stays usable until the roll, then pay-as-you-go from the wallet',
+    )
+  })
+
+  // New copy: this state used to produce no note at all.
+  it('states a scheduled cancellation even with no downgrade queued behind it', () => {
+    expect(cycleFacts({ ...plan, cancelAtPeriodEnd: true }, now, catalog).note).toBe(
+      'Ends Sep 5 — quota stays usable until the roll, then pay-as-you-go from the wallet',
+    )
+  })
+
   // A negotiated plan never appears in the public catalog, so there is no name
   // to resolve — but the note still has to say something.
   it('falls back to the id only when the catalog cannot name the queued plan', () => {

--- a/apps/dashboard/src/components/billing/ThisCycleCard.tsx
+++ b/apps/dashboard/src/components/billing/ThisCycleCard.tsx
@@ -5,6 +5,7 @@
 
 import { OrganizationPlan, Plan } from '@/billing-api'
 import { Metric, Panel, PanelNote, SectionTitle, SegmentedBar } from '@/components/ascii'
+import { queuedChange } from '@/components/billing/planChange'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useOwnerPlanQuery, useOwnerWalletQuery } from '@/hooks/queries/billingQueries'
 import { usePlansQuery } from '@/hooks/queries/usePlansQuery'
@@ -21,11 +22,14 @@ import { differenceInCalendarDays, format } from 'date-fns'
 export function cycleFacts(plan: OrganizationPlan, now: Date, catalog: Plan[] = []) {
   const daysLeft = Math.max(0, differenceInCalendarDays(plan.cycleTo, now))
   const rollDay = format(plan.cycleTo, 'MMM d')
+  // Shared with the Overview panel: a scheduled cancellation outranks the
+  // downgrade queued behind it, so this tab cannot promise a roll the other
+  // tab says will never come.
+  const queued = queuedChange(plan)
   // A plan id is not user-facing copy. Fall back to it only when the public
   // catalog cannot name the queued plan — a negotiated one never appears there.
-  const queuedName = plan.pendingPlanId
-    ? (catalog.find((entry) => entry.id === plan.pendingPlanId)?.name ?? plan.pendingPlanId)
-    : null
+  const queuedName =
+    queued?.kind === 'downgrade' ? (catalog.find((entry) => entry.id === queued.planId)?.name ?? queued.planId) : null
   return {
     unlimited: plan.includedQuotaCents === null,
     daysLeft,
@@ -33,9 +37,11 @@ export function cycleFacts(plan: OrganizationPlan, now: Date, catalog: Plan[] = 
     note:
       plan.status === 'canceled'
         ? `Canceled — quota stays usable until ${rollDay}, then pay-as-you-go from the wallet`
-        : queuedName
-          ? `Downgrades to ${queuedName} when the cycle rolls on ${rollDay}`
-          : null,
+        : queued?.kind === 'cancel'
+          ? `Ends ${rollDay} — quota stays usable until the roll, then pay-as-you-go from the wallet`
+          : queuedName
+            ? `Downgrades to ${queuedName} when the cycle rolls on ${rollDay}`
+            : null,
   }
 }
 

--- a/apps/dashboard/src/components/billing/planChange.test.ts
+++ b/apps/dashboard/src/components/billing/planChange.test.ts
@@ -5,7 +5,7 @@
 
 import { OrganizationPlan, Plan } from '@/billing-api'
 import { describe, expect, it } from 'vitest'
-import { isUpgradeTo, planCardCta, planChangeSummary, scheduledChange } from './planChange'
+import { isUpgradeTo, planCardCta, planChangeSummary, queuedChange, scheduledChange } from './planChange'
 
 const CATALOG: Plan[] = [
   {
@@ -58,6 +58,21 @@ const summarize = (
   plan: OrganizationPlan | null,
   wallet?: Parameters<typeof planChangeSummary>[0]['wallet'],
 ) => planChangeSummary({ planId, catalog: CATALOG, plan, wallet })
+
+const catalogEntry = (planId: string): Plan => {
+  const entry = CATALOG.find((plan) => plan.id === planId)
+  if (!entry) {
+    throw new Error(`no catalog entry for ${planId}`)
+  }
+  return entry
+}
+
+const cta = (planId: string, plan: OrganizationPlan | null) =>
+  planCardCta({
+    plan: catalogEntry(planId),
+    organizationPlan: plan,
+    currentPriceCents: plan ? (CATALOG.find((entry) => entry.id === plan.planId)?.priceMonthlyCents ?? null) : null,
+  })
 
 describe('isUpgradeTo', () => {
   it('treats an unpriced current plan as the $0 floor', () => {
@@ -245,6 +260,18 @@ describe('blocked', () => {
     expect(summarize('max', LIVE_PRO).blocked).toBeNull()
   })
 
+  // A pending cancel supersedes a queued downgrade, so the queued plan is not
+  // actually going to start. planCardCta already applies that rule and leaves
+  // the card enabled; if blockFor disagrees, that card links to a page with no
+  // action on it.
+  it('does not call a queued plan scheduled when a cancellation supersedes it', () => {
+    const canceling: OrganizationPlan = { ...LIVE_PRO, pendingPlanId: 'starter', cancelAtPeriodEnd: true }
+    const summary = summarize('starter', canceling)
+
+    expect(summary.blocked).toBeNull()
+    expect(cta('starter', canceling).disabled).toBe(false)
+  })
+
   // `blocked` already says there is nothing to confirm; a caveat saying
   // "confirming replaces it" renders right beside it and contradicts it.
   it('drops the queued-change caveat when the queued plan is the one being viewed', () => {
@@ -344,20 +371,6 @@ describe('scheduledChange', () => {
 })
 
 describe('planCardCta', () => {
-  const catalogEntry = (planId: string): Plan => {
-    const entry = CATALOG.find((plan) => plan.id === planId)
-    if (!entry) {
-      throw new Error(`no catalog entry for ${planId}`)
-    }
-    return entry
-  }
-  const cta = (planId: string, plan: OrganizationPlan | null) =>
-    planCardCta({
-      plan: catalogEntry(planId),
-      organizationPlan: plan,
-      currentPriceCents: plan ? (CATALOG.find((entry) => entry.id === plan.planId)?.priceMonthlyCents ?? null) : null,
-    })
-
   it('marks the live plan as current and offers nothing to click', () => {
     expect(cta('pro', LIVE_PRO)).toEqual({ kind: 'current', label: 'Current plan', disabled: true })
   })
@@ -386,5 +399,29 @@ describe('planCardCta', () => {
 
   it('reads every plan as an upgrade when there is no subscription', () => {
     expect(cta('starter', null).kind).toBe('upgrade')
+  })
+})
+
+describe('queuedChange', () => {
+  it('reports nothing queued against an untouched cycle', () => {
+    expect(queuedChange(LIVE_PRO)).toBeNull()
+    expect(queuedChange(null)).toBeNull()
+  })
+
+  it('names the plan a queued downgrade rolls into', () => {
+    expect(queuedChange({ ...LIVE_PRO, pendingPlanId: 'starter' })).toEqual({
+      kind: 'downgrade',
+      planId: 'starter',
+    })
+  })
+
+  // The plan id stays set behind a cancellation, but that downgrade never runs.
+  // Every surface reads this one predicate so none of them can disagree.
+  it('lets a cancellation outrank the downgrade queued behind it', () => {
+    expect(queuedChange({ ...LIVE_PRO, pendingPlanId: 'starter', cancelAtPeriodEnd: true })).toEqual({ kind: 'cancel' })
+  })
+
+  it('reports nothing queued once the cycle has already lapsed', () => {
+    expect(queuedChange({ ...LIVE_PRO, pendingPlanId: 'starter', status: 'canceled' })).toBeNull()
   })
 })

--- a/apps/dashboard/src/components/billing/planChange.ts
+++ b/apps/dashboard/src/components/billing/planChange.ts
@@ -62,6 +62,28 @@ export function isUpgradeTo(plan: Plan, currentPriceCents: number | null): boole
   return (plan.priceMonthlyCents ?? 0) > (currentPriceCents ?? 0)
 }
 
+/** What a cycle will actually roll into. */
+export type QueuedChange = { kind: 'cancel' } | { kind: 'downgrade'; planId: string }
+
+/**
+ * A scheduled cancellation outranks a queued downgrade: the plan id stays set
+ * behind it, but that change never happens. A cycle that already lapsed
+ * (`status: 'canceled'`) rolls into nothing at all.
+ *
+ * Every surface that states, offers, or blocks a queued change reads this.
+ * Four hand-written copies of the rule drifted apart once already, which left
+ * an enabled plan card pointing at a confirmation page with no button on it.
+ */
+export function queuedChange(plan: OrganizationPlan | null | undefined): QueuedChange | null {
+  if (!plan || plan.status === 'canceled') {
+    return null
+  }
+  if (plan.cancelAtPeriodEnd) {
+    return { kind: 'cancel' }
+  }
+  return plan.pendingPlanId ? { kind: 'downgrade', planId: plan.pendingPlanId } : null
+}
+
 /** `null` price means negotiated outside the catalog, not free. */
 function price(plan: Plan | undefined, fallback: string): string {
   if (!plan) {
@@ -152,7 +174,7 @@ export function planChangeSummary({
     walletNote: wallet
       ? `Usage beyond the included quota draws on the wallet, which holds ${formatAmount(wallet.balanceCents)}.`
       : null,
-    caveats: caveatsFor({ planId, plan, current, catalog, rollDay, ended }),
+    caveats: caveatsFor({ planId, plan, current, catalog, rollDay }),
     blocked: blockFor({ planId, target, plan, ended, rollDay }),
   }
 }
@@ -219,14 +241,12 @@ function caveatsFor({
   current,
   catalog,
   rollDay,
-  ended,
 }: {
   planId: string
   plan: OrganizationPlan | null
   current: Plan | undefined
   catalog: Plan[]
   rollDay: string | null
-  ended: boolean
 }): PlanChangeNote[] {
   const caveats: PlanChangeNote[] = []
   // A live plan with no catalog row is a negotiated deal: there is no public
@@ -238,19 +258,18 @@ function caveatsFor({
       text: `${plan.planName} is a negotiated plan, so there is no catalog price to compare against. Switching to a standard plan may be refused — talk to sales first.`,
     })
   }
-  if (plan?.cancelAtPeriodEnd && !ended) {
+  const queued = queuedChange(plan)
+  if (queued?.kind === 'cancel') {
     caveats.push({
       tone: 'warn',
       text: `Your subscription is set to end${rollDay ? ` on ${rollDay}` : ''}. Confirming replaces that with this change.`,
     })
-    // Two suppressions. Nothing is queued against a cycle that already lapsed,
-    // whatever id the plan still carries. And when the queued plan IS the one
-    // being viewed, `blocked` already says there is nothing to confirm — adding
-    // "confirming replaces it" beside that contradicts it.
-  } else if (plan?.pendingPlanId && !ended && plan.pendingPlanId !== planId) {
+    // When the queued plan IS the one being viewed, `blocked` already says there
+    // is nothing to confirm — "confirming replaces it" beside that contradicts it.
+  } else if (queued?.kind === 'downgrade' && queued.planId !== planId) {
     caveats.push({
       tone: 'info',
-      text: `A change to ${planName(plan.pendingPlanId, catalog)} is already queued${
+      text: `A change to ${planName(queued.planId, catalog)} is already queued${
         rollDay ? ` for ${rollDay}` : ''
       }. Confirming replaces it.`,
     })
@@ -279,10 +298,9 @@ function blockFor({
   if (plan && !ended && plan.planId === planId) {
     return { kind: 'same-plan', redirect: true }
   }
-  // A lapsed cycle can still carry the id it was going to roll into, but that
-  // change will never happen — resubscribing to it is a real action, not a
-  // no-op, and calling it "already scheduled" would contradict the effect line.
-  if (!ended && plan?.pendingPlanId === planId) {
+  // Only a downgrade that is genuinely still coming leaves nothing to confirm.
+  const queued = queuedChange(plan)
+  if (queued?.kind === 'downgrade' && queued.planId === planId) {
     return {
       kind: 'already-queued',
       redirect: false,
@@ -303,14 +321,7 @@ export interface ScheduledChange {
   keptLabel: string
 }
 
-/**
- * What is queued against this cycle, if anything. `null` once the cycle has
- * already lapsed (`status: 'canceled'`): there is no roll left to schedule
- * against, so nothing to keep.
- *
- * A cancellation outranks a queued downgrade — the same precedence
- * `cycleFacts` uses, so the two surfaces never disagree about what happens.
- */
+/** The queued change as the Active Plan panel states it, with the control that discards it. */
 export function scheduledChange({
   plan,
   catalog,
@@ -318,7 +329,8 @@ export function scheduledChange({
   plan: OrganizationPlan | null | undefined
   catalog: Plan[]
 }): ScheduledChange | null {
-  if (!plan || plan.status === 'canceled') {
+  const queued = queuedChange(plan)
+  if (!plan || !queued) {
     return null
   }
   const on = format(plan.cycleTo, 'MMM d, yyyy')
@@ -326,23 +338,20 @@ export function scheduledChange({
   const keepLabel = `Keep ${plan.planName}`
   const keptLabel = `Staying on ${plan.planName}`
 
-  if (plan.cancelAtPeriodEnd) {
+  if (queued.kind === 'cancel') {
     return { kind: 'cancel', text: `Your subscription ends ${on} — ${keeps}`, keepLabel, keptLabel }
   }
-  if (plan.pendingPlanId) {
-    // An id is not user-facing copy. A queued plan the public catalog cannot
-    // name is a negotiated one; say what happens without inventing a name.
-    const queued = catalog.find((entry) => entry.id === plan.pendingPlanId)
-    return {
-      kind: 'downgrade',
-      text: queued
-        ? `Your downgrade to ${queued.name} is scheduled for ${on} — ${keeps}`
-        : `Your plan changes on ${on} — ${keeps}`,
-      keepLabel,
-      keptLabel,
-    }
+  // An id is not user-facing copy. A queued plan the public catalog cannot
+  // name is a negotiated one; say what happens without inventing a name.
+  const named = catalog.find((entry) => entry.id === queued.planId)
+  return {
+    kind: 'downgrade',
+    text: named
+      ? `Your downgrade to ${named.name} is scheduled for ${on} — ${keeps}`
+      : `Your plan changes on ${on} — ${keeps}`,
+    keepLabel,
+    keptLabel,
   }
-  return null
 }
 
 /** What a plan's card offers. `disabled` covers both "already yours" and "already queued". */
@@ -369,9 +378,8 @@ export function planCardCta({
   if (live?.planId === plan.id) {
     return { kind: 'current', label: 'Current plan', disabled: true }
   }
-  // A pending cancel replaces any queued downgrade, so the card is only
-  // "scheduled" while that cancel is not what is actually coming.
-  if (live?.pendingPlanId === plan.id && !live.cancelAtPeriodEnd) {
+  const queued = queuedChange(organizationPlan)
+  if (live && queued?.kind === 'downgrade' && queued.planId === plan.id) {
     return { kind: 'scheduled', label: `Starts ${format(live.cycleTo, 'MMM d')}`, disabled: true }
   }
   return isUpgradeTo(plan, currentPriceCents)


### PR DESCRIPTION
Follow-up to #1325. CodeRabbit reviewed it after merge and found that `blockFor` and
`planCardCta` disagreed once a cancellation was queued alongside a pending plan id, leaving an
enabled plan card pointing at a confirmation page with no button on it.

The report was correct. The underlying cause is broader than the one disagreement: the rule
*"a scheduled cancellation outranks the downgrade queued behind it"* was written out at four
separate sites, and `cycleFacts` never applied it at all. Fixing only the reported pair would
have left the same shape one file over.

## Before

```
planChange.ts:241   caveatsFor()     plan?.cancelAtPeriodEnd && !ended
planChange.ts:288   blockFor()       !ended && plan?.pendingPlanId === planId
                                     ← BUG: no cancel exclusion, unlike planCardCta
planChange.ts:332   scheduledChange()  plan.cancelAtPeriodEnd
planChange.ts:377   planCardCta()    live?.pendingPlanId === plan.id && !live.cancelAtPeriodEnd

ThisCycleCard.tsx:21  cycleFacts()   ← BUG: never reads cancelAtPeriodEnd at all
```

With `cancelAtPeriodEnd: true` and `pendingPlanId: 'starter'`:

| Surface | Said |
| --- | --- |
| Starter card | enabled **Downgrade** |
| its confirmation page | *"Starter is already scheduled to start … There is nothing to confirm"*, no button |
| Overview panel | *"Your subscription ends Sep 5, 2026"* |
| Usage tab | *"Downgrades to Starter when the cycle rolls on Sep 5"* |

## After

```
planChange.ts:71   queuedChange(plan) → { kind: 'cancel' } | { kind: 'downgrade', planId } | null
                     lapsed cycle → nothing · cancel outranks downgrade · else the pending id
  ├─ caveatsFor()        queued?.kind === 'cancel' | 'downgrade' && planId !== target
  ├─ blockFor()          queued?.kind === 'downgrade' && queued.planId === planId
  ├─ scheduledChange()   queued.kind === 'cancel' | 'downgrade'
  ├─ planCardCta()       queued?.kind === 'downgrade' && queued.planId === plan.id
  └─ cycleFacts()        queued?.kind === 'cancel' → "Ends <day> …"     ThisCycleCard.tsx
```

No caller mentions `cancelAtPeriodEnd` or `status` any more. Switching to a plan whose
downgrade a cancellation has superseded is now what it always was: a real action that replaces
the cancellation.

## Verification

- `vitest run` (apps/dashboard): **190 passed, 26 files**
- `tsc -p tsconfig.app.json --noEmit`: exit 0
- `eslint` on both touched source files: exit 0 — this is what caught an unreachable `return`
  left by an earlier draft of the refactor
- `prettier --check` on the touched billing files: clean

**Mutation evidence that the rule is genuinely single-sourced:** deleting only the two-line
cancel branch inside `queuedChange` fails **8 tests across all five surfaces** and both test
files. Before this change the rule was four independent copies, so no single edit could have
failed them all — which is exactly why the drift went unnoticed.

New tests: four for `queuedChange` itself, one pinning that `blockFor` and `planCardCta` now
agree, and two in `ThisCycleCard.test.ts` — one for the cross-tab contradiction, one for
`cancelAtPeriodEnd` with no downgrade behind it, a state that previously produced no note.

## Notes for the reviewer

- **`cycleFacts` gained user-facing copy**, not just a guard: *"Ends `<day>` — quota stays
  usable until the roll, then pay-as-you-go from the wallet"*. That state used to render
  nothing. Pinned by its own test.
- `"until the roll"` is a bare noun where neighbouring copy uses the verb form
  (*"when the cycle rolls on"*). Flagged in review and left as-is; happy to change it.
- `cycleFacts`' note is now a three-level ternary. Prettier-formatted and fully tested, but at
  the edge of the repo's "boring code" bar.

## Not addressed here

CodeRabbit's second comment on #1325 — `BillingPlanChange` renders its skeleton indefinitely
when the members fetch fails, because `SelectedOrganizationProvider` swallows that error and
leaves `organizationMembers` empty. Still valid. A proper fix needs a `membersLoading` flag on
`ISelectedOrganizationContext`, which is shared provider infrastructure and does not belong in
a guard fix.

Also unchanged from #1325: `Keep <plan>` still depends on boxlite-commerce treating a
re-asserted current plan as "discard what is queued", which nothing in this repo can verify.

https://claude.ai/code/session_01WcBSS7RKkMWziPtmc3jk9d


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved billing plan-change messaging when cancellation and downgrade requests overlap.
  * Cancellations now take precedence over queued downgrades and correctly show the cycle-end date.
  * Queued downgrade plans display their catalog name, with a fallback when unavailable.
  * Expired billing cycles no longer show outdated scheduled changes.
* **Tests**
  * Added coverage for cancellation, downgrade, and pay-as-you-go transition scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->