### PR TITLE
fix: complete first plugin bootstrap

### DIFF
--- a/.agent-tooling/codex-plugin-bootstrap.sh
+++ b/.agent-tooling/codex-plugin-bootstrap.sh
@@ -147,22 +147,62 @@ codex_plugin_catalog() {
     return 1
   fi
   jq -e '
-    (.installed | type == "array") and
-    (.available | type == "array") and
-    ([(.installed[], .available[]) | select(
-      .pluginId == "boxlite-agent-tooling@boxlite-agent-tooling" and
+    def target:
+      .pluginId == "boxlite-agent-tooling@boxlite-agent-tooling";
+    def valid_metadata:
       .name == "boxlite-agent-tooling" and
       .marketplaceName == "boxlite-agent-tooling" and
-      (.version | type == "string" and length > 0) and
       (.enabled | type == "boolean") and
       .installPolicy == "INSTALLED_BY_DEFAULT" and
-      .authPolicy == "ON_INSTALL"
-    )] | length == 1)
+      .authPolicy == "ON_INSTALL";
+    (.installed | type == "array") and
+    (.available | type == "array") and
+    ([(.installed[], .available[]) | select(target)] | length == 1) and
+    all(.installed[];
+      (target | not) or
+      (valid_metadata and .installed == true and
+       (.version | type == "string" and length > 0))) and
+    all(.available[];
+      (target | not) or
+      (valid_metadata and .installed == false and
+       has("version") and
+       ((.version == null) or (.version | type == "string" and length > 0))))
   ' <<< "$catalog" >/dev/null || {
     printf 'agent-tooling: Codex marketplace boxlite-agent-tooling does not advertise the expected plugin at ref %s\n' "$tooling_ref" >&2
     return 1
   }
   printf '%s' "$catalog"
+}
+
+read_catalog_plugin_state() {
+  local available_plugin_version
+  installed_count="$(jq -r '[.installed[] | select(
+    .pluginId == "boxlite-agent-tooling@boxlite-agent-tooling" and .installed == true
+  )] | length' <<< "$catalog")"
+  if [[ "$installed_count" == 1 ]]; then
+    catalog_plugin_version="$(jq -er '.installed[] | select(
+      .pluginId == "boxlite-agent-tooling@boxlite-agent-tooling" and .installed == true
+    ) | .version' <<< "$catalog")" || {
+      printf 'agent-tooling: Codex installed plugin has no usable version\n' >&2
+      return 1
+    }
+    return 0
+  fi
+  [[ "$installed_count" == 0 ]] || {
+    printf 'agent-tooling: Codex reported an ambiguous boxlite-agent-tooling installation\n' >&2
+    return 1
+  }
+
+  available_plugin_version="$(jq -r '.available[] | select(
+    .pluginId == "boxlite-agent-tooling@boxlite-agent-tooling" and .installed == false
+  ) | .version // ""' <<< "$catalog")"
+  if [[ -n "$available_plugin_version" &&
+        "$available_plugin_version" != "$configured_plugin_version" ]]; then
+    printf 'agent-tooling: Codex available plugin version %s does not match configured marketplace manifest version %s\n' \
+      "$available_plugin_version" "$configured_plugin_version" >&2
+    return 1
+  fi
+  catalog_plugin_version="$configured_plugin_version"
 }
 
 marketplaces="$(codex plugin marketplace list --json)" || {
@@ -253,17 +293,21 @@ validate_codex_marketplace_file "$configured_marketplace_file" || {
     "$tooling_ref" "$configured_marketplace_file" >&2
   exit 1
 }
+configured_plugin_manifest="$marketplace_root/plugins/boxlite-agent-tooling/.codex-plugin/plugin.json"
+read_configured_plugin_version() {
+  configured_plugin_version="$(jq -er '
+    select(.name == "boxlite-agent-tooling") |
+    .version | select(type == "string" and length > 0)
+  ' "$configured_plugin_manifest" 2>/dev/null)" || {
+    printf 'agent-tooling: configured Codex marketplace has no valid plugin version: %s\n' \
+      "$configured_plugin_manifest" >&2
+    return 1
+  }
+}
+read_configured_plugin_version || exit 1
 
 catalog="$(codex_plugin_catalog)" || exit 1
-installed_count="$(jq -r '[.installed[] | select(
-  .pluginId == "boxlite-agent-tooling@boxlite-agent-tooling" and .installed == true
-)] | length' <<< "$catalog")"
-catalog_plugin_version="$(jq -er '(.installed[], .available[]) | select(
-  .pluginId == "boxlite-agent-tooling@boxlite-agent-tooling"
-) | .version' <<< "$catalog")" || {
-  printf 'agent-tooling: Codex catalog has no usable boxlite-agent-tooling version\n' >&2
-  exit 1
-}
+read_catalog_plugin_state || exit 1
 
 if [[ "$catalog_plugin_version" != "$expected_plugin_version" ]]; then
   [[ -z "$hold_sha" ]] || {
@@ -302,16 +346,14 @@ if [[ "$catalog_plugin_version" != "$expected_plugin_version" ]]; then
     exit 1
   }
 
-  catalog="$(codex_plugin_catalog)" || exit 1
-  installed_count="$(jq -r '[.installed[] | select(
-    .pluginId == "boxlite-agent-tooling@boxlite-agent-tooling" and .installed == true
-  )] | length' <<< "$catalog")"
-  catalog_plugin_version="$(jq -er '(.installed[], .available[]) | select(
-    .pluginId == "boxlite-agent-tooling@boxlite-agent-tooling"
-  ) | .version' <<< "$catalog")" || {
-    printf 'agent-tooling: Codex catalog has no usable version after marketplace upgrade\n' >&2
+  read_configured_plugin_version || exit 1
+  [[ "$configured_plugin_version" == "$expected_plugin_version" ]] || {
+    printf 'agent-tooling: configured Codex marketplace stayed at %s after upgrade; expected %s\n' \
+      "$configured_plugin_version" "$expected_plugin_version" >&2
     exit 1
   }
+  catalog="$(codex_plugin_catalog)" || exit 1
+  read_catalog_plugin_state || exit 1
   [[ "$catalog_plugin_version" == "$expected_plugin_version" ]] || {
     printf 'agent-tooling: Codex plugin stayed at %s after upgrade; expected %s\n' \
       "$catalog_plugin_version" "$expected_plugin_version" >&2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,18 +2,6 @@
   "env": {
     "VERDICT_GATE_HARD_BLOCK": "1"
   },
-  "extraKnownMarketplaces": {
-    "boxlite-agent-tooling": {
-      "source": {
-        "source": "github",
-        "repo": "boxlite-ai/agent-tooling",
-        "ref": "main"
-      }
-    }
-  },
-  "enabledPlugins": {
-    "boxlite-agent-tooling@boxlite-agent-tooling": true
-  },
   "hooks": {
     "SessionStart": [
       {
@@ -36,8 +24,8 @@
               "bash",
               "${CLAUDE_PROJECT_DIR}/.agent-tooling/claude-plugin-bootstrap.sh"
             ],
-            "statusMessage": "Checking BoxLite agent tooling",
-            "timeout": 180
+            "timeout": 180,
+            "statusMessage": "Checking BoxLite agent tooling"
           }
         ]
       }
@@ -60,5 +48,17 @@
         ]
       }
     ]
+  },
+  "enabledPlugins": {
+    "boxlite-agent-tooling@boxlite-agent-tooling": true
+  },
+  "extraKnownMarketplaces": {
+    "boxlite-agent-tooling": {
+      "source": {
+        "source": "github",
+        "repo": "boxlite-ai/agent-tooling",
+        "ref": "main"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Complete the trusted first-install path merged in #1343 by accepting the OpenAI CLI's explicit null version for an uninstalled marketplace entry and by committing Claude Code settings in host-canonical order.

Related shared-tooling fix: boxlite-ai/agent-tooling#11.

## Before

```text
trusted repository start
├─ OpenAI CLI startup hook
│  └─ uninstalled marketplace entry reports version: null
│     └─ bootstrap rejects the catalog  ← BUG: plugin installation never runs
└─ Claude Code SessionStart
   └─ project plugin installs
      └─ host rewrites settings order  ← BUG: a clean clone becomes dirty
```

## After

```text
trusted repository start
├─ OpenAI CLI startup hook
│  ├─ require an explicit version field
│  ├─ accept null only while uninstalled
│  └─ install, re-read, and require the adopted version
└─ Claude Code SessionStart
   ├─ read settings already in host-canonical order
   └─ install the project plugin without changing tracked files
```

## Changes

- Keep fail-closed catalog validation while allowing the actual first-install response shape.
- Validate the configured manifest before installation and the installed version afterward.
- Canonicalize only settings field order; preserve the existing submodule startup hook and all settings values.

## Verification

- Shared bootstrap and lifecycle suites: 444 passed.
- Local syntax, ShellCheck, JSON, profile, installation, settings-order, and diff checks passed.
- OpenAI CLI 0.148.0 and Claude Code 2.1.245 first and repeat starts passed in isolated configuration with a clean working tree. GitHub HTTPS timed out during that audit, so transport used a temporary local mirror while canonical GitHub sources remained configured.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin marketplace validation to correctly handle unavailable plugins and required versions.
  * Added consistency checks to ensure configured and installed plugin versions match.
  * Improved marketplace upgrade verification and catalog state handling.

* **Style**
  * Reorganized plugin and hook configuration entries for clearer, more consistent formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->