### PR TITLE
fix(guest): enable protected link sysctls

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -232,7 +232,7 @@ test\:unit\:rust:
 # nextest's process-per-test isolation is what makes the whole crate runnable:
 # several suites assert on process-global state (raw fd numbers, waitpid), so
 # they can interfere under a shared process. The cargo fallback has no such
-# isolation, so it stays on the two modules that are pure logic.
+# isolation, so it stays on the modules that are pure logic.
 test\:unit\:guest:
 	@if [ "$$(uname)" != "Linux" ]; then \
 		echo "⏭️  Guest unit tests require Linux"; \
@@ -242,7 +242,7 @@ test\:unit\:guest:
 	if command -v cargo-nextest >/dev/null 2>&1; then \
 		cargo nextest run --no-tests=fail -p boxlite-guest; \
 	else \
-		cargo test -p boxlite-guest --bins -- --test-threads=1 capabilit spec::tests; \
+		cargo test -p boxlite-guest --bins -- --test-threads=1 capabilit spec::tests sysctl::tests; \
 	fi
 
 # Keep ordinary ownership tests unprivileged. Only explicitly ignored tests

--- a/src/boxlite/tests/security_enforcement.rs
+++ b/src/boxlite/tests/security_enforcement.rs
@@ -3,6 +3,7 @@
 //! 1. Read-only virtiofs volumes enforced at hypervisor level
 //! 2. Dangerous capabilities excluded (CAP_SYS_ADMIN etc.)
 //! 3. TSI network isolation when network disabled
+//! 4. Protected-link sysctls block unprivileged hardlink attacks
 //!
 //! Run with:
 //!
@@ -54,7 +55,7 @@ async fn exec_exit_code(bx: &LiteBox, cmd: BoxCommand) -> i32 {
 }
 
 // ============================================================================
-// TEST SUITE: single VM for virtiofs + capabilities tests
+// TEST SUITE: single VM for virtiofs + capabilities + protected-links tests
 // ============================================================================
 
 #[tokio::test(flavor = "multi_thread")]
@@ -96,6 +97,7 @@ async fn virtiofs_readonly_and_capabilities() {
         .expect("create box");
     bx.start().await.expect("start box");
 
+    protected_links_block_unprivileged_hardlinks(&bx).await;
     readonly_volume_readable(&bx).await;
     readonly_volume_blocks_write(&bx).await;
     readonly_volume_blocks_remount(&bx).await;
@@ -106,6 +108,99 @@ async fn virtiofs_readonly_and_capabilities() {
 
     bx.stop().await.expect("stop box");
     let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
+}
+
+/// Protected-link sysctls must be active before the first unprivileged workload.
+async fn protected_links_block_unprivileged_hardlinks(bx: &LiteBox) {
+    let security_state = exec_stdout(
+        bx,
+        BoxCommand::new("sh")
+            .args([
+                "-c",
+                "id -u; cat /proc/sys/fs/protected_hardlinks; \
+                 cat /proc/sys/fs/protected_symlinks; grep '^CapEff:' /proc/self/status",
+            ])
+            .user("1000:1000"),
+    )
+    .await;
+
+    let mut lines = security_state.lines();
+    assert_eq!(
+        lines.next(),
+        Some("1000"),
+        "security probe must run as the unprivileged uid"
+    );
+    assert_eq!(
+        lines.next(),
+        Some("1"),
+        "fs.protected_hardlinks must be enabled before workloads start"
+    );
+    assert_eq!(
+        lines.next(),
+        Some("1"),
+        "fs.protected_symlinks must be enabled before workloads start"
+    );
+
+    let cap_eff_line = lines.next().expect("security probe should report CapEff");
+    let cap_eff_hex = cap_eff_line
+        .strip_prefix("CapEff:")
+        .expect("security probe should emit a CapEff line")
+        .trim();
+    let cap_eff = u64::from_str_radix(cap_eff_hex, 16).expect("CapEff should be hexadecimal");
+
+    // CAP_FOWNER = bit 3. If it leaked across exec, it would bypass protected_hardlinks.
+    let cap_fowner = 1u64 << 3;
+    assert_eq!(
+        cap_eff & cap_fowner,
+        0,
+        "unprivileged workload must not retain CAP_FOWNER, CapEff=0x{cap_eff:x}"
+    );
+
+    exec_stdout(
+        bx,
+        BoxCommand::new("sh").args([
+            "-c",
+            "set -eu; base=/tmp/boxlite-protected-links; \
+             mkdir \"$base\" \"$base/attacker\"; \
+             printf 'classified\\n' > \"$base/source\"; \
+             chmod 0444 \"$base/source\"; chown 0:0 \"$base/source\"; \
+             chown 1000:1000 \"$base/attacker\"",
+        ]),
+    )
+    .await;
+
+    let (exit, output) = exec_full(
+        bx,
+        BoxCommand::new("sh")
+            .args([
+                "-c",
+                "ln /tmp/boxlite-protected-links/source \
+                 /tmp/boxlite-protected-links/attacker/link 2>&1",
+            ])
+            .user("1000:1000"),
+    )
+    .await;
+    assert_ne!(
+        exit, 0,
+        "unprivileged user must not hardlink a root-owned, non-writable file"
+    );
+    assert!(
+        output
+            .to_ascii_lowercase()
+            .contains("operation not permitted"),
+        "hardlink denial should report EPERM, got: {output}"
+    );
+
+    let link_count = exec_stdout(
+        bx,
+        BoxCommand::new("stat").args(["-c", "%h", "/tmp/boxlite-protected-links/source"]),
+    )
+    .await;
+    assert_eq!(
+        link_count.trim(),
+        "1",
+        "failed hardlink attempt must not change the source link count"
+    );
 }
 
 /// Read-only virtiofs volume can be read.

--- a/src/guest/src/main.rs
+++ b/src/guest/src/main.rs
@@ -21,6 +21,8 @@ mod reaper;
 mod service;
 #[cfg(target_os = "linux")]
 mod storage;
+#[cfg(target_os = "linux")]
+mod sysctl;
 
 #[cfg(target_os = "linux")]
 use boxlite_shared::errors::BoxliteResult;
@@ -100,6 +102,14 @@ fn main() -> BoxliteResult<()> {
     eprintln!("[guest] T+{}ms: tracing initialized", boot_elapsed_ms());
 
     info!("BoxLite Guest Agent starting");
+
+    // libkrun's minimal init mounts /proc but does not apply a distro's sysctl
+    // defaults. Harden the guest before it can spawn any workload processes.
+    sysctl::apply_boot_hardening()?;
+    eprintln!(
+        "[guest] T+{}ms: kernel hardening applied",
+        boot_elapsed_ms()
+    );
 
     // Start zygote BEFORE tokio creates any threads.
     // The zygote handles all clone3() calls in a single-threaded context,

--- a/src/guest/src/sysctl.rs
+++ b/src/guest/src/sysctl.rs
@@ -1,0 +1,103 @@
+//! Guest kernel settings that a minimal microVM init does not apply for us.
+
+use boxlite_shared::errors::{BoxliteError, BoxliteResult};
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::Path;
+
+const PROC_SYS_ROOT: &str = "/proc/sys";
+
+struct SysctlSetting {
+    name: &'static str,
+    relative_path: &'static str,
+    value: &'static str,
+}
+
+const PROTECTED_LINK_SETTINGS: &[SysctlSetting] = &[
+    SysctlSetting {
+        name: "fs.protected_hardlinks",
+        relative_path: "fs/protected_hardlinks",
+        value: "1",
+    },
+    SysctlSetting {
+        name: "fs.protected_symlinks",
+        relative_path: "fs/protected_symlinks",
+        value: "1",
+    },
+];
+
+/// Apply the security-critical sysctls expected on every BoxLite guest kernel.
+pub(crate) fn apply_boot_hardening() -> BoxliteResult<()> {
+    apply_boot_hardening_at(Path::new(PROC_SYS_ROOT))
+}
+
+fn apply_boot_hardening_at(proc_sys_root: &Path) -> BoxliteResult<()> {
+    for setting in PROTECTED_LINK_SETTINGS {
+        write_setting(proc_sys_root, setting)?;
+    }
+    Ok(())
+}
+
+fn write_setting(proc_sys_root: &Path, setting: &SysctlSetting) -> BoxliteResult<()> {
+    let path = proc_sys_root.join(setting.relative_path);
+    let mut file = OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(&path)
+        .map_err(|error| {
+            BoxliteError::Internal(format!(
+                "Failed to set guest sysctl {}={} via {}: {}",
+                setting.name,
+                setting.value,
+                path.display(),
+                error
+            ))
+        })?;
+    file.write_all(setting.value.as_bytes()).map_err(|error| {
+        BoxliteError::Internal(format!(
+            "Failed to set guest sysctl {}={} via {}: {}",
+            setting.name,
+            setting.value,
+            path.display(),
+            error
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn boot_hardening_protects_hardlinks_and_symlinks() {
+        let proc_sys = tempfile::tempdir().expect("create fake /proc/sys");
+        for relative_path in ["fs/protected_hardlinks", "fs/protected_symlinks"] {
+            let path = proc_sys.path().join(relative_path);
+            fs::create_dir_all(path.parent().expect("sysctl has a parent"))
+                .expect("create fake sysctl directory");
+            fs::write(path, "0").expect("seed disabled sysctl");
+        }
+
+        apply_boot_hardening_at(proc_sys.path()).expect("apply boot hardening");
+
+        for relative_path in ["fs/protected_hardlinks", "fs/protected_symlinks"] {
+            let value = fs::read_to_string(proc_sys.path().join(relative_path))
+                .expect("read hardened sysctl");
+            assert_eq!(value, "1", "{relative_path} must be enabled");
+        }
+    }
+
+    #[test]
+    fn boot_hardening_reports_the_missing_sysctl() {
+        let proc_sys = tempfile::tempdir().expect("create fake /proc/sys");
+
+        let error = apply_boot_hardening_at(proc_sys.path())
+            .expect_err("missing protected-link sysctls must fail closed");
+
+        assert!(
+            error.to_string().contains("fs.protected_hardlinks=1"),
+            "error should identify the sysctl that could not be applied: {error}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Enable Linux protected-hardlink and protected-symlink sysctls during guest agent boot, before the zygote or any workload process can start. This restores security defaults normally supplied by distro `sysctl.d` configuration in BoxLite's minimal guest init.

## Call graph

Before
  `main` (`Guest agent` · `src/guest/src/main.rs:75`) — initializes logging, then starts the zygote ← BUG: skips protected-link kernel hardening
    └─ `Zygote::start` (`Zygote` · `src/guest/src/container/zygote.rs:120`) — can spawn workloads while both sysctls remain disabled

After
  `main` (`Guest agent` · `src/guest/src/main.rs:75`) — hardens the kernel before starting the zygote
    ├─ `apply_boot_hardening` (`sysctl` · `src/guest/src/sysctl.rs:30`) — applies the protected-link policy
    │  └─ `write_setting` (`sysctl` · `src/guest/src/sysctl.rs:41`) — writes both `/proc/sys/fs/protected_*` values or fails closed
    └─ `Zygote::start` (`Zygote` · `src/guest/src/container/zygote.rs:120`) — starts only after hardening succeeds

Fixes #1154

## Changes

- Set `fs.protected_hardlinks=1` and `fs.protected_symlinks=1` at guest startup.
- Return a contextual startup error if either security setting cannot be applied.
- Cover successful application and the fail-closed path with guest unit tests, including Cargo's serial fallback suite.

## How to verify

- `make test:unit:guest`
- `make fmt:check:rust`
- `make lint:rust`

## Risks / rollout

- Guest startup now deliberately fails if the kernel does not expose or permit either protected-link sysctl, instead of running with the unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Guest startup now enables kernel protections against unsafe hardlinks and symlinks before launching workloads.
  * Startup reports when hardening is complete and stops with a clear error if required protections cannot be applied.
  * Unprivileged workloads are protected from creating unauthorized hardlinks to protected files.

* **Testing**
  * Added coverage for successful hardening and fail-closed behavior when required system settings are unavailable.
  * Added validation that protected-link enforcement preserves file integrity and expected permissions.
  * Updated test documentation to reflect the expanded guest test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->