### PR TITLE
fix(billing): scale concurrency chart to usage

### DIFF
--- a/apps/dashboard/src/components/billing/ConcurrencyTimeline.test.ts
+++ b/apps/dashboard/src/components/billing/ConcurrencyTimeline.test.ts
@@ -32,19 +32,21 @@ vi.mock('recharts', () => ({
     createElement('div', { 'data-testid': 'line-chart', 'data-points': JSON.stringify(data) }, children),
   ReferenceLine: ({ y }: { y: number }) => createElement('div', { 'data-testid': 'limit-line' }, String(y)),
   XAxis: () => null,
-  YAxis: () => null,
+  YAxis: ({ domain }: { domain: [number, number] }) =>
+    createElement('div', { 'data-testid': 'y-axis', 'data-domain': JSON.stringify(domain) }),
 }))
 
 import { ConcurrencyTimeline, concurrencyAxisMaximum } from './ConcurrencyTimeline'
 
 describe('concurrencyAxisMaximum', () => {
-  it('keeps both the observed peak and the plan limit inside the chart', () => {
-    expect(concurrencyAxisMaximum([{ time: 0, runningBoxes: 105 }], 100)).toBe(120)
-    expect(concurrencyAxisMaximum([{ time: 0, runningBoxes: 30 }], 100)).toBe(120)
+  it('adds readable headroom above the observed peak', () => {
+    expect(concurrencyAxisMaximum([{ time: 0, runningBoxes: 105 }])).toBe(120)
+    expect(concurrencyAxisMaximum([{ time: 0, runningBoxes: 30 }])).toBe(40)
+    expect(concurrencyAxisMaximum([{ time: 0, runningBoxes: 1 }])).toBe(2)
   })
 
   it('keeps an empty series readable', () => {
-    expect(concurrencyAxisMaximum([], null)).toBe(2)
+    expect(concurrencyAxisMaximum([])).toBe(2)
   })
 })
 
@@ -127,7 +129,30 @@ describe('ConcurrencyTimeline', () => {
     ])
   })
 
-  it('renders the optional plan-limit label and reference line', () => {
+  it('scales low usage independently from a distant plan limit', () => {
+    mocks.concurrencyQuery.mockReturnValue({
+      data: { points: [{ observedAt: '2026-08-23T00:00:00.000Z', runningBoxes: 1 }] },
+      isError: false,
+      isLoading: false,
+      refetch,
+    })
+    mocks.planConcurrencyLimit.mockReturnValue(1000)
+
+    renderTimeline()
+
+    const yAxis = document.querySelector<HTMLElement>('[data-testid="y-axis"]')
+    expect(JSON.parse(yAxis?.dataset.domain ?? '[]')).toEqual([0, 2])
+    expect(document.body.textContent).toContain('limit = 1000')
+    expect(document.querySelector('[data-testid="limit-line"]')).toBeNull()
+  })
+
+  it('renders the optional plan-limit label and an in-range reference line', () => {
+    mocks.concurrencyQuery.mockReturnValue({
+      data: { points: [{ observedAt: '2026-08-23T00:00:00.000Z', runningBoxes: 100 }] },
+      isError: false,
+      isLoading: false,
+      refetch,
+    })
     mocks.planConcurrencyLimit.mockReturnValue(100)
 
     renderTimeline()

--- a/apps/dashboard/src/components/billing/ConcurrencyTimeline.tsx
+++ b/apps/dashboard/src/components/billing/ConcurrencyTimeline.tsx
@@ -25,8 +25,8 @@ type TimelinePoint = { time: number; runningBoxes: number }
 
 const shortDay = (value: number) => new Date(value).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
 
-export function concurrencyAxisMaximum(points: TimelinePoint[], limit: number | null): number {
-  const highest = Math.max(limit ?? 0, ...points.map((point) => point.runningBoxes), 1)
+export function concurrencyAxisMaximum(points: TimelinePoint[]): number {
+  const highest = Math.max(...points.map((point) => point.runningBoxes), 1)
   const interval = highest <= 10 ? 2 : highest <= 50 ? 10 : highest <= 200 ? 20 : 100
   return Math.max(interval, (Math.floor(highest / interval) + 1) * interval)
 }
@@ -48,7 +48,8 @@ export function ConcurrencyTimeline() {
       })),
     [query.data?.points],
   )
-  const axisMaximum = concurrencyAxisMaximum(points, limit)
+  const axisMaximum = concurrencyAxisMaximum(points)
+  const isLimitInChartRange = limit != null && limit <= axisMaximum
 
   return (
     <section>
@@ -107,12 +108,11 @@ export function ConcurrencyTimeline() {
                   width={36}
                   tick={{ fontSize: 10 }}
                 />
-                {limit != null && (
+                {isLimitInChartRange && (
                   <ReferenceLine
                     y={limit}
                     stroke="hsl(var(--muted-foreground))"
                     strokeDasharray="6 4"
-                    ifOverflow="extendDomain"
                   />
                 )}
                 <ChartTooltip


### PR DESCRIPTION
## Summary
Scale the concurrency timeline around observed usage so small changes remain visible when the plan limit is much higher. Keep the plan limit in the header and draw its reference line only when it falls inside the usage scale.

## Call graph

Before
  ConcurrencyTimeline       (React component · apps/dashboard/src/components/billing/ConcurrencyTimeline.tsx:34) — maps usage and plan data
    └─ concurrencyAxisMaximum (function · apps/dashboard/src/components/billing/ConcurrencyTimeline.tsx:28) ← BUG: includes the plan limit and flattens low usage
         └─ YAxis / ReferenceLine (Recharts · apps/dashboard/src/components/billing/ConcurrencyTimeline.tsx:101) — extends the domain to the limit

After
  ConcurrencyTimeline       (React component · apps/dashboard/src/components/billing/ConcurrencyTimeline.tsx:34) — separates usage scale from limit context
    └─ concurrencyAxisMaximum (function · apps/dashboard/src/components/billing/ConcurrencyTimeline.tsx:28) — adds headroom above the observed peak
         ├─ YAxis             (Recharts · apps/dashboard/src/components/billing/ConcurrencyTimeline.tsx:101) — uses the observed usage domain
         └─ ReferenceLine     (Recharts · apps/dashboard/src/components/billing/ConcurrencyTimeline.tsx:111) — renders only when the limit is in range

## Changes
- Compute the Y-axis maximum from observed concurrency instead of the plan limit.
- Preserve the plan-limit label while hiding out-of-range reference lines.
- Cover `usage = 1, limit = 1000` and in-range limit behavior.

## How to verify
- `yarn vitest run --config dashboard/vite.config.mts src/components/billing/ConcurrencyTimeline.test.ts`
- `yarn nx build dashboard --skip-nx-cache`
- `make lint:apps`

## Risks / rollout
- Large limits no longer appear as dashed lines when they are outside the visible usage range; the numeric limit remains visible in the card header.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrency timeline scaling so charts remain focused on observed usage, even when plan limits are much higher.
  * Plan-limit reference lines and labels now appear only when they fall within the visible chart range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->