### PR TITLE
fix(proxy): stop caching auth acceptances

### DIFF
--- a/apps/proxy/pkg/proxy/get_box_target.go
+++ b/apps/proxy/pkg/proxy/get_box_target.go
@@ -30,6 +30,20 @@ const (
 	activityUpdateTimeout    = 10 * time.Second
 	directPreviewBoxIDLength = 12
 	directPreviewBoxIDPrefix = "d-"
+
+	// Only rejections are cached. A cached acceptance is what a revoked credential
+	// rides on: nothing evicts these entries, and with config.Redis unset the cache
+	// is in-process and out of the API's reach entirely, so any TTL at all is a
+	// window in which a deleted key still reaches the box. The API absorbs the
+	// revalidation traffic in Redis (preview:token, preview:access), so the cost is
+	// a round trip per request, not a database lookup per request.
+	//
+	// A rejection is not what a revoked credential rides on, so shortening it
+	// alongside the acceptance would only send repeated bad credentials back to the
+	// API more often. It keeps the TTL both verdicts shared before. The ceiling is
+	// the other direction: a caller who has just been granted access waits this
+	// long behind the cached refusal.
+	authInvalidCacheTTL = 2 * time.Minute
 )
 
 func (p *Proxy) GetProxyTarget(ctx *gin.Context) (*common_proxy.RequestTarget, error) {
@@ -330,8 +344,11 @@ func (p *Proxy) validateAndCache(
 		return nil, validationErr
 	}
 
-	if err := p.boxAuthKeyValidCache.Set(ctx, cacheKey, isValid, 2*time.Minute); err != nil {
-		slog.ErrorContext(ctx, "Failed to set box auth key valid in cache", "error", err)
+	// Acceptances are deliberately not cached -- see authInvalidCacheTTL.
+	if !isValid {
+		if err := p.boxAuthKeyValidCache.Set(ctx, cacheKey, isValid, authInvalidCacheTTL); err != nil {
+			slog.ErrorContext(ctx, "Failed to set box auth key valid in cache", "error", err)
+		}
 	}
 
 	return &isValid, nil

--- a/apps/proxy/pkg/proxy/get_box_target_test.go
+++ b/apps/proxy/pkg/proxy/get_box_target_test.go
@@ -67,8 +67,10 @@ func TestCacheErrorsDoNotLogPreviewCredentials(t *testing.T) {
 	if _, err := proxy.getBoxPublic(context.Background(), signedToken); err != nil {
 		t.Fatalf("getBoxPublic() error = %v", err)
 	}
+	// A rejection, because only rejections are cached -- an acceptance never reaches
+	// the failing Set and so would never produce the log line asserted below.
 	if _, err := proxy.validateAndCache(context.Background(), signedToken, authKey, func() (bool, error) {
-		return true, nil
+		return false, nil
 	}); err != nil {
 		t.Fatalf("validateAndCache() error = %v", err)
 	}
@@ -313,5 +315,128 @@ func TestActivityPollControllerStopIsIdempotent(t *testing.T) {
 	case <-controller.done:
 	default:
 		t.Fatal("activity poll was not stopped")
+	}
+}
+
+type recordedCacheWrite struct {
+	key string
+	ttl time.Duration
+}
+
+type recordingCache[T any] struct {
+	writes []recordedCacheWrite
+}
+
+func (*recordingCache[T]) Get(context.Context, string) (*T, error) {
+	return nil, errors.New("cache miss")
+}
+
+func (c *recordingCache[T]) Set(_ context.Context, key string, _ T, ttl time.Duration) error {
+	c.writes = append(c.writes, recordedCacheWrite{key: key, ttl: ttl})
+	return nil
+}
+
+func (*recordingCache[T]) Delete(context.Context, string) error {
+	return nil
+}
+
+func (*recordingCache[T]) Has(context.Context, string) (bool, error) {
+	return false, nil
+}
+
+func cacheAuthResult(t *testing.T, isValid bool) []recordedCacheWrite {
+	t.Helper()
+
+	cache := &recordingCache[bool]{}
+	proxy := &Proxy{boxAuthKeyValidCache: cache}
+
+	if _, err := proxy.validateAndCache(context.Background(), "AbCdEf123456", "blk_live_secret", func() (bool, error) {
+		return isValid, nil
+	}); err != nil {
+		t.Fatalf("validateAndCache() error = %v", err)
+	}
+
+	return cache.writes
+}
+
+// A cached acceptance is what a revoked credential rides on: nothing evicts the
+// entry, and in production config.Redis is nil so the cache is in-process and the
+// API cannot reach it either. Any TTL at all reopens the window the API closes on
+// delete, so the acceptance is not cached at any TTL.
+func TestValidAuthResultIsNotCached(t *testing.T) {
+	writes := cacheAuthResult(t, true)
+
+	for _, write := range writes {
+		t.Errorf("valid auth result cached under %q for %v, want no cache write", write.key, write.ttl)
+	}
+}
+
+func TestInvalidAuthResultIsCached(t *testing.T) {
+	// Revocation latency no longer rides on this cache at all, so shortening the
+	// rejection TTL buys nothing and only sends repeated bad credentials back to the
+	// API more often. It stays at the two minutes both verdicts shared before.
+	const wantTTL = 2 * time.Minute
+
+	writes := cacheAuthResult(t, false)
+
+	if len(writes) != 1 {
+		t.Fatalf("invalid auth result made %d cache writes, want 1", len(writes))
+	}
+	if writes[0].ttl != wantTTL {
+		t.Errorf("invalid auth result cached for %v, want %v", writes[0].ttl, wantTTL)
+	}
+}
+
+// The acceptance is re-derived from the API on every request -- that, not a TTL, is
+// what bounds how long a deleted credential keeps reaching the box.
+func TestValidAuthResultIsRevalidatedOnEveryRequest(t *testing.T) {
+	ctx := context.Background()
+	proxy := &Proxy{boxAuthKeyValidCache: common_cache.NewMapCache[bool](ctx)}
+
+	validations := 0
+	validate := func() (bool, error) {
+		validations++
+		return true, nil
+	}
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		isValid, err := proxy.validateAndCache(ctx, "AbCdEf123456", "blk_live_secret", validate)
+		if err != nil {
+			t.Fatalf("validateAndCache() attempt %d error = %v", attempt, err)
+		}
+		if !*isValid {
+			t.Fatalf("validateAndCache() attempt %d = false, want true", attempt)
+		}
+		if validations != attempt {
+			t.Fatalf("validateAndCache() reached the API %d times after %d calls, want %d", validations, attempt, attempt)
+		}
+	}
+}
+
+// The rejection is still cached, so a credential the API has already refused does
+// not get to spend an API round trip on every retry.
+func TestCachedInvalidAuthResultIsServedWithoutRevalidating(t *testing.T) {
+	ctx := context.Background()
+	proxy := &Proxy{boxAuthKeyValidCache: common_cache.NewMapCache[bool](ctx)}
+
+	validations := 0
+	validate := func() (bool, error) {
+		validations++
+		return false, nil
+	}
+	if _, err := proxy.validateAndCache(ctx, "AbCdEf123456", "blk_live_secret", validate); err != nil {
+		t.Fatalf("validateAndCache() error = %v", err)
+	}
+
+	isValid, err := proxy.validateAndCache(ctx, "AbCdEf123456", "blk_live_secret", validate)
+	if err != nil {
+		t.Fatalf("validateAndCache() error = %v", err)
+	}
+
+	if validations != 1 {
+		t.Errorf("validateAndCache() reached the API %d times, want 1 -- the second call should be cached", validations)
+	}
+	if *isValid {
+		t.Error("validateAndCache() = true, want the cached rejection")
 	}
 }


### PR DESCRIPTION
## Summary

A deleted API key kept reaching a private box through the preview proxy for about two minutes. The proxy cached the verdict "this credential may reach this box" and nothing invalidated it, so the TTL was the only bound. The proxy now caches rejections only: an acceptance is re-derived from the API on every request, so a revoked credential stops working as soon as the API says so.

## Call graph

```text
Before
  GetProxyTarget                   (Proxy · apps/proxy/pkg/proxy/get_box_target.go:49)   — resolves a preview host to a box target
    └─ Authenticate                (Proxy · apps/proxy/pkg/proxy/auth.go:18)             — gates a non-public box on the caller's credential
         └─ getBoxBearerTokenValid (Proxy · apps/proxy/pkg/proxy/get_box_target.go:314)
              └─ validateAndCache  (Proxy · apps/proxy/pkg/proxy/get_box_target.go:322)  ← BUG: caches the acceptance for 2m, so a deleted key keeps passing
                   └─ hasBoxAccess (Proxy · apps/proxy/pkg/proxy/auth_callback.go:190)   — reached only on a miss, i.e. at most once per 2m

After
  GetProxyTarget                   (Proxy · apps/proxy/pkg/proxy/get_box_target.go:49)
    └─ Authenticate                (Proxy · apps/proxy/pkg/proxy/auth.go:18)
         └─ getBoxBearerTokenValid (Proxy · apps/proxy/pkg/proxy/get_box_target.go:314)
              └─ validateAndCache  (Proxy · apps/proxy/pkg/proxy/get_box_target.go:322)  — caches rejections only (get_box_target.go:348)
                   └─ hasBoxAccess (Proxy · apps/proxy/pkg/proxy/auth_callback.go:190)   — reached on every request, 401 on the first one after the delete
```

Fixes #1418

Nothing evicts an acceptance and nothing can: the API never learns which boxes a credential was cached against, and in production `config.Redis` is unset, so the cache is per-task and in-process. Shortening the TTL only shrinks the window; removing the entry closes it.

## Changes

- `validateAndCache` writes to `boxAuthKeyValidCache` only when the verdict is a rejection. `authValidCacheTTL` is gone; `authInvalidCacheTTL` keeps the 2m both verdicts shared.
- Rejections stay at 2m. Revocation never rode on them, so shortening them would only send repeated bad credentials back to the API more often. The ceiling is the other direction: a caller who has just been granted access waits out the cached refusal.

## How to verify

- `cd apps/proxy && go test ./pkg/proxy/`
- End to end: open a private box's preview URL with an API key, delete the key, refresh. The next request fails instead of the one two minutes later.

## Risks / rollout

- One validation round trip per proxied request instead of one per (box, credential) pair per 2m. It does **not** become a query per request — the API answers both paths from Redis:
  - auth key / box token → `preview:token:<box>:<token>`, 3s either way (`apps/api/src/box/controllers/preview.controller.ts:104-111`)
  - bearer API key → `api-key:validation:<hash>`, `API_KEY_VALIDATION_CACHE_TTL_SECONDS` (default 10s, `apps/api/src/auth/api-key.strategy.ts:98-101`), then `preview:access:<box>:<user>`, 30s allow / 3s deny (`preview.controller.ts:144-148`)
- Revocation lag is now the API's to set, not the proxy's. Deleting a key deletes its validation entry outright (`apps/api/src/api-key/api-key.service.ts:179`), so the bound is the 3s `preview:token` entry on the auth-key path rather than any TTL here. `preview:access` is keyed by user, so its 30s gates org membership, not the credential.
- `api_key.lastUsedAt` write volume is unchanged: `updateLastUsedAt` holds a 10s Redis cooldown per key (`api-key.service.ts:155-164`), so extra revalidations are dropped before the update.
- Less ride-through on API blips. A 60s API hiccup used to be invisible to established preview sessions; now every request depends on the API answering, after 3 retries with 150ms/300ms backoff.
- `validateAndCache` has no request coalescing, so a burst of concurrent requests for one credential each makes its own call. Bounded in practice — browsers cap concurrent connections per host, and WebSockets authenticate once at handshake.
- Restoring a proxy-side acceptance cache safely would need a revocation feed the proxy polls. Out of scope: the proxy must not take a Redis dependency, so it cannot read a shared tombstone.
