### PR TITLE
feat(api): add Backoffice inventory endpoints

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -115,6 +115,14 @@ API_KEY_VALIDATION_CACHE_TTL_SECONDS=10
 API_KEY_USER_CACHE_TTL_SECONDS=60
 
 ADMIN_API_KEY=supersecret
+
+# Backoffice workload API. Keep disabled until the current SHA-256 digest is
+# configured. Store the high-entropy raw credential only on the Backoffice
+# side; BoxLite receives digest values and permits a bounded current/next
+# overlap during rotation.
+BACKOFFICE_INTERNAL_API_ENABLED=false
+BACKOFFICE_READ_TOKEN_DIGEST_CURRENT=
+BACKOFFICE_READ_TOKEN_DIGEST_NEXT=
 ADMIN_MAX_CPU_PER_BOX=4
 ADMIN_MAX_MEMORY_PER_BOX=8
 ADMIN_MAX_DISK_PER_BOX=10

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -36,7 +36,7 @@ import { HealthModule } from './health/health.module'
 import { OpenFeatureModule } from '@openfeature/nestjs-sdk'
 import { OpenFeaturePostHogProvider } from './common/providers/openfeature-posthog.provider'
 import { LoggerModule } from 'nestjs-pino'
-import { getPinoTransport, swapMessageAndObject } from './common/utils/pino.util'
+import { getPinoTransport, PINO_HTTP_REDACT, swapMessageAndObject } from './common/utils/pino.util'
 import { Redis } from 'ioredis'
 import { ThrottlerStorageRedisService } from '@nest-lab/throttler-storage-redis'
 import { RegionModule } from './region/region.module'
@@ -45,6 +45,7 @@ import { AdminModule } from './admin/admin.module'
 import { ClickHouseModule } from './clickhouse/clickhouse.module'
 import { BoxTelemetryModule } from './box-telemetry/box-telemetry.module'
 import { BoxliteRestModule } from './boxlite-rest/boxlite-rest.module'
+import { BackofficeInternalModule } from './backoffice-internal/backoffice-internal.module'
 
 @Module({
   imports: [
@@ -56,6 +57,7 @@ import { BoxliteRestModule } from './boxlite-rest/boxlite-rest.module'
           pinoHttp: {
             autoLogging: logConfig.requests.enabled,
             level: logConfig.level,
+            redact: PINO_HTTP_REDACT,
             hooks: {
               logMethod: swapMessageAndObject,
             },
@@ -201,6 +203,7 @@ import { BoxliteRestModule } from './boxlite-rest/boxlite-rest.module'
     ClickHouseModule,
     BoxTelemetryModule,
     BoxliteRestModule,
+    BackofficeInternalModule,
     OpenFeatureModule.forRoot({
       contextFactory: (request: ExecutionContext) => {
         const req = request.switchToHttp().getRequest()

--- a/apps/api/src/backoffice-internal/backoffice-internal.controller.spec.ts
+++ b/apps/api/src/backoffice-internal/backoffice-internal.controller.spec.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { createHash } from 'node:crypto'
+import type { INestApplication } from '@nestjs/common'
+import { Test } from '@nestjs/testing'
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger'
+import type { AddressInfo } from 'node:net'
+import { TypedConfigService } from '../config/typed-config.service'
+import { BackofficeInternalController } from './backoffice-internal.controller'
+import { BackofficeWorkloadAuthenticator, BackofficeWorkloadAuthGuard } from './backoffice-workload-auth'
+
+const CURRENT_TOKEN = 'synthetic-current-workload-token'
+const NEXT_TOKEN = 'synthetic-next-workload-token'
+const digest = (token: string) => createHash('sha256').update(token).digest('hex')
+
+describe('Backoffice internal readiness', () => {
+  let app: INestApplication | undefined
+
+  async function startApp(enabled: boolean) {
+    const values: Record<string, unknown> = {
+      'backofficeInternal.enabled': enabled,
+      'backofficeInternal.readTokenDigests.current': enabled ? digest(CURRENT_TOKEN) : undefined,
+      'backofficeInternal.readTokenDigests.next': enabled ? digest(NEXT_TOKEN) : undefined,
+    }
+    const moduleRef = await Test.createTestingModule({
+      controllers: [BackofficeInternalController],
+      providers: [
+        BackofficeWorkloadAuthenticator,
+        BackofficeWorkloadAuthGuard,
+        {
+          provide: TypedConfigService,
+          useValue: { get: (key: string) => values[key] },
+        },
+      ],
+    }).compile()
+
+    app = moduleRef.createNestApplication()
+    app.setGlobalPrefix('api')
+    await app.listen(0, '127.0.0.1')
+  }
+
+  async function request(method: 'GET' | 'POST', token?: string): Promise<Response> {
+    if (!app) {
+      throw new Error('test application is not running')
+    }
+    const address = app.getHttpServer().address() as AddressInfo
+    return fetch(`http://127.0.0.1:${address.port}/api/internal/backoffice/v1/readiness`, {
+      method,
+      headers: token ? { authorization: `Bearer ${token}` } : undefined,
+    })
+  }
+
+  afterEach(async () => {
+    await app?.close()
+    app = undefined
+  })
+
+  it('returns 404 while the route family is disabled', async () => {
+    await startApp(false)
+
+    expect((await request('GET')).status).toBe(404)
+  })
+
+  it('rejects missing and invalid bearer credentials without reflecting them', async () => {
+    await startApp(true)
+
+    expect((await request('GET')).status).toBe(401)
+    const invalidToken = 'synthetic-invalid-workload-token'
+    const invalidResponse = await request('GET', invalidToken)
+
+    expect(invalidResponse.status).toBe(401)
+    expect(await invalidResponse.text()).not.toContain(invalidToken)
+  })
+
+  it.each([CURRENT_TOKEN, NEXT_TOKEN])('returns the capability handshake for a valid rotation slot', async (token) => {
+    await startApp(true)
+
+    const response = await request('GET', token)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    expect(body).toMatchObject({
+      service: 'boxlite-api',
+      contract: { major: 1, minor: 0 },
+      capabilities: [],
+    })
+    expect(Number.isNaN(Date.parse(body.generatedAt))).toBe(false)
+    expect(JSON.stringify(body)).not.toContain(token)
+  })
+
+  it('does not register a non-GET readiness route', async () => {
+    await startApp(true)
+
+    expect((await request('POST', CURRENT_TOKEN)).status).toBe(404)
+  })
+
+  it('omits the internal route from the public OpenAPI document', async () => {
+    await startApp(true)
+    if (!app) {
+      throw new Error('test application is not running')
+    }
+
+    const document = SwaggerModule.createDocument(app, new DocumentBuilder().build())
+
+    expect(Object.keys(document.paths).filter((path) => path.includes('/internal/backoffice/'))).toEqual([])
+  })
+})

--- a/apps/api/src/backoffice-internal/backoffice-internal.controller.spec.ts
+++ b/apps/api/src/backoffice-internal/backoffice-internal.controller.spec.ts
@@ -4,12 +4,13 @@
  */
 
 import { createHash } from 'node:crypto'
-import type { INestApplication } from '@nestjs/common'
+import { ValidationPipe, type INestApplication } from '@nestjs/common'
 import { Test } from '@nestjs/testing'
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger'
 import type { AddressInfo } from 'node:net'
 import { TypedConfigService } from '../config/typed-config.service'
 import { BackofficeInternalController } from './backoffice-internal.controller'
+import { BackofficeInventoryReader } from './backoffice-inventory.reader'
 import { BackofficeWorkloadAuthenticator, BackofficeWorkloadAuthGuard } from './backoffice-workload-auth'
 
 const CURRENT_TOKEN = 'synthetic-current-workload-token'
@@ -18,6 +19,16 @@ const digest = (token: string) => createHash('sha256').update(token).digest('hex
 
 describe('Backoffice internal readiness', () => {
   let app: INestApplication | undefined
+  const inventory = {
+    boxes: jest
+      .fn()
+      .mockResolvedValue({ items: [], nextCursor: null, limit: 100, observedAt: '2026-08-25T10:00:00.000Z' }),
+    box: jest.fn().mockResolvedValue({ id: 'AbCdEf123456' }),
+    runners: jest
+      .fn()
+      .mockResolvedValue({ items: [], nextCursor: null, limit: 100, observedAt: '2026-08-25T10:00:00.000Z' }),
+    runner: jest.fn().mockResolvedValue({ id: '22222222-2222-4222-8222-222222222222' }),
+  }
 
   async function startApp(enabled: boolean) {
     const values: Record<string, unknown> = {
@@ -30,6 +41,7 @@ describe('Backoffice internal readiness', () => {
       providers: [
         BackofficeWorkloadAuthenticator,
         BackofficeWorkloadAuthGuard,
+        { provide: BackofficeInventoryReader, useValue: inventory },
         {
           provide: TypedConfigService,
           useValue: { get: (key: string) => values[key] },
@@ -39,6 +51,7 @@ describe('Backoffice internal readiness', () => {
 
     app = moduleRef.createNestApplication()
     app.setGlobalPrefix('api')
+    app.useGlobalPipes(new ValidationPipe({ transform: true }))
     await app.listen(0, '127.0.0.1')
   }
 
@@ -57,6 +70,8 @@ describe('Backoffice internal readiness', () => {
     await app?.close()
     app = undefined
   })
+
+  beforeEach(() => jest.clearAllMocks())
 
   it('returns 404 while the route family is disabled', async () => {
     await startApp(false)
@@ -86,7 +101,7 @@ describe('Backoffice internal readiness', () => {
     expect(body).toMatchObject({
       service: 'boxlite-api',
       contract: { major: 1, minor: 0 },
-      capabilities: [],
+      capabilities: ['boxes.read', 'runners.read'],
     })
     expect(Number.isNaN(Date.parse(body.generatedAt))).toBe(false)
     expect(JSON.stringify(body)).not.toContain(token)
@@ -96,6 +111,40 @@ describe('Backoffice internal readiness', () => {
     await startApp(true)
 
     expect((await request('POST', CURRENT_TOKEN)).status).toBe(404)
+  })
+
+  it.each([
+    ['/api/internal/backoffice/v1/boxes', 'boxes'],
+    ['/api/internal/backoffice/v1/boxes/AbCdEf123456', 'box'],
+    ['/api/internal/backoffice/v1/runners', 'runners'],
+    ['/api/internal/backoffice/v1/runners/22222222-2222-4222-8222-222222222222', 'runner'],
+  ])('protects the inventory route %s with the workload credential', async (path, method) => {
+    await startApp(true)
+    if (!app) throw new Error('test application is not running')
+    const address = app.getHttpServer().address() as AddressInfo
+
+    const unauthorized = await fetch(`http://127.0.0.1:${address.port}${path}`)
+    const authorized = await fetch(`http://127.0.0.1:${address.port}${path}`, {
+      headers: { authorization: `Bearer ${CURRENT_TOKEN}` },
+    })
+
+    expect(unauthorized.status).toBe(401)
+    expect(authorized.status).toBe(200)
+    expect(authorized.headers.get('cache-control')).toBe('no-store')
+    expect(inventory[method as keyof typeof inventory]).toHaveBeenCalled()
+  })
+
+  it('rejects an inventory page limit above the contract maximum', async () => {
+    await startApp(true)
+    if (!app) throw new Error('test application is not running')
+    const address = app.getHttpServer().address() as AddressInfo
+
+    const response = await fetch(`http://127.0.0.1:${address.port}/api/internal/backoffice/v1/boxes?limit=201`, {
+      headers: { authorization: `Bearer ${CURRENT_TOKEN}` },
+    })
+
+    expect(response.status).toBe(400)
+    expect(inventory.boxes).not.toHaveBeenCalled()
   })
 
   it('omits the internal route from the public OpenAPI document', async () => {

--- a/apps/api/src/backoffice-internal/backoffice-internal.controller.ts
+++ b/apps/api/src/backoffice-internal/backoffice-internal.controller.ts
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { Controller, Get, Header, UseGuards } from '@nestjs/common'
+import { Controller, Get, Header, Param, Query, UseGuards } from '@nestjs/common'
 import { ApiExcludeController } from '@nestjs/swagger'
+import { BackofficeBoxesQueryDto, BackofficeRunnersQueryDto } from './backoffice-inventory.dto'
+import { BackofficeInventoryReader } from './backoffice-inventory.reader'
 import {
   BackofficeWorkloadAuthGuard,
   BackofficeWorkloadRouteScope,
@@ -15,6 +17,8 @@ import {
 @Controller('internal/backoffice/v1')
 @UseGuards(BackofficeWorkloadAuthGuard)
 export class BackofficeInternalController {
+  constructor(private readonly inventory: BackofficeInventoryReader) {}
+
   @Get('readiness')
   @Header('Cache-Control', 'no-store')
   @RequireBackofficeWorkloadRoute(BackofficeWorkloadRouteScope.READINESS)
@@ -22,8 +26,36 @@ export class BackofficeInternalController {
     return {
       service: 'boxlite-api',
       contract: { major: 1, minor: 0 },
-      capabilities: [],
+      capabilities: ['boxes.read', 'runners.read'],
       generatedAt: new Date().toISOString(),
     }
+  }
+
+  @Get('boxes')
+  @Header('Cache-Control', 'no-store')
+  @RequireBackofficeWorkloadRoute(BackofficeWorkloadRouteScope.BOXES)
+  boxes(@Query() query: BackofficeBoxesQueryDto) {
+    return this.inventory.boxes(query)
+  }
+
+  @Get('boxes/:boxId')
+  @Header('Cache-Control', 'no-store')
+  @RequireBackofficeWorkloadRoute(BackofficeWorkloadRouteScope.BOX)
+  box(@Param('boxId') boxId: string) {
+    return this.inventory.box(boxId)
+  }
+
+  @Get('runners')
+  @Header('Cache-Control', 'no-store')
+  @RequireBackofficeWorkloadRoute(BackofficeWorkloadRouteScope.RUNNERS)
+  runners(@Query() query: BackofficeRunnersQueryDto) {
+    return this.inventory.runners(query)
+  }
+
+  @Get('runners/:runnerId')
+  @Header('Cache-Control', 'no-store')
+  @RequireBackofficeWorkloadRoute(BackofficeWorkloadRouteScope.RUNNER)
+  runner(@Param('runnerId') runnerId: string) {
+    return this.inventory.runner(runnerId)
   }
 }

--- a/apps/api/src/backoffice-internal/backoffice-internal.controller.ts
+++ b/apps/api/src/backoffice-internal/backoffice-internal.controller.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Controller, Get, Header, UseGuards } from '@nestjs/common'
+import { ApiExcludeController } from '@nestjs/swagger'
+import {
+  BackofficeWorkloadAuthGuard,
+  BackofficeWorkloadRouteScope,
+  RequireBackofficeWorkloadRoute,
+} from './backoffice-workload-auth'
+
+@ApiExcludeController()
+@Controller('internal/backoffice/v1')
+@UseGuards(BackofficeWorkloadAuthGuard)
+export class BackofficeInternalController {
+  @Get('readiness')
+  @Header('Cache-Control', 'no-store')
+  @RequireBackofficeWorkloadRoute(BackofficeWorkloadRouteScope.READINESS)
+  readiness() {
+    return {
+      service: 'boxlite-api',
+      contract: { major: 1, minor: 0 },
+      capabilities: [],
+      generatedAt: new Date().toISOString(),
+    }
+  }
+}

--- a/apps/api/src/backoffice-internal/backoffice-internal.module.ts
+++ b/apps/api/src/backoffice-internal/backoffice-internal.module.ts
@@ -4,11 +4,18 @@
  */
 
 import { Module } from '@nestjs/common'
+import { TypeOrmModule } from '@nestjs/typeorm'
+import { Box } from '../box/entities/box.entity'
+import { Job } from '../box/entities/job.entity'
+import { Runner } from '../box/entities/runner.entity'
+import { Region } from '../region/entities/region.entity'
 import { BackofficeInternalController } from './backoffice-internal.controller'
+import { BackofficeInventoryReader } from './backoffice-inventory.reader'
 import { BackofficeWorkloadAuthenticator, BackofficeWorkloadAuthGuard } from './backoffice-workload-auth'
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Box, Runner, Job, Region])],
   controllers: [BackofficeInternalController],
-  providers: [BackofficeWorkloadAuthenticator, BackofficeWorkloadAuthGuard],
+  providers: [BackofficeWorkloadAuthenticator, BackofficeWorkloadAuthGuard, BackofficeInventoryReader],
 })
 export class BackofficeInternalModule {}

--- a/apps/api/src/backoffice-internal/backoffice-internal.module.ts
+++ b/apps/api/src/backoffice-internal/backoffice-internal.module.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Module } from '@nestjs/common'
+import { BackofficeInternalController } from './backoffice-internal.controller'
+import { BackofficeWorkloadAuthenticator, BackofficeWorkloadAuthGuard } from './backoffice-workload-auth'
+
+@Module({
+  controllers: [BackofficeInternalController],
+  providers: [BackofficeWorkloadAuthenticator, BackofficeWorkloadAuthGuard],
+})
+export class BackofficeInternalModule {}

--- a/apps/api/src/backoffice-internal/backoffice-inventory.dto.ts
+++ b/apps/api/src/backoffice-internal/backoffice-inventory.dto.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Type } from 'class-transformer'
+import { IsEnum, IsInt, IsOptional, IsString, IsUUID, Max, MaxLength, Min } from 'class-validator'
+import { BoxState } from '../box/enums/box-state.enum'
+import { RunnerState } from '../box/enums/runner-state.enum'
+
+export const BACKOFFICE_INVENTORY_DEFAULT_LIMIT = 100
+export const BACKOFFICE_INVENTORY_MAX_LIMIT = 200
+
+class BackofficeInventoryPageQueryDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(1024)
+  cursor?: string
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(BACKOFFICE_INVENTORY_MAX_LIMIT)
+  limit = BACKOFFICE_INVENTORY_DEFAULT_LIMIT
+}
+
+export class BackofficeBoxesQueryDto extends BackofficeInventoryPageQueryDto {
+  @IsOptional()
+  @IsUUID()
+  organizationId?: string
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  regionId?: string
+
+  @IsOptional()
+  @IsUUID()
+  runnerId?: string
+
+  @IsOptional()
+  @IsEnum(BoxState)
+  state?: BoxState
+}
+
+export class BackofficeRunnersQueryDto extends BackofficeInventoryPageQueryDto {
+  @IsOptional()
+  @IsUUID()
+  organizationId?: string
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  regionId?: string
+
+  @IsOptional()
+  @IsEnum(RunnerState)
+  state?: RunnerState
+}

--- a/apps/api/src/backoffice-internal/backoffice-inventory.mapper.spec.ts
+++ b/apps/api/src/backoffice-internal/backoffice-inventory.mapper.spec.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Box } from '../box/entities/box.entity'
+import { Runner } from '../box/entities/runner.entity'
+import { BoxDesiredState } from '../box/enums/box-desired-state.enum'
+import { BoxState } from '../box/enums/box-state.enum'
+import { RunnerState } from '../box/enums/runner-state.enum'
+import { toBackofficeBoxSummary, toBackofficeRunnerSummary } from './backoffice-inventory.mapper'
+
+const CREATED_AT = new Date('2026-08-24T10:00:00.000Z')
+const UPDATED_AT = new Date('2026-08-25T10:00:00.000Z')
+
+describe('Backoffice internal inventory redaction', () => {
+  it('maps a Box through an explicit operational allowlist', () => {
+    const box = {
+      id: 'AbCdEf123456',
+      organizationId: '11111111-1111-4111-8111-111111111111',
+      name: 'safe-box-name',
+      region: 'us-east',
+      runnerId: '22222222-2222-4222-8222-222222222222',
+      desiredState: BoxDesiredState.STARTED,
+      state: BoxState.STARTED,
+      cpu: 2,
+      mem: 4,
+      disk: 10,
+      createdAt: CREATED_AT,
+      updatedAt: UPDATED_AT,
+      authToken: 'synthetic-box-auth-token',
+      env: { SYNTHETIC_PASSWORD: 'synthetic-password-value' },
+      labels: { confidential: 'synthetic-sensitive-label' },
+      networkAllowList: '10.0.0.0/8',
+      volumes: [{ volumeId: 'volume-1', mountPath: '/synthetic-private-path' }],
+      errorReason: 'synthetic-raw-error',
+    } as unknown as Box
+
+    const result = toBackofficeBoxSummary(box, 3)
+
+    expect(result).toEqual({
+      id: 'AbCdEf123456',
+      name: 'safe-box-name',
+      organizationId: '11111111-1111-4111-8111-111111111111',
+      runnerId: '22222222-2222-4222-8222-222222222222',
+      regionId: 'us-east',
+      desiredState: BoxDesiredState.STARTED,
+      observedState: BoxState.STARTED,
+      resources: {
+        cpuMillis: 2000,
+        memoryBytes: '4294967296',
+        storageBytes: '10737418240',
+      },
+      activeJobCount: 3,
+      observedAt: UPDATED_AT.toISOString(),
+      createdAt: CREATED_AT.toISOString(),
+      updatedAt: UPDATED_AT.toISOString(),
+    })
+    const serialized = JSON.stringify(result)
+    for (const forbidden of [
+      box.authToken,
+      'synthetic-password-value',
+      'synthetic-sensitive-label',
+      box.networkAllowList,
+      '/synthetic-private-path',
+      box.errorReason,
+    ]) {
+      expect(serialized).not.toContain(forbidden)
+    }
+  })
+
+  it('maps a Runner without credentials, internal origins, or raw health errors', () => {
+    const runner = {
+      id: '33333333-3333-4333-8333-333333333333',
+      name: 'runner-a',
+      region: 'us-east',
+      state: RunnerState.READY,
+      unschedulable: false,
+      draining: false,
+      apiVersion: '2',
+      appVersion: 'v0.9.7',
+      cpu: 8,
+      memoryGiB: 16,
+      diskGiB: 100,
+      currentAllocatedCpu: 3,
+      currentAllocatedMemoryGiB: 5,
+      currentAllocatedDiskGiB: 20,
+      currentCpuUsagePercentage: 37.5,
+      currentMemoryUsagePercentage: 42,
+      currentDiskUsagePercentage: 21,
+      currentStartedBoxes: 4,
+      availabilityScore: 91,
+      lastChecked: UPDATED_AT,
+      createdAt: CREATED_AT,
+      updatedAt: UPDATED_AT,
+      apiKey: 'synthetic-runner-api-key',
+      domain: 'synthetic.internal.example',
+      apiUrl: 'https://synthetic-api.internal.example',
+      proxyUrl: 'https://synthetic-proxy.internal.example',
+      serviceHealth: [{ serviceName: 'daemon', healthy: false, errorReason: 'synthetic-service-error' }],
+    } as unknown as Runner
+
+    const result = toBackofficeRunnerSummary(runner, {
+      boxCount: 7,
+      activeJobCount: 2,
+      queueDepth: 1,
+    })
+
+    expect(result).toEqual({
+      id: runner.id,
+      name: 'runner-a',
+      regionId: 'us-east',
+      state: RunnerState.READY,
+      unschedulable: false,
+      draining: false,
+      versions: { api: '2', app: 'v0.9.7' },
+      capacity: {
+        cpuMillis: 8000,
+        memoryBytes: '17179869184',
+        storageBytes: '107374182400',
+      },
+      allocated: {
+        cpuMillis: 3000,
+        memoryBytes: '5368709120',
+        storageBytes: '21474836480',
+      },
+      usage: { cpuPercentage: 37.5, memoryPercentage: 42, storagePercentage: 21 },
+      boxCount: 7,
+      startedBoxCount: 4,
+      activeJobCount: 2,
+      queueDepth: 1,
+      availabilityScore: 91,
+      lastHeartbeatAt: UPDATED_AT.toISOString(),
+      observedAt: UPDATED_AT.toISOString(),
+      createdAt: CREATED_AT.toISOString(),
+      updatedAt: UPDATED_AT.toISOString(),
+    })
+    const serialized = JSON.stringify(result)
+    for (const forbidden of [runner.apiKey, runner.domain, runner.apiUrl, runner.proxyUrl, 'synthetic-service-error']) {
+      expect(serialized).not.toContain(forbidden)
+    }
+  })
+})

--- a/apps/api/src/backoffice-internal/backoffice-inventory.mapper.ts
+++ b/apps/api/src/backoffice-internal/backoffice-inventory.mapper.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import type { Box } from '../box/entities/box.entity'
+import type { Runner } from '../box/entities/runner.entity'
+
+const GIBIBYTE = 1024 ** 3
+
+export interface BackofficeBoxSummary {
+  id: string
+  name: string
+  organizationId: string
+  runnerId: string | null
+  regionId: string
+  desiredState: Box['desiredState']
+  observedState: Box['state']
+  resources: {
+    cpuMillis: number
+    memoryBytes: string
+    storageBytes: string
+  }
+  activeJobCount: number
+  observedAt: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface BackofficeRunnerSummary {
+  id: string
+  name: string
+  regionId: string
+  state: Runner['state']
+  unschedulable: boolean
+  draining: boolean
+  versions: {
+    api: string
+    app: string | null
+  }
+  capacity: {
+    cpuMillis: number
+    memoryBytes: string
+    storageBytes: string
+  }
+  allocated: {
+    cpuMillis: number
+    memoryBytes: string
+    storageBytes: string
+  }
+  usage: {
+    cpuPercentage: number
+    memoryPercentage: number
+    storagePercentage: number
+  }
+  boxCount: number
+  startedBoxCount: number
+  activeJobCount: number
+  queueDepth: number
+  availabilityScore: number
+  lastHeartbeatAt: string | null
+  observedAt: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface BackofficeRunnerCounts {
+  boxCount: number
+  activeJobCount: number
+  queueDepth: number
+}
+
+function gibibytesToBytes(value: number): string {
+  return Math.round(value * GIBIBYTE).toString()
+}
+
+function coresToMillis(value: number): number {
+  return Math.round(value * 1000)
+}
+
+export function toBackofficeBoxSummary(box: Box, activeJobCount: number): BackofficeBoxSummary {
+  return {
+    id: box.id,
+    name: box.name,
+    organizationId: box.organizationId,
+    runnerId: box.runnerId ?? null,
+    regionId: box.region,
+    desiredState: box.desiredState,
+    observedState: box.state,
+    resources: {
+      cpuMillis: coresToMillis(box.cpu),
+      memoryBytes: gibibytesToBytes(box.mem),
+      storageBytes: gibibytesToBytes(box.disk),
+    },
+    activeJobCount,
+    observedAt: box.updatedAt.toISOString(),
+    createdAt: box.createdAt.toISOString(),
+    updatedAt: box.updatedAt.toISOString(),
+  }
+}
+
+export function toBackofficeRunnerSummary(runner: Runner, counts: BackofficeRunnerCounts): BackofficeRunnerSummary {
+  return {
+    id: runner.id,
+    name: runner.name,
+    regionId: runner.region,
+    state: runner.state,
+    unschedulable: runner.unschedulable,
+    draining: runner.draining,
+    versions: { api: runner.apiVersion, app: runner.appVersion },
+    capacity: {
+      cpuMillis: coresToMillis(runner.cpu),
+      memoryBytes: gibibytesToBytes(runner.memoryGiB),
+      storageBytes: gibibytesToBytes(runner.diskGiB),
+    },
+    allocated: {
+      cpuMillis: coresToMillis(runner.currentAllocatedCpu),
+      memoryBytes: gibibytesToBytes(runner.currentAllocatedMemoryGiB),
+      storageBytes: gibibytesToBytes(runner.currentAllocatedDiskGiB),
+    },
+    usage: {
+      cpuPercentage: runner.currentCpuUsagePercentage,
+      memoryPercentage: runner.currentMemoryUsagePercentage,
+      storagePercentage: runner.currentDiskUsagePercentage,
+    },
+    boxCount: counts.boxCount,
+    startedBoxCount: runner.currentStartedBoxes,
+    activeJobCount: counts.activeJobCount,
+    queueDepth: counts.queueDepth,
+    availabilityScore: runner.availabilityScore,
+    lastHeartbeatAt: runner.lastChecked?.toISOString() ?? null,
+    observedAt: runner.updatedAt.toISOString(),
+    createdAt: runner.createdAt.toISOString(),
+    updatedAt: runner.updatedAt.toISOString(),
+  }
+}

--- a/apps/api/src/backoffice-internal/backoffice-inventory.reader.spec.ts
+++ b/apps/api/src/backoffice-internal/backoffice-inventory.reader.spec.ts
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BadRequestException, NotFoundException } from '@nestjs/common'
+import type { Repository } from 'typeorm'
+import { Box } from '../box/entities/box.entity'
+import { Job } from '../box/entities/job.entity'
+import { Runner } from '../box/entities/runner.entity'
+import { BoxDesiredState } from '../box/enums/box-desired-state.enum'
+import { BoxState } from '../box/enums/box-state.enum'
+import { RunnerState } from '../box/enums/runner-state.enum'
+import { Region } from '../region/entities/region.entity'
+import { BackofficeInventoryReader } from './backoffice-inventory.reader'
+
+const box = (id: string, organizationId = '11111111-1111-4111-8111-111111111111'): Box =>
+  ({
+    id,
+    organizationId,
+    name: `box-${id}`,
+    region: 'us-east',
+    runnerId: '22222222-2222-4222-8222-222222222222',
+    desiredState: BoxDesiredState.STARTED,
+    state: BoxState.STARTED,
+    cpu: 2,
+    mem: 4,
+    disk: 10,
+    createdAt: new Date('2026-08-24T10:00:00.000Z'),
+    updatedAt: new Date('2026-08-25T10:00:00.000Z'),
+  }) as Box
+
+const runner = (id: string): Runner =>
+  ({
+    id,
+    name: `runner-${id}`,
+    region: 'us-east',
+    state: RunnerState.READY,
+    unschedulable: false,
+    draining: false,
+    apiVersion: '2',
+    appVersion: 'v0.9.7',
+    cpu: 8,
+    memoryGiB: 16,
+    diskGiB: 100,
+    currentAllocatedCpu: 2,
+    currentAllocatedMemoryGiB: 4,
+    currentAllocatedDiskGiB: 10,
+    currentCpuUsagePercentage: 20,
+    currentMemoryUsagePercentage: 25,
+    currentDiskUsagePercentage: 10,
+    currentStartedBoxes: 2,
+    availabilityScore: 95,
+    lastChecked: new Date('2026-08-25T10:00:00.000Z'),
+    createdAt: new Date('2026-08-24T10:00:00.000Z'),
+    updatedAt: new Date('2026-08-25T10:00:00.000Z'),
+  }) as Runner
+
+function aggregateQuery(rows: unknown[] = []) {
+  return {
+    select: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    groupBy: jest.fn().mockReturnThis(),
+    addGroupBy: jest.fn().mockReturnThis(),
+    getRawMany: jest.fn().mockResolvedValue(rows),
+  }
+}
+
+function repositories() {
+  const boxJobs = aggregateQuery([{ id: 'AbCdEf123456', status: 'PENDING', count: '2' }])
+  const runnerBoxes = aggregateQuery([{ id: '22222222-2222-4222-8222-222222222222', count: '3' }])
+  const runnerJobs = aggregateQuery([
+    { id: '22222222-2222-4222-8222-222222222222', status: 'PENDING', count: '1' },
+    { id: '22222222-2222-4222-8222-222222222222', status: 'IN_PROGRESS', count: '2' },
+  ])
+  const boxRepository = {
+    find: jest.fn(),
+    findOne: jest.fn(),
+    createQueryBuilder: jest.fn().mockReturnValue(runnerBoxes),
+  }
+  const runnerRepository = { find: jest.fn(), findOne: jest.fn() }
+  const jobRepository = {
+    find: jest.fn(),
+    createQueryBuilder: jest.fn((alias: string) => (alias === 'boxJob' ? boxJobs : runnerJobs)),
+  }
+  const regionRepository = { find: jest.fn() }
+  const reader = new BackofficeInventoryReader(
+    boxRepository as unknown as Repository<Box>,
+    runnerRepository as unknown as Repository<Runner>,
+    jobRepository as unknown as Repository<Job>,
+    regionRepository as unknown as Repository<Region>,
+  )
+  return { reader, boxRepository, runnerRepository, jobRepository, regionRepository }
+}
+
+describe('Backoffice internal inventory reader', () => {
+  it('uses a stable scoped cursor and selects only allowlisted Box columns', async () => {
+    const { reader, boxRepository } = repositories()
+    boxRepository.find.mockResolvedValueOnce([box('AbCdEf123456'), box('BcDeFg234567')]).mockResolvedValueOnce([])
+
+    const first = await reader.boxes({ limit: 1, organizationId: '11111111-1111-4111-8111-111111111111' })
+
+    expect(first.items).toHaveLength(1)
+    expect(first.items[0]).toMatchObject({ id: 'AbCdEf123456', activeJobCount: 2 })
+    expect(first.nextCursor).toEqual(expect.any(String))
+    const firstQuery = boxRepository.find.mock.calls[0][0]
+    expect(firstQuery).toMatchObject({ order: { id: 'ASC' }, take: 2 })
+    expect(firstQuery.where).toMatchObject({ organizationId: '11111111-1111-4111-8111-111111111111' })
+    expect(Object.keys(firstQuery.select)).not.toEqual(
+      expect.arrayContaining(['authToken', 'env', 'labels', 'networkAllowList', 'volumes', 'errorReason']),
+    )
+    if (!first.nextCursor) throw new Error('expected the first page to have a cursor')
+
+    await expect(reader.boxes({ limit: 1, cursor: first.nextCursor })).resolves.toMatchObject({ items: [] })
+    await expect(reader.runners({ limit: 1, cursor: first.nextCursor })).rejects.toBeInstanceOf(BadRequestException)
+  })
+
+  it('returns Boxes across organization boundaries when no organization filter is present', async () => {
+    const { reader, boxRepository } = repositories()
+    boxRepository.find.mockResolvedValue([
+      box('AbCdEf123456', '11111111-1111-4111-8111-111111111111'),
+      box('BcDeFg234567', '44444444-4444-4444-8444-444444444444'),
+    ])
+
+    const page = await reader.boxes({ limit: 100 })
+
+    expect(page.items.map((item) => item.organizationId)).toEqual([
+      '11111111-1111-4111-8111-111111111111',
+      '44444444-4444-4444-8444-444444444444',
+    ])
+    expect(boxRepository.find.mock.calls[0][0].where).not.toHaveProperty('organizationId')
+  })
+
+  it('filters Runners across custom regions without selecting credentials or origins', async () => {
+    const { reader, runnerRepository, regionRepository } = repositories()
+    regionRepository.find.mockResolvedValue([{ id: 'us-east' }])
+    runnerRepository.find.mockResolvedValue([runner('22222222-2222-4222-8222-222222222222')])
+
+    const page = await reader.runners({
+      limit: 100,
+      organizationId: '11111111-1111-4111-8111-111111111111',
+      state: RunnerState.READY,
+    })
+
+    expect(page.items[0]).toMatchObject({ boxCount: 3, activeJobCount: 3, queueDepth: 1 })
+    const query = runnerRepository.find.mock.calls[0][0]
+    expect(query).toMatchObject({ order: { id: 'ASC' }, take: 101 })
+    expect(Object.keys(query.select)).not.toEqual(
+      expect.arrayContaining(['apiKey', 'domain', 'apiUrl', 'proxyUrl', 'serviceHealth']),
+    )
+  })
+
+  it('intersects organization and region filters instead of widening either one', async () => {
+    const { reader, runnerRepository, regionRepository } = repositories()
+    regionRepository.find.mockResolvedValue([{ id: 'eu-west' }])
+
+    const page = await reader.runners({
+      limit: 100,
+      organizationId: '11111111-1111-4111-8111-111111111111',
+      regionId: 'us-east',
+    })
+
+    expect(page.items).toEqual([])
+    expect(runnerRepository.find).not.toHaveBeenCalled()
+  })
+
+  it('returns bounded Box detail references without loading Job payloads', async () => {
+    const { reader, boxRepository, jobRepository } = repositories()
+    boxRepository.findOne.mockResolvedValue(box('AbCdEf123456'))
+    jobRepository.find.mockResolvedValue(Array.from({ length: 201 }, (_, index) => ({ id: `job-${index}` })))
+
+    const detail = await reader.box('AbCdEf123456')
+
+    expect(detail.activeJobIds).toHaveLength(200)
+    expect(detail.activeJobIdsTruncated).toBe(true)
+    expect(jobRepository.find.mock.calls[0][0]).toMatchObject({ select: { id: true }, take: 201 })
+  })
+
+  it('returns bounded Runner impact references without loading Box or Job secrets', async () => {
+    const { reader, boxRepository, runnerRepository, jobRepository } = repositories()
+    runnerRepository.findOne.mockResolvedValue(runner('22222222-2222-4222-8222-222222222222'))
+    boxRepository.find.mockResolvedValue(Array.from({ length: 201 }, (_, index) => ({ id: `box-${index}` })))
+    jobRepository.find.mockResolvedValue(Array.from({ length: 201 }, (_, index) => ({ id: `job-${index}` })))
+
+    const detail = await reader.runner('22222222-2222-4222-8222-222222222222')
+
+    expect(detail.boxIds).toHaveLength(200)
+    expect(detail.boxIdsTruncated).toBe(true)
+    expect(detail.activeJobIds).toHaveLength(200)
+    expect(detail.activeJobIdsTruncated).toBe(true)
+    expect(boxRepository.find.mock.calls[0][0]).toMatchObject({ select: { id: true }, take: 201 })
+    expect(jobRepository.find.mock.calls[0][0]).toMatchObject({ select: { id: true }, take: 201 })
+  })
+
+  it('fails safely for malformed cursors and missing details', async () => {
+    const { reader, boxRepository, runnerRepository } = repositories()
+    boxRepository.findOne.mockResolvedValue(null)
+    runnerRepository.findOne.mockResolvedValue(null)
+    const malformed = 'synthetic-malformed-cursor-value'
+
+    await expect(reader.boxes({ limit: 100, cursor: malformed })).rejects.toMatchObject({
+      message: 'Invalid pagination cursor',
+    })
+    await expect(reader.boxes({ limit: 100, cursor: malformed })).rejects.not.toThrow(malformed)
+    await expect(reader.box('not-a-box-id')).rejects.toBeInstanceOf(BadRequestException)
+    await expect(reader.runner('not-a-runner-id')).rejects.toBeInstanceOf(BadRequestException)
+    await expect(reader.box('AbCdEf123456')).rejects.toBeInstanceOf(NotFoundException)
+    await expect(reader.runner('22222222-2222-4222-8222-222222222222')).rejects.toBeInstanceOf(NotFoundException)
+  })
+})

--- a/apps/api/src/backoffice-internal/backoffice-inventory.reader.ts
+++ b/apps/api/src/backoffice-internal/backoffice-inventory.reader.ts
@@ -1,0 +1,325 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common'
+import { InjectRepository } from '@nestjs/typeorm'
+import { FindOptionsSelect, FindOptionsWhere, In, MoreThan, Not, Repository } from 'typeorm'
+import { Box } from '../box/entities/box.entity'
+import { Job } from '../box/entities/job.entity'
+import { Runner } from '../box/entities/runner.entity'
+import { BoxState } from '../box/enums/box-state.enum'
+import { JobStatus } from '../box/enums/job-status.enum'
+import { ResourceType } from '../box/enums/resource-type.enum'
+import { BOX_ID_REGEX } from '../box/utils/box-id.util'
+import { Region } from '../region/entities/region.entity'
+import {
+  BACKOFFICE_INVENTORY_DEFAULT_LIMIT,
+  BackofficeBoxesQueryDto,
+  BackofficeRunnersQueryDto,
+} from './backoffice-inventory.dto'
+import {
+  BackofficeBoxSummary,
+  BackofficeRunnerCounts,
+  BackofficeRunnerSummary,
+  toBackofficeBoxSummary,
+  toBackofficeRunnerSummary,
+} from './backoffice-inventory.mapper'
+
+const ACTIVE_JOB_STATUSES = [JobStatus.PENDING, JobStatus.IN_PROGRESS]
+const INACTIVE_BOX_STATES = [BoxState.DESTROYED, BoxState.ARCHIVED]
+const DETAIL_REFERENCE_LIMIT = 200
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+const BOX_SELECT: FindOptionsSelect<Box> = {
+  id: true,
+  organizationId: true,
+  name: true,
+  region: true,
+  runnerId: true,
+  desiredState: true,
+  state: true,
+  cpu: true,
+  mem: true,
+  disk: true,
+  createdAt: true,
+  updatedAt: true,
+}
+
+const RUNNER_SELECT: FindOptionsSelect<Runner> = {
+  id: true,
+  name: true,
+  region: true,
+  state: true,
+  unschedulable: true,
+  draining: true,
+  apiVersion: true,
+  appVersion: true,
+  cpu: true,
+  memoryGiB: true,
+  diskGiB: true,
+  currentAllocatedCpu: true,
+  currentAllocatedMemoryGiB: true,
+  currentAllocatedDiskGiB: true,
+  currentCpuUsagePercentage: true,
+  currentMemoryUsagePercentage: true,
+  currentDiskUsagePercentage: true,
+  currentStartedBoxes: true,
+  availabilityScore: true,
+  lastChecked: true,
+  createdAt: true,
+  updatedAt: true,
+}
+
+type InventoryResource = 'boxes' | 'runners'
+
+interface InventoryCursor {
+  v: 1
+  resource: InventoryResource
+  id: string
+}
+
+interface CountRow {
+  id: string
+  status?: JobStatus
+  count: string
+}
+
+export interface BackofficeInventoryPage<T> {
+  items: T[]
+  nextCursor: string | null
+  limit: number
+  observedAt: string
+}
+
+export interface BackofficeBoxDetail extends BackofficeBoxSummary {
+  activeJobIds: string[]
+  activeJobIdsTruncated: boolean
+}
+
+export interface BackofficeRunnerDetail extends BackofficeRunnerSummary {
+  boxIds: string[]
+  boxIdsTruncated: boolean
+  activeJobIds: string[]
+  activeJobIdsTruncated: boolean
+}
+
+function encodeCursor(resource: InventoryResource, id: string): string {
+  return Buffer.from(JSON.stringify({ v: 1, resource, id } satisfies InventoryCursor)).toString('base64url')
+}
+
+function decodeCursor(resource: InventoryResource, cursor?: string): string | undefined {
+  if (!cursor) return undefined
+
+  try {
+    const value = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8')) as Partial<InventoryCursor>
+    const validId =
+      resource === 'boxes'
+        ? typeof value.id === 'string' && BOX_ID_REGEX.test(value.id)
+        : typeof value.id === 'string' && UUID.test(value.id)
+    if (value.v !== 1 || value.resource !== resource || !validId) throw new Error('invalid cursor')
+    return value.id
+  } catch {
+    throw new BadRequestException('Invalid pagination cursor')
+  }
+}
+
+function countById(rows: CountRow[]): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const row of rows) counts.set(row.id, (counts.get(row.id) ?? 0) + Number(row.count))
+  return counts
+}
+
+function boundedIds<T extends { id: string }>(items: T[]): { ids: string[]; truncated: boolean } {
+  return {
+    ids: items.slice(0, DETAIL_REFERENCE_LIMIT).map((item) => item.id),
+    truncated: items.length > DETAIL_REFERENCE_LIMIT,
+  }
+}
+
+@Injectable()
+export class BackofficeInventoryReader {
+  constructor(
+    @InjectRepository(Box) private readonly boxRepository: Repository<Box>,
+    @InjectRepository(Runner) private readonly runnerRepository: Repository<Runner>,
+    @InjectRepository(Job) private readonly jobRepository: Repository<Job>,
+    @InjectRepository(Region) private readonly regionRepository: Repository<Region>,
+  ) {}
+
+  async boxes(query: BackofficeBoxesQueryDto): Promise<BackofficeInventoryPage<BackofficeBoxSummary>> {
+    const limit = query.limit ?? BACKOFFICE_INVENTORY_DEFAULT_LIMIT
+    const cursorId = decodeCursor('boxes', query.cursor)
+    const where: FindOptionsWhere<Box> = {}
+    if (cursorId) where.id = MoreThan(cursorId)
+    if (query.organizationId) where.organizationId = query.organizationId
+    if (query.regionId) where.region = query.regionId
+    if (query.runnerId) where.runnerId = query.runnerId
+    if (query.state) where.state = query.state
+
+    const rows = await this.boxRepository.find({ select: BOX_SELECT, where, order: { id: 'ASC' }, take: limit + 1 })
+    const pageRows = rows.slice(0, limit)
+    const activeJobCounts = await this.boxActiveJobCounts(pageRows.map((box) => box.id))
+
+    return {
+      items: pageRows.map((box) => toBackofficeBoxSummary(box, activeJobCounts.get(box.id) ?? 0)),
+      nextCursor: rows.length > limit ? encodeCursor('boxes', pageRows[pageRows.length - 1].id) : null,
+      limit,
+      observedAt: new Date().toISOString(),
+    }
+  }
+
+  async box(id: string): Promise<BackofficeBoxDetail> {
+    if (!BOX_ID_REGEX.test(id)) throw new BadRequestException('Invalid Box ID')
+    const box = await this.boxRepository.findOne({ select: BOX_SELECT, where: { id } })
+    if (!box) throw new NotFoundException('Box not found')
+
+    const [activeJobCounts, activeJobs] = await Promise.all([
+      this.boxActiveJobCounts([id]),
+      this.jobRepository.find({
+        select: { id: true },
+        where: { resourceType: ResourceType.BOX, resourceId: id, status: In(ACTIVE_JOB_STATUSES) },
+        order: { id: 'ASC' },
+        take: DETAIL_REFERENCE_LIMIT + 1,
+      }),
+    ])
+    const references = boundedIds(activeJobs)
+    return {
+      ...toBackofficeBoxSummary(box, activeJobCounts.get(id) ?? 0),
+      activeJobIds: references.ids,
+      activeJobIdsTruncated: references.truncated,
+    }
+  }
+
+  async runners(query: BackofficeRunnersQueryDto): Promise<BackofficeInventoryPage<BackofficeRunnerSummary>> {
+    const limit = query.limit ?? BACKOFFICE_INVENTORY_DEFAULT_LIMIT
+    const cursorId = decodeCursor('runners', query.cursor)
+    const where: FindOptionsWhere<Runner> = {}
+    if (cursorId) where.id = MoreThan(cursorId)
+    if (query.regionId) where.region = query.regionId
+    if (query.state) where.state = query.state
+
+    if (query.organizationId) {
+      const regions = await this.regionRepository.find({
+        select: { id: true },
+        where: { organizationId: query.organizationId },
+      })
+      const regionIds = regions.map((region) => region.id)
+      if (query.regionId) {
+        if (!regionIds.includes(query.regionId)) return this.emptyPage(limit)
+      } else {
+        if (regionIds.length === 0) return this.emptyPage(limit)
+        where.region = In(regionIds)
+      }
+    }
+
+    const rows = await this.runnerRepository.find({
+      select: RUNNER_SELECT,
+      where,
+      order: { id: 'ASC' },
+      take: limit + 1,
+    })
+    const pageRows = rows.slice(0, limit)
+    const counts = await this.runnerCounts(pageRows.map((runner) => runner.id))
+
+    return {
+      items: pageRows.map((runner) => toBackofficeRunnerSummary(runner, counts.get(runner.id) ?? this.zeroCounts())),
+      nextCursor: rows.length > limit ? encodeCursor('runners', pageRows[pageRows.length - 1].id) : null,
+      limit,
+      observedAt: new Date().toISOString(),
+    }
+  }
+
+  async runner(id: string): Promise<BackofficeRunnerDetail> {
+    if (!UUID.test(id)) throw new BadRequestException('Invalid Runner ID')
+    const runner = await this.runnerRepository.findOne({ select: RUNNER_SELECT, where: { id } })
+    if (!runner) throw new NotFoundException('Runner not found')
+
+    const [counts, boxes, activeJobs] = await Promise.all([
+      this.runnerCounts([id]),
+      this.boxRepository.find({
+        select: { id: true },
+        where: { runnerId: id, state: Not(In(INACTIVE_BOX_STATES)) },
+        order: { id: 'ASC' },
+        take: DETAIL_REFERENCE_LIMIT + 1,
+      }),
+      this.jobRepository.find({
+        select: { id: true },
+        where: { runnerId: id, status: In(ACTIVE_JOB_STATUSES) },
+        order: { id: 'ASC' },
+        take: DETAIL_REFERENCE_LIMIT + 1,
+      }),
+    ])
+    const boxReferences = boundedIds(boxes)
+    const jobReferences = boundedIds(activeJobs)
+    return {
+      ...toBackofficeRunnerSummary(runner, counts.get(id) ?? this.zeroCounts()),
+      boxIds: boxReferences.ids,
+      boxIdsTruncated: boxReferences.truncated,
+      activeJobIds: jobReferences.ids,
+      activeJobIdsTruncated: jobReferences.truncated,
+    }
+  }
+
+  private async boxActiveJobCounts(boxIds: string[]): Promise<Map<string, number>> {
+    if (boxIds.length === 0) return new Map()
+    const rows = await this.jobRepository
+      .createQueryBuilder('boxJob')
+      .select('boxJob.resourceId', 'id')
+      .addSelect('boxJob.status', 'status')
+      .addSelect('COUNT(boxJob.id)', 'count')
+      .where('boxJob.resourceType = :resourceType', { resourceType: ResourceType.BOX })
+      .andWhere('boxJob.resourceId IN (:...boxIds)', { boxIds })
+      .andWhere('boxJob.status IN (:...statuses)', { statuses: ACTIVE_JOB_STATUSES })
+      .groupBy('boxJob.resourceId')
+      .addGroupBy('boxJob.status')
+      .getRawMany<CountRow>()
+    return countById(rows)
+  }
+
+  private async runnerCounts(runnerIds: string[]): Promise<Map<string, BackofficeRunnerCounts>> {
+    if (runnerIds.length === 0) return new Map()
+    const [boxRows, jobRows] = await Promise.all([
+      this.boxRepository
+        .createQueryBuilder('box')
+        .select('box.runnerId', 'id')
+        .addSelect('COUNT(box.id)', 'count')
+        .where('box.runnerId IN (:...runnerIds)', { runnerIds })
+        .andWhere('box.state NOT IN (:...inactiveStates)', { inactiveStates: INACTIVE_BOX_STATES })
+        .groupBy('box.runnerId')
+        .getRawMany<CountRow>(),
+      this.jobRepository
+        .createQueryBuilder('runnerJob')
+        .select('runnerJob.runnerId', 'id')
+        .addSelect('runnerJob.status', 'status')
+        .addSelect('COUNT(runnerJob.id)', 'count')
+        .where('runnerJob.runnerId IN (:...runnerIds)', { runnerIds })
+        .andWhere('runnerJob.status IN (:...statuses)', { statuses: ACTIVE_JOB_STATUSES })
+        .groupBy('runnerJob.runnerId')
+        .addGroupBy('runnerJob.status')
+        .getRawMany<CountRow>(),
+    ])
+    const counts = new Map<string, BackofficeRunnerCounts>()
+    for (const runnerId of runnerIds) counts.set(runnerId, this.zeroCounts())
+    for (const row of boxRows) {
+      const runnerCounts = counts.get(row.id)
+      if (runnerCounts) runnerCounts.boxCount = Number(row.count)
+    }
+    for (const row of jobRows) {
+      const runnerCounts = counts.get(row.id)
+      if (!runnerCounts) continue
+      const count = Number(row.count)
+      runnerCounts.activeJobCount += count
+      if (row.status === JobStatus.PENDING) runnerCounts.queueDepth += count
+    }
+    return counts
+  }
+
+  private emptyPage<T>(limit: number): BackofficeInventoryPage<T> {
+    return { items: [], nextCursor: null, limit, observedAt: new Date().toISOString() }
+  }
+
+  private zeroCounts(): BackofficeRunnerCounts {
+    return { boxCount: 0, activeJobCount: 0, queueDepth: 0 }
+  }
+}

--- a/apps/api/src/backoffice-internal/backoffice-workload-auth.spec.ts
+++ b/apps/api/src/backoffice-internal/backoffice-workload-auth.spec.ts
@@ -60,7 +60,7 @@ describe('Backoffice workload authentication', () => {
     expect(authenticator.authenticate(`Bearer ${token}`)).toEqual({
       role: 'backoffice-workload',
       credential: 'read',
-      routeScopes: [BackofficeWorkloadRouteScope.READINESS],
+      routeScopes: Object.values(BackofficeWorkloadRouteScope),
     })
   })
 
@@ -108,7 +108,7 @@ describe('Backoffice workload authentication', () => {
     expect(request.user).toEqual({
       role: 'backoffice-workload',
       credential: 'read',
-      routeScopes: [BackofficeWorkloadRouteScope.READINESS],
+      routeScopes: Object.values(BackofficeWorkloadRouteScope),
     })
   })
 
@@ -128,6 +128,25 @@ describe('Backoffice workload authentication', () => {
     const { context, request } = executionContext(ScopedHandler.prototype.readiness, `Bearer ${CURRENT_TOKEN}`)
     request.originalUrl = '/api/internal/backoffice/v1/boxes'
 
+    expect(() => guard.canActivate(context)).toThrow(ForbiddenException)
+  })
+
+  it.each([
+    [BackofficeWorkloadRouteScope.BOXES, '/api/internal/backoffice/v1/boxes'],
+    [BackofficeWorkloadRouteScope.BOX, '/api/internal/backoffice/v1/boxes/AbCdEf123456'],
+    [BackofficeWorkloadRouteScope.RUNNERS, '/api/internal/backoffice/v1/runners'],
+    [BackofficeWorkloadRouteScope.RUNNER, '/api/internal/backoffice/v1/runners/22222222-2222-4222-8222-222222222222'],
+  ])('matches the protected inventory scope %s without widening it', (scope, originalUrl) => {
+    class InventoryHandler {
+      @RequireBackofficeWorkloadRoute(scope)
+      read() {}
+    }
+    const guard = new BackofficeWorkloadAuthGuard(new BackofficeWorkloadAuthenticator(config()), new Reflector())
+    const { context, request } = executionContext(InventoryHandler.prototype.read, `Bearer ${CURRENT_TOKEN}`)
+    request.originalUrl = originalUrl
+
+    expect(guard.canActivate(context)).toBe(true)
+    request.originalUrl = `${originalUrl}/unexpected`
     expect(() => guard.canActivate(context)).toThrow(ForbiddenException)
   })
 })

--- a/apps/api/src/backoffice-internal/backoffice-workload-auth.spec.ts
+++ b/apps/api/src/backoffice-internal/backoffice-workload-auth.spec.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { createHash } from 'node:crypto'
+import { ForbiddenException, NotFoundException, UnauthorizedException } from '@nestjs/common'
+import { Reflector } from '@nestjs/core'
+import type { ExecutionContext } from '@nestjs/common'
+import { TypedConfigService } from '../config/typed-config.service'
+import {
+  BackofficeWorkloadAuthenticator,
+  BackofficeWorkloadAuthGuard,
+  BackofficeWorkloadRouteScope,
+  RequireBackofficeWorkloadRoute,
+} from './backoffice-workload-auth'
+
+const CURRENT_TOKEN = 'synthetic-current-workload-token'
+const NEXT_TOKEN = 'synthetic-next-workload-token'
+const digest = (token: string) => createHash('sha256').update(token).digest('hex')
+
+function config(enabled = true) {
+  const values: Record<string, unknown> = {
+    'backofficeInternal.enabled': enabled,
+    'backofficeInternal.readTokenDigests.current': enabled ? digest(CURRENT_TOKEN) : undefined,
+    'backofficeInternal.readTokenDigests.next': enabled ? digest(NEXT_TOKEN) : undefined,
+  }
+  return {
+    get: jest.fn((key: string) => values[key]),
+  } as unknown as TypedConfigService
+}
+
+class ScopedHandler {
+  @RequireBackofficeWorkloadRoute(BackofficeWorkloadRouteScope.READINESS)
+  readiness() {}
+
+  undecorated() {}
+}
+
+function executionContext(handler: () => void, authorization?: string): { context: ExecutionContext; request: any } {
+  const request = {
+    method: 'GET',
+    originalUrl: '/api/internal/backoffice/v1/readiness',
+    headers: { authorization },
+  }
+  return {
+    request,
+    context: {
+      getHandler: () => handler,
+      getClass: () => ScopedHandler,
+      switchToHttp: () => ({ getRequest: () => request }),
+    } as unknown as ExecutionContext,
+  }
+}
+
+describe('Backoffice workload authentication', () => {
+  it.each([CURRENT_TOKEN, NEXT_TOKEN])('accepts a configured rotation slot', (token) => {
+    const authenticator = new BackofficeWorkloadAuthenticator(config())
+
+    expect(authenticator.authenticate(`Bearer ${token}`)).toEqual({
+      role: 'backoffice-workload',
+      credential: 'read',
+      routeScopes: [BackofficeWorkloadRouteScope.READINESS],
+    })
+  })
+
+  it.each([
+    undefined,
+    '',
+    'Basic synthetic-current-workload-token',
+    'Bearer',
+    'Bearer ',
+    'Bearer wrong-workload-token',
+    'Bearer token with spaces',
+  ])('rejects missing, malformed, or invalid authorization without reflecting it', (authorization) => {
+    const authenticator = new BackofficeWorkloadAuthenticator(config())
+
+    try {
+      authenticator.authenticate(authorization)
+      throw new Error('expected authentication to fail')
+    } catch (error) {
+      expect(error).toBeInstanceOf(UnauthorizedException)
+      if (authorization) {
+        expect(String(error)).not.toContain(authorization)
+      }
+    }
+  })
+
+  it('hides the route while the feature is disabled', () => {
+    const guard = new BackofficeWorkloadAuthGuard(new BackofficeWorkloadAuthenticator(config(false)), new Reflector())
+    const { context } = executionContext(ScopedHandler.prototype.readiness, `Bearer ${CURRENT_TOKEN}`)
+
+    expect(() => guard.canActivate(context)).toThrow(NotFoundException)
+  })
+
+  it('fails closed when a guarded handler has no declared route scope', () => {
+    const guard = new BackofficeWorkloadAuthGuard(new BackofficeWorkloadAuthenticator(config()), new Reflector())
+    const { context } = executionContext(ScopedHandler.prototype.undecorated, `Bearer ${CURRENT_TOKEN}`)
+
+    expect(() => guard.canActivate(context)).toThrow(ForbiddenException)
+  })
+
+  it('attaches the validated workload principal for the declared route scope', () => {
+    const guard = new BackofficeWorkloadAuthGuard(new BackofficeWorkloadAuthenticator(config()), new Reflector())
+    const { context, request } = executionContext(ScopedHandler.prototype.readiness, `Bearer ${CURRENT_TOKEN}`)
+
+    expect(guard.canActivate(context)).toBe(true)
+    expect(request.user).toEqual({
+      role: 'backoffice-workload',
+      credential: 'read',
+      routeScopes: [BackofficeWorkloadRouteScope.READINESS],
+    })
+  })
+
+  it('rejects a valid principal that lacks the route scope', () => {
+    const authenticator = {
+      isEnabled: () => true,
+      authenticate: () => ({ role: 'backoffice-workload', credential: 'read', routeScopes: [] }),
+    }
+    const guard = new BackofficeWorkloadAuthGuard(authenticator as any, new Reflector())
+    const { context } = executionContext(ScopedHandler.prototype.readiness, `Bearer ${CURRENT_TOKEN}`)
+
+    expect(() => guard.canActivate(context)).toThrow(ForbiddenException)
+  })
+
+  it('rejects a scope annotation applied to a different method or path', () => {
+    const guard = new BackofficeWorkloadAuthGuard(new BackofficeWorkloadAuthenticator(config()), new Reflector())
+    const { context, request } = executionContext(ScopedHandler.prototype.readiness, `Bearer ${CURRENT_TOKEN}`)
+    request.originalUrl = '/api/internal/backoffice/v1/boxes'
+
+    expect(() => guard.canActivate(context)).toThrow(ForbiddenException)
+  })
+})

--- a/apps/api/src/backoffice-internal/backoffice-workload-auth.ts
+++ b/apps/api/src/backoffice-internal/backoffice-workload-auth.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { createHash, timingSafeEqual } from 'node:crypto'
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+  SetMetadata,
+  UnauthorizedException,
+} from '@nestjs/common'
+import { Reflector } from '@nestjs/core'
+import type { Request } from 'express'
+import { TypedConfigService } from '../config/typed-config.service'
+
+export const BackofficeWorkloadRouteScope = {
+  READINESS: 'GET /api/internal/backoffice/v1/readiness',
+} as const
+
+export type BackofficeWorkloadRouteScope =
+  (typeof BackofficeWorkloadRouteScope)[keyof typeof BackofficeWorkloadRouteScope]
+
+export interface BackofficeWorkloadPrincipal {
+  role: 'backoffice-workload'
+  credential: 'read'
+  routeScopes: BackofficeWorkloadRouteScope[]
+}
+
+const BACKOFFICE_WORKLOAD_ROUTE_SCOPE = 'backoffice-workload-route-scope'
+const BEARER_AUTHORIZATION = /^Bearer ([A-Za-z0-9\-._~+/]+=*)$/i
+
+export const RequireBackofficeWorkloadRoute = (scope: BackofficeWorkloadRouteScope) =>
+  SetMetadata(BACKOFFICE_WORKLOAD_ROUTE_SCOPE, scope)
+
+@Injectable()
+export class BackofficeWorkloadAuthenticator {
+  private readonly enabled: boolean
+  private readonly readTokenDigests: Buffer[]
+
+  constructor(config: TypedConfigService) {
+    this.enabled = config.get('backofficeInternal.enabled')
+    this.readTokenDigests = [
+      config.get('backofficeInternal.readTokenDigests.current'),
+      config.get('backofficeInternal.readTokenDigests.next'),
+    ]
+      .filter((digest): digest is string => digest !== undefined)
+      .map((digest) => Buffer.from(digest, 'hex'))
+  }
+
+  isEnabled(): boolean {
+    return this.enabled
+  }
+
+  authenticate(authorization: unknown): BackofficeWorkloadPrincipal {
+    const match = typeof authorization === 'string' ? BEARER_AUTHORIZATION.exec(authorization) : null
+    if (!match) {
+      throw new UnauthorizedException('Valid Backoffice workload credentials are required')
+    }
+
+    const presentedDigest = createHash('sha256').update(match[1]).digest()
+    let matched = 0
+    for (const configuredDigest of this.readTokenDigests) {
+      matched |= Number(timingSafeEqual(presentedDigest, configuredDigest))
+    }
+    if (matched === 0) {
+      throw new UnauthorizedException('Valid Backoffice workload credentials are required')
+    }
+
+    return {
+      role: 'backoffice-workload',
+      credential: 'read',
+      routeScopes: [BackofficeWorkloadRouteScope.READINESS],
+    }
+  }
+}
+
+type BackofficeRequest = Request & { user?: BackofficeWorkloadPrincipal }
+
+@Injectable()
+export class BackofficeWorkloadAuthGuard implements CanActivate {
+  constructor(
+    private readonly authenticator: BackofficeWorkloadAuthenticator,
+    private readonly reflector: Reflector,
+  ) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    if (!this.authenticator.isEnabled()) {
+      throw new NotFoundException()
+    }
+
+    const requiredScope = this.reflector.get<BackofficeWorkloadRouteScope>(
+      BACKOFFICE_WORKLOAD_ROUTE_SCOPE,
+      context.getHandler(),
+    )
+    if (!requiredScope) {
+      throw new ForbiddenException('Backoffice workload route scope is required')
+    }
+
+    const request = context.switchToHttp().getRequest<BackofficeRequest>()
+    const requestedScope = `${request.method} ${request.originalUrl?.split('?', 1)[0]}`
+    if (requestedScope !== requiredScope) {
+      throw new ForbiddenException('Backoffice workload route scope does not match the request')
+    }
+
+    const principal = this.authenticator.authenticate(request.headers.authorization)
+    if (!principal.routeScopes.includes(requiredScope)) {
+      throw new ForbiddenException('Backoffice workload credential is not allowed for this route')
+    }
+
+    request.user = principal
+    return true
+  }
+}

--- a/apps/api/src/backoffice-internal/backoffice-workload-auth.ts
+++ b/apps/api/src/backoffice-internal/backoffice-workload-auth.ts
@@ -19,6 +19,10 @@ import { TypedConfigService } from '../config/typed-config.service'
 
 export const BackofficeWorkloadRouteScope = {
   READINESS: 'GET /api/internal/backoffice/v1/readiness',
+  BOXES: 'GET /api/internal/backoffice/v1/boxes',
+  BOX: 'GET /api/internal/backoffice/v1/boxes/:boxId',
+  RUNNERS: 'GET /api/internal/backoffice/v1/runners',
+  RUNNER: 'GET /api/internal/backoffice/v1/runners/:runnerId',
 } as const
 
 export type BackofficeWorkloadRouteScope =
@@ -32,6 +36,13 @@ export interface BackofficeWorkloadPrincipal {
 
 const BACKOFFICE_WORKLOAD_ROUTE_SCOPE = 'backoffice-workload-route-scope'
 const BEARER_AUTHORIZATION = /^Bearer ([A-Za-z0-9\-._~+/]+=*)$/i
+const ROUTE_SCOPE_PATTERNS: Record<BackofficeWorkloadRouteScope, RegExp> = {
+  [BackofficeWorkloadRouteScope.READINESS]: /^GET \/api\/internal\/backoffice\/v1\/readiness$/,
+  [BackofficeWorkloadRouteScope.BOXES]: /^GET \/api\/internal\/backoffice\/v1\/boxes$/,
+  [BackofficeWorkloadRouteScope.BOX]: /^GET \/api\/internal\/backoffice\/v1\/boxes\/[^/]+$/,
+  [BackofficeWorkloadRouteScope.RUNNERS]: /^GET \/api\/internal\/backoffice\/v1\/runners$/,
+  [BackofficeWorkloadRouteScope.RUNNER]: /^GET \/api\/internal\/backoffice\/v1\/runners\/[^/]+$/,
+}
 
 export const RequireBackofficeWorkloadRoute = (scope: BackofficeWorkloadRouteScope) =>
   SetMetadata(BACKOFFICE_WORKLOAD_ROUTE_SCOPE, scope)
@@ -73,7 +84,7 @@ export class BackofficeWorkloadAuthenticator {
     return {
       role: 'backoffice-workload',
       credential: 'read',
-      routeScopes: [BackofficeWorkloadRouteScope.READINESS],
+      routeScopes: Object.values(BackofficeWorkloadRouteScope),
     }
   }
 }
@@ -102,7 +113,7 @@ export class BackofficeWorkloadAuthGuard implements CanActivate {
 
     const request = context.switchToHttp().getRequest<BackofficeRequest>()
     const requestedScope = `${request.method} ${request.originalUrl?.split('?', 1)[0]}`
-    if (requestedScope !== requiredScope) {
+    if (!ROUTE_SCOPE_PATTERNS[requiredScope].test(requestedScope)) {
       throw new ForbiddenException('Backoffice workload route scope does not match the request')
     }
 

--- a/apps/api/src/common/utils/pino.util.spec.ts
+++ b/apps/api/src/common/utils/pino.util.spec.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Writable } from 'node:stream'
+import pino from 'pino'
+import { PINO_HTTP_REDACT } from './pino.util'
+
+describe('Pino request redaction', () => {
+  it('removes bearer credentials while retaining non-sensitive request context', async () => {
+    const token = 'synthetic-log-redaction-workload-token'
+    let output = ''
+    const destination = new Writable({
+      write(chunk, _encoding, callback) {
+        output += chunk.toString()
+        callback()
+      },
+    })
+    const logger = pino({ redact: PINO_HTTP_REDACT }, destination)
+
+    logger.info({ req: { method: 'GET', headers: { authorization: `Bearer ${token}`, accept: 'application/json' } } })
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(output).not.toContain(token)
+    expect(JSON.parse(output)).toMatchObject({
+      req: {
+        method: 'GET',
+        headers: {
+          authorization: '[REDACTED]',
+          accept: 'application/json',
+        },
+      },
+    })
+  })
+})

--- a/apps/api/src/common/utils/pino.util.ts
+++ b/apps/api/src/common/utils/pino.util.ts
@@ -7,6 +7,11 @@
 import pino, { TransportSingleOptions } from 'pino'
 import { TypedConfigService } from '../../config/typed-config.service'
 
+export const PINO_HTTP_REDACT = {
+  paths: ['req.headers.authorization'],
+  censor: '[REDACTED]',
+}
+
 /*
  * This is a workaround to swap the message and object in the arguments array.
  * It is needed because the logger in nestjs-pino is not compatible with nestjs console logger.

--- a/apps/api/src/config/backoffice-internal-config.spec.ts
+++ b/apps/api/src/config/backoffice-internal-config.spec.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { createHash } from 'node:crypto'
+import { backofficeInternalConfig } from './configuration'
+
+const digest = (token: string) => createHash('sha256').update(token).digest('hex')
+
+describe('backoffice internal config', () => {
+  it('is disabled by default without requiring credential digests', () => {
+    expect(backofficeInternalConfig({})).toEqual({
+      enabled: false,
+      readTokenDigests: {
+        current: undefined,
+        next: undefined,
+      },
+    })
+  })
+
+  it('fails closed when enabled without a current read-token digest', () => {
+    expect(() =>
+      backofficeInternalConfig({
+        BACKOFFICE_INTERNAL_API_ENABLED: 'true',
+      }),
+    ).toThrow('BACKOFFICE_READ_TOKEN_DIGEST_CURRENT is required when BACKOFFICE_INTERNAL_API_ENABLED is true')
+  })
+
+  it('accepts a bounded current/next digest overlap and normalizes hex case', () => {
+    const current = digest('synthetic-current-workload-token')
+    const next = digest('synthetic-next-workload-token').toUpperCase()
+
+    expect(
+      backofficeInternalConfig({
+        BACKOFFICE_INTERNAL_API_ENABLED: 'true',
+        BACKOFFICE_READ_TOKEN_DIGEST_CURRENT: current,
+        BACKOFFICE_READ_TOKEN_DIGEST_NEXT: next,
+      }),
+    ).toEqual({
+      enabled: true,
+      readTokenDigests: {
+        current,
+        next: next.toLowerCase(),
+      },
+    })
+  })
+
+  it('rejects malformed digests without echoing their value', () => {
+    const malformed = 'not-a-sha256-digest'
+
+    expect(() =>
+      backofficeInternalConfig({
+        BACKOFFICE_READ_TOKEN_DIGEST_CURRENT: malformed,
+      }),
+    ).toThrow('BACKOFFICE_READ_TOKEN_DIGEST_CURRENT must be a SHA-256 hex digest')
+
+    try {
+      backofficeInternalConfig({ BACKOFFICE_READ_TOKEN_DIGEST_CURRENT: malformed })
+    } catch (error) {
+      expect(String(error)).not.toContain(malformed)
+    }
+  })
+})

--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -199,6 +199,36 @@ export function boxMigrationConfig(env: NodeJS.ProcessEnv = process.env) {
   return { archivePrefix: `${scheme}${segments.join('/')}/` }
 }
 
+const SHA256_HEX_DIGEST = /^[a-fA-F0-9]{64}$/
+
+function optionalSha256Digest(value: string | undefined, name: string): string | undefined {
+  const digest = value?.trim()
+  if (!digest) {
+    return undefined
+  }
+  if (!SHA256_HEX_DIGEST.test(digest)) {
+    // A malformed value may still be derived from a credential. Name the
+    // setting, never the value, so boot failures remain safe to log.
+    throw new Error(`${name} must be a SHA-256 hex digest`)
+  }
+  return digest.toLowerCase()
+}
+
+export function backofficeInternalConfig(env: NodeJS.ProcessEnv = process.env) {
+  const enabled = env.BACKOFFICE_INTERNAL_API_ENABLED === 'true'
+  const current = optionalSha256Digest(env.BACKOFFICE_READ_TOKEN_DIGEST_CURRENT, 'BACKOFFICE_READ_TOKEN_DIGEST_CURRENT')
+  const next = optionalSha256Digest(env.BACKOFFICE_READ_TOKEN_DIGEST_NEXT, 'BACKOFFICE_READ_TOKEN_DIGEST_NEXT')
+
+  if (enabled && !current) {
+    throw new Error('BACKOFFICE_READ_TOKEN_DIGEST_CURRENT is required when BACKOFFICE_INTERNAL_API_ENABLED is true')
+  }
+
+  return {
+    enabled,
+    readTokenDigests: { current, next },
+  }
+}
+
 const configuration = {
   production: process.env.NODE_ENV === 'production',
   version: process.env.VERSION || '0.0.0-dev',
@@ -466,6 +496,7 @@ const configuration = {
   admin: {
     apiKey: process.env.ADMIN_API_KEY,
   },
+  backofficeInternal: backofficeInternalConfig(),
   skipUserEmailVerification: process.env.SKIP_USER_EMAIL_VERIFICATION === 'true',
   // Whether a newly created non-default organization starts suspended until a
   // payment method exists. Separate from billingApiUrl on purpose: pointing the

--- a/apps/infra/.env.example
+++ b/apps/infra/.env.example
@@ -162,6 +162,12 @@ OIDC_AUDIENCE=https://dev.example.com/api
 # PROXY_API_KEY=
 # DEFAULT_RUNNER_API_KEY=
 
+# Backoffice workload API is disabled by default. The two credentials below
+# are SST secrets containing SHA-256 hex digests, never raw Bearer tokens:
+#   BACKOFFICE_READ_TOKEN_DIGEST_CURRENT
+#   BACKOFFICE_READ_TOKEN_DIGEST_NEXT
+# BACKOFFICE_INTERNAL_API_ENABLED=false
+
 # 4c. Endpoints & URLs — auto-derived from STACK_DOMAIN; pin for custom DNS /
 # topology. PROXY_DOMAIN configures the public hostname, certificate, and
 # wildcard alias on SST's TLS NLB listener; keep the URL values aligned with it.

--- a/apps/infra/deployment/key-policy.ts
+++ b/apps/infra/deployment/key-policy.ts
@@ -37,6 +37,7 @@ import { CLICKHOUSE_STAGE_CONFIG_KEYS } from './clickhouse.js'
 export const STORABLE_STAGE_CONFIG_KEYS: readonly string[] = [
   'ADMIN_API_KEY',
   'APP_URL',
+  'BACKOFFICE_INTERNAL_API_ENABLED',
   'BILLING_API_URL',
   'BOXLITE_API_KEY',
   'BOXLITE_API_URL',
@@ -232,6 +233,8 @@ const STORE_EXCLUDED_KEYS = new Set([
  * it here fails rather than quietly becoming clobberable.
  */
 export const APP_SECRET_NAMES = [
+  'BACKOFFICE_READ_TOKEN_DIGEST_CURRENT',
+  'BACKOFFICE_READ_TOKEN_DIGEST_NEXT',
   'OIDC_CLIENT_ID',
   'OIDC_MANAGEMENT_API_CLIENT_ID',
   'OIDC_MANAGEMENT_API_CLIENT_SECRET',

--- a/apps/infra/docs/deployment.md
+++ b/apps/infra/docs/deployment.md
@@ -363,7 +363,7 @@ each stage you run.
 
 | What | Stored in | Set by |
 | --- | --- | --- |
-| App secrets (`OIDC_CLIENT_ID`, Auth0 Management API, Svix, PostHog, `USAGE_EXPORT_TOKEN`) | SST secret store | `npm run bootstrap`; others via `npm run sst -- secret set <NAME> --stage <stage>` reading stdin |
+| App secrets (`OIDC_CLIENT_ID`, Auth0 Management API, Svix, PostHog, `USAGE_EXPORT_TOKEN`, Backoffice read-token digests) | SST secret store | `npm run bootstrap`; others via `npm run sst -- secret set <NAME> --stage <stage>` reading stdin |
 | SES SMTP credential (`SMTP_USER`, `SMTP_PASSWORD`) | SST secret store | `npm run bootstrap -- --stage <stage> --provision-ses`, which mints the send-only IAM user the deploy role cannot create and derives the SMTP password from its key. Rerunning rotates it |
 | Cloudflare creds (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_DEFAULT_ACCOUNT_ID`) | AWS SSM SecureString for local use; GitHub Environment secrets for CI (which win) | `npm run bootstrap` |
 | Stage config (`STACK_DOMAIN`, `OIDC_*`, toggles) | SST secret store | `npm run bootstrap`, from your local `.env` |

--- a/apps/infra/stack/api.ts
+++ b/apps/infra/stack/api.ts
@@ -36,6 +36,8 @@ export interface ApiInputs {
   oidcMgmtClientSecret: sst.Secret
   posthogApiKey: sst.Secret
   svixAuthToken: sst.Secret
+  backofficeReadTokenDigestCurrent: sst.Secret
+  backofficeReadTokenDigestNext: sst.Secret
   usageExportToken: sst.Secret
   oidcIssuer: string
   publicOidcIssuer: string | undefined
@@ -70,6 +72,8 @@ export function buildApi(input: ApiInputs) {
     oidcMgmtClientSecret,
     posthogApiKey,
     svixAuthToken,
+    backofficeReadTokenDigestCurrent,
+    backofficeReadTokenDigestNext,
     usageExportToken,
     oidcIssuer,
     publicOidcIssuer,
@@ -276,6 +280,12 @@ const api = new sst.aws.Service('Api', {
 
     // Admin
     ADMIN_API_KEY: envOr('ADMIN_API_KEY', adminApiKey.result),
+
+    // Backoffice workload access is opt-in. Only SHA-256 digests reach the
+    // task; current/next provide a bounded credential-rotation overlap.
+    BACKOFFICE_INTERNAL_API_ENABLED: envOr('BACKOFFICE_INTERNAL_API_ENABLED', 'false'),
+    BACKOFFICE_READ_TOKEN_DIGEST_CURRENT: backofficeReadTokenDigestCurrent.value,
+    BACKOFFICE_READ_TOKEN_DIGEST_NEXT: backofficeReadTokenDigestNext.value,
 
     // Observability read/write path. These stay server-side; never expose
     // ClickHouse credentials to the dashboard bundle.

--- a/apps/infra/stack/contract.test.ts
+++ b/apps/infra/stack/contract.test.ts
@@ -475,6 +475,24 @@ test('passes explicit management API endpoints into the API service', () => {
   assert.match(apiService, /OIDC_MANAGEMENT_API_TOKEN_URL: process\.env\.OIDC_MANAGEMENT_API_TOKEN_URL/)
 })
 
+test('keeps Backoffice workload credentials digest-only and disabled by default', () => {
+  const apiService = configSection("const api = new sst.aws.Service('Api'", '// Assumed by the Api task role')
+
+  assert.match(liveConfig, /new sst\.Secret\('BACKOFFICE_READ_TOKEN_DIGEST_CURRENT', ''\)/)
+  assert.match(liveConfig, /new sst\.Secret\('BACKOFFICE_READ_TOKEN_DIGEST_NEXT', ''\)/)
+  assert.match(
+    apiService,
+    /BACKOFFICE_INTERNAL_API_ENABLED: envOr\('BACKOFFICE_INTERNAL_API_ENABLED', 'false'\)/,
+  )
+  assert.match(
+    apiService,
+    /BACKOFFICE_READ_TOKEN_DIGEST_CURRENT: backofficeReadTokenDigestCurrent\.value/,
+  )
+  assert.match(apiService, /BACKOFFICE_READ_TOKEN_DIGEST_NEXT: backofficeReadTokenDigestNext\.value/)
+  assert.doesNotMatch(liveConfig, /BACKOFFICE_READ_TOKEN(?:[^_]|$)/)
+  assert.doesNotMatch(environmentExample, /^BACKOFFICE_READ_TOKEN=/m)
+})
+
 test('reports the canonical workspace release unless VERSION overrides it', () => {
   assert.match(liveConfig, /const workspaceVersion = readWorkspaceVersion\(\)/)
   assert.match(liveConfig, /resolvePublicDeploymentConfig\(process\.env, workspaceVersion\)/)

--- a/apps/infra/stack/deploy.ts
+++ b/apps/infra/stack/deploy.ts
@@ -85,6 +85,11 @@ export async function deployStack() {
     const oidcMgmtClientSecret = new sst.Secret('OIDC_MANAGEMENT_API_CLIENT_SECRET')
     const posthogApiKey = new sst.Secret('POSTHOG_API_KEY', '')
     const svixAuthToken = new sst.Secret('SVIX_AUTH_TOKEN', '')
+    // BoxLite receives only one-way token digests. The raw Backoffice
+    // credential remains in Backoffice's secret store and never enters this
+    // stack's state, task definition, logs, or environment.
+    const backofficeReadTokenDigestCurrent = new sst.Secret('BACKOFFICE_READ_TOKEN_DIGEST_CURRENT', '')
+    const backofficeReadTokenDigestNext = new sst.Secret('BACKOFFICE_READ_TOKEN_DIGEST_NEXT', '')
     // The credential the usage exporter presents to Commerce's ingest route:
     // half of a shared secret whose other half is a Secrets Manager container
     // owned by boxlite-commerce's own stack, so both ends are set out of band
@@ -264,6 +269,8 @@ export async function deployStack() {
       oidcMgmtClientSecret,
       posthogApiKey,
       svixAuthToken,
+      backofficeReadTokenDigestCurrent,
+      backofficeReadTokenDigestNext,
       usageExportToken,
       oidcIssuer,
       publicOidcIssuer,


### PR DESCRIPTION
## Summary

Add protected, read-only Backoffice APIs for querying Box and Runner inventory across organizations. Provide stable pagination, filtering, bounded detail references, and explicit response-field allowlists without exposing credentials or internal configuration.

## Call graph

Before

```text
canActivate  (BackofficeWorkloadAuthGuard · apps/api/src/backoffice-internal/backoffice-workload-auth.ts:101)  — protects readiness only
  └─ readiness  (BackofficeInternalController · apps/api/src/backoffice-internal/backoffice-internal.controller.ts:25)  — advertises no inventory capabilities
```

After

```text
canActivate  (BackofficeWorkloadAuthGuard · apps/api/src/backoffice-internal/backoffice-workload-auth.ts:101)  — enforce the exact Bearer-authenticated inventory route scope
  └─ boxes / box / runners / runner  (BackofficeInternalController · apps/api/src/backoffice-internal/backoffice-internal.controller.ts:37)  — validate input and expose no-store read endpoints
       └─ boxes / box / runners / runner  (BackofficeInventoryReader · apps/api/src/backoffice-internal/backoffice-inventory.reader.ts:150)  — apply cross-organization filters, keyset pagination, bounded counts, and explicit database selects
            ├─ toBackofficeBoxSummary  (Mapper · apps/api/src/backoffice-internal/backoffice-inventory.mapper.ts:81)  — map the Box response allowlist
            └─ toBackofficeRunnerSummary  (Mapper · apps/api/src/backoffice-internal/backoffice-inventory.mapper.ts:102)  — map the Runner response allowlist
```

## Changes

- Add four read-only endpoints:
  - `GET /api/internal/backoffice/v1/boxes`
  - `GET /api/internal/backoffice/v1/boxes/:boxId`
  - `GET /api/internal/backoffice/v1/runners`
  - `GET /api/internal/backoffice/v1/runners/:runnerId`
- Extend the Bearer route scopes with exact method/path matching for each endpoint.
- Support cross-organization queries with organization, region, runner, and state filters where applicable.
- Add resource-scoped opaque cursor pagination with a default limit of 100 and a maximum of 200.
- Return active Job counts and bounded Box/Job ID references for detail responses.
- Use explicit database selects and response mappers; sensitive fields such as `apiKey`, `authToken`, environment variables, internal origins, network configuration, mount paths, and raw errors are neither selected nor returned.
- Keep responses out of public OpenAPI and set `Cache-Control: no-store`.
- Advertise `boxes.read` and `runners.read` through the readiness endpoint.
- Add coverage for authentication, exact route scopes, cross-organization filtering, pagination, malformed cursors and IDs, bounded references, and sensitive-field redaction.

## How to verify

```bash
make test:apps FILTER='Backoffice internal inventory|Backoffice workload authentication|Backoffice internal readiness'
make lint:apps
git diff --check bearer_check..HEAD
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional internal Backoffice API for readiness checks and paginated box and runner inventory.
  * Added filtering, detail views, operational summaries, and bounded pagination for inventory data.
  * Added secure token-based access with support for credential rotation.
* **Security**
  * Authorization credentials are redacted from HTTP logs.
  * Sensitive operational and credential fields are excluded from inventory responses.
* **Documentation**
  * Added configuration and deployment guidance for enabling the Backoffice API and managing access credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->