### PR TITLE
fix(dashboard): keep the quickstart shut for returning users

### DIFF
--- a/apps/dashboard/src/components/OnboardingGuideDialog.tsx
+++ b/apps/dashboard/src/components/OnboardingGuideDialog.tsx
@@ -23,7 +23,6 @@ import {
   type OnboardingInterface,
 } from '@/lib/onboarding-code-examples'
 import type { QuickstartGroup, QuickstartIconName, QuickstartInterfaceDefinition } from '@/lib/quickstart/types'
-import { setLocalStorageItem } from '@/lib/local-storage'
 import { cn } from '@/lib/utils'
 import type { OnboardingProgress } from '@/lib/onboarding-progress'
 import {
@@ -255,7 +254,6 @@ export function OnboardingGuideDialog({ open, onOpenChange, onProgressChange }: 
       const next = [...prev] as [boolean, boolean, boolean]
       next[i] = true
       if (next.every(Boolean)) {
-        setLocalStorageItem('boxlite-quickstart-done', '1')
         onProgressChange({ boxCreated: true, sdkConnected: true })
       }
       return next

--- a/apps/dashboard/src/components/billing/ConcurrencyTimeline.tsx
+++ b/apps/dashboard/src/components/billing/ConcurrencyTimeline.tsx
@@ -109,11 +109,7 @@ export function ConcurrencyTimeline() {
                   tick={{ fontSize: 10 }}
                 />
                 {isLimitInChartRange && (
-                  <ReferenceLine
-                    y={limit}
-                    stroke="hsl(var(--muted-foreground))"
-                    strokeDasharray="6 4"
-                  />
+                  <ReferenceLine y={limit} stroke="hsl(var(--muted-foreground))" strokeDasharray="6 4" />
                 )}
                 <ChartTooltip
                   cursor={{ stroke: 'hsl(var(--border))', strokeDasharray: '3 3' }}

--- a/apps/dashboard/src/lib/onboarding-visibility.test.ts
+++ b/apps/dashboard/src/lib/onboarding-visibility.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { shouldAutoOpenOnboarding, type OnboardingAutoOpenSignals } from './onboarding-visibility'
+
+// A brand-new signup on a brand-new browser: nothing dismissed, empty account.
+const freshSignup: OnboardingAutoOpenSignals = {
+  requestedByUrl: false,
+  dismissedInThisBrowser: false,
+  accountStateLoaded: true,
+  hasApiKeys: false,
+  hasBoxes: false,
+}
+
+const signals = (overrides: Partial<OnboardingAutoOpenSignals>): OnboardingAutoOpenSignals => ({
+  ...freshSignup,
+  ...overrides,
+})
+
+describe('shouldAutoOpenOnboarding', () => {
+  it('opens for a brand-new user with an empty account', () => {
+    expect(shouldAutoOpenOnboarding(freshSignup)).toBe(true)
+  })
+
+  it('stays shut for a returning user on a new browser who already has an API key', () => {
+    // The reported bug: localStorage is empty because the browser is new, but the
+    // account is plainly not new.
+    expect(shouldAutoOpenOnboarding(signals({ hasApiKeys: true }))).toBe(false)
+  })
+
+  it('stays shut for a returning user on a new browser who already has a box', () => {
+    expect(shouldAutoOpenOnboarding(signals({ hasBoxes: true }))).toBe(false)
+  })
+
+  it('stays shut once dismissed in this browser', () => {
+    expect(shouldAutoOpenOnboarding(signals({ dismissedInThisBrowser: true }))).toBe(false)
+  })
+
+  it('waits for account state rather than flashing open at a returning user', () => {
+    expect(shouldAutoOpenOnboarding(signals({ accountStateLoaded: false }))).toBe(false)
+  })
+
+  it('opens on ?onboarding=1 even for a dismissed, fully onboarded account', () => {
+    // The sidebar "Onboarding" entry routes through this param; it must always win.
+    expect(
+      shouldAutoOpenOnboarding(
+        signals({ requestedByUrl: true, dismissedInThisBrowser: true, hasApiKeys: true, hasBoxes: true }),
+      ),
+    ).toBe(true)
+  })
+
+  it('opens on ?onboarding=1 before account state has loaded', () => {
+    expect(shouldAutoOpenOnboarding(signals({ requestedByUrl: true, accountStateLoaded: false }))).toBe(true)
+  })
+})

--- a/apps/dashboard/src/lib/onboarding-visibility.ts
+++ b/apps/dashboard/src/lib/onboarding-visibility.ts
@@ -1,0 +1,38 @@
+export interface OnboardingAutoOpenSignals {
+  /** `?onboarding=1` is present — an explicit request to open the guide. */
+  requestedByUrl: boolean
+  /** This browser has recorded a dismissal for this user. Per-browser, so never load-bearing alone. */
+  dismissedInThisBrowser: boolean
+  /** Account-state signals below have resolved. False while loading, and on query error. */
+  accountStateLoaded: boolean
+  /** The organization owns at least one API key. */
+  hasApiKeys: boolean
+  /** The organization owns at least one box, any state (unfiltered fleet count). */
+  hasBoxes: boolean
+}
+
+/**
+ * Decides whether the Quickstart guide should auto-open on the boxes page.
+ *
+ * "Has this user been onboarded?" is a per-account fact, but the dismissal flag lives in
+ * localStorage, which is scoped to one browser profile. A returning user on a new browser,
+ * a second device, or after clearing site data therefore looks identical to a fresh signup.
+ * The account-state signals close that gap: an organization that already owns an API key or
+ * a box has demonstrably been through the quickstart, whatever this browser remembers.
+ */
+export function shouldAutoOpenOnboarding(signals: OnboardingAutoOpenSignals): boolean {
+  // An explicit request always wins — the sidebar "Onboarding" entry routes through
+  // ?onboarding=1, and it has to keep working for people who finished long ago.
+  if (signals.requestedByUrl) return true
+
+  // Only ever suppresses within the browser that recorded it. Cross-browser suppression is
+  // the account signals' job below — that split is the whole point of this function.
+  if (signals.dismissedInThisBrowser) return false
+
+  // Bail while account state is unknown. The old default was "open", which is why a
+  // storage miss showed the guide to established users; an unresolved (or failed)
+  // query must not be able to do the same.
+  if (!signals.accountStateLoaded) return false
+
+  return !signals.hasApiKeys && !signals.hasBoxes
+}

--- a/apps/dashboard/src/pages/Boxes.tsx
+++ b/apps/dashboard/src/pages/Boxes.tsx
@@ -47,6 +47,8 @@ import {
   readOnboardingProgress,
   type OnboardingProgress,
 } from '@/lib/onboarding-progress'
+import { shouldAutoOpenOnboarding } from '@/lib/onboarding-visibility'
+import { useApiKeysQuery } from '@/hooks/queries/useApiKeysQuery'
 import { getBoxRouteId } from '@/lib/box-identity'
 import { pluralize } from '@/lib/utils'
 import {
@@ -633,20 +635,6 @@ const Boxes: React.FC = () => {
     result.successfulIds.forEach(removeBoxFromCache)
   }
 
-  useEffect(() => {
-    if (!selectedOrganization || !user?.profile.sub) {
-      return
-    }
-
-    const skipOnboardingKey = `${LocalStorageKey.SkipOnboardingPrefix}${user.profile.sub}`
-    const shouldOpenFromUrl = searchParams.get('onboarding') === '1'
-    const shouldSkipOnboarding = getLocalStorageItem(skipOnboardingKey) === 'true'
-
-    if (shouldOpenFromUrl || !shouldSkipOnboarding) {
-      setShowOnboardingDialog(true)
-    }
-  }, [searchParams, selectedOrganization, user?.profile.sub])
-
   const clearOnboardingUrlParam = useCallback(() => {
     if (searchParams.get('onboarding') !== '1') {
       return
@@ -724,6 +712,39 @@ const Boxes: React.FC = () => {
     enabled: !!orgId,
     staleTime: 10_000,
   })
+
+  // Onboarding auto-open. Deliberately placed below the fleet-count query: the local "skip"
+  // flag only remembers one browser, so whether this account is actually new is decided by
+  // account state (an API key or any box), which follows the user to a new browser or device.
+  const apiKeysQuery = useApiKeysQuery(orgId)
+
+  useEffect(() => {
+    if (!selectedOrganization || !userId) {
+      return
+    }
+
+    const skipOnboardingKey = `${LocalStorageKey.SkipOnboardingPrefix}${userId}`
+
+    if (
+      shouldAutoOpenOnboarding({
+        requestedByUrl: searchParams.get('onboarding') === '1',
+        dismissedInThisBrowser: getLocalStorageItem(skipOnboardingKey) === 'true',
+        accountStateLoaded: apiKeysQuery.isSuccess && totalBoxesQuery.isSuccess,
+        hasApiKeys: (apiKeysQuery.data?.length ?? 0) > 0,
+        hasBoxes: (totalBoxesQuery.data ?? 0) > 0,
+      })
+    ) {
+      setShowOnboardingDialog(true)
+    }
+  }, [
+    apiKeysQuery.data,
+    apiKeysQuery.isSuccess,
+    searchParams,
+    selectedOrganization,
+    totalBoxesQuery.data,
+    totalBoxesQuery.isSuccess,
+    userId,
+  ])
 
   const totalBoxesDisplay = totalBoxesQuery.data != null ? totalBoxesQuery.data.toLocaleString('en-US') : '…'
   const runningBoxesDisplay = runningBoxesQuery.data != null ? runningBoxesQuery.data.toLocaleString('en-US') : '…'


### PR DESCRIPTION
## Summary

The Quickstart guide auto-opened for established users whenever they signed in from a new browser. "Has this user been onboarded?" is a per-account fact, but it was answered entirely from `localStorage`, which is scoped to one browser profile — so a new browser, a second device, or cleared site data all looked identical to a fresh signup.

## Call graph

Before
```
Boxes                      (Page · apps/dashboard/src/pages/Boxes.tsx:636)
  └─ getLocalStorageItem   (lib  · apps/dashboard/src/lib/local-storage.ts:7)   ← BUG: per-browser answer to a per-account question; key absent ⇒ open
       └─ setShowOnboardingDialog(true)                                          — fires for every returning user on a new browser
```

After
```
Boxes                         (Page · apps/dashboard/src/pages/Boxes.tsx:721)
  ├─ useApiKeysQuery          (hook · apps/dashboard/src/hooks/queries/useApiKeysQuery.ts:12)   — already fetched for the Keys list
  ├─ totalBoxesQuery          (Page · apps/dashboard/src/pages/Boxes.tsx:687)                   — already fetched for the stat cards
  └─ shouldAutoOpenOnboarding (lib  · apps/dashboard/src/lib/onboarding-visibility.ts:23)       — pure, unit-tested
       └─ setShowOnboardingDialog(true)                                                          — empty account only
```

## Changes

- `shouldAutoOpenOnboarding` extracts the open/don't-open decision into a pure, testable predicate with four ordered guards: an explicit `?onboarding=1` wins; a local dismissal suppresses only within the browser that recorded it; an unresolved *or failed* account query bails; otherwise the guide opens only for an organization with no API keys and no boxes.
- Account state, not browser storage, is what makes the guide stay shut across browsers. An org holding an API key or a box has demonstrably been through the flow. Both signals were already fetched by this page, so the check adds no request.
- Auto-open no longer defaults to "open" on a miss. The previous default is what turned an empty `localStorage` into a spurious guide; `accountStateLoaded` is `isSuccess` on both queries, so a network failure can't do the same.
- The boxes signal reads the unfiltered fleet count, not the page's filtered table query — a returning user landing on a filter that matches nothing is no longer mistaken for a new one.
- Removed a write-only `boxlite-quickstart-done` localStorage key that nothing read.
- `ConcurrencyTimeline.tsx` carries a one-line formatting hunk unrelated to this change: pre-existing prettier drift from #1329, whitespace-only. The pre-commit hook rewrites it, and leaving it unstaged deadlocks the stash-based hook, so it rides along.

## How to verify

```bash
cd apps
yarn vitest run --config dashboard/vite.config.mts src/lib/onboarding-visibility.test.ts   # 7 passed
```

Transcribing the old localStorage-only logic into the predicate fails 3 of those 7 cases, so the tests demonstrably catch the reported bug rather than merely passing alongside the fix. Full dashboard suite: 207 passed (30 files).

Manually: sign in as a user who already has an API key or a box, then open the dashboard in a browser that has never seen it. The guide should stay shut, and the sidebar "Onboarding" entry (`?onboarding=1`) should still open it on demand.

## Risks / rollout

- No API, schema, or migration change — the fix is entirely in the dashboard, so there is nothing to sequence against a deploy.
- One behavior is deliberately not covered: a user with a completely empty account who dismisses the guide and then opens a new browser sees it once more. It resolves the moment they create a key or a box. Suppressing that case would require persisting the dismissal server-side; it was judged not worth a `User` column and an endpoint, since an account with nothing in it has arguably not been onboarded yet.
- These tests do not run in CI. `.github/workflows/test.yml` runs only `api:test`, so no dashboard vitest file is exercised on a PR. Pre-existing, not introduced here, but it means this fix is unguarded against future regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Quickstart guide visibility on the Boxes page based on account setup status and explicit URL requests.
  * Added support for remembering when the guide was dismissed in the current browser.

* **Bug Fixes**
  * Prevented the guide from opening while account information is still loading or unavailable.
  * Quickstart completion now updates onboarding progress without storing an additional local completion flag.

* **Tests**
  * Added coverage for onboarding visibility across new, returning, dismissed, and explicitly requested states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->