### PR TITLE
fix(gvproxy)!: bind allow_net host checks to the resolved destination

### DIFF
--- a/src/deps/libgvproxy-sys/gvproxy-bridge/allow_net_filter.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/allow_net_filter.go
@@ -24,6 +24,9 @@ type AllowNetFilter struct {
 	exactHosts       map[string]bool  // "api.openai.com" → true
 	wildcardSuffixes []string         // ".example.com"
 	hasHostnameRules bool
+
+	exactHostIPs      map[string][]net.IP // "api.openai.com" → resolved IPv4 set (egress pin)
+	wildcardSuffixIPs map[string][]net.IP // ".example.com" → resolved IPv4 set (egress pin)
 }
 
 // NewAllowNetFilter parses allow_net rules into IP/CIDR and hostname categories.
@@ -145,6 +148,51 @@ func (f *AllowNetFilter) MatchesHostname(hostname string) bool {
 // HasHostnameRules returns true if any hostname/wildcard rules exist.
 func (f *AllowNetFilter) HasHostnameRules() bool {
 	return f.hasHostnameRules
+}
+
+// SetResolvedHostIPs installs the gateway DNS resolution results for hostname
+// rules, keyed the same way as exactHosts/wildcardSuffixes. The TCP forwarder
+// uses these to pin the dialed IP to the hostname's own resolution.
+func (f *AllowNetFilter) SetResolvedHostIPs(exact, wildcard map[string][]net.IP) {
+	f.exactHostIPs = exact
+	f.wildcardSuffixIPs = wildcard
+}
+
+// AllowHostToIP reports whether hostname is allow-listed AND destIP is one of
+// the IPs the gateway DNS resolved for it (the egress pin). It is the single
+// point that ties the guest-supplied hostname to the dialed IP, closing the
+// domain-fronting decoupling that MatchesHostname alone leaves open. A
+// hostname can be covered by an exact rule and one or more wildcards (or
+// overlapping wildcards), so the check unions across every matching rule:
+// destIP is allowed when any matching rule resolves it, independent of rule
+// order, and fails closed only when none do.
+func (f *AllowNetFilter) AllowHostToIP(hostname string, destIP net.IP) bool {
+	hostname = strings.ToLower(strings.TrimSuffix(hostname, "."))
+	if hostname == "" {
+		return false
+	}
+	ip4 := destIP.To4()
+	if ip4 == nil {
+		return false
+	}
+	if f.exactHosts[hostname] && containsIPv4(f.exactHostIPs[hostname], ip4) {
+		return true
+	}
+	for _, suffix := range f.wildcardSuffixes {
+		if strings.HasSuffix(hostname, suffix) && containsIPv4(f.wildcardSuffixIPs[suffix], ip4) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsIPv4(ips []net.IP, target net.IP) bool {
+	for _, ip := range ips {
+		if ip.Equal(target) {
+			return true
+		}
+	}
+	return false
 }
 
 func toIPv4Key(ip net.IP) [4]byte {

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/allow_net_filter_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/allow_net_filter_test.go
@@ -2,20 +2,50 @@ package main
 
 import (
 	"net"
+	"strings"
 	"sync"
 	"testing"
 
 	"gvisor.dev/gvisor/pkg/tcpip"
 )
 
-// testFilter builds a filter exactly the way gvproxy_create does, via the
-// production newAllowNetFilter. Constructing NewAllowNetFilter directly here
-// would let the set of always-allowed internal addresses drift between the
-// tests and the box that actually runs.
+// testFilter builds a filter exactly the way gvproxy_create does — via the
+// production newAllowNetFilter, which owns the set of always-allowed internal
+// addresses — but injects deterministic stub resolutions instead of real DNS
+// lookups so the egress pin is testable offline. Going through the production
+// constructor keeps that address set from drifting between tests and a box.
 func testFilter(rules ...string) *AllowNetFilter {
 	cfg := testGvproxyConfig()
 	cfg.AllowNet = rules
-	return newAllowNetFilter(cfg)
+	exact, wildcard := stubResolvedHostIPs(rules)
+	return newAllowNetFilter(cfg, exact, wildcard)
+}
+
+// stubResolvedHostIPs assigns each hostname rule a deterministic IPv4 so
+// AllowHostToIP can be exercised without real DNS. Exact hosts → 10.0.0.1;
+// wildcard suffixes → 10.0.0.2. Keys mirror buildAllowNet (lowercased).
+func stubResolvedHostIPs(rules []string) (map[string][]net.IP, map[string][]net.IP) {
+	exact := make(map[string][]net.IP)
+	wildcard := make(map[string][]net.IP)
+	for _, rule := range rules {
+		rule = strings.TrimSpace(rule)
+		if rule == "" || net.ParseIP(rule) != nil {
+			continue
+		}
+		if _, _, err := net.ParseCIDR(rule); err == nil {
+			continue
+		}
+		host := rule
+		if h, _, err := net.SplitHostPort(rule); err == nil {
+			host = h
+		}
+		if strings.HasPrefix(host, "*.") {
+			wildcard["."+strings.ToLower(host[2:])] = []net.IP{net.ParseIP("10.0.0.2").To4()}
+			continue
+		}
+		exact[strings.ToLower(host)] = []net.IP{net.ParseIP("10.0.0.1").To4()}
+	}
+	return exact, wildcard
 }
 
 func TestAllowNetFilter_ExactIP(t *testing.T) {
@@ -152,6 +182,75 @@ func TestResolveTCPDestination_HostAliasUsesPreNATIPForPolicy(t *testing.T) {
 	if !dialIP.Equal(net.ParseIP("127.0.0.1")) {
 		t.Fatalf("expected dial destination to use NAT loopback, got %v", dialIP)
 	}
+}
+
+// TestAllowHostToIP_BlocksDomainFronting is the reproducer for the
+// domain-fronting bypass: a guest dialing an attacker IP while presenting an
+// allowed hostname must be rejected. With the old MatchesHostname-only gate,
+// this hostname/IP decoupling let the connection through.
+func TestAllowHostToIP_BlocksDomainFronting(t *testing.T) {
+	f := testFilter("allowed.example")
+	allowed := net.ParseIP("10.0.0.1") // stubResolvedHostIPs pins allowed.example here
+	attacker := net.ParseIP("203.0.113.7")
+
+	assertTrue(t, f.AllowHostToIP("allowed.example", allowed), "hostname + its resolved IP allowed")
+	assertFalse(t, f.AllowHostToIP("allowed.example", attacker), "hostname + attacker IP blocked (domain fronting)")
+}
+
+func TestAllowHostToIP_ExactHostname(t *testing.T) {
+	f := testFilter("api.example.com")
+	assertTrue(t, f.AllowHostToIP("api.example.com", net.ParseIP("10.0.0.1")), "resolved IP allowed")
+	assertFalse(t, f.AllowHostToIP("api.example.com", net.ParseIP("10.0.0.2")), "unresolved IP blocked")
+	assertFalse(t, f.AllowHostToIP("other.example.com", net.ParseIP("10.0.0.1")), "unlisted hostname blocked")
+}
+
+func TestAllowHostToIP_Wildcard(t *testing.T) {
+	f := testFilter("*.example.com")
+	// stubResolvedHostIPs pins wildcard suffixes to 10.0.0.2.
+	assertTrue(t, f.AllowHostToIP("foo.example.com", net.ParseIP("10.0.0.2")), "wildcard subdomain + base IP allowed")
+	assertFalse(t, f.AllowHostToIP("foo.example.com", net.ParseIP("203.0.113.7")), "wildcard subdomain + attacker IP blocked")
+	assertFalse(t, f.AllowHostToIP("evil.net", net.ParseIP("10.0.0.2")), "non-matching hostname blocked")
+}
+
+func TestAllowHostToIP_OverlappingWildcards_Union(t *testing.T) {
+	// a.sub.example.com matches both *.example.com and *.sub.example.com. The
+	// pin must accept destIP from either rule, not just whichever suffix is
+	// listed first in wildcardSuffixes.
+	f := NewAllowNetFilter([]string{"*.example.com", "*.sub.example.com"}, "192.168.127.1", "192.168.127.2")
+	f.SetResolvedHostIPs(nil, map[string][]net.IP{
+		".example.com":     {net.ParseIP("10.0.0.1").To4()},
+		".sub.example.com": {net.ParseIP("10.0.0.9").To4()},
+	})
+	assertTrue(t, f.AllowHostToIP("a.sub.example.com", net.ParseIP("10.0.0.9")), "narrower wildcard's IP allowed")
+	assertTrue(t, f.AllowHostToIP("a.sub.example.com", net.ParseIP("10.0.0.1")), "broader wildcard's IP allowed")
+	assertFalse(t, f.AllowHostToIP("a.sub.example.com", net.ParseIP("203.0.113.7")), "unresolved IP blocked")
+}
+
+func TestAllowHostToIP_ExactRuleDoesNotShadowWildcard(t *testing.T) {
+	// An exact rule whose DNS failed (empty pin) must not shadow a wildcard
+	// that also covers the hostname: the union of matching rules still applies.
+	f := NewAllowNetFilter([]string{"api.example.com", "*.example.com"}, "192.168.127.1", "192.168.127.2")
+	f.SetResolvedHostIPs(
+		map[string][]net.IP{"api.example.com": nil},
+		map[string][]net.IP{".example.com": {net.ParseIP("10.0.0.1").To4()}},
+	)
+	assertTrue(t, f.AllowHostToIP("api.example.com", net.ParseIP("10.0.0.1")), "wildcard authorizes when exact rule has no pin")
+	assertFalse(t, f.AllowHostToIP("api.example.com", net.ParseIP("203.0.113.7")), "unresolved IP still blocked")
+}
+
+func TestAllowHostToIP_EmptyOrMissingHostname(t *testing.T) {
+	f := testFilter("api.example.com")
+	assertFalse(t, f.AllowHostToIP("", net.ParseIP("10.0.0.1")), "empty hostname blocked")
+	assertFalse(t, f.AllowHostToIP("api.example.com", nil), "nil IP blocked")
+}
+
+func TestAllowHostToIP_IPOnlyRulesUnaffected(t *testing.T) {
+	// IP/CIDR-only allowlists have no hostname rules, so the pin is never
+	// consulted; MatchesIP continues to govern (decideTCPRoute never routes
+	// hostname inspection without HasHostnameRules).
+	f := testFilter("1.2.3.4")
+	assertFalse(t, f.HasHostnameRules(), "IP-only allowlist has no hostname rules")
+	assertTrue(t, f.MatchesIP(net.ParseIP("1.2.3.4")), "IP rule still matches")
 }
 
 func assertTrue(t *testing.T, v bool, msg string) {

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/config_build_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/config_build_test.go
@@ -32,7 +32,7 @@ func testGvproxyConfig() GvproxyConfig {
 }
 
 func TestBuildTapConfig_UsesHostAliasDNSZone(t *testing.T) {
-	tapConfig := buildTapConfig(testGvproxyConfig(), types.QemuProtocol)
+	tapConfig := buildTapConfig(testGvproxyConfig(), types.QemuProtocol, nil)
 
 	if len(tapConfig.DNS) == 0 {
 		t.Fatal("expected at least one DNS zone")
@@ -57,7 +57,14 @@ func TestBuildTapConfig_KeepsBuiltinZonesBeforeAllowNet(t *testing.T) {
 	config := testGvproxyConfig()
 	config.AllowNet = []string{"example.com"}
 
-	tapConfig := buildTapConfig(config, types.QemuProtocol)
+	// Deterministic allow_net zones stand in for a real buildAllowNet call:
+	// this test only verifies zone ordering, so resolving example.com would add
+	// a flaky/offline DNS dependency without strengthening the assertions.
+	allowNetZones := []types.Zone{
+		{Name: "example.com."},
+		{Name: ""}, // root sinkhole, which buildAllowNet appends too
+	}
+	tapConfig := buildTapConfig(config, types.QemuProtocol, allowNetZones)
 
 	if len(tapConfig.DNS) < 2 {
 		t.Fatalf("expected built-in and allowlist DNS zones, got %d", len(tapConfig.DNS))
@@ -72,7 +79,7 @@ func TestBuildTapConfig_KeepsBuiltinZonesBeforeAllowNet(t *testing.T) {
 }
 
 func TestBuildTapConfig_RoutesHostAliasToLoopback(t *testing.T) {
-	tapConfig := buildTapConfig(testGvproxyConfig(), types.QemuProtocol)
+	tapConfig := buildTapConfig(testGvproxyConfig(), types.QemuProtocol, nil)
 
 	if got := tapConfig.NAT["192.168.127.254"]; got != "127.0.0.1" {
 		t.Fatalf("expected host IP NAT to loopback, got %q", got)

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/dns_filter.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/dns_filter.go
@@ -15,18 +15,39 @@ import (
 	logrus "github.com/sirupsen/logrus"
 )
 
-// buildAllowNetDNSZones creates DNS zones that implement allowlist filtering.
+// allowNetResolution bundles the DNS zones and the hostname→IP maps produced by
+// one pass over the allow_net rules. Sharing that single resolution between the
+// gateway DNS and the TCP egress pin guarantees the guest and the pin see the
+// same IPs (same DNS, same moment) — see allow_net_filter.AllowHostToIP.
 //
-// Strategy:
-//   - For each allowed hostname: resolve to IPs, create a zone with A records
-//   - For wildcard patterns (*.example.com): create zone with Regexp records
-//   - Add catch-all root zone "" with DefaultIP 0.0.0.0 (sinkhole)
+// The resolution is FROZEN at box build time: buildAllowNet runs once in
+// gvproxy_create and is never re-resolved for the box's lifetime. A domain that
+// changes its IP after the box starts therefore becomes unreachable until the
+// box is recreated — a known, accepted limitation of hostname allow_net.
 //
-// Zone matching is first-match-wins with suffix matching. Specific zones
-// are added before the root zone, so allowed hosts resolve normally while
-// everything else gets sinkholed.
-func buildAllowNetDNSZones(allowNet []string) []types.Zone {
+// Coupling contract: the egress pin (exactIPs/suffixIPs) must always be fed
+// from the SAME resolution as the DNS zones. If a future change adds runtime
+// re-resolution (e.g. to pick up IP changes), it must refresh the pin map from
+// that same re-resolution too — otherwise AllowHostToIP keeps enforcing the
+// stale IPs and would block the freshly-resolved destination.
+type allowNetResolution struct {
+	zones     []types.Zone
+	exactIPs  map[string][]net.IP // "api.openai.com" → resolved IPv4 set
+	suffixIPs map[string][]net.IP // ".example.com" → resolved base-domain IPv4 set
+}
+
+// buildAllowNet resolves every hostname rule once and returns the DNS zones
+// plus the hostname→IP maps used to pin TCP egress.
+func buildAllowNet(allowNet []string) allowNetResolution {
+	return buildAllowNetWithResolver(allowNet, systemLookupIPAddr)
+}
+
+// buildAllowNetWithResolver is the testable core of buildAllowNet: the resolver
+// is injected so tests can pin a deterministic resolution.
+func buildAllowNetWithResolver(allowNet []string, lookup func(context.Context, string) ([]net.IP, error)) allowNetResolution {
 	zoneRecords := make(map[string][]types.Record)
+	exactIPs := make(map[string][]net.IP)
+	suffixIPs := make(map[string][]net.IP)
 
 	for _, rule := range allowNet {
 		rule = strings.TrimSpace(rule)
@@ -48,14 +69,14 @@ func buildAllowNetDNSZones(allowNet []string) []types.Zone {
 			host = h
 		}
 
-		// Wildcard: *.example.com
+		// Wildcard: *.example.com — pinned to the base domain's resolution.
 		if strings.HasPrefix(host, "*.") {
 			domain := host[2:]
 			zoneName := domain + "."
 			zoneRecords[zoneName] = append(zoneRecords[zoneName], types.Record{
 				Regexp: regexp.MustCompile(".*"),
 			})
-			resolveAndAddRecords(domain, domain+".", zoneRecords)
+			suffixIPs["."+strings.ToLower(domain)] = resolveAndAddRecords(domain, zoneName, zoneRecords, lookup)
 			continue
 		}
 
@@ -63,9 +84,9 @@ func buildAllowNetDNSZones(allowNet []string) []types.Zone {
 		parts := strings.SplitN(host, ".", 2)
 		if len(parts) == 2 {
 			zoneName := parts[1] + "."
-			resolveAndAddRecords(host, zoneName, zoneRecords)
+			exactIPs[strings.ToLower(host)] = resolveAndAddRecords(host, zoneName, zoneRecords, lookup)
 		} else {
-			resolveAndAddRecords(host, host+".", zoneRecords)
+			exactIPs[strings.ToLower(host)] = resolveAndAddRecords(host, host+".", zoneRecords, lookup)
 		}
 	}
 
@@ -93,37 +114,70 @@ func buildAllowNetDNSZones(allowNet []string) []types.Zone {
 		"total_zones": len(zones),
 	}).Info("allowNet: DNS sinkhole configured")
 
-	return zones
+	return allowNetResolution{zones: zones, exactIPs: exactIPs, suffixIPs: suffixIPs}
 }
 
-// resolveAndAddRecords resolves a hostname and adds A records to the zone.
-func resolveAndAddRecords(hostname, zoneName string, zoneRecords map[string][]types.Record) {
-	ctx := context.Background()
+// buildAllowNetDNSZones creates DNS zones that implement allowlist filtering.
+//
+// Strategy:
+//   - For each allowed hostname: resolve to IPs, create a zone with A records
+//   - For wildcard patterns (*.example.com): create zone with Regexp records
+//   - Add catch-all root zone "" with DefaultIP 0.0.0.0 (sinkhole)
+//
+// Zone matching is first-match-wins with suffix matching. Specific zones
+// are added before the root zone, so allowed hosts resolve normally while
+// everything else gets sinkholed.
+func buildAllowNetDNSZones(allowNet []string) []types.Zone {
+	return buildAllowNet(allowNet).zones
+}
+
+// systemLookupIPAddr resolves a hostname via the host's system DNS. It is the
+// production resolver behind the buildAllowNet seam.
+func systemLookupIPAddr(ctx context.Context, host string) ([]net.IP, error) {
 	resolver := &net.Resolver{PreferGo: false}
-	ips, err := resolver.LookupIPAddr(ctx, hostname)
+	addrs, err := resolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	ips := make([]net.IP, 0, len(addrs))
+	for _, a := range addrs {
+		ips = append(ips, a.IP)
+	}
+	return ips, nil
+}
+
+// resolveAndAddRecords resolves a hostname, adds A records to the zone, and
+// returns the resolved IPv4 set so callers can pin egress to the same IPs.
+func resolveAndAddRecords(hostname, zoneName string, zoneRecords map[string][]types.Record, lookup func(context.Context, string) ([]net.IP, error)) []net.IP {
+	ctx := context.Background()
+	ips, err := lookup(ctx, hostname)
 	if err != nil {
 		logrus.WithFields(logrus.Fields{
 			"hostname": hostname,
 			"error":    err,
 		}).Warn("allowNet: DNS resolution failed for allowed host")
-		return
+		return nil
 	}
 
 	trimmed := strings.TrimSuffix(hostname+".", "."+zoneName)
 
+	var v4 []net.IP
 	for _, ip := range ips {
-		if ip.IP.To4() == nil {
+		if ip.To4() == nil {
 			continue // Skip IPv6 for now
 		}
+		ip4 := ip.To4()
+		v4 = append(v4, ip4)
 		zoneRecords[zoneName] = append(zoneRecords[zoneName], types.Record{
 			Name: trimmed,
-			IP:   ip.IP.To4(),
+			IP:   ip4,
 		})
 		logrus.WithFields(logrus.Fields{
 			"hostname": hostname,
-			"ip":       ip.IP,
+			"ip":       ip,
 			"zone":     zoneName,
 			"label":    trimmed,
 		}).Debug("allowNet: resolved and added DNS record")
 	}
+	return v4
 }

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/dns_filter_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/dns_filter_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"net"
 	"testing"
 )
@@ -51,5 +52,69 @@ func TestBuildAllowNetDNSZones_EmptyList(t *testing.T) {
 	}
 	if zones[0].Name != "" {
 		t.Errorf("single zone should be root, got %q", zones[0].Name)
+	}
+}
+
+// TestBuildAllowNet_FrozenBuildTimeResolution pins the frozen-resolution
+// contract: buildAllowNet resolves each hostname once at build time and bakes
+// the result into BOTH the DNS zones and the egress pin map. A domain that
+// changes its IP afterwards is not picked up by the running box — a fresh build
+// (a new box) is required. If re-resolution is ever added, this test and the
+// pin must be updated together (see allowNetResolution's coupling contract).
+func TestBuildAllowNet_FrozenBuildTimeResolution(t *testing.T) {
+	lookup := func(_ context.Context, _ string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("10.0.0.1").To4()}, nil
+	}
+
+	res := buildAllowNetWithResolver([]string{"api.example.com"}, lookup)
+
+	// The single resolution is baked into the pin map...
+	if got := res.exactIPs["api.example.com"]; len(got) != 1 || !got[0].Equal(net.ParseIP("10.0.0.1")) {
+		t.Fatalf("pin map should hold the resolved IP, got %v", got)
+	}
+	// ...and into the DNS zone A record (same source, same IP).
+	if len(res.zones) != 2 {
+		t.Fatalf("expected 2 zones (per-TLD + root), got %d", len(res.zones))
+	}
+	zone := res.zones[0]
+	if zone.Name != "example.com." || len(zone.Records) != 1 || !zone.Records[0].IP.Equal(net.ParseIP("10.0.0.1")) {
+		t.Fatalf("DNS zone should bake the same IP as the pin, got zone=%q records=%v", zone.Name, zone.Records)
+	}
+
+	// Simulate the domain switching IP after the box is built.
+	lookup = func(_ context.Context, _ string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("10.0.0.2").To4()}, nil
+	}
+
+	// The already-built resolution is frozen — it still serves the old IP.
+	if got := res.exactIPs["api.example.com"]; len(got) != 1 || !got[0].Equal(net.ParseIP("10.0.0.1")) {
+		t.Fatalf("built resolution must stay frozen after the domain changes IP, got %v", got)
+	}
+
+	// Only a fresh build (a recreated box) picks up the new IP.
+	fresh := buildAllowNetWithResolver([]string{"api.example.com"}, lookup)
+	if got := fresh.exactIPs["api.example.com"]; len(got) != 1 || !got[0].Equal(net.ParseIP("10.0.0.2")) {
+		t.Fatalf("a fresh build should resolve the new IP, got %v", got)
+	}
+}
+
+// TestBuildAllowNet_PinCoversSameHostsAsDNS asserts the pin map is keyed by
+// exactly the hostname rules the gateway DNS serves, so the pin can never
+// diverge from the DNS zones. IP/CIDR rules produce no hostname pin keys.
+func TestBuildAllowNet_PinCoversSameHostsAsDNS(t *testing.T) {
+	lookup := func(_ context.Context, _ string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("10.0.0.1").To4()}, nil
+	}
+
+	res := buildAllowNetWithResolver([]string{"api.openai.com", "*.anthropic.com", "1.2.3.4", "10.0.0.0/8"}, lookup)
+
+	if _, ok := res.exactIPs["api.openai.com"]; !ok {
+		t.Errorf("expected exact pin key for api.openai.com")
+	}
+	if _, ok := res.suffixIPs[".anthropic.com"]; !ok {
+		t.Errorf("expected wildcard suffix pin key for .anthropic.com")
+	}
+	if len(res.exactIPs) != 1 || len(res.suffixIPs) != 1 {
+		t.Errorf("IP/CIDR rules must not produce hostname pin keys, got exact=%v suffix=%v", res.exactIPs, res.suffixIPs)
 	}
 }

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/forked_tcp.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/forked_tcp.go
@@ -118,7 +118,7 @@ func TCPWithFilter(s *stack.Stack, nat map[tcpip.Address]tcpip.Address,
 			standardForward(r, destAddr)
 			return
 		case tcpRouteInspect:
-			inspectAndForward(r, destAddr, destPort, filter, ca, secretMatcher)
+			inspectAndForward(r, destAddr, destIP, destPort, filter, ca, secretMatcher)
 			return
 		default:
 			// No matching rule: block
@@ -164,7 +164,7 @@ func standardForward(r *tcp.ForwarderRequest, destAddr string) {
 // inspectAndForward: Accept → Peek SNI/Host → check allowlist → Dial → relay.
 // The flow is reversed from upstream because we need to read from the guest
 // before deciding whether to connect to the upstream server.
-func inspectAndForward(r *tcp.ForwarderRequest, destAddr string, destPort uint16, filter *AllowNetFilter, ca *BoxCA, secretMatcher *SecretHostMatcher) {
+func inspectAndForward(r *tcp.ForwarderRequest, destAddr string, destIP net.IP, destPort uint16, filter *AllowNetFilter, ca *BoxCA, secretMatcher *SecretHostMatcher) {
 	// Step 1: Accept TCP from guest first (reversed from upstream)
 	var wq waiter.Queue
 	ep, tcpErr := r.CreateEndpoint(&wq)
@@ -200,8 +200,10 @@ func inspectAndForward(r *tcp.ForwarderRequest, destAddr string, destPort uint16
 		return
 	}
 
-	// Step 4: Check allowlist (skip if no allowlist — secrets-only mode allows all traffic)
-	if filter != nil && (hostname == "" || !filter.MatchesHostname(hostname)) {
+	// Step 4: Check allowlist (skip if no allowlist — secrets-only mode allows all traffic).
+	// The pin ties the guest-supplied hostname to the dialed IP: a hostname
+	// alone no longer authorizes a connection to an arbitrary guest-chosen IP.
+	if filter != nil && (hostname == "" || !filter.AllowHostToIP(hostname, destIP)) {
 		logrus.WithFields(logrus.Fields{
 			"dst":      destAddr,
 			"hostname": hostname,

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/gvproxy_create_latency_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/gvproxy_create_latency_test.go
@@ -28,7 +28,7 @@ func TestVirtualNetworkNewWithinLatencyBudget(t *testing.T) {
 
 	// Warm up once: the first construction pays one-time lazy-init costs
 	// that are not representative of the steady-state per-box cost.
-	if vn, err := virtualnetwork.New(buildTapConfig(testGvproxyConfig(), types.QemuProtocol)); err != nil {
+	if vn, err := virtualnetwork.New(buildTapConfig(testGvproxyConfig(), types.QemuProtocol, nil)); err != nil {
 		t.Fatalf("warmup virtualnetwork.New failed: %v", err)
 	} else {
 		_ = vn
@@ -36,7 +36,7 @@ func TestVirtualNetworkNewWithinLatencyBudget(t *testing.T) {
 
 	samples := make([]time.Duration, 0, iters)
 	for i := 0; i < iters; i++ {
-		cfg := buildTapConfig(testGvproxyConfig(), types.QemuProtocol)
+		cfg := buildTapConfig(testGvproxyConfig(), types.QemuProtocol, nil)
 		start := time.Now()
 		vn, err := virtualnetwork.New(cfg)
 		elapsed := time.Since(start)

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
@@ -212,7 +212,7 @@ type GvproxyInstance struct {
 	secretMatcher *SecretHostMatcher             // Hostname→secrets lookup (nil if no secrets)
 }
 
-func buildDNSZones(config GvproxyConfig) []types.Zone {
+func buildDNSZones(config GvproxyConfig, allowNetZones []types.Zone) []types.Zone {
 	dnsZones := make([]types.Zone, 0, len(config.DNSZones)+1)
 	for _, zone := range config.DNSZones {
 		dnsZone := types.Zone{
@@ -229,7 +229,6 @@ func buildDNSZones(config GvproxyConfig) []types.Zone {
 	}
 
 	if len(config.AllowNet) > 0 {
-		allowNetZones := buildAllowNetDNSZones(config.AllowNet)
 		dnsZones = append(dnsZones, allowNetZones...)
 		logrus.WithField("rules", len(config.AllowNet)).Info("Network allowlist enabled (DNS sinkhole)")
 	}
@@ -250,11 +249,15 @@ func buildDNSZones(config GvproxyConfig) []types.Zone {
 //
 // Returns nil when allow_net is empty, which the transport handlers read as
 // "forward everything".
-func newAllowNetFilter(config GvproxyConfig) *AllowNetFilter {
-	return NewAllowNetFilter(config.AllowNet, config.GatewayIP, config.GuestIP)
+func newAllowNetFilter(config GvproxyConfig, exactIPs, suffixIPs map[string][]net.IP) *AllowNetFilter {
+	f := NewAllowNetFilter(config.AllowNet, config.GatewayIP, config.GuestIP)
+	if f != nil {
+		f.SetResolvedHostIPs(exactIPs, suffixIPs)
+	}
+	return f
 }
 
-func buildTapConfig(config GvproxyConfig, protocol types.Protocol) *types.Configuration {
+func buildTapConfig(config GvproxyConfig, protocol types.Protocol, allowNetZones []types.Zone) *types.Configuration {
 	nat := make(map[string]string)
 	gatewayVirtualIPs := []string{config.GatewayIP}
 	if config.HostIP != "" {
@@ -277,7 +280,7 @@ func buildTapConfig(config GvproxyConfig, protocol types.Protocol) *types.Config
 		NAT:               nat,
 		GatewayVirtualIPs: gatewayVirtualIPs,
 		Protocol:          protocol,
-		DNS:               buildDNSZones(config),
+		DNS:               buildDNSZones(config, allowNetZones),
 		DNSSearchDomains:  config.DNSSearchDomains,
 		CaptureFile:       "",
 	}
@@ -339,8 +342,22 @@ func gvproxy_create(configJSON *C.char, errOut **C.char) C.longlong {
 		protocol = types.QemuProtocol
 	}
 
+	// Resolve hostname rules once so the gateway DNS zones and the TCP egress
+	// pin share the same IP set (see allow_net_filter.AllowHostToIP). This
+	// resolution is frozen for the box's lifetime: a domain that changes IP
+	// after startup is unreachable until the box is recreated. If re-resolution
+	// is ever added, it must refresh the pin from the same source.
+	// Skipped for an empty allow_net (the common case): building it would only
+	// allocate a root sinkhole zone and log "DNS sinkhole configured" for a box
+	// with no egress policy. buildDNSZones and newAllowNetFilter both already
+	// gate on len(config.AllowNet) > 0, so a nil resolution is safe to pass.
+	var resolved allowNetResolution
+	if len(config.AllowNet) > 0 {
+		resolved = buildAllowNet(config.AllowNet)
+	}
+
 	// Create gvisor-tap-vsock configuration from provided config
-	tapConfig := buildTapConfig(config, protocol)
+	tapConfig := buildTapConfig(config, protocol, resolved.zones)
 
 	// Set CaptureFile if provided
 	if config.CaptureFile != nil && *config.CaptureFile != "" {
@@ -449,7 +466,7 @@ func gvproxy_create(configJSON *C.char, errOut **C.char) C.longlong {
 		if len(config.AllowNet) > 0 || instance.secretMatcher != nil {
 			var allowNetFilter *AllowNetFilter
 			if len(config.AllowNet) > 0 {
-				allowNetFilter = newAllowNetFilter(config)
+				allowNetFilter = newAllowNetFilter(config, resolved.exactIPs, resolved.suffixIPs)
 			}
 			// Fatal on purpose: the handlers left behind are upstream's
 			// unfiltered forwarders, so a box that starts anyway would carry

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/udp_filter_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/udp_filter_test.go
@@ -57,7 +57,15 @@ func startNetwork(t *testing.T, allowNet []string) *guestTap {
 
 	cfg := testGvproxyConfig()
 	cfg.AllowNet = allowNet
-	tapConfig := buildTapConfig(cfg, types.QemuProtocol)
+	// Mirror gvproxy_create: only resolve hostname rules when an allow_net is
+	// present. An empty allow_net is the common case and needs no resolution;
+	// the nil zones/maps are safe because buildDNSZones and newAllowNetFilter
+	// already gate on len(cfg.AllowNet) > 0.
+	var resolved allowNetResolution
+	if len(cfg.AllowNet) > 0 {
+		resolved = buildAllowNet(cfg.AllowNet)
+	}
+	tapConfig := buildTapConfig(cfg, types.QemuProtocol, resolved.zones)
 	// Route the unlisted TEST-NET destination to a test-owned loopback
 	// listener. The forwarders dial the NAT-translated address; the allowlist
 	// still sees 198.51.100.9.
@@ -69,7 +77,7 @@ func startNetwork(t *testing.T, allowNet []string) *guestTap {
 	}
 
 	if len(cfg.AllowNet) > 0 {
-		filter := newAllowNetFilter(cfg)
+		filter := newAllowNetFilter(cfg, resolved.exactIPs, resolved.suffixIPs)
 		if err := installAllowNetHandlers(vn, tapConfig, tapConfig.Ec2MetadataAccess, filter, nil, nil); err != nil {
 			t.Fatalf("installAllowNetHandlers: %v", err)
 		}


### PR DESCRIPTION
## Summary

Hostname `allow_net` rules authorized egress by SNI/Host alone, so a guest could present an allowed hostname while dialing an arbitrary IP — domain fronting, decoupling the checked name from the actual destination. This resolves each hostname rule once at box build and pins the TCP dialed IP to that resolution, sharing the result between the gateway DNS zones and the egress check so the guest and the pin can never disagree.

## Call graph

Before

```text
gvproxy_create            (main.go) — builds DNS zones and the filter separately
  ├─ buildDNSZones → buildAllowNetDNSZones (dns_filter.go) — resolves hostname rules, used only by DNS
  └─ newAllowNetFilter    (main.go) — parses rules into AllowNetFilter (no resolved IPs)
TCPWithFilter             (forked_tcp.go:58) — routes hostname rules to inspect
  └─ inspectAndForward    (forked_tcp.go:206)
       └─ filter.MatchesHostname(hostname)  ← BUG: SNI/Host alone authorizes egress to any guest-chosen IP
            └─ net.Dial(destAddr)            — dials the guest-supplied destination
```

After

```text
gvproxy_create            (main.go:350)
  └─ buildAllowNet        (dns_filter.go:41) — one resolution shared by DNS zones and the egress pin
       ├─ zones            → buildTapConfig → buildDNSZones (main.go:215)
       └─ exactIPs/suffixIPs → newAllowNetFilter → SetResolvedHostIPs (allow_net_filter.go:156)
TCPWithFilter             (forked_tcp.go:58)
  └─ inspectAndForward    (forked_tcp.go:206)
       └─ filter.AllowHostToIP(hostname, destIP) (allow_net_filter.go:166) — hostname AND the dialed IP must be that host's own resolution
            └─ net.Dial(destAddr)
```

Fixes POL-265.

## Changes

- Resolve each hostname rule once at box build and share that resolution between the gateway DNS zones and the new egress pin, so the guest and the pin see the same IPs.
- Add `AllowNetFilter.SetResolvedHostIPs` and `AllowHostToIP`; swap the TCP inspect gate from `MatchesHostname` to `AllowHostToIP`.
- Freeze the resolution for the box's lifetime: a domain that changes its A record after startup is unreachable until the box is recreated.
- Tests for hostname/IP decoupling (domain fronting), exact/wildcard rules, pin determinism, and frozen build-time resolution.

## How to verify

- `cd src/deps/libgvproxy-sys/gvproxy-bridge && go test ./...`

## Risks / rollout

- Resolution is frozen at box build; a domain that changes its A record after startup is unreachable until the box is recreated (documented in `dns_filter.go`).
- Wildcard rules pin egress to the base domain's resolved IPs, matching the gateway DNS zone the wildcard builds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Strengthened hostname allowlisting by verifying connections reach IPs resolved for the approved hostname.
  * Prevented domain-fronting and unauthorized hostname-to-IP substitutions.
  * Ensured DNS filtering and outbound checks use the same resolved addresses throughout the gateway session.
  * Preserved existing IP and CIDR allowlist behavior.

* **Tests**
  * Added coverage for exact and wildcard hostnames, missing inputs, frozen DNS resolutions, and domain-fronting protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->