### PR TITLE
fix(dashboard): title the console tab BoxLite Cloud

### DIFF
--- a/apps/dashboard/index.html
+++ b/apps/dashboard/index.html
@@ -6,7 +6,7 @@
     <link rel="icon" href="/favicon.ico" sizes="16x16 32x32 48x48" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>BoxLite</title>
+    <title>BoxLite Cloud</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link


### PR DESCRIPTION
## Summary

The console's browser tab read `BoxLite` — the name of the open-source runtime, the same string a user already sees on the CLI and in the SDKs. The tab belongs to the hosted console, so it now says `BoxLite Cloud`.

## Call graph

**Before**

```
index.html:9  <title>BoxLite</title>
              ← names the runtime, not the hosted console this tab belongs to
```

**After**

```
index.html:9  <title>BoxLite Cloud</title>
```

Nothing in `src/` assigns `document.title` (`grep -rn "document.title" src/` → no hits outside an SVG `<title>`), so this one element is the whole tab title on every route. There is no web-app manifest and no test asserting the old string.

## Validation

Served HTML and the rendered document title, from `start:mock`:

```
$ curl -s http://localhost:3102/ | grep -o "<title>[^<]*</title>"
<title>BoxLite Cloud</title>

# browser-reported document title
"BoxLite Cloud"
```

No screenshot: a viewport capture does not include the browser's tab strip, so it could not show the thing being changed.

## Follow-up worth considering, not in this PR

Because the title is static, every route shows the same string — `Billing`, `Boxes` and a box's terminal are indistinguishable in a tab strip or in history. Per-route titles (`Billing · BoxLite Cloud`) would fix that, but they need a title hook wired through the router and are a larger change than a rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated the dashboard page title to “BoxLite Cloud.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->