### PR TITLE
fix(auth): return 403 with a code for unverified email

### DIFF
--- a/apps/api/src/auth/combined-auth.guard.spec.ts
+++ b/apps/api/src/auth/combined-auth.guard.spec.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { HttpStatus, UnauthorizedException } from '@nestjs/common'
+import { CombinedAuthGuard } from './combined-auth.guard'
+import {
+  EMAIL_VERIFICATION_REQUIRED_CODE,
+  EmailVerificationRequiredException,
+} from '../exceptions/email-verification-required.exception'
+
+describe('CombinedAuthGuard.handleRequest', () => {
+  it('delivers an email-verification rejection to the client intact', () => {
+    const guard = new CombinedAuthGuard()
+    const rejection = new EmailVerificationRequiredException()
+
+    let thrown: unknown
+    try {
+      guard.handleRequest(rejection, false)
+    } catch (error) {
+      thrown = error
+    }
+
+    // Same instance, so the status and code JwtStrategy chose survive the guard.
+    // Flattening it to 401 tells the dashboard the token is stale and re-arms a
+    // re-login loop that cannot clear an unverified address.
+    expect(thrown).toBe(rejection)
+    expect((thrown as EmailVerificationRequiredException).getStatus()).toBe(HttpStatus.FORBIDDEN)
+    expect((thrown as EmailVerificationRequiredException).getResponse()).toMatchObject({
+      code: 'email_verification_required',
+    })
+    // Pinned to the literal, not the constant: asserting the constant against
+    // itself proves nothing, and the dashboard keeps its own copy of this string
+    // (apps/dashboard/src/api/errors.ts). A rename on either side must break a
+    // test rather than silently desync the wire contract.
+    expect(EMAIL_VERIFICATION_REQUIRED_CODE).toBe('email_verification_required')
+  })
+
+  it('still flattens an ordinary strategy failure to a generic 401', () => {
+    const guard = new CombinedAuthGuard()
+
+    // A caller must not learn which strategy rejected it: a wrong key and an
+    // unknown key have to look identical.
+    expect(() => guard.handleRequest(new Error('jwt malformed'), false)).toThrow(UnauthorizedException)
+    expect(() => guard.handleRequest(new Error('jwt malformed'), false)).toThrow('Invalid credentials')
+  })
+
+  it('still rejects when no strategy produced a user', () => {
+    const guard = new CombinedAuthGuard()
+
+    expect(() => guard.handleRequest(null, false)).toThrow(UnauthorizedException)
+  })
+
+  it('returns the authenticated user on success', () => {
+    const guard = new CombinedAuthGuard()
+    const user = { userId: 'user-1' }
+
+    expect(guard.handleRequest(null, user)).toBe(user)
+  })
+})

--- a/apps/api/src/auth/combined-auth.guard.ts
+++ b/apps/api/src/auth/combined-auth.guard.ts
@@ -6,6 +6,7 @@
 
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common'
 import { AuthGuard } from '@nestjs/passport'
+import { EmailVerificationRequiredException } from '../exceptions/email-verification-required.exception'
 
 /**
  * Main authentication guard for the application.
@@ -15,12 +16,23 @@ import { AuthGuard } from '@nestjs/passport'
  *
  * `handleRequest` is invoked once — either when a strategy succeeds or when all strategies fail.
  * It returns the authenticated user object or throws a generic `UnauthorizedException`.
+ *
+ * The generic reply is deliberate: a caller must not learn which strategy rejected it or why,
+ * so a wrong key and an unknown key are indistinguishable. A deliberate policy rejection is the
+ * exception — it describes the authenticated caller's own account state, tells them nothing they
+ * do not already know, and carries the status and machine code the client needs to act on.
  */
 @Injectable()
 export class CombinedAuthGuard extends AuthGuard(['api-key', 'jwt']) {
   private readonly logger = new Logger(CombinedAuthGuard.name)
 
   handleRequest(err: any, user: any) {
+    // Flattening this to 401 would strip the status the client branches on and re-arm its
+    // stale-token recovery, bouncing an unverified user through a login that cannot help.
+    if (err instanceof EmailVerificationRequiredException) {
+      throw err
+    }
+
     if (err || !user) {
       this.logger.debug('Authentication failed', { err, user })
       throw new UnauthorizedException('Invalid credentials')

--- a/apps/api/src/auth/jwt.strategy.spec.ts
+++ b/apps/api/src/auth/jwt.strategy.spec.ts
@@ -5,11 +5,15 @@
  */
 
 import { Request } from 'express'
-import { UnauthorizedException } from '@nestjs/common'
+import { HttpStatus } from '@nestjs/common'
 import * as jose from 'jose'
 import { JwtStrategy, requireVerifiedAuth0DatabaseEmail } from './jwt.strategy'
 import { UserService } from '../user/user.service'
 import { TypedConfigService } from '../config/typed-config.service'
+import {
+  EMAIL_VERIFICATION_REQUIRED_CODE,
+  EmailVerificationRequiredException,
+} from '../exceptions/email-verification-required.exception'
 
 const DEFAULT_REGION_ID = 'region-default-id'
 
@@ -61,7 +65,7 @@ describe('JwtStrategy.validate — auto-created user', () => {
 
     await expect(
       strategy.validate(request, { sub: 'auth0|user-1', email: 'new@boxlite.dev', email_verified: false }),
-    ).rejects.toThrow(UnauthorizedException)
+    ).rejects.toThrow(EmailVerificationRequiredException)
     expect(userService.findOne).not.toHaveBeenCalled()
     expect(userService.create).not.toHaveBeenCalled()
   })
@@ -79,9 +83,32 @@ describe('JwtStrategy.validate — auto-created user', () => {
 describe('requireVerifiedAuth0DatabaseEmail', () => {
   it('rejects false or missing verification on Auth0 database identities', () => {
     expect(() => requireVerifiedAuth0DatabaseEmail({ sub: 'auth0|123', email_verified: false })).toThrow(
-      UnauthorizedException,
+      EmailVerificationRequiredException,
     )
-    expect(() => requireVerifiedAuth0DatabaseEmail({ sub: 'auth0|123' })).toThrow(UnauthorizedException)
+    expect(() => requireVerifiedAuth0DatabaseEmail({ sub: 'auth0|123' })).toThrow(EmailVerificationRequiredException)
+  })
+
+  // 401 would tell the dashboard the token is stale, which re-arms a re-login
+  // loop that cannot clear an unverified address. 403 says the token is fine
+  // and the bearer is not yet allowed — the client can then show a real screen.
+  it('rejects with 403 and a machine-readable code, never 401', () => {
+    let thrown: unknown
+    try {
+      requireVerifiedAuth0DatabaseEmail({ sub: 'auth0|123', email_verified: false })
+    } catch (error) {
+      thrown = error
+    }
+
+    const exception = thrown as EmailVerificationRequiredException
+    expect(exception).toBeInstanceOf(EmailVerificationRequiredException)
+    expect(exception.getStatus()).toBe(HttpStatus.FORBIDDEN)
+    expect(exception.getResponse()).toMatchObject({ code: 'email_verification_required' })
+
+    // Pinned to the literal, not the constant: asserting the constant against
+    // itself proves nothing, and the dashboard keeps its own copy of this string
+    // (apps/dashboard/src/api/errors.ts). A rename on either side must break a
+    // test rather than silently desync the wire contract.
+    expect(EMAIL_VERIFICATION_REQUIRED_CODE).toBe('email_verification_required')
   })
 
   it('accepts verified Auth0 database and non-Auth0 identities', () => {
@@ -100,7 +127,7 @@ describe('JwtStrategy.verifyToken', () => {
       protectedHeader: { alg: 'RS256' },
     } as any)
 
-    await expect(strategy.verifyToken('already-issued-token')).rejects.toThrow(UnauthorizedException)
+    await expect(strategy.verifyToken('already-issued-token')).rejects.toThrow(EmailVerificationRequiredException)
   })
 
   it('returns a verified Auth0 database payload', async () => {

--- a/apps/api/src/auth/jwt.strategy.ts
+++ b/apps/api/src/auth/jwt.strategy.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common'
+import { Injectable, Logger } from '@nestjs/common'
 import { PassportStrategy } from '@nestjs/passport'
 import { ExtractJwt, Strategy } from 'passport-jwt'
 import { passportJwtSecret } from 'jwks-rsa'
@@ -14,6 +14,7 @@ import { AuthContext } from '../common/interfaces/auth-context.interface'
 import { Request } from 'express'
 import { CustomHeaders } from '../common/constants/header.constants'
 import { TypedConfigService } from '../config/typed-config.service'
+import { EmailVerificationRequiredException } from '../exceptions/email-verification-required.exception'
 
 interface JwtStrategyConfig {
   jwksUri: string
@@ -25,6 +26,10 @@ interface JwtStrategyConfig {
  * Auth0 database identities use the `auth0|` subject prefix. Social and
  * enterprise identities have provider-specific prefixes and stay outside this
  * database-account policy.
+ *
+ * Rejects with 403, not 401: the token itself is valid, so a client that
+ * recovers from 401 by re-authenticating would loop forever against a state
+ * only the user can clear. See EmailVerificationRequiredException.
  */
 export function requireVerifiedAuth0DatabaseEmail(
   payload: Pick<JWTPayload, 'sub'> & {
@@ -32,7 +37,7 @@ export function requireVerifiedAuth0DatabaseEmail(
   },
 ): void {
   if (payload.sub?.startsWith('auth0|') && payload.email_verified !== true) {
-    throw new UnauthorizedException('Email verification required')
+    throw new EmailVerificationRequiredException()
   }
 }
 

--- a/apps/api/src/exceptions/email-verification-required.exception.ts
+++ b/apps/api/src/exceptions/email-verification-required.exception.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { HttpException, HttpStatus } from '@nestjs/common'
+
+/**
+ * Machine-readable discriminator for this rejection. The dashboard branches on
+ * it rather than on the human message — see EMAIL_VERIFICATION_REQUIRED_CODE in
+ * apps/dashboard/src/api/errors.ts, which must stay byte-identical.
+ */
+export const EMAIL_VERIFICATION_REQUIRED_CODE = 'email_verification_required'
+
+/**
+ * The caller's token is valid — signature, audience, issuer and expiry all
+ * check out — but the identity behind it has not verified its email address.
+ *
+ * 403, not 401: RFC 6750 section 3.1 reserves 401 `invalid_token` for a token
+ * the resource server cannot accept, and 403 for a good token whose bearer
+ * lacks the privilege. The distinction is load-bearing here — the dashboard
+ * treats every 401 as a stale token and bounces to a fresh login, a recovery
+ * that can never clear a rejection which survives re-authentication.
+ */
+export class EmailVerificationRequiredException extends HttpException {
+  constructor() {
+    super({ message: 'Email verification required', code: EMAIL_VERIFICATION_REQUIRED_CODE }, HttpStatus.FORBIDDEN)
+  }
+}

--- a/apps/dashboard/src/api/apiClient.test.ts
+++ b/apps/dashboard/src/api/apiClient.test.ts
@@ -6,14 +6,14 @@ const config = { apiUrl: 'http://api.test/api' } as never
 // Fresh module per test so the module-level `isHandlingUnauthorized` guard
 // doesn't leak across cases. A custom axios adapter makes every request resolve
 // to `status` with an empty body, so the response interceptor sees the 401.
-async function makeClient(onUnauthorized: () => Promise<void> | void, status = 401) {
+async function makeClient(onUnauthorized: () => Promise<void> | void, status = 401, body: unknown = {}) {
   vi.resetModules()
   const axios = (await import('axios')).default
   // A custom adapter must settle the response itself (axios doesn't re-apply
   // validateStatus to a custom adapter's return), so reject non-2xx with an
   // AxiosError carrying `.response`, exactly like the built-in adapters.
   axios.defaults.adapter = (async (cfg: unknown) => {
-    const response = { data: {}, status, statusText: '', headers: {}, config: cfg }
+    const response = { data: body, status, statusText: '', headers: {}, config: cfg }
     if (status >= 200 && status < 300) return response
     const err = new Error(`Request failed with status code ${status}`) as Error & Record<string, unknown>
     err.response = response
@@ -53,6 +53,36 @@ describe('ApiClient 401 -> bounded re-login recovery', () => {
     const api = await makeClient(onUnauthorized)
     await expect(api.organizationsApi.listOrganizations()).rejects.toBeTruthy()
     expect(onUnauthorized).not.toHaveBeenCalled()
+  })
+
+  // A 403 is not an authentication failure, so none of the recovery machinery
+  // above may engage: the token is valid and re-logging in cannot change the
+  // account state the API is objecting to.
+  it('a coded 403 becomes a typed error and never triggers re-login', async () => {
+    const onUnauthorized = vi.fn(() => Promise.resolve())
+    const api = await makeClient(onUnauthorized, 403, {
+      message: 'Email verification required',
+      code: 'email_verification_required',
+    })
+
+    // Imported after makeClient's vi.resetModules() so these are the same class
+    // objects the freshly-imported apiClient constructs.
+    const { EmailVerificationRequiredError } = await import('./errors')
+
+    await expect(api.organizationsApi.listOrganizations()).rejects.toBeInstanceOf(EmailVerificationRequiredError)
+    expect(onUnauthorized).not.toHaveBeenCalled()
+    expect(window.sessionStorage.getItem('boxlite.reauth-attempted')).toBeNull()
+  })
+
+  it('an uncoded error stays a plain BoxliteError', async () => {
+    const onUnauthorized = vi.fn(() => Promise.resolve())
+    const api = await makeClient(onUnauthorized, 403, { message: 'Forbidden' })
+
+    const { BoxliteError, EmailVerificationRequiredError } = await import('./errors')
+
+    const error = await api.organizationsApi.listOrganizations().catch((e: unknown) => e)
+    expect(error).toBeInstanceOf(BoxliteError)
+    expect(error).not.toBeInstanceOf(EmailVerificationRequiredError)
   })
 
   it('a rejecting onUnauthorized resets state and surfaces an error (no hang)', async () => {

--- a/apps/dashboard/src/api/apiClient.ts
+++ b/apps/dashboard/src/api/apiClient.ts
@@ -124,7 +124,15 @@ export class ApiClient {
           errorMessage = error.response?.data?.message || error.response?.data || error.message || String(error)
         }
 
-        throw BoxliteError.fromString(String(errorMessage), { cause: error instanceof Error ? error : undefined })
+        // The envelope's machine-readable `code` is what the UI branches on; the
+        // message is only for display. A rejection the API describes (say, an
+        // unverified email) must not be flattened into an anonymous error here.
+        const responseCode = error?.response?.data?.code
+
+        throw BoxliteError.fromString(String(errorMessage), {
+          cause: error instanceof Error ? error : undefined,
+          code: typeof responseCode === 'string' ? responseCode : undefined,
+        })
       },
     )
 

--- a/apps/dashboard/src/api/errors.ts
+++ b/apps/dashboard/src/api/errors.ts
@@ -4,8 +4,23 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
+/**
+ * Machine-readable rejection code carried in the API's error envelope (`code`,
+ * shaped by apps/api/src/filters/all-exceptions.filter.ts). Branch on this
+ * rather than on the human message, which is free to change. Must stay
+ * byte-identical to EMAIL_VERIFICATION_REQUIRED_CODE in
+ * apps/api/src/exceptions/email-verification-required.exception.ts.
+ */
+export const EMAIL_VERIFICATION_REQUIRED_CODE = 'email_verification_required'
+
 export class BoxliteError extends Error {
-  public static fromError(error: Error): BoxliteError {
+  public static fromError(error: Error, code?: string): BoxliteError {
+    if (code === EMAIL_VERIFICATION_REQUIRED_CODE) {
+      return new EmailVerificationRequiredError(error.message, {
+        cause: error.cause,
+      })
+    }
+
     if (String(error).includes('Organization is suspended')) {
       return new OrganizationSuspendedError(error.message, {
         cause: error.cause,
@@ -17,9 +32,17 @@ export class BoxliteError extends Error {
     })
   }
 
-  public static fromString(error: string, options?: { cause?: Error }): BoxliteError {
-    return BoxliteError.fromError(new Error(error, options))
+  public static fromString(error: string, options?: { cause?: Error; code?: string }): BoxliteError {
+    return BoxliteError.fromError(new Error(error, { cause: options?.cause }), options?.code)
   }
 }
 
 export class OrganizationSuspendedError extends BoxliteError {}
+
+/**
+ * The API accepted the token and still refused the request: this identity has
+ * not verified its email address. Distinct from an authentication failure —
+ * signing in again cannot clear it, only verifying can, so the UI must offer
+ * verification rather than another round trip through login.
+ */
+export class EmailVerificationRequiredError extends BoxliteError {}

--- a/apps/dashboard/src/components/ErrorBoundaryFallback.test.tsx
+++ b/apps/dashboard/src/components/ErrorBoundaryFallback.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+/*
+ * Modified by BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ErrorBoundaryFallback } from './ErrorBoundaryFallback'
+import { BoxliteError, EmailVerificationRequiredError, EMAIL_VERIFICATION_REQUIRED_CODE } from '@/api/errors'
+import { RoutePath } from '@/enums/RoutePath'
+
+let container: HTMLDivElement
+let root: Root
+
+beforeAll(() => {
+  ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+})
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  vi.restoreAllMocks()
+})
+
+function render(error: unknown) {
+  act(() => root.render(<ErrorBoundaryFallback error={error} resetErrorBoundary={vi.fn()} />))
+  // The dialog portals out of `container`, so assert against the whole document.
+  return document.body.textContent ?? ''
+}
+
+describe('ErrorBoundaryFallback', () => {
+  it('offers verification, not a crash report, for an unverified email', () => {
+    const text = render(new EmailVerificationRequiredError('Email verification required'))
+
+    expect(text).toContain('Verify your email address')
+    // The generic branch's furniture would be actively misleading here: this is
+    // an account state the user can fix, not a fault to report.
+    expect(text).not.toContain('Something went wrong')
+    expect(text).not.toContain('Stack Trace')
+  })
+
+  it('sends the user through logout, the only path that can reach verification', () => {
+    // Reloading or retrying replays the same unverified identity; ending the IdP
+    // session is what lets the next sign-in render the hosted verification step.
+    const assign = vi.fn()
+    vi.spyOn(window, 'location', 'get').mockReturnValue({
+      ...window.location,
+      assign,
+    } as unknown as Location)
+
+    render(new EmailVerificationRequiredError('Email verification required'))
+
+    const button = Array.from(document.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Sign out and verify'),
+    )
+    // Narrows the type without a non-null assertion, and fails loudly if the
+    // screen ever stops offering the only action that can clear the 403.
+    if (!button) throw new Error('verification screen must offer a sign-out action')
+
+    act(() => button.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+    expect(assign).toHaveBeenCalledWith(RoutePath.LOGOUT)
+  })
+
+  it('still shows the crash report for any other error', () => {
+    const text = render(new BoxliteError('Runner is unreachable'))
+
+    expect(text).toContain('Something went wrong')
+    expect(text).toContain('Runner is unreachable')
+    expect(text).not.toContain('Verify your email address')
+  })
+
+  // The API sends this literal (apps/api/src/exceptions/email-verification-required.exception.ts);
+  // asserting the constant against itself would prove nothing, so pin the value.
+  it('pins the wire code the API is expected to send', () => {
+    expect(EMAIL_VERIFICATION_REQUIRED_CODE).toBe('email_verification_required')
+  })
+})

--- a/apps/dashboard/src/components/ErrorBoundaryFallback.tsx
+++ b/apps/dashboard/src/components/ErrorBoundaryFallback.tsx
@@ -4,11 +4,53 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
+import { EmailVerificationRequiredError } from '@/api/errors'
 import { Dialog, DialogHeader, DialogDescription, DialogTitle, DialogContent } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
+import { RoutePath } from '@/enums/RoutePath'
 import { FallbackProps } from 'react-error-boundary'
 
+/**
+ * Signing out is the recovery: it ends the IdP session, so the sign-in that
+ * follows is a fresh interactive login — the only flow that can render the
+ * hosted email verification step. Reloading or retrying replays the same
+ * unverified identity.
+ *
+ * /logout marks the session just-logged-out, which LandingPage honours by
+ * showing a manual sign-in button instead of auto-redirecting (see
+ * lib/auth-session.ts). That pause is wanted here: it keeps a still-unverified
+ * account from being bounced straight back into the same 403.
+ *
+ * This boundary sits outside the router and the auth provider (see main.tsx), so
+ * it navigates the whole page rather than reaching for useNavigate/useAuth.
+ */
+function EmailVerificationRequired() {
+  return (
+    <Dialog open>
+      <DialogContent className="[&>button]:hidden">
+        <DialogHeader>
+          <DialogTitle>Verify your email address</DialogTitle>
+          <DialogDescription>
+            You're signed in, but BoxLite needs a verified email address before it can load your account. Check your
+            inbox for the verification link, then sign in again to finish.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex justify-end">
+          <Button onClick={() => window.location.assign(RoutePath.LOGOUT)}>Sign out and verify</Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
 export function ErrorBoundaryFallback({ error, resetErrorBoundary }: FallbackProps) {
+  // An account-state rejection is not a crash: the stack trace and "try again"
+  // are noise, and the only useful action is the one that can clear it.
+  if (error instanceof EmailVerificationRequiredError) {
+    return <EmailVerificationRequired />
+  }
+
   const caughtError = error instanceof Error ? error : undefined
   const errorMessage = caughtError?.message || (typeof error === 'string' ? error : 'Unknown error')
 

--- a/apps/dashboard/src/components/billing/ConcurrencyTimeline.tsx
+++ b/apps/dashboard/src/components/billing/ConcurrencyTimeline.tsx
@@ -109,11 +109,7 @@ export function ConcurrencyTimeline() {
                   tick={{ fontSize: 10 }}
                 />
                 {isLimitInChartRange && (
-                  <ReferenceLine
-                    y={limit}
-                    stroke="hsl(var(--muted-foreground))"
-                    strokeDasharray="6 4"
-                  />
+                  <ReferenceLine y={limit} stroke="hsl(var(--muted-foreground))" strokeDasharray="6 4" />
                 )}
                 <ChartTooltip
                   cursor={{ stroke: 'hsl(var(--border))', strokeDasharray: '3 3' }}

--- a/apps/infra/docs/deployment.md
+++ b/apps/infra/docs/deployment.md
@@ -518,10 +518,15 @@ the dashboard's.
 at startup. Fix connectivity; the next `/api/config` self-heals.
 
 **`Email verification required`** — an Auth0 database token lacks a strict
-`email_verified: true` claim. For dashboard/desktop use browser login to finish
-the hosted verification Form. On SSH, finish verification through the dashboard
-in another browser, then retry device login. Verify the `boxlite-login-policy`
-Action is deployed and bound using the login-policy preview command above.
+`email_verified: true` claim. The API answers `403` with
+`code: email_verification_required`; the token itself is valid, so signing in
+again cannot clear it and the dashboard shows a "Verify your email address"
+screen rather than bouncing through login. For dashboard/desktop use browser
+login to finish the hosted verification Form. On SSH, finish verification
+through the dashboard in another browser, then retry device login. Verify the
+`boxlite-login-policy` Action is deployed and bound using the login-policy
+preview command above — without it an existing unverified account has no way to
+reach the Form, and the 403 never clears.
 
 **Runner never reaches `READY`** — its `BOXLITE_RUNNER_TOKEN` must equal the DB
 row's `apiKey`. Check `journalctl -u boxlite-runner` via `aws ssm start-session`.


### PR DESCRIPTION
## Summary

An unverified Auth0 database identity was rejected with `401`, which the dashboard reads as a stale token: it dropped the session, forced a re-login, received the same `401`, and dead-ended on "Authentication failed after re-login" — a state no re-authentication can clear. The token is valid, so the rejection is now `403` with `code: email_verification_required`, and the dashboard offers verification instead of another trip through login.

## Call graph

Before

```text
GET /api/organizations                (unverified auth0| identity, valid token)
  └─ AuthGuard('jwt')                 (Passport · apps/api/src/organization/controllers/organization.controller.ts:297) — rethrows the strategy error unchanged
       └─ requireVerifiedAuth0DatabaseEmail
                                      (JwtStrategy · apps/api/src/auth/jwt.strategy.ts:35) — ← BUG: answers 401 for a token that is valid, so the client cannot tell "stale credential" from "account not yet permitted"
  ↓ 401
  └─ handleUnauthorized               (ApiClient · apps/dashboard/src/api/apiClient.ts:166) — drops the session and re-logs in; the fresh token is rejected identically
       └─ ErrorBoundaryFallback       (React · apps/dashboard/src/components/ErrorBoundaryFallback.tsx:11) — renders a crash dialog and a stack trace for an account state the user could fix
```

After

```text
GET /api/organizations                (unverified auth0| identity, valid token)
  └─ AuthGuard('jwt')                 (Passport · apps/api/src/organization/controllers/organization.controller.ts:297) — rethrows the strategy error unchanged
       └─ requireVerifiedAuth0DatabaseEmail
                                      (JwtStrategy · apps/api/src/auth/jwt.strategy.ts:40) — raises the coded policy rejection
            └─ EmailVerificationRequiredException
                                      (HttpException · apps/api/src/exceptions/email-verification-required.exception.ts:26) — 403 + code, per RFC 6750 §3.1
  ├─ handleRequest                    (CombinedAuthGuard · apps/api/src/auth/combined-auth.guard.ts:32) — forwards this one rejection intact; every other strategy error still flattens to a generic 401
  ↓ 403 {message, code: email_verification_required}
  └─ response interceptor             (ApiClient · apps/dashboard/src/api/apiClient.ts:130) — 401 recovery is never armed; carries the envelope code through
       └─ fromError                   (BoxliteError · apps/dashboard/src/api/errors.ts:17) — types it as EmailVerificationRequiredError
            └─ ErrorBoundaryFallback  (React · apps/dashboard/src/components/ErrorBoundaryFallback.tsx:50) — renders "Verify your email address" with the action that can clear it
```

No tracking issue exists for this; #1290 covers billing email verification, a different surface.

## Changes

- Reject unverified Auth0 database identities with `403` and a machine-readable `code` instead of `401`. The token is valid — 401 tells a client its credential is stale, which invites a re-login loop that cannot succeed.
- Forward that one rejection through `CombinedAuthGuard` rather than flattening it. Without this the endpoints behind that guard would answer `401 "Invalid credentials"` while the endpoints behind the stock guard answer `403`, for the same account state.
- Type the rejection on the dashboard from the envelope `code` (a field `AllExceptionsFilter` already emitted and nothing consumed) and branch the error boundary onto it: no stack trace, and a "Sign out and verify" action, since ending the IdP session is what lets the next sign-in render the hosted verification Form.
- A `403` no longer matches the `UnauthorizedException` branch in `AllExceptionsFilter`, so these rejections stop counting toward failed-auth throttling. A valid token is not a credential failure.

## How to verify

- `cd apps && yarn nx test api` — 76 suites, 563 pass, 72 skipped.
- `cd apps/dashboard && npx vitest run --root .` — 30 files, 206 pass. Note `apps/dashboard` declares no nx `test` target, so `make test:apps` does not reach these; see Risks.
- Revert `apps/api/src/auth/jwt.strategy.ts` and `apps/api/src/auth/combined-auth.guard.ts` and re-run the API suite: 5 failures, including `Expected: [EmailVerificationRequiredException] Received: [UnauthorizedException: Invalid credentials]`.

## Risks / rollout

- The API-side gate takes effect on deploy; the Auth0-side remediation does not. `boxlite-login-policy` must be applied to the tenant, or an already-unverified account reaches a correct screen with no Form behind it. Verify with the login-policy preview command in `apps/infra/docs/deployment.md`.
- `apps/dashboard` has no nx `test` target, so none of its 30 vitest files — including the two this change relies on — run in CI, and no tsconfig typechecks dashboard test files. Pre-existing; worth a follow-up.
- The verification screen covers errors reaching the React error boundary, i.e. the `OrganizationsProvider` boot path. That path gates every authenticated route so it fails first for an unverified user, but a `403` from any other query surfaces as a toast.
- The Socket.IO and WS-proxy `verifyToken` consumers swallow the rejection in a bare `catch` and still answer a generic 401. Unchanged by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dedicated handling for unverified email accounts, including a clear verification-required error.
  - Dashboard now displays tailored guidance to verify an email and provides a sign-out action to recover access.
  - Verification errors retain a stable code for consistent client handling.

- **Bug Fixes**
  - Prevented email verification errors from being incorrectly treated as generic authentication failures.
  - Preserved existing behavior for invalid credentials and other authorization errors.

- **Documentation**
  - Expanded deployment troubleshooting guidance for unverified email tokens and verification recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->