### PR TITLE
feat(api): secure Backoffice workload readiness

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -115,6 +115,14 @@ API_KEY_VALIDATION_CACHE_TTL_SECONDS=10
 API_KEY_USER_CACHE_TTL_SECONDS=60
 
 ADMIN_API_KEY=supersecret
+
+# Backoffice workload API. Keep disabled until the current SHA-256 digest is
+# configured. Store the high-entropy raw credential only on the Backoffice
+# side; BoxLite receives digest values and permits a bounded current/next
+# overlap during rotation.
+BACKOFFICE_INTERNAL_API_ENABLED=false
+BACKOFFICE_READ_TOKEN_DIGEST_CURRENT=
+BACKOFFICE_READ_TOKEN_DIGEST_NEXT=
 ADMIN_MAX_CPU_PER_BOX=4
 ADMIN_MAX_MEMORY_PER_BOX=8
 ADMIN_MAX_DISK_PER_BOX=10

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -36,7 +36,7 @@ import { HealthModule } from './health/health.module'
 import { OpenFeatureModule } from '@openfeature/nestjs-sdk'
 import { OpenFeaturePostHogProvider } from './common/providers/openfeature-posthog.provider'
 import { LoggerModule } from 'nestjs-pino'
-import { getPinoTransport, swapMessageAndObject } from './common/utils/pino.util'
+import { getPinoTransport, PINO_HTTP_REDACT, swapMessageAndObject } from './common/utils/pino.util'
 import { Redis } from 'ioredis'
 import { ThrottlerStorageRedisService } from '@nest-lab/throttler-storage-redis'
 import { RegionModule } from './region/region.module'
@@ -45,6 +45,7 @@ import { AdminModule } from './admin/admin.module'
 import { ClickHouseModule } from './clickhouse/clickhouse.module'
 import { BoxTelemetryModule } from './box-telemetry/box-telemetry.module'
 import { BoxliteRestModule } from './boxlite-rest/boxlite-rest.module'
+import { BackofficeInternalModule } from './backoffice-internal/backoffice-internal.module'
 
 @Module({
   imports: [
@@ -56,6 +57,7 @@ import { BoxliteRestModule } from './boxlite-rest/boxlite-rest.module'
           pinoHttp: {
             autoLogging: logConfig.requests.enabled,
             level: logConfig.level,
+            redact: PINO_HTTP_REDACT,
             hooks: {
               logMethod: swapMessageAndObject,
             },
@@ -201,6 +203,7 @@ import { BoxliteRestModule } from './boxlite-rest/boxlite-rest.module'
     ClickHouseModule,
     BoxTelemetryModule,
     BoxliteRestModule,
+    BackofficeInternalModule,
     OpenFeatureModule.forRoot({
       contextFactory: (request: ExecutionContext) => {
         const req = request.switchToHttp().getRequest()

--- a/apps/api/src/backoffice-internal/backoffice-internal.controller.spec.ts
+++ b/apps/api/src/backoffice-internal/backoffice-internal.controller.spec.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { createHash } from 'node:crypto'
+import type { INestApplication } from '@nestjs/common'
+import { Test } from '@nestjs/testing'
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger'
+import type { AddressInfo } from 'node:net'
+import { TypedConfigService } from '../config/typed-config.service'
+import { BackofficeInternalController } from './backoffice-internal.controller'
+import { BackofficeWorkloadAuthenticator, BackofficeWorkloadAuthGuard } from './backoffice-workload-auth'
+
+const CURRENT_TOKEN = 'synthetic-current-workload-token'
+const NEXT_TOKEN = 'synthetic-next-workload-token'
+const digest = (token: string) => createHash('sha256').update(token).digest('hex')
+
+describe('Backoffice internal readiness', () => {
+  let app: INestApplication | undefined
+
+  async function startApp(enabled: boolean) {
+    const values: Record<string, unknown> = {
+      'backofficeInternal.enabled': enabled,
+      'backofficeInternal.readTokenDigests.current': enabled ? digest(CURRENT_TOKEN) : undefined,
+      'backofficeInternal.readTokenDigests.next': enabled ? digest(NEXT_TOKEN) : undefined,
+    }
+    const moduleRef = await Test.createTestingModule({
+      controllers: [BackofficeInternalController],
+      providers: [
+        BackofficeWorkloadAuthenticator,
+        BackofficeWorkloadAuthGuard,
+        {
+          provide: TypedConfigService,
+          useValue: { get: (key: string) => values[key] },
+        },
+      ],
+    }).compile()
+
+    app = moduleRef.createNestApplication()
+    app.setGlobalPrefix('api')
+    await app.listen(0, '127.0.0.1')
+  }
+
+  async function request(method: 'GET' | 'POST', token?: string): Promise<Response> {
+    if (!app) {
+      throw new Error('test application is not running')
+    }
+    const address = app.getHttpServer().address() as AddressInfo
+    return fetch(`http://127.0.0.1:${address.port}/api/internal/backoffice/v1/readiness`, {
+      method,
+      headers: token ? { authorization: `Bearer ${token}` } : undefined,
+    })
+  }
+
+  afterEach(async () => {
+    await app?.close()
+    app = undefined
+  })
+
+  it('returns 404 while the route family is disabled', async () => {
+    await startApp(false)
+
+    expect((await request('GET')).status).toBe(404)
+  })
+
+  it('rejects missing and invalid bearer credentials without reflecting them', async () => {
+    await startApp(true)
+
+    expect((await request('GET')).status).toBe(401)
+    const invalidToken = 'synthetic-invalid-workload-token'
+    const invalidResponse = await request('GET', invalidToken)
+
+    expect(invalidResponse.status).toBe(401)
+    expect(await invalidResponse.text()).not.toContain(invalidToken)
+  })
+
+  it.each([CURRENT_TOKEN, NEXT_TOKEN])('returns the capability handshake for a valid rotation slot', async (token) => {
+    await startApp(true)
+
+    const response = await request('GET', token)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    expect(body).toMatchObject({
+      service: 'boxlite-api',
+      contract: { major: 1, minor: 0 },
+      capabilities: [],
+    })
+    expect(Number.isNaN(Date.parse(body.generatedAt))).toBe(false)
+    expect(JSON.stringify(body)).not.toContain(token)
+  })
+
+  it('does not register a non-GET readiness route', async () => {
+    await startApp(true)
+
+    expect((await request('POST', CURRENT_TOKEN)).status).toBe(404)
+  })
+
+  it('omits the internal route from the public OpenAPI document', async () => {
+    await startApp(true)
+    if (!app) {
+      throw new Error('test application is not running')
+    }
+
+    const document = SwaggerModule.createDocument(app, new DocumentBuilder().build())
+
+    expect(Object.keys(document.paths).filter((path) => path.includes('/internal/backoffice/'))).toEqual([])
+  })
+})

--- a/apps/api/src/backoffice-internal/backoffice-internal.controller.ts
+++ b/apps/api/src/backoffice-internal/backoffice-internal.controller.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Controller, Get, Header, UseGuards } from '@nestjs/common'
+import { ApiExcludeController } from '@nestjs/swagger'
+import {
+  BackofficeWorkloadAuthGuard,
+  BackofficeWorkloadRouteScope,
+  RequireBackofficeWorkloadRoute,
+} from './backoffice-workload-auth'
+
+@ApiExcludeController()
+@Controller('internal/backoffice/v1')
+@UseGuards(BackofficeWorkloadAuthGuard)
+export class BackofficeInternalController {
+  @Get('readiness')
+  @Header('Cache-Control', 'no-store')
+  @RequireBackofficeWorkloadRoute(BackofficeWorkloadRouteScope.READINESS)
+  readiness() {
+    return {
+      service: 'boxlite-api',
+      contract: { major: 1, minor: 0 },
+      capabilities: [],
+      generatedAt: new Date().toISOString(),
+    }
+  }
+}

--- a/apps/api/src/backoffice-internal/backoffice-internal.module.ts
+++ b/apps/api/src/backoffice-internal/backoffice-internal.module.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Module } from '@nestjs/common'
+import { BackofficeInternalController } from './backoffice-internal.controller'
+import { BackofficeWorkloadAuthenticator, BackofficeWorkloadAuthGuard } from './backoffice-workload-auth'
+
+@Module({
+  controllers: [BackofficeInternalController],
+  providers: [BackofficeWorkloadAuthenticator, BackofficeWorkloadAuthGuard],
+})
+export class BackofficeInternalModule {}

--- a/apps/api/src/backoffice-internal/backoffice-workload-auth.spec.ts
+++ b/apps/api/src/backoffice-internal/backoffice-workload-auth.spec.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { createHash } from 'node:crypto'
+import { ForbiddenException, NotFoundException, UnauthorizedException } from '@nestjs/common'
+import { Reflector } from '@nestjs/core'
+import type { ExecutionContext } from '@nestjs/common'
+import { TypedConfigService } from '../config/typed-config.service'
+import {
+  BackofficeWorkloadAuthenticator,
+  BackofficeWorkloadAuthGuard,
+  BackofficeWorkloadRouteScope,
+  RequireBackofficeWorkloadRoute,
+} from './backoffice-workload-auth'
+
+const CURRENT_TOKEN = 'synthetic-current-workload-token'
+const NEXT_TOKEN = 'synthetic-next-workload-token'
+const digest = (token: string) => createHash('sha256').update(token).digest('hex')
+
+function config(enabled = true) {
+  const values: Record<string, unknown> = {
+    'backofficeInternal.enabled': enabled,
+    'backofficeInternal.readTokenDigests.current': enabled ? digest(CURRENT_TOKEN) : undefined,
+    'backofficeInternal.readTokenDigests.next': enabled ? digest(NEXT_TOKEN) : undefined,
+  }
+  return {
+    get: jest.fn((key: string) => values[key]),
+  } as unknown as TypedConfigService
+}
+
+class ScopedHandler {
+  @RequireBackofficeWorkloadRoute(BackofficeWorkloadRouteScope.READINESS)
+  readiness() {}
+
+  undecorated() {}
+}
+
+function executionContext(handler: () => void, authorization?: string): { context: ExecutionContext; request: any } {
+  const request = {
+    method: 'GET',
+    originalUrl: '/api/internal/backoffice/v1/readiness',
+    headers: { authorization },
+  }
+  return {
+    request,
+    context: {
+      getHandler: () => handler,
+      getClass: () => ScopedHandler,
+      switchToHttp: () => ({ getRequest: () => request }),
+    } as unknown as ExecutionContext,
+  }
+}
+
+describe('Backoffice workload authentication', () => {
+  it.each([CURRENT_TOKEN, NEXT_TOKEN])('accepts a configured rotation slot', (token) => {
+    const authenticator = new BackofficeWorkloadAuthenticator(config())
+
+    expect(authenticator.authenticate(`Bearer ${token}`)).toEqual({
+      role: 'backoffice-workload',
+      credential: 'read',
+      routeScopes: [BackofficeWorkloadRouteScope.READINESS],
+    })
+  })
+
+  it.each([
+    undefined,
+    '',
+    'Basic synthetic-current-workload-token',
+    'Bearer',
+    'Bearer ',
+    'Bearer wrong-workload-token',
+    'Bearer token with spaces',
+  ])('rejects missing, malformed, or invalid authorization without reflecting it', (authorization) => {
+    const authenticator = new BackofficeWorkloadAuthenticator(config())
+
+    try {
+      authenticator.authenticate(authorization)
+      throw new Error('expected authentication to fail')
+    } catch (error) {
+      expect(error).toBeInstanceOf(UnauthorizedException)
+      if (authorization) {
+        expect(String(error)).not.toContain(authorization)
+      }
+    }
+  })
+
+  it('hides the route while the feature is disabled', () => {
+    const guard = new BackofficeWorkloadAuthGuard(new BackofficeWorkloadAuthenticator(config(false)), new Reflector())
+    const { context } = executionContext(ScopedHandler.prototype.readiness, `Bearer ${CURRENT_TOKEN}`)
+
+    expect(() => guard.canActivate(context)).toThrow(NotFoundException)
+  })
+
+  it('fails closed when a guarded handler has no declared route scope', () => {
+    const guard = new BackofficeWorkloadAuthGuard(new BackofficeWorkloadAuthenticator(config()), new Reflector())
+    const { context } = executionContext(ScopedHandler.prototype.undecorated, `Bearer ${CURRENT_TOKEN}`)
+
+    expect(() => guard.canActivate(context)).toThrow(ForbiddenException)
+  })
+
+  it('attaches the validated workload principal for the declared route scope', () => {
+    const guard = new BackofficeWorkloadAuthGuard(new BackofficeWorkloadAuthenticator(config()), new Reflector())
+    const { context, request } = executionContext(ScopedHandler.prototype.readiness, `Bearer ${CURRENT_TOKEN}`)
+
+    expect(guard.canActivate(context)).toBe(true)
+    expect(request.user).toEqual({
+      role: 'backoffice-workload',
+      credential: 'read',
+      routeScopes: [BackofficeWorkloadRouteScope.READINESS],
+    })
+  })
+
+  it('rejects a valid principal that lacks the route scope', () => {
+    const authenticator = {
+      isEnabled: () => true,
+      authenticate: () => ({ role: 'backoffice-workload', credential: 'read', routeScopes: [] }),
+    }
+    const guard = new BackofficeWorkloadAuthGuard(authenticator as any, new Reflector())
+    const { context } = executionContext(ScopedHandler.prototype.readiness, `Bearer ${CURRENT_TOKEN}`)
+
+    expect(() => guard.canActivate(context)).toThrow(ForbiddenException)
+  })
+
+  it('rejects a scope annotation applied to a different method or path', () => {
+    const guard = new BackofficeWorkloadAuthGuard(new BackofficeWorkloadAuthenticator(config()), new Reflector())
+    const { context, request } = executionContext(ScopedHandler.prototype.readiness, `Bearer ${CURRENT_TOKEN}`)
+    request.originalUrl = '/api/internal/backoffice/v1/boxes'
+
+    expect(() => guard.canActivate(context)).toThrow(ForbiddenException)
+  })
+})

--- a/apps/api/src/backoffice-internal/backoffice-workload-auth.ts
+++ b/apps/api/src/backoffice-internal/backoffice-workload-auth.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { createHash, timingSafeEqual } from 'node:crypto'
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+  SetMetadata,
+  UnauthorizedException,
+} from '@nestjs/common'
+import { Reflector } from '@nestjs/core'
+import type { Request } from 'express'
+import { TypedConfigService } from '../config/typed-config.service'
+
+export const BackofficeWorkloadRouteScope = {
+  READINESS: 'GET /api/internal/backoffice/v1/readiness',
+} as const
+
+export type BackofficeWorkloadRouteScope =
+  (typeof BackofficeWorkloadRouteScope)[keyof typeof BackofficeWorkloadRouteScope]
+
+export interface BackofficeWorkloadPrincipal {
+  role: 'backoffice-workload'
+  credential: 'read'
+  routeScopes: BackofficeWorkloadRouteScope[]
+}
+
+const BACKOFFICE_WORKLOAD_ROUTE_SCOPE = 'backoffice-workload-route-scope'
+const BEARER_AUTHORIZATION = /^Bearer ([A-Za-z0-9\-._~+/]+=*)$/i
+
+export const RequireBackofficeWorkloadRoute = (scope: BackofficeWorkloadRouteScope) =>
+  SetMetadata(BACKOFFICE_WORKLOAD_ROUTE_SCOPE, scope)
+
+@Injectable()
+export class BackofficeWorkloadAuthenticator {
+  private readonly enabled: boolean
+  private readonly readTokenDigests: Buffer[]
+
+  constructor(config: TypedConfigService) {
+    this.enabled = config.get('backofficeInternal.enabled')
+    this.readTokenDigests = [
+      config.get('backofficeInternal.readTokenDigests.current'),
+      config.get('backofficeInternal.readTokenDigests.next'),
+    ]
+      .filter((digest): digest is string => digest !== undefined)
+      .map((digest) => Buffer.from(digest, 'hex'))
+  }
+
+  isEnabled(): boolean {
+    return this.enabled
+  }
+
+  authenticate(authorization: unknown): BackofficeWorkloadPrincipal {
+    const match = typeof authorization === 'string' ? BEARER_AUTHORIZATION.exec(authorization) : null
+    if (!match) {
+      throw new UnauthorizedException('Valid Backoffice workload credentials are required')
+    }
+
+    const presentedDigest = createHash('sha256').update(match[1]).digest()
+    let matched = 0
+    for (const configuredDigest of this.readTokenDigests) {
+      matched |= Number(timingSafeEqual(presentedDigest, configuredDigest))
+    }
+    if (matched === 0) {
+      throw new UnauthorizedException('Valid Backoffice workload credentials are required')
+    }
+
+    return {
+      role: 'backoffice-workload',
+      credential: 'read',
+      routeScopes: [BackofficeWorkloadRouteScope.READINESS],
+    }
+  }
+}
+
+type BackofficeRequest = Request & { user?: BackofficeWorkloadPrincipal }
+
+@Injectable()
+export class BackofficeWorkloadAuthGuard implements CanActivate {
+  constructor(
+    private readonly authenticator: BackofficeWorkloadAuthenticator,
+    private readonly reflector: Reflector,
+  ) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    if (!this.authenticator.isEnabled()) {
+      throw new NotFoundException()
+    }
+
+    const requiredScope = this.reflector.get<BackofficeWorkloadRouteScope>(
+      BACKOFFICE_WORKLOAD_ROUTE_SCOPE,
+      context.getHandler(),
+    )
+    if (!requiredScope) {
+      throw new ForbiddenException('Backoffice workload route scope is required')
+    }
+
+    const request = context.switchToHttp().getRequest<BackofficeRequest>()
+    const requestedScope = `${request.method} ${request.originalUrl?.split('?', 1)[0]}`
+    if (requestedScope !== requiredScope) {
+      throw new ForbiddenException('Backoffice workload route scope does not match the request')
+    }
+
+    const principal = this.authenticator.authenticate(request.headers.authorization)
+    if (!principal.routeScopes.includes(requiredScope)) {
+      throw new ForbiddenException('Backoffice workload credential is not allowed for this route')
+    }
+
+    request.user = principal
+    return true
+  }
+}

--- a/apps/api/src/common/utils/pino.util.spec.ts
+++ b/apps/api/src/common/utils/pino.util.spec.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Writable } from 'node:stream'
+import pino from 'pino'
+import { PINO_HTTP_REDACT } from './pino.util'
+
+describe('Pino request redaction', () => {
+  it('removes bearer credentials while retaining non-sensitive request context', async () => {
+    const token = 'synthetic-log-redaction-workload-token'
+    let output = ''
+    const destination = new Writable({
+      write(chunk, _encoding, callback) {
+        output += chunk.toString()
+        callback()
+      },
+    })
+    const logger = pino({ redact: PINO_HTTP_REDACT }, destination)
+
+    logger.info({ req: { method: 'GET', headers: { authorization: `Bearer ${token}`, accept: 'application/json' } } })
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(output).not.toContain(token)
+    expect(JSON.parse(output)).toMatchObject({
+      req: {
+        method: 'GET',
+        headers: {
+          authorization: '[REDACTED]',
+          accept: 'application/json',
+        },
+      },
+    })
+  })
+})

--- a/apps/api/src/common/utils/pino.util.ts
+++ b/apps/api/src/common/utils/pino.util.ts
@@ -7,6 +7,11 @@
 import pino, { TransportSingleOptions } from 'pino'
 import { TypedConfigService } from '../../config/typed-config.service'
 
+export const PINO_HTTP_REDACT = {
+  paths: ['req.headers.authorization'],
+  censor: '[REDACTED]',
+}
+
 /*
  * This is a workaround to swap the message and object in the arguments array.
  * It is needed because the logger in nestjs-pino is not compatible with nestjs console logger.

--- a/apps/api/src/config/backoffice-internal-config.spec.ts
+++ b/apps/api/src/config/backoffice-internal-config.spec.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { createHash } from 'node:crypto'
+import { backofficeInternalConfig } from './configuration'
+
+const digest = (token: string) => createHash('sha256').update(token).digest('hex')
+
+describe('backoffice internal config', () => {
+  it('is disabled by default without requiring credential digests', () => {
+    expect(backofficeInternalConfig({})).toEqual({
+      enabled: false,
+      readTokenDigests: {
+        current: undefined,
+        next: undefined,
+      },
+    })
+  })
+
+  it('fails closed when enabled without a current read-token digest', () => {
+    expect(() =>
+      backofficeInternalConfig({
+        BACKOFFICE_INTERNAL_API_ENABLED: 'true',
+      }),
+    ).toThrow('BACKOFFICE_READ_TOKEN_DIGEST_CURRENT is required when BACKOFFICE_INTERNAL_API_ENABLED is true')
+  })
+
+  it('accepts a bounded current/next digest overlap and normalizes hex case', () => {
+    const current = digest('synthetic-current-workload-token')
+    const next = digest('synthetic-next-workload-token').toUpperCase()
+
+    expect(
+      backofficeInternalConfig({
+        BACKOFFICE_INTERNAL_API_ENABLED: 'true',
+        BACKOFFICE_READ_TOKEN_DIGEST_CURRENT: current,
+        BACKOFFICE_READ_TOKEN_DIGEST_NEXT: next,
+      }),
+    ).toEqual({
+      enabled: true,
+      readTokenDigests: {
+        current,
+        next: next.toLowerCase(),
+      },
+    })
+  })
+
+  it('rejects malformed digests without echoing their value', () => {
+    const malformed = 'not-a-sha256-digest'
+
+    expect(() =>
+      backofficeInternalConfig({
+        BACKOFFICE_READ_TOKEN_DIGEST_CURRENT: malformed,
+      }),
+    ).toThrow('BACKOFFICE_READ_TOKEN_DIGEST_CURRENT must be a SHA-256 hex digest')
+
+    try {
+      backofficeInternalConfig({ BACKOFFICE_READ_TOKEN_DIGEST_CURRENT: malformed })
+    } catch (error) {
+      expect(String(error)).not.toContain(malformed)
+    }
+  })
+})

--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -199,6 +199,36 @@ export function boxMigrationConfig(env: NodeJS.ProcessEnv = process.env) {
   return { archivePrefix: `${scheme}${segments.join('/')}/` }
 }
 
+const SHA256_HEX_DIGEST = /^[a-fA-F0-9]{64}$/
+
+function optionalSha256Digest(value: string | undefined, name: string): string | undefined {
+  const digest = value?.trim()
+  if (!digest) {
+    return undefined
+  }
+  if (!SHA256_HEX_DIGEST.test(digest)) {
+    // A malformed value may still be derived from a credential. Name the
+    // setting, never the value, so boot failures remain safe to log.
+    throw new Error(`${name} must be a SHA-256 hex digest`)
+  }
+  return digest.toLowerCase()
+}
+
+export function backofficeInternalConfig(env: NodeJS.ProcessEnv = process.env) {
+  const enabled = env.BACKOFFICE_INTERNAL_API_ENABLED === 'true'
+  const current = optionalSha256Digest(env.BACKOFFICE_READ_TOKEN_DIGEST_CURRENT, 'BACKOFFICE_READ_TOKEN_DIGEST_CURRENT')
+  const next = optionalSha256Digest(env.BACKOFFICE_READ_TOKEN_DIGEST_NEXT, 'BACKOFFICE_READ_TOKEN_DIGEST_NEXT')
+
+  if (enabled && !current) {
+    throw new Error('BACKOFFICE_READ_TOKEN_DIGEST_CURRENT is required when BACKOFFICE_INTERNAL_API_ENABLED is true')
+  }
+
+  return {
+    enabled,
+    readTokenDigests: { current, next },
+  }
+}
+
 const configuration = {
   production: process.env.NODE_ENV === 'production',
   version: process.env.VERSION || '0.0.0-dev',
@@ -466,6 +496,7 @@ const configuration = {
   admin: {
     apiKey: process.env.ADMIN_API_KEY,
   },
+  backofficeInternal: backofficeInternalConfig(),
   skipUserEmailVerification: process.env.SKIP_USER_EMAIL_VERIFICATION === 'true',
   // Whether a newly created non-default organization starts suspended until a
   // payment method exists. Separate from billingApiUrl on purpose: pointing the

--- a/apps/infra/.env.example
+++ b/apps/infra/.env.example
@@ -162,6 +162,12 @@ OIDC_AUDIENCE=https://dev.example.com/api
 # PROXY_API_KEY=
 # DEFAULT_RUNNER_API_KEY=
 
+# Backoffice workload API is disabled by default. The two credentials below
+# are SST secrets containing SHA-256 hex digests, never raw Bearer tokens:
+#   BACKOFFICE_READ_TOKEN_DIGEST_CURRENT
+#   BACKOFFICE_READ_TOKEN_DIGEST_NEXT
+# BACKOFFICE_INTERNAL_API_ENABLED=false
+
 # 4c. Endpoints & URLs — auto-derived from STACK_DOMAIN; pin for custom DNS /
 # topology. PROXY_DOMAIN configures the public hostname, certificate, and
 # wildcard alias on SST's TLS NLB listener; keep the URL values aligned with it.

--- a/apps/infra/deployment/key-policy.ts
+++ b/apps/infra/deployment/key-policy.ts
@@ -37,6 +37,7 @@ import { CLICKHOUSE_STAGE_CONFIG_KEYS } from './clickhouse.js'
 export const STORABLE_STAGE_CONFIG_KEYS: readonly string[] = [
   'ADMIN_API_KEY',
   'APP_URL',
+  'BACKOFFICE_INTERNAL_API_ENABLED',
   'BILLING_API_URL',
   'BOXLITE_API_KEY',
   'BOXLITE_API_URL',
@@ -232,6 +233,8 @@ const STORE_EXCLUDED_KEYS = new Set([
  * it here fails rather than quietly becoming clobberable.
  */
 export const APP_SECRET_NAMES = [
+  'BACKOFFICE_READ_TOKEN_DIGEST_CURRENT',
+  'BACKOFFICE_READ_TOKEN_DIGEST_NEXT',
   'OIDC_CLIENT_ID',
   'OIDC_MANAGEMENT_API_CLIENT_ID',
   'OIDC_MANAGEMENT_API_CLIENT_SECRET',

--- a/apps/infra/docs/deployment.md
+++ b/apps/infra/docs/deployment.md
@@ -363,7 +363,7 @@ each stage you run.
 
 | What | Stored in | Set by |
 | --- | --- | --- |
-| App secrets (`OIDC_CLIENT_ID`, Auth0 Management API, Svix, PostHog, `USAGE_EXPORT_TOKEN`) | SST secret store | `npm run bootstrap`; others via `npm run sst -- secret set <NAME> --stage <stage>` reading stdin |
+| App secrets (`OIDC_CLIENT_ID`, Auth0 Management API, Svix, PostHog, `USAGE_EXPORT_TOKEN`, Backoffice read-token digests) | SST secret store | `npm run bootstrap`; others via `npm run sst -- secret set <NAME> --stage <stage>` reading stdin |
 | SES SMTP credential (`SMTP_USER`, `SMTP_PASSWORD`) | SST secret store | `npm run bootstrap -- --stage <stage> --provision-ses`, which mints the send-only IAM user the deploy role cannot create and derives the SMTP password from its key. Rerunning rotates it |
 | Cloudflare creds (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_DEFAULT_ACCOUNT_ID`) | AWS SSM SecureString for local use; GitHub Environment secrets for CI (which win) | `npm run bootstrap` |
 | Stage config (`STACK_DOMAIN`, `OIDC_*`, toggles) | SST secret store | `npm run bootstrap`, from your local `.env` |

--- a/apps/infra/stack/api.ts
+++ b/apps/infra/stack/api.ts
@@ -36,6 +36,8 @@ export interface ApiInputs {
   oidcMgmtClientSecret: sst.Secret
   posthogApiKey: sst.Secret
   svixAuthToken: sst.Secret
+  backofficeReadTokenDigestCurrent: sst.Secret
+  backofficeReadTokenDigestNext: sst.Secret
   usageExportToken: sst.Secret
   oidcIssuer: string
   publicOidcIssuer: string | undefined
@@ -70,6 +72,8 @@ export function buildApi(input: ApiInputs) {
     oidcMgmtClientSecret,
     posthogApiKey,
     svixAuthToken,
+    backofficeReadTokenDigestCurrent,
+    backofficeReadTokenDigestNext,
     usageExportToken,
     oidcIssuer,
     publicOidcIssuer,
@@ -276,6 +280,12 @@ const api = new sst.aws.Service('Api', {
 
     // Admin
     ADMIN_API_KEY: envOr('ADMIN_API_KEY', adminApiKey.result),
+
+    // Backoffice workload access is opt-in. Only SHA-256 digests reach the
+    // task; current/next provide a bounded credential-rotation overlap.
+    BACKOFFICE_INTERNAL_API_ENABLED: envOr('BACKOFFICE_INTERNAL_API_ENABLED', 'false'),
+    BACKOFFICE_READ_TOKEN_DIGEST_CURRENT: backofficeReadTokenDigestCurrent.value,
+    BACKOFFICE_READ_TOKEN_DIGEST_NEXT: backofficeReadTokenDigestNext.value,
 
     // Observability read/write path. These stay server-side; never expose
     // ClickHouse credentials to the dashboard bundle.

--- a/apps/infra/stack/contract.test.ts
+++ b/apps/infra/stack/contract.test.ts
@@ -475,6 +475,24 @@ test('passes explicit management API endpoints into the API service', () => {
   assert.match(apiService, /OIDC_MANAGEMENT_API_TOKEN_URL: process\.env\.OIDC_MANAGEMENT_API_TOKEN_URL/)
 })
 
+test('keeps Backoffice workload credentials digest-only and disabled by default', () => {
+  const apiService = configSection("const api = new sst.aws.Service('Api'", '// Assumed by the Api task role')
+
+  assert.match(liveConfig, /new sst\.Secret\('BACKOFFICE_READ_TOKEN_DIGEST_CURRENT', ''\)/)
+  assert.match(liveConfig, /new sst\.Secret\('BACKOFFICE_READ_TOKEN_DIGEST_NEXT', ''\)/)
+  assert.match(
+    apiService,
+    /BACKOFFICE_INTERNAL_API_ENABLED: envOr\('BACKOFFICE_INTERNAL_API_ENABLED', 'false'\)/,
+  )
+  assert.match(
+    apiService,
+    /BACKOFFICE_READ_TOKEN_DIGEST_CURRENT: backofficeReadTokenDigestCurrent\.value/,
+  )
+  assert.match(apiService, /BACKOFFICE_READ_TOKEN_DIGEST_NEXT: backofficeReadTokenDigestNext\.value/)
+  assert.doesNotMatch(liveConfig, /BACKOFFICE_READ_TOKEN(?:[^_]|$)/)
+  assert.doesNotMatch(environmentExample, /^BACKOFFICE_READ_TOKEN=/m)
+})
+
 test('reports the canonical workspace release unless VERSION overrides it', () => {
   assert.match(liveConfig, /const workspaceVersion = readWorkspaceVersion\(\)/)
   assert.match(liveConfig, /resolvePublicDeploymentConfig\(process\.env, workspaceVersion\)/)

--- a/apps/infra/stack/deploy.ts
+++ b/apps/infra/stack/deploy.ts
@@ -85,6 +85,11 @@ export async function deployStack() {
     const oidcMgmtClientSecret = new sst.Secret('OIDC_MANAGEMENT_API_CLIENT_SECRET')
     const posthogApiKey = new sst.Secret('POSTHOG_API_KEY', '')
     const svixAuthToken = new sst.Secret('SVIX_AUTH_TOKEN', '')
+    // BoxLite receives only one-way token digests. The raw Backoffice
+    // credential remains in Backoffice's secret store and never enters this
+    // stack's state, task definition, logs, or environment.
+    const backofficeReadTokenDigestCurrent = new sst.Secret('BACKOFFICE_READ_TOKEN_DIGEST_CURRENT', '')
+    const backofficeReadTokenDigestNext = new sst.Secret('BACKOFFICE_READ_TOKEN_DIGEST_NEXT', '')
     // The credential the usage exporter presents to Commerce's ingest route:
     // half of a shared secret whose other half is a Secrets Manager container
     // owned by boxlite-commerce's own stack, so both ends are set out of band
@@ -264,6 +269,8 @@ export async function deployStack() {
       oidcMgmtClientSecret,
       posthogApiKey,
       svixAuthToken,
+      backofficeReadTokenDigestCurrent,
+      backofficeReadTokenDigestNext,
       usageExportToken,
       oidcIssuer,
       publicOidcIssuer,


### PR DESCRIPTION
## Summary

Add a default-disabled, versioned readiness endpoint for Backoffice-to-BoxLite workload access. Authenticate the endpoint with a read-only Bearer credential while storing and deploying only SHA-256 token digests in BoxLite.

## Call graph

Before

```text
GET /api/internal/backoffice/v1/readiness
  └─ route absent
```

After

```text
GET /api/internal/backoffice/v1/readiness
  └─ canActivate  (BackofficeWorkloadAuthGuard · apps/api/src/backoffice-internal/backoffice-workload-auth.ts:90)  — enforce default-off and exact route scope
       └─ authenticate  (BackofficeWorkloadAuthenticator · apps/api/src/backoffice-internal/backoffice-workload-auth.ts:58)  — hash the presented token and compare current/next digests in constant time
            └─ readiness  (BackofficeInternalController · apps/api/src/backoffice-internal/backoffice-internal.controller.ts:21)  — return the no-store v1 contract and advertised capabilities
```

## Changes

- Add `GET /api/internal/backoffice/v1/readiness`, excluded from public OpenAPI and returned with `Cache-Control: no-store`.
- Add a fail-closed guard with an exact method/path scope; disabled deployments return `404`, invalid credentials return a generic `401`, and missing or mismatched route metadata returns `403`.
- Validate SHA-256 digest configuration at startup and support `current` plus `next` digests for bounded credential rotation.
- Compare the presented Bearer token through SHA-256 and `timingSafeEqual`; raw Backoffice credentials are never stored in BoxLite configuration or SST state.
- Redact `Authorization` request headers from Pino logs.
- Wire the enable flag and digest-only secrets through SST, deployment policy, environment examples, and deployment documentation.
- Keep readiness capabilities empty until the protected Box and Runner read APIs are available.

## How to verify

```bash
make test:apps FILTER='Backoffice internal readiness|Backoffice workload authentication|backoffice internal config|Pino request redaction'
make lint:apps
make fmt:check:apps
```

The SST deployment contract tests verify that only digest settings are linked into the API task and that access to raw Backoffice credentials is not introduced.

## Risks / rollout

- The endpoint remains unavailable unless `BACKOFFICE_INTERNAL_API_ENABLED=true` and a valid current digest is configured.
- Rotate credentials by provisioning the next digest, switching callers, then promoting it to current.
- Disable the feature flag to remove the endpoint without changing public API behavior.

