### PR TITLE
fix(dashboard): allow top-ups without a saved card

### DIFF
--- a/apps/dashboard/src/billing-api/billingApiClient.test.ts
+++ b/apps/dashboard/src/billing-api/billingApiClient.test.ts
@@ -6,9 +6,13 @@ import { BillingApiClient } from './billingApiClient'
 // locally, so the wire mapping is exercised without a server. Each test sets
 // the JSON the "server" returns and reads back what URL was requested.
 let requestedUrl = ''
+let requestedMethod = ''
+let requestedData: unknown
 function serve(data: unknown): BillingApiClient {
-  axios.defaults.adapter = (async (cfg: { url?: string; baseURL?: string }) => {
+  axios.defaults.adapter = (async (cfg: { url?: string; baseURL?: string; method?: string; data?: unknown }) => {
     requestedUrl = `${cfg.baseURL ?? ''}${cfg.url ?? ''}`
+    requestedMethod = cfg.method ?? ''
+    requestedData = cfg.data
     return { data, status: 200, statusText: 'OK', headers: {}, config: cfg }
   }) as never
   return new BillingApiClient('http://billing.test/api/billing', 'tok')
@@ -80,6 +84,18 @@ describe('upgradePlan', () => {
     const api = serve(undefined)
     const url = await api.upgradePlan('org-1', 'max')
     expect(url).toBeUndefined()
+  })
+})
+
+describe('topUpWallet', () => {
+  it('posts the amount and returns the hosted payment URL', async () => {
+    const payment = { url: 'https://checkout.stripe.com/pay/cs_top_up' }
+    const api = serve(payment)
+
+    await expect(api.topUpWallet('org-without-card', 10_000)).resolves.toEqual(payment)
+    expect(requestedMethod).toBe('post')
+    expect(requestedUrl).toBe('http://billing.test/api/billing/organization/org-without-card/wallet/top-up')
+    expect(JSON.parse(String(requestedData))).toEqual({ amountCents: 10_000 })
   })
 })
 

--- a/apps/dashboard/src/components/billing/BillingAlerts.tsx
+++ b/apps/dashboard/src/components/billing/BillingAlerts.tsx
@@ -35,7 +35,7 @@ export function BillingAlerts() {
         user.profile.email_verified &&
         selectedOrganization?.isDefaultForAuthenticatedUser && (
           <StatusBanner tone="neutral" icon={<SparklesIcon className="size-4 shrink-0" />}>
-            Connect a credit card to enable wallet top-ups.
+            Connect a credit card to enable automatic top-ups.
           </StatusBanner>
         )}
     </>

--- a/apps/dashboard/src/components/billing/WalletSection.integration.test.tsx
+++ b/apps/dashboard/src/components/billing/WalletSection.integration.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { WalletSection } from './WalletSection'
+
+const mocks = vi.hoisted(() => ({
+  fetchCheckoutUrl: vi.fn(),
+  redeemCoupon: vi.fn(),
+  setAutomaticTopUp: vi.fn(),
+  topUpWallet: vi.fn(),
+}))
+
+vi.mock('@/hooks/useSelectedOrganization', () => ({
+  useSelectedOrganization: () => ({ selectedOrganization: { id: 'org-without-card' } }),
+}))
+
+vi.mock('react-oidc-context', () => ({
+  useAuth: () => ({ user: { profile: { email_verified: true } } }),
+}))
+
+vi.mock('@/hooks/queries/billingQueries', () => ({
+  useFetchOwnerCheckoutUrlQuery: () => mocks.fetchCheckoutUrl,
+  useIsOwnerCheckoutUrlFetching: () => false,
+  useOwnerBillingPortalUrlQuery: () => ({ data: undefined, isLoading: false }),
+  useOwnerInvoicesQuery: () => ({ data: { items: [], totalItems: 0, totalPages: 0 }, isLoading: false }),
+  useOwnerWalletQuery: () => ({
+    data: {
+      balanceCents: 0,
+      ongoingBalanceCents: 0,
+      name: 'Wallet',
+      creditCardConnected: false,
+    },
+    isLoading: false,
+  }),
+}))
+
+vi.mock('@/hooks/mutations/useRedeemCouponMutation', () => ({
+  useRedeemCouponMutation: () => ({ mutateAsync: mocks.redeemCoupon, isPending: false }),
+}))
+
+vi.mock('@/hooks/mutations/useSetAutomaticTopUpMutation', () => ({
+  useSetAutomaticTopUpMutation: () => ({ mutateAsync: mocks.setAutomaticTopUp, isPending: false }),
+}))
+
+vi.mock('@/hooks/mutations/useTopUpWalletMutation', () => ({
+  useTopUpWalletMutation: () => ({ mutateAsync: mocks.topUpWallet, isPending: false }),
+}))
+
+vi.mock('@/components/Invoices', () => ({ InvoicesTable: () => null }))
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+}
+
+describe('WalletSection top-up checkout', () => {
+  let root: Root | null = null
+
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    mocks.topUpWallet.mockResolvedValue({ url: 'https://checkout.stripe.com/pay/cs_top_up' })
+  })
+
+  afterEach(() => {
+    act(() => root?.unmount())
+    root = null
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('opens the returned payment page for an organization without a saved card', async () => {
+    const checkoutWindow = { location: { href: '' }, close: vi.fn() }
+    const open = vi.spyOn(window, 'open').mockReturnValue(checkoutWindow as unknown as Window)
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+
+    await act(async () => {
+      root = createRoot(host)
+      root.render(<WalletSection />)
+    })
+    await flush()
+
+    const topUpButton = [...document.querySelectorAll<HTMLButtonElement>('button')].find(
+      (button) => button.textContent?.trim() === 'Top up →',
+    )
+    expect(topUpButton).toBeDefined()
+    expect(topUpButton?.disabled).toBe(false)
+
+    await act(async () => topUpButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+    await flush()
+
+    expect(open).toHaveBeenCalledWith('', '_blank')
+    expect(mocks.topUpWallet).toHaveBeenCalledWith({ organizationId: 'org-without-card', amountCents: 10_000 })
+    expect(checkoutWindow.location.href).toBe('https://checkout.stripe.com/pay/cs_top_up')
+  })
+})

--- a/apps/dashboard/src/components/billing/WalletSection.test.ts
+++ b/apps/dashboard/src/components/billing/WalletSection.test.ts
@@ -2,29 +2,22 @@ import { describe, expect, it } from 'vitest'
 import { MIN_TOP_UP_DOLLARS, topUpGate } from './WalletSection'
 
 describe('topUpGate', () => {
-  it('names the missing card rather than leaving the button dead and unexplained', () => {
-    expect(topUpGate(false, 100)).toEqual({
-      enabled: false,
-      reason: 'Connect a payment method above to add funds.',
-    })
+  it('allows a top-up without a saved card so Checkout can collect one', () => {
+    expect(topUpGate(100)).toEqual({ enabled: true, reason: null })
   })
 
   it('stays quiet with nothing chosen yet — a disabled button needs no excuse there', () => {
-    expect(topUpGate(true, undefined)).toEqual({ enabled: false, reason: null })
-    expect(topUpGate(true, 0)).toEqual({ enabled: false, reason: null })
+    expect(topUpGate(undefined)).toEqual({ enabled: false, reason: null })
+    expect(topUpGate(0)).toEqual({ enabled: false, reason: null })
   })
 
   it('states the minimum instead of letting Commerce reject the round trip', () => {
-    expect(topUpGate(true, 5)).toEqual({ enabled: false, reason: 'Minimum top-up is $10.' })
-    expect(topUpGate(true, MIN_TOP_UP_DOLLARS - 0.01).reason).toBe('Minimum top-up is $10.')
+    expect(topUpGate(5)).toEqual({ enabled: false, reason: 'Minimum top-up is $10.' })
+    expect(topUpGate(MIN_TOP_UP_DOLLARS - 0.01).reason).toBe('Minimum top-up is $10.')
   })
 
   it('allows the minimum itself and anything above it', () => {
-    expect(topUpGate(true, MIN_TOP_UP_DOLLARS)).toEqual({ enabled: true, reason: null })
-    expect(topUpGate(true, 25)).toEqual({ enabled: true, reason: null })
-  })
-
-  it('reports the card before the amount — fixing the amount would not unblock anything', () => {
-    expect(topUpGate(false, 5).reason).toBe('Connect a payment method above to add funds.')
+    expect(topUpGate(MIN_TOP_UP_DOLLARS)).toEqual({ enabled: true, reason: null })
+    expect(topUpGate(25)).toEqual({ enabled: true, reason: null })
   })
 })

--- a/apps/dashboard/src/components/billing/WalletSection.tsx
+++ b/apps/dashboard/src/components/billing/WalletSection.tsx
@@ -39,20 +39,8 @@ export const MIN_TOP_UP_DOLLARS = 10
  */
 const DEFAULT_AUTO_RELOAD: AutomaticTopUp = { thresholdAmount: 20, targetAmount: 100 }
 
-/**
- * Whether Top up can run, and why not when it cannot.
- *
- * A silently disabled button was the whole problem here: the real blocker is a
- * missing card, which the control itself never said. `reason` is null only when
- * there is nothing to say yet — no amount picked — which needs no explanation.
- */
-export function topUpGate(
-  creditCardConnected: boolean,
-  amountDollars: number | undefined,
-): { enabled: boolean; reason: string | null } {
-  if (!creditCardConnected) {
-    return { enabled: false, reason: 'Connect a payment method above to add funds.' }
-  }
+/** Whether Top up can run, and why not when it cannot. */
+export function topUpGate(amountDollars: number | undefined): { enabled: boolean; reason: string | null } {
   if (!amountDollars) {
     return { enabled: false, reason: null }
   }
@@ -211,7 +199,7 @@ export function WalletSection() {
 
   const isBillingLoading = walletQuery.isLoading && billingPortalUrlQuery.isLoading
   const cardConnected = Boolean(wallet?.creditCardConnected)
-  const topUp = topUpGate(cardConnected, selectedPreset ?? oneTimeTopUpAmount)
+  const topUp = topUpGate(selectedPreset ?? oneTimeTopUpAmount)
   // Read the indicator off the saved wallet, not the form: the form is
   // pre-filled with defaults, which would otherwise read as already on.
   const autoReloadActive =


### PR DESCRIPTION
## Summary

One-time wallet top-ups treated `creditCardConnected` as a prerequisite even though the existing flow hands the payment to hosted Stripe Checkout. An organization with no saved card therefore saw a disabled `Top up` button and could never reach the page that collects its payment method.

Remove the card check only from one-time top-up eligibility. Amount and minimum validation remain unchanged, while automatic reload still requires a saved card.

## Call graph

Before

```text
WalletSection (React · WalletSection.tsx:53)
├─ topUpGate(cardConnected, amount)
│  └─ !cardConnected → disabled        ← BUG: stops before Checkout
└─ handleTopUpWallet() (:174)          — unreachable without a card
   └─ useTopUpWalletMutation()
      └─ BillingApiClient.topUpWallet()
         └─ POST /organization/:id/wallet/top-up → { url }
            └─ pre-opened window.location.href = url
```

After

```text
WalletSection (React · WalletSection.tsx:53)
├─ topUpGate(amount) (:43)             — amount and $10 minimum only
├─ handleTopUpWallet() (:174)
│  └─ useTopUpWalletMutation() (useTopUpWalletMutation.ts:17)
│     └─ BillingApiClient.topUpWallet() (billingApiClient.ts:166)
│        └─ POST /organization/:id/wallet/top-up { amountCents }
│           └─ returned Stripe URL → pre-opened window.location.href
└─ automatic top-up controls (:398, :425, :456)
   └─ cardConnected remains required
```

## Changes

- Reduce `topUpGate` to the rules it owns: an amount must be selected and meet the existing $10 minimum.
- Keep `creditCardConnected` on the automatic-reload inputs and save action, so recurring charges still require a stored payment method.
- Update the no-card banner to describe automatic top-ups instead of claiming that all wallet top-ups are unavailable.
- Cover the no-card click path from the enabled button through the organization id, 10,000-cent request, and returned Stripe URL.
- Pin `BillingApiClient.topUpWallet` to the existing POST path and `{ amountCents }` request body.

## Verification

- Failing-first: with both production files reverted and the new tests retained, the focused suite reported 5 failed and 8 passed; the DOM test found `Top up` disabled for an organization without a card.
- `yarn vitest run --config dashboard/vite.config.mts dashboard/src/components/billing/WalletSection.test.ts dashboard/src/components/billing/WalletSection.integration.test.tsx dashboard/src/billing-api/billingApiClient.test.ts` — 13/13 passed.
- `yarn vitest run --config dashboard/vite.config.mts` — 200/200 passed across 29 files.
- `make lint:apps` — 0 errors; 33 existing warnings in untouched files.
- `git diff-tree --check HEAD^ HEAD` — passed.

## Risks / rollout

- No API or wallet-crediting contract changes; the dashboard still uses the existing top-up endpoint and follows its returned hosted URL.
- The checkout window is still opened synchronously before the request, so popup handling and failure cleanup are unchanged.
- Automatic reload remains unavailable until a card is connected.

## Summary
<!-- 1-2 sentences: what this changes and why. -->

## Call graph
<!-- Required. The end-to-end path this PR touches, before and after; one line
     per hop, only the hops that change. Worked example and the bug-fix markers:
     CONTRIBUTING.md#commit--pr-messages. -->

Before
<!-- replace with the hops: fn_name (Type · path/file.rs:LOC) — role -->

After
<!-- replace with the same hops, post-change -->

Fixes #<!-- issue number — bug fixes only; delete this line otherwise -->

## Changes
- <!-- notable change — what changed, not a restatement of the diff -->

## How to verify
- <!-- a command or step a reviewer can run -->

## Risks / rollout
- <!-- only if any; delete this section otherwise -->

<!-- Describe the change, not the process: no pasted logs, no AI/conversation
     narrative, no secrets. Keep it tight and delete sections that don't apply. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wallet top-ups can now be initiated without a saved payment card.
  * Selecting a top-up amount opens a secure checkout flow to complete payment.
* **Updates**
  * Automatic top-up alerts now clearly distinguish automatic top-ups from manual wallet top-ups.
* **Bug Fixes**
  * Improved top-up validation so valid amounts are accepted independently of saved-card status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->