### PR TITLE
fix(runtime): keep host diagnostics out of client-facing errors

### DIFF
--- a/src/boxlite/src/jailer/bwrap.rs
+++ b/src/boxlite/src/jailer/bwrap.rs
@@ -30,7 +30,7 @@
 
 use crate::runtime::advanced_options::SecurityOptions;
 use crate::runtime::layout::FilesystemLayout;
-use crate::util::find_binary;
+use crate::util::{HostDiagnostic, find_binary};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::OnceLock;
@@ -104,10 +104,15 @@ pub fn is_available() -> bool {
 /// guidance combining Chrome errno + sysctl detection.
 ///
 /// Returns `Ok(())` if working, `Err` with diagnostic guidance.
-pub fn can_create_user_namespace() -> Result<(), String> {
+pub(crate) fn can_create_user_namespace() -> Result<(), HostDiagnostic> {
     let bwrap_path = match get_bwrap_path() {
         Some(p) => p,
-        None => return Err("bwrap binary not found (neither system nor bundled)".to_string()),
+        None => {
+            return Err(HostDiagnostic::new(
+                "The sandbox could not be initialized on this host.",
+                "bwrap binary not found (neither system nor bundled)",
+            ));
+        }
     };
 
     // Chrome-style raw probe for kernel-level diagnosis.
@@ -145,7 +150,10 @@ pub fn can_create_user_namespace() -> Result<(), String> {
                 &stderr,
             ))
         }
-        Err(e) => Err(format!("failed to run bwrap: {}", e)),
+        Err(e) => Err(HostDiagnostic::new(
+            "The sandbox could not be initialized on this host.",
+            format!("failed to run bwrap: {}", e),
+        )),
     }
 }
 
@@ -163,7 +171,7 @@ fn build_diagnostic(
     bwrap_source: &str,
     bwrap_path: &Path,
     bwrap_stderr: &str,
-) -> String {
+) -> HostDiagnostic {
     let mut msg = format!(
         "bwrap --unshare-user failed ({} bwrap at {})",
         bwrap_source,
@@ -247,7 +255,7 @@ fn build_diagnostic(
         msg.push_str("\n  See: https://boxlite.dev/docs/faq#sandbox-userns");
     }
 
-    msg
+    HostDiagnostic::new("The sandbox could not be initialized on this host.", msg)
 }
 
 /// Compute the AppArmor profile directory (`~/.boxlite/apparmor/`).
@@ -746,15 +754,15 @@ mod tests {
             Ok(()) => {
                 // bwrap user namespaces are available
             }
-            Err(e) => {
-                // Should contain diagnostic info
-                assert!(!e.is_empty(), "Error message should not be empty");
-                // Diagnostic should mention bwrap
+            Err(diag) => {
+                // The operator half must carry the diagnostic info...
                 assert!(
-                    e.contains("bwrap"),
-                    "Diagnostic should mention bwrap: {}",
-                    e
+                    diag.operator().contains("bwrap"),
+                    "operator report should mention bwrap: {}",
+                    diag.operator()
                 );
+                // ...and the client half must not.
+                crate::util::assert_client_safe(diag.client(), "test-box");
             }
         }
     }

--- a/src/boxlite/src/jailer/bwrap.rs
+++ b/src/boxlite/src/jailer/bwrap.rs
@@ -762,7 +762,7 @@ mod tests {
                     diag.operator()
                 );
                 // ...and the client half must not.
-                crate::util::assert_client_safe(diag.client(), "test-box");
+                crate::util::assert_client_safe(&diag.client, "test-box");
             }
         }
     }

--- a/src/boxlite/src/jailer/sandbox/bwrap.rs
+++ b/src/boxlite/src/jailer/sandbox/bwrap.rs
@@ -34,12 +34,14 @@ impl Sandbox for BwrapSandbox {
         if bwrap::is_available()
             && let Err(diagnostic) = bwrap::can_create_user_namespace()
         {
-            return Err(BoxliteError::Config(format!(
-                "Sandbox preflight failed: bwrap cannot create user namespaces.\n\n\
-                 {diagnostic}\n\n\
-                 To skip the sandbox (development only):\n  \
-                   SecurityOptions::disabled()"
-            )));
+            // The fix commands and the `SecurityOptions::disabled()` escape hatch
+            // need a host shell — operator-only. The tenant gets one sentence.
+            tracing::error!(
+                "Sandbox preflight failed: bwrap cannot create user namespaces.\n{}\n\
+                 To skip the sandbox (development only): SecurityOptions::disabled()",
+                diagnostic.operator()
+            );
+            return Err(BoxliteError::Config(diagnostic.into_client()));
         }
 
         let cgroup_config = cgroup::CgroupConfig::from(ctx.resource_limits);

--- a/src/boxlite/src/litebox/crash_report.rs
+++ b/src/boxlite/src/litebox/crash_report.rs
@@ -1,21 +1,29 @@
-//! Crash report formatting for user-friendly error messages.
+//! Crash report formatting, split by audience.
 //!
-//! Transforms raw [`ExitInfo`] into human-readable crash reports
-//! with context-aware troubleshooting suggestions.
+//! Transforms raw [`ExitInfo`] into a terse client-facing sentence and a rich
+//! operator report. Only the former may cross the API boundary — see
+//! [`CrashReport`] and [`crate::util`]'s diagnostic module for why.
 
 use crate::vmm::{ExitInfo, exit_info::ExitErrorKind};
 use std::path::Path;
 
-/// Formatted crash report for user-friendly error messages.
+/// A box-start failure, split by audience.
 ///
-/// Combines parsed exit information with formatted messages suitable
-/// for displaying to users.
+/// The same crash has two readers with opposite needs. An engineer on the host
+/// wants the console path, the shim stderr and the exit code; an API tenant must
+/// see none of it — those paths are on someone else's machine. So the rich text
+/// is not discarded, it is *routed*: callers log [`operator_report`] and pass
+/// only [`client_message`] to the `BoxliteError` payload that crosses the wire.
+///
+/// [`operator_report`]: CrashReport::operator_report
+/// [`client_message`]: CrashReport::client_message
 #[derive(Debug)]
 pub struct CrashReport {
-    /// User-friendly error message with troubleshooting hints.
-    pub user_message: String,
-    /// Raw debug info (stderr content for signals).
-    pub debug_info: String,
+    /// Terse, caller-safe sentence. The only field allowed past the API boundary.
+    pub client_message: String,
+    /// Full diagnostic: paths, shim stderr, exit code, troubleshooting hints.
+    /// Log this; never return it to a caller.
+    pub operator_report: String,
     /// Category the shim recorded, so callers can pick the matching
     /// [`BoxliteError`](boxlite_shared::errors::BoxliteError) variant.
     pub error_kind: ExitErrorKind,
@@ -24,14 +32,14 @@ pub struct CrashReport {
 impl CrashReport {
     /// Create a crash report from exit file and context.
     ///
-    /// Parses the JSON exit file and formats a user-friendly message
-    /// with context-specific troubleshooting suggestions.
+    /// Parses the JSON exit file and formats both audiences' messages with
+    /// context-specific troubleshooting suggestions.
     ///
     /// # Arguments
     /// * `exit_file` - Path to the JSON exit file written by shim
-    /// * `console_log` - Path to console log (for error message)
-    /// * `stderr_file` - Path to stderr file (for error message)
-    /// * `box_id` - Box identifier (for error message)
+    /// * `console_log` - Path to console log (operator report only)
+    /// * `stderr_file` - Path to stderr file (operator report only)
+    /// * `box_id` - Box identifier (operator report only)
     /// * `exit_code` - Exit code from waitpid (if available)
     pub fn from_exit_file(
         exit_file: &Path,
@@ -61,104 +69,138 @@ impl CrashReport {
             );
         };
 
-        // Use stderr_content we already read from file (single source of truth)
-        let debug_info = stderr_content;
-
-        // Build user-friendly message based on crash type
-        let mut user_message = match &info {
+        // Build both audiences' messages based on crash type.
+        let (client_message, mut operator_report) = match &info {
             ExitInfo::Signal { signal, .. } => match signal.as_str() {
-                "SIGABRT" => format!(
-                    "Box {box_id} failed to start: internal error (SIGABRT)\n\n\
-                     The VM crashed during initialization.\n\n\
-                     Common causes:\n\
-                     • Missing or incompatible native libraries\n\
-                     • Invalid VM configuration (memory, CPU)\n\
-                     • Resource limits exceeded\n\n\
-                     Debug files:\n\
-                     • Console: {console_display}\n\
-                     • Stderr:  {stderr_display}"
+                "SIGABRT" => (
+                    "The VM failed to start: internal error (SIGABRT).".to_string(),
+                    format!(
+                        "Box {box_id} failed to start: internal error (SIGABRT)\n\n\
+                         The VM crashed during initialization.\n\n\
+                         Common causes:\n\
+                         • Missing or incompatible native libraries\n\
+                         • Invalid VM configuration (memory, CPU)\n\
+                         • Resource limits exceeded\n\n\
+                         Debug files:\n\
+                         • Console: {console_display}\n\
+                         • Stderr:  {stderr_display}"
+                    ),
                 ),
-                "SIGSEGV" | "SIGBUS" => format!(
-                    "Box {box_id} failed to start: memory error ({signal})\n\n\
-                     The VM encountered a memory access error.\n\n\
-                     Common causes:\n\
-                     • Insufficient memory available\n\
-                     • Library version mismatch\n\
-                     • Corrupted binary or library\n\n\
-                     Debug files:\n\
-                     • Console: {console_display}\n\
-                     • Stderr:  {stderr_display}"
+                "SIGSEGV" | "SIGBUS" => (
+                    format!("The VM failed to start: memory error ({signal})."),
+                    format!(
+                        "Box {box_id} failed to start: memory error ({signal})\n\n\
+                         The VM encountered a memory access error.\n\n\
+                         Common causes:\n\
+                         • Insufficient memory available\n\
+                         • Library version mismatch\n\
+                         • Corrupted binary or library\n\n\
+                         Debug files:\n\
+                         • Console: {console_display}\n\
+                         • Stderr:  {stderr_display}"
+                    ),
                 ),
-                "SIGILL" => format!(
-                    "Box {box_id} failed to start: invalid instruction (SIGILL)\n\n\
-                     The VM encountered an unsupported CPU instruction.\n\n\
-                     Common causes:\n\
-                     • CPU compatibility issue\n\
-                     • Binary compiled for different architecture\n\n\
-                     Debug files:\n\
-                     • Console: {console_display}\n\
-                     • Stderr:  {stderr_display}"
+                "SIGILL" => (
+                    "The VM failed to start: invalid instruction (SIGILL).".to_string(),
+                    format!(
+                        "Box {box_id} failed to start: invalid instruction (SIGILL)\n\n\
+                         The VM encountered an unsupported CPU instruction.\n\n\
+                         Common causes:\n\
+                         • CPU compatibility issue\n\
+                         • Binary compiled for different architecture\n\n\
+                         Debug files:\n\
+                         • Console: {console_display}\n\
+                         • Stderr:  {stderr_display}"
+                    ),
                 ),
-                "SIGSYS" => format!(
-                    "Box {box_id} failed to start: seccomp violation (SIGSYS)\n\n\
-                     The VM was killed by a seccomp filter blocking a required syscall.\n\n\
-                     Common causes:\n\
-                     • Seccomp filter missing syscalls needed by gvproxy (Go runtime)\n\
-                     • Custom seccomp profile too restrictive\n\n\
-                     Debug files:\n\
-                     • Console: {console_display}\n\
-                     • Stderr:  {stderr_display}\n\n\
-                     Tip: Run with RUST_LOG=debug or strace to identify the blocked syscall"
+                "SIGSYS" => (
+                    "The VM failed to start: seccomp violation (SIGSYS).".to_string(),
+                    format!(
+                        "Box {box_id} failed to start: seccomp violation (SIGSYS)\n\n\
+                         The VM was killed by a seccomp filter blocking a required syscall.\n\n\
+                         Common causes:\n\
+                         • Seccomp filter missing syscalls needed by gvproxy (Go runtime)\n\
+                         • Custom seccomp profile too restrictive\n\n\
+                         Debug files:\n\
+                         • Console: {console_display}\n\
+                         • Stderr:  {stderr_display}\n\n\
+                         Tip: Run with RUST_LOG=debug or strace to identify the blocked syscall"
+                    ),
                 ),
-                _ => format!(
-                    "Box {box_id} failed to start\n\n\
-                     The VM exited unexpectedly during startup.\n\n\
-                     Debug files:\n\
-                     • Console: {console_display}\n\
-                     • Stderr:  {stderr_display}"
+                _ => (
+                    "The VM failed to start.".to_string(),
+                    format!(
+                        "Box {box_id} failed to start\n\n\
+                         The VM exited unexpectedly during startup.\n\n\
+                         Debug files:\n\
+                         • Console: {console_display}\n\
+                         • Stderr:  {stderr_display}"
+                    ),
                 ),
             },
             ExitInfo::Panic {
                 message, location, ..
-            } => format!(
-                "Box {box_id} failed to start: panic\n\n\
-                 The shim process panicked during initialization.\n\n\
-                 Panic: {message}\n\
-                 Location: {location}\n\n\
-                 Debug files:\n\
-                 • Console: {console_display}\n\
-                 • Stderr:  {stderr_display}"
+            } => (
+                // The panic message and its source location name BoxLite
+                // internals, so they stay operator-side.
+                "The VM failed to start: internal panic.".to_string(),
+                format!(
+                    "Box {box_id} failed to start: panic\n\n\
+                     The shim process panicked during initialization.\n\n\
+                     Panic: {message}\n\
+                     Location: {location}\n\n\
+                     Debug files:\n\
+                     • Console: {console_display}\n\
+                     • Stderr:  {stderr_display}"
+                ),
             ),
-            ExitInfo::Error { message, .. } => format!(
-                "Box {box_id} failed to start: error\n\n\
-                 The shim process exited with an error.\n\n\
-                 Error: {message}\n\n\
-                 Debug files:\n\
-                 • Console: {console_display}\n\
-                 • Stderr:  {stderr_display}"
+            ExitInfo::Error {
+                message,
+                error_kind,
+                ..
+            } => (
+                // `Unsupported` is the one category whose text is curated for
+                // callers — a host-capability statement ("nested virtualization
+                // is unavailable") with no path, command or component in it.
+                // See `ExitErrorKind::of`. Everything else is an engine failure
+                // whose text is shim-internal.
+                match error_kind {
+                    ExitErrorKind::Unsupported => format!("Unsupported host capability: {message}"),
+                    ExitErrorKind::Engine => "The VM failed to start.".to_string(),
+                },
+                format!(
+                    "Box {box_id} failed to start: error\n\n\
+                     The shim process exited with an error.\n\n\
+                     Error: {message}\n\n\
+                     Debug files:\n\
+                     • Console: {console_display}\n\
+                     • Stderr:  {stderr_display}"
+                ),
             ),
         };
 
         // Include brief debug info if available (first 5 lines)
-        if !debug_info.is_empty() {
-            let brief_debug: Vec<&str> = debug_info.lines().take(5).collect();
-            user_message.push_str("\n\nError output:\n");
-            user_message.push_str(&brief_debug.join("\n"));
-            if debug_info.lines().count() > 5 {
-                user_message.push_str("\n... (see stderr file for full output)");
+        if !stderr_content.is_empty() {
+            let brief_debug: Vec<&str> = stderr_content.lines().take(5).collect();
+            operator_report.push_str("\n\nError output:\n");
+            operator_report.push_str(&brief_debug.join("\n"));
+            if stderr_content.lines().count() > 5 {
+                operator_report.push_str("\n... (see stderr file for full output)");
             }
         }
 
         Self {
-            user_message,
-            debug_info,
+            client_message,
+            operator_report,
             error_kind: info.error_kind(),
         }
     }
 
     /// Create crash report when no exit file exists (pre-main crash).
     ///
-    /// Uses exit code and raw stderr content to provide diagnostic info.
+    /// Uses exit code and raw stderr content to build the operator report. The
+    /// client message stays generic: nothing about a pre-main crash is
+    /// actionable without host access.
     fn from_raw_exit(
         box_id: &str,
         exit_code: Option<i32>,
@@ -240,8 +282,8 @@ impl CrashReport {
         ));
 
         Self {
-            user_message: msg,
-            debug_info: stderr_content.to_string(),
+            client_message: "The VM failed to start.".to_string(),
+            operator_report: msg,
             // No exit file means the shim died before it could categorize.
             error_kind: ExitErrorKind::Engine,
         }
@@ -317,10 +359,11 @@ mod tests {
             Some(1),
         );
 
-        assert!(report.user_message.contains("test-box failed to start"));
-        assert!(report.user_message.contains("Exit code: 1"));
-        assert!(report.user_message.contains("dyld: Library not loaded"));
-        assert!(report.user_message.contains("Diagnostic commands"));
+        assert!(report.operator_report.contains("test-box failed to start"));
+        assert!(!report.client_message.contains("test-box"));
+        assert!(report.operator_report.contains("Exit code: 1"));
+        assert!(report.operator_report.contains("dyld: Library not loaded"));
+        assert!(report.operator_report.contains("Diagnostic commands"));
     }
 
     #[test]
@@ -338,7 +381,7 @@ mod tests {
             Some(134), // 128 + 6 (SIGABRT)
         );
 
-        assert!(report.user_message.contains("Exit code: 134 (SIGABRT)"));
+        assert!(report.operator_report.contains("Exit code: 134 (SIGABRT)"));
     }
 
     #[test]
@@ -364,9 +407,9 @@ mod tests {
             Some(134),
         );
 
-        assert!(report.user_message.contains("SIGABRT"));
-        assert!(report.user_message.contains("internal error"));
-        assert_eq!(report.debug_info, "error details");
+        assert!(report.client_message.contains("SIGABRT"));
+        assert!(report.client_message.contains("internal error"));
+        assert!(report.operator_report.contains("error details"));
     }
 
     #[test]
@@ -390,9 +433,11 @@ mod tests {
             Some(101),
         );
 
-        assert!(report.user_message.contains("panic"));
-        assert!(report.user_message.contains("assertion failed"));
-        assert!(report.user_message.contains("main.rs:42:5"));
+        assert!(report.client_message.contains("panic"));
+        // Panic text and source location stay operator-side.
+        assert!(report.operator_report.contains("assertion failed"));
+        assert!(report.operator_report.contains("main.rs:42:5"));
+        assert!(!report.client_message.contains("main.rs:42:5"));
     }
 
     #[test]
@@ -416,8 +461,12 @@ mod tests {
             Some(1),
         );
 
-        assert!(report.user_message.contains("error"));
-        assert!(report.user_message.contains("Failed to create VM instance"));
+        assert!(report.operator_report.contains("error"));
+        assert!(
+            report
+                .operator_report
+                .contains("Failed to create VM instance")
+        );
     }
 
     #[test]
@@ -441,13 +490,15 @@ mod tests {
             Some(159),
         );
 
-        assert!(report.user_message.contains("SIGSYS"));
-        assert!(report.user_message.contains("seccomp violation"));
-        assert!(report.user_message.contains("strace"));
+        assert!(report.client_message.contains("SIGSYS"));
+        assert!(report.client_message.contains("seccomp violation"));
+        // The strace hint needs a host shell — operator-side only.
+        assert!(report.operator_report.contains("strace"));
+        assert!(!report.client_message.contains("strace"));
     }
 
     #[test]
-    fn test_debug_info_truncation() {
+    fn test_stderr_truncation_in_operator_report() {
         let dir = tempfile::tempdir().unwrap();
         let exit_file = dir.path().join("exit");
         let console_log = dir.path().join("console.log");
@@ -474,14 +525,14 @@ mod tests {
             Some(134),
         );
 
-        assert!(report.user_message.contains("line 1"));
-        assert!(report.user_message.contains("line 5"));
+        assert!(report.operator_report.contains("line 1"));
+        assert!(report.operator_report.contains("line 5"));
         assert!(
             report
-                .user_message
+                .operator_report
                 .contains("... (see stderr file for full output)")
         );
-        assert!(!report.user_message.contains("line 6")); // Truncated
+        assert!(!report.operator_report.contains("line 6")); // Truncated
     }
 
     #[test]
@@ -515,16 +566,16 @@ mod tests {
 
         assert!(
             report
-                .user_message
+                .operator_report
                 .contains("Exit code: 0 (clean shutdown)")
         );
         assert!(
             report
-                .user_message
+                .operator_report
                 .contains("guest agent exited immediately")
         );
-        assert!(report.user_message.contains("Console output: empty"));
-        assert!(report.user_message.contains("Diagnostic commands"));
+        assert!(report.operator_report.contains("Console output: empty"));
+        assert!(report.operator_report.contains("Diagnostic commands"));
     }
 
     #[test]
@@ -547,10 +598,10 @@ mod tests {
 
         assert!(
             report
-                .user_message
+                .operator_report
                 .contains("Exit code: 0 (clean shutdown)")
         );
-        assert!(report.user_message.contains("kernel messages only"));
+        assert!(report.operator_report.contains("kernel messages only"));
     }
 
     #[test]
@@ -573,11 +624,113 @@ mod tests {
 
         assert!(
             report
-                .user_message
+                .operator_report
                 .contains("Exit code: 0 (clean shutdown)")
         );
         // Should NOT contain the empty/kernel annotations
-        assert!(!report.user_message.contains("Console output:"));
+        assert!(!report.operator_report.contains("Console output:"));
+    }
+
+    /// Every crash-report template must keep host diagnostics out of the
+    /// client-facing message. Regression guard for POL-329, where the 400 body
+    /// of `POST /v1/boxes` carried console paths, shim stderr and `dmesg`.
+    #[test]
+    fn test_client_message_never_leaks_host_diagnostics() {
+        // (label, exit-file JSON or None for the no-exit-file path, exit code)
+        let cases: &[(&str, Option<&str>, Option<i32>)] = &[
+            (
+                "sigabrt",
+                Some(r#"{"type":"signal","exit_code":134,"signal":"SIGABRT"}"#),
+                Some(134),
+            ),
+            (
+                "sigsegv",
+                Some(r#"{"type":"signal","exit_code":139,"signal":"SIGSEGV"}"#),
+                Some(139),
+            ),
+            (
+                "sigbus",
+                Some(r#"{"type":"signal","exit_code":138,"signal":"SIGBUS"}"#),
+                Some(138),
+            ),
+            (
+                "sigill",
+                Some(r#"{"type":"signal","exit_code":132,"signal":"SIGILL"}"#),
+                Some(132),
+            ),
+            (
+                "sigsys",
+                Some(r#"{"type":"signal","exit_code":159,"signal":"SIGSYS"}"#),
+                Some(159),
+            ),
+            (
+                "signal_other",
+                Some(r#"{"type":"signal","exit_code":143,"signal":"SIGTERM"}"#),
+                Some(143),
+            ),
+            (
+                "panic",
+                Some(
+                    r#"{"type":"panic","exit_code":101,"message":"assertion failed","location":"/home/dev/src/main.rs:42:5"}"#,
+                ),
+                Some(101),
+            ),
+            (
+                "error_engine",
+                Some(r#"{"type":"error","exit_code":1,"message":"Failed to create VM instance"}"#),
+                Some(1),
+            ),
+            (
+                "error_unsupported",
+                Some(
+                    r#"{"type":"error","exit_code":1,"message":"nested virtualization is unavailable","error_kind":"unsupported"}"#,
+                ),
+                Some(1),
+            ),
+            ("no_exit_file", None, Some(159)),
+            ("no_exit_file_clean", None, Some(0)),
+            ("no_exit_file_unknown_code", None, None),
+        ];
+
+        for (label, exit_json, exit_code) in cases {
+            let dir = tempfile::tempdir().unwrap();
+            let exit_file = dir.path().join("exit");
+            let console_log = dir.path().join("logs").join("console.log");
+            let stderr_file = dir.path().join("shim.stderr");
+            std::fs::create_dir_all(console_log.parent().unwrap()).unwrap();
+
+            if let Some(json) = exit_json {
+                std::fs::write(&exit_file, json).unwrap();
+            }
+            // Shim stderr as it looks in production: internal component timing.
+            std::fs::write(
+                &stderr_file,
+                "[shim] T+0ms: main() entered\n[krun] krun_start_enter called\n",
+            )
+            .unwrap();
+            std::fs::write(&console_log, "").unwrap();
+
+            let report = CrashReport::from_exit_file(
+                &exit_file,
+                &console_log,
+                &stderr_file,
+                "vIsLhQP34dQF",
+                *exit_code,
+            );
+
+            crate::util::assert_client_safe(&report.client_message, "vIsLhQP34dQF");
+
+            // The detail is routed, not dropped: the operator still gets the
+            // box id and the console path this case would have leaked.
+            assert!(
+                report.operator_report.contains("vIsLhQP34dQF"),
+                "{label}: operator report lost the box id"
+            );
+            assert!(
+                report.operator_report.contains("console.log"),
+                "{label}: operator report lost the console path"
+            );
+        }
     }
 
     #[test]

--- a/src/boxlite/src/litebox/init/tasks/guest_connect.rs
+++ b/src/boxlite/src/litebox/init/tasks/guest_connect.rs
@@ -11,7 +11,7 @@ use crate::litebox::CrashReport;
 use crate::pipeline::PipelineTask;
 use crate::portal::GuestSession;
 use crate::runtime::layout::{BoxFilesystemLayout, FsLayoutConfig};
-use crate::util::{ProcessExit, ProcessMonitor};
+use crate::util::{HostDiagnostic, ProcessExit, ProcessMonitor};
 use crate::vmm::exit_info::ExitErrorKind;
 use async_trait::async_trait;
 use boxlite_shared::BoxTransport;
@@ -190,7 +190,12 @@ async fn wait_for_guest_ready(
                         (true, true) => "guest booted but agent did not connect to vsock READY port",
                         (false, _) => "shim died silently (see stderr / exit file)",
                     };
-                    Err(BoxliteError::Engine(format!(
+                    let diagnostic = HostDiagnostic::new(
+                        format!(
+                            "The VM failed to start: timed out after {}s waiting for it to become ready.",
+                            timeout.as_secs()
+                        ),
+                        format!(
                         "Box {box_id} failed to start: timeout after {}s\n\n\
                          Evidence at T+{}s:\n\
                          • shim_alive          = {}\n\
@@ -217,7 +222,10 @@ async fn wait_for_guest_ready(
                         } else {
                             format!("\nConsole tail (last {} bytes):\n{}\n", console_tail.len(), console_tail)
                         }
-                    )))
+                        ),
+                    );
+                    tracing::error!("{}", diagnostic.operator());
+                    Err(BoxliteError::Engine(diagnostic.into_client()))
                 }
             }
         }
@@ -231,17 +239,13 @@ async fn wait_for_guest_ready(
                 exit_code,
             );
 
-            // Log raw debug info for troubleshooting
-            if !report.debug_info.is_empty() {
-                tracing::error!(
-                    "Box crash details (raw stderr):\n{}",
-                    report.debug_info
-                );
-            }
+            // The full report — paths, shim stderr, exit code — goes to the
+            // host log. Only the terse sentence reaches the caller.
+            tracing::error!("Box crash details:\n{}", report.operator_report);
 
             Err(match report.error_kind {
-                ExitErrorKind::Unsupported => BoxliteError::Unsupported(report.user_message),
-                ExitErrorKind::Engine => BoxliteError::Engine(report.user_message),
+                ExitErrorKind::Unsupported => BoxliteError::Unsupported(report.client_message),
+                ExitErrorKind::Engine => BoxliteError::Engine(report.client_message),
             })
         }
     }
@@ -436,10 +440,11 @@ mod tests {
         );
         let err = err.to_string();
         assert!(
-            err.contains("test-box failed to start"),
-            "Expected user-friendly error with box_id, got: {}",
+            err.contains("The VM failed to start."),
+            "Expected terse client message, got: {}",
             err
         );
+        crate::util::assert_client_safe(&err, "test-box");
 
         // Should complete in ~500ms (one poll interval), not 30s
         assert!(
@@ -597,16 +602,13 @@ mod tests {
         .await;
 
         let err = result.expect_err("timeout branch must fire").to_string();
-        // Substrings come from production code, not the test body.
-        assert!(err.contains("test-box failed to start"), "got: {err}");
-        assert!(err.contains("Evidence at T+"), "got: {err}");
-        assert!(err.contains("shim_alive          = false"), "got: {err}");
-        assert!(err.contains("console_bytes       = 21"), "got: {err}");
-        assert!(err.contains("ready_socket_exists = true"), "got: {err}");
-        assert!(
-            err.contains("Console tail"),
-            "tail block missing when console has bytes: {err}"
-        );
+        // The client message is terse and must not carry host internals. The
+        // evidence block (shim_alive, console bytes, tail) is operator-only.
+        assert!(err.contains("timed out"), "got: {err}");
+        crate::util::assert_client_safe(&err, "test-box");
+        assert!(!err.contains("Evidence at T+"), "got: {err}");
+        assert!(!err.contains("shim_alive"), "got: {err}");
+        assert!(!err.contains("Console tail"), "got: {err}");
     }
 
     // ─────────────────────────────────────────────────────────────────────

--- a/src/boxlite/src/litebox/init/tasks/vmm_attach.rs
+++ b/src/boxlite/src/litebox/init/tasks/vmm_attach.rs
@@ -74,7 +74,15 @@ impl PipelineTask<InitCtx> for VmmAttachTask {
                         box_id.as_str(),
                         None,
                     );
-                    report.user_message
+                    // This path logged nothing before: the crash cause reached
+                    // the caller and nowhere else. Route the detail to the host
+                    // log so it survives the terse caller-facing message.
+                    tracing::error!(
+                        box_id = %box_id,
+                        "Box crashed in a prior lifecycle:\n{}",
+                        report.operator_report
+                    );
+                    report.client_message
                 } else {
                     "Box process is no longer running (PID file missing, process dead, \
                      or start-time mismatch indicating PID reuse)"

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -1470,7 +1470,12 @@ impl RuntimeImpl {
                             box_id.as_str(),
                             None,
                         );
-                        state.mark_failed(&report.user_message);
+                        state.mark_failed(&report.client_message);
+                        tracing::error!(
+                            box_id = %box_id,
+                            "Box crashed in a prior lifecycle:\n{}",
+                            report.operator_report
+                        );
                         tracing::warn!(
                             box_id = %box_id,
                             "Box crashed; marked Failed with crash report"

--- a/src/boxlite/src/system_check.rs
+++ b/src/boxlite/src/system_check.rs
@@ -454,7 +454,7 @@ mod tests {
             (kvm_open_failed("EACCES".into()), "vIsLhQP34dQF"),
             (kvm_smoke_failed(7, 5, "6.8.0"), "vIsLhQP34dQF"),
         ] {
-            crate::util::assert_client_safe(diag.client(), box_id);
+            crate::util::assert_client_safe(&diag.client, box_id);
             // The detail is routed, not dropped.
             assert!(
                 diag.operator().contains("/dev/kvm"),
@@ -475,7 +475,7 @@ mod tests {
             (kvm_smoke_failed(3, 5, "6.8.0"), "smoke failed"),
         ];
         for (diag, label) in cases {
-            crate::util::assert_client_safe(diag.client(), "test-box");
+            crate::util::assert_client_safe(&diag.client, "test-box");
             // The operator half is where the guidance belongs.
             assert!(
                 diag.operator().contains("modprobe")

--- a/src/boxlite/src/system_check.rs
+++ b/src/boxlite/src/system_check.rs
@@ -7,6 +7,7 @@
 //! The `HypervisorProbe` trait provides platform-abstracted hypervisor
 //! diagnostics for both startup validation and post-failure error refinement.
 
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use crate::util::HostDiagnostic;
 use boxlite_shared::{BoxliteError, BoxliteResult};
 
@@ -369,7 +370,7 @@ fn check_hypervisor_framework() -> BoxliteResult<()> {
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", not(target_arch = "aarch64")))]
 fn hvf_unsupported_arch(arch: &str) -> HostDiagnostic {
     HostDiagnostic::new(
         "BoxLite on macOS requires Apple Silicon (ARM64).",
@@ -381,7 +382,7 @@ fn hvf_unsupported_arch(arch: &str) -> HostDiagnostic {
     )
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 fn hvf_sysctl_failed(error: String) -> HostDiagnostic {
     HostDiagnostic::new(
         "Hypervisor.framework could not be checked.",
@@ -392,7 +393,7 @@ fn hvf_sysctl_failed(error: String) -> HostDiagnostic {
     )
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 fn hvf_unavailable() -> HostDiagnostic {
     HostDiagnostic::new(
         "Hypervisor.framework is not available on this host.",

--- a/src/boxlite/src/system_check.rs
+++ b/src/boxlite/src/system_check.rs
@@ -7,6 +7,7 @@
 //! The `HypervisorProbe` trait provides platform-abstracted hypervisor
 //! diagnostics for both startup validation and post-failure error refinement.
 
+use crate::util::HostDiagnostic;
 use boxlite_shared::{BoxliteError, BoxliteResult};
 
 // ── HypervisorProbe trait ──────────────────────────────────────────────────
@@ -123,37 +124,22 @@ fn open_kvm() -> BoxliteResult<std::fs::File> {
     const DEV: &str = "/dev/kvm";
 
     if !Path::new(DEV).exists() {
-        let mut msg = format!(
-            "{DEV} does not exist\n\n\
-             Suggestions:\n\
-             - Enable KVM in BIOS/UEFI (VT-x for Intel, AMD-V for AMD)\n\
-             - Load the KVM module: sudo modprobe kvm_intel  # or kvm_amd\n\
-             - Check: lsmod | grep kvm"
-        );
-
-        if Path::new("/proc/sys/fs/binfmt_misc/WSLInterop").exists() {
-            msg.push_str(
-                "\n\nWSL2 detected:\n\
-                 - Requires Windows 11 or Windows 10 build 21390+\n\
-                 - Add 'nestedVirtualization=true' to .wslconfig\n\
-                 - Restart WSL: wsl --shutdown",
-            );
-        }
-
-        return Err(BoxliteError::Unsupported(msg));
+        let diagnostic = kvm_missing();
+        tracing::error!("{}", diagnostic.operator());
+        return Err(BoxliteError::Unsupported(diagnostic.into_client()));
     }
 
     std::fs::OpenOptions::new()
         .read(true)
         .write(true)
         .open(DEV)
-        .map_err(|e| match e.kind() {
-            std::io::ErrorKind::PermissionDenied => BoxliteError::Unsupported(format!(
-                "{DEV}: permission denied\n\n\
-                 Fix:\n\
-                 - sudo usermod -aG kvm $USER && newgrp kvm"
-            )),
-            _ => BoxliteError::Unsupported(format!("{DEV}: {e}")),
+        .map_err(|e| {
+            let diagnostic = match e.kind() {
+                std::io::ErrorKind::PermissionDenied => kvm_permission_denied(),
+                _ => kvm_open_failed(e.to_string()),
+            };
+            tracing::error!("{}", diagnostic.operator());
+            BoxliteError::Unsupported(diagnostic.into_client())
         })
 }
 
@@ -189,15 +175,64 @@ fn smoke_test_kvm(kvm: &std::fs::File) -> BoxliteResult<()> {
         .unwrap_or("unknown")
         .to_string();
 
-    Err(BoxliteError::Unsupported(format!(
-        "KVM smoke test failed: vCPU exit reason {exit_reason} (expected {KVM_EXIT_HLT})\n\n\
-         /dev/kvm exists but cannot execute guest code (host kernel: {kernel}).\n\n\
+    let diagnostic = kvm_smoke_failed(exit_reason, KVM_EXIT_HLT, &kernel);
+    tracing::error!("{}", diagnostic.operator());
+    Err(BoxliteError::Unsupported(diagnostic.into_client()))
+}
+
+/// `/dev/kvm` is absent. The operator guidance (BIOS, module, WSL2) needs a
+/// host shell; the caller only learns KVM is unavailable.
+#[cfg(target_os = "linux")]
+fn kvm_missing() -> HostDiagnostic {
+    let mut msg = String::from(
+        "/dev/kvm does not exist\n\n\
          Suggestions:\n\
-         - Ensure nested virtualization is enabled (cloud instances need this explicitly)\n\
+         - Enable KVM in BIOS/UEFI (VT-x for Intel, AMD-V for AMD)\n\
          - Load the KVM module: sudo modprobe kvm_intel  # or kvm_amd\n\
-         - Check: lsmod | grep kvm\n\
-         - See https://github.com/boxlite-ai/boxlite/blob/main/docs/faq.md"
-    )))
+         - Check: lsmod | grep kvm",
+    );
+
+    if std::path::Path::new("/proc/sys/fs/binfmt_misc/WSLInterop").exists() {
+        msg.push_str(
+            "\n\nWSL2 detected:\n\
+             - Requires Windows 11 or Windows 10 build 21390+\n\
+             - Add 'nestedVirtualization=true' to .wslconfig\n\
+             - Restart WSL: wsl --shutdown",
+        );
+    }
+
+    HostDiagnostic::new("KVM is not available on this host.", msg)
+}
+
+#[cfg(target_os = "linux")]
+fn kvm_permission_denied() -> HostDiagnostic {
+    HostDiagnostic::new(
+        "KVM is available but access is denied for the current user.",
+        "/dev/kvm: permission denied\n\n\
+         Fix:\n\
+         - sudo usermod -aG kvm $USER && newgrp kvm",
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn kvm_open_failed(error: String) -> HostDiagnostic {
+    HostDiagnostic::new("KVM could not be opened.", format!("/dev/kvm: {error}"))
+}
+
+#[cfg(target_os = "linux")]
+fn kvm_smoke_failed(exit_reason: i32, expected: i32, kernel: &str) -> HostDiagnostic {
+    HostDiagnostic::new(
+        "KVM is present but cannot run a virtual machine on this host.",
+        format!(
+            "KVM smoke test failed: vCPU exit reason {exit_reason} (expected {expected})\n\n\
+             /dev/kvm exists but cannot execute guest code (host kernel: {kernel}).\n\n\
+             Suggestions:\n\
+             - Ensure nested virtualization is enabled (cloud instances need this explicitly)\n\
+             - Load the KVM module: sudo modprobe kvm_intel  # or kvm_amd\n\
+             - Check: lsmod | grep kvm\n\
+             - See https://github.com/boxlite-ai/boxlite/blob/main/docs/faq.md"
+        ),
+    )
 }
 
 // ── macOS: Hypervisor.framework ─────────────────────────────────────────────
@@ -252,13 +287,12 @@ impl HypervisorProbe for HvfProbe {
             hvf_ffi::HV_NO_RESOURCES => {
                 tracing::error!(
                     hvf_code = ret,
-                    "HVF diagnostic: HV_NO_RESOURCES — VM address spaces exhausted"
+                    "HVF diagnostic: HV_NO_RESOURCES — VM address spaces exhausted \
+                     (see sysctl kern.hv.max_address_spaces)"
                 );
                 BoxliteError::ResourceExhausted(
-                    "macOS Hypervisor.framework VM address spaces exhausted \
-                     (kern.hv.max_address_spaces limit reached). \
-                     Stop some boxes with `boxlite stop` and retry. \
-                     See: sysctl kern.hv.max_address_spaces"
+                    "macOS Hypervisor.framework VM address spaces are exhausted. \
+                     Stop some running boxes and retry."
                         .into(),
                 )
             }
@@ -280,24 +314,17 @@ impl HypervisorProbe for HvfProbe {
             hvf_ffi::HV_DENIED => {
                 tracing::error!(
                     hvf_code = ret,
-                    "HVF diagnostic: HV_DENIED — missing entitlement"
+                    "HVF diagnostic: HV_DENIED — missing entitlement \
+                     (the shim binary needs com.apple.security.hypervisor)"
                 );
-                BoxliteError::Unsupported(
-                    "Hypervisor.framework access denied. \
-                     The boxlite-shim binary needs the \
-                     com.apple.security.hypervisor entitlement."
-                        .into(),
-                )
+                BoxliteError::Unsupported("Hypervisor.framework access is denied.".into())
             }
             _ => {
                 tracing::error!(
                     hvf_code = format!("{ret:#x}"),
-                    "HVF diagnostic: unexpected error code"
+                    "HVF diagnostic: unexpected error code (original error: {error})"
                 );
-                BoxliteError::Engine(format!(
-                    "{}. HVF diagnostic probe returned error code {ret:#x}",
-                    error
-                ))
+                BoxliteError::Engine("The VM failed to start.".into())
             }
         }
     }
@@ -306,12 +333,11 @@ impl HypervisorProbe for HvfProbe {
 #[cfg(target_os = "macos")]
 fn check_hypervisor_framework() -> BoxliteResult<()> {
     #[cfg(not(target_arch = "aarch64"))]
-    return Err(BoxliteError::Unsupported(format!(
-        "Unsupported architecture: {}\n\n\
-         BoxLite on macOS requires Apple Silicon (ARM64).\n\
-         Intel Macs are not supported.",
-        std::env::consts::ARCH
-    )));
+    {
+        let diagnostic = hvf_unsupported_arch(std::env::consts::ARCH);
+        tracing::error!("{}", diagnostic.operator());
+        return Err(BoxliteError::Unsupported(diagnostic.into_client()));
+    }
 
     #[cfg(target_arch = "aarch64")]
     {
@@ -319,16 +345,15 @@ fn check_hypervisor_framework() -> BoxliteResult<()> {
             .arg("kern.hv_support")
             .output()
             .map_err(|e| {
-                BoxliteError::Unsupported(format!(
-                    "Failed to check Hypervisor.framework: {e}\n\n\
-                     Check manually: sysctl kern.hv_support"
-                ))
+                let diagnostic = hvf_sysctl_failed(e.to_string());
+                tracing::error!("{}", diagnostic.operator());
+                BoxliteError::Unsupported(diagnostic.into_client())
             })?;
 
         if !output.status.success() {
-            return Err(BoxliteError::Unsupported(
-                "sysctl kern.hv_support failed".into(),
-            ));
+            let diagnostic = hvf_sysctl_failed("non-zero exit status".to_string());
+            tracing::error!("{}", diagnostic.operator());
+            return Err(BoxliteError::Unsupported(diagnostic.into_client()));
         }
 
         let stdout = String::from_utf8_lossy(&output.stdout);
@@ -337,15 +362,45 @@ fn check_hypervisor_framework() -> BoxliteResult<()> {
         if value == "1" {
             Ok(())
         } else {
-            Err(BoxliteError::Unsupported(
-                "Hypervisor.framework is not available\n\n\
-                 Suggestions:\n\
-                 - Verify macOS 10.10 or later\n\
-                 - Check: sysctl kern.hv_support"
-                    .into(),
-            ))
+            let diagnostic = hvf_unavailable();
+            tracing::error!("{}", diagnostic.operator());
+            Err(BoxliteError::Unsupported(diagnostic.into_client()))
         }
     }
+}
+
+#[cfg(target_os = "macos")]
+fn hvf_unsupported_arch(arch: &str) -> HostDiagnostic {
+    HostDiagnostic::new(
+        "BoxLite on macOS requires Apple Silicon (ARM64).",
+        format!(
+            "Unsupported architecture: {arch}\n\n\
+             BoxLite on macOS requires Apple Silicon (ARM64).\n\
+             Intel Macs are not supported."
+        ),
+    )
+}
+
+#[cfg(target_os = "macos")]
+fn hvf_sysctl_failed(error: String) -> HostDiagnostic {
+    HostDiagnostic::new(
+        "Hypervisor.framework could not be checked.",
+        format!(
+            "Failed to check Hypervisor.framework: {error}\n\n\
+                 Check manually: sysctl kern.hv_support"
+        ),
+    )
+}
+
+#[cfg(target_os = "macos")]
+fn hvf_unavailable() -> HostDiagnostic {
+    HostDiagnostic::new(
+        "Hypervisor.framework is not available on this host.",
+        "Hypervisor.framework is not available\n\n\
+         Suggestions:\n\
+         - Verify macOS 10.10 or later\n\
+         - Check: sysctl kern.hv_support",
+    )
 }
 
 // ── Unsupported platforms ──────────────────────────────────────────────────
@@ -384,6 +439,50 @@ mod tests {
                     "Error should mention the hypervisor: {msg}"
                 );
             }
+        }
+    }
+
+    /// The client-facing halves of the KVM diagnostics must not carry host
+    /// internals — the regression guard for POL-329 on the Linux producers.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn kvm_client_messages_are_safe() {
+        for (diag, box_id) in [
+            (kvm_missing(), "vIsLhQP34dQF"),
+            (kvm_permission_denied(), "vIsLhQP34dQF"),
+            (kvm_open_failed("EACCES".into()), "vIsLhQP34dQF"),
+            (kvm_smoke_failed(7, 5, "6.8.0"), "vIsLhQP34dQF"),
+        ] {
+            crate::util::assert_client_safe(diag.client(), box_id);
+            // The detail is routed, not dropped.
+            assert!(
+                diag.operator().contains("/dev/kvm"),
+                "operator report lost the KVM detail"
+            );
+        }
+    }
+
+    /// The Linux KVM diagnostics must keep host guidance out of the client
+    /// message. Same regression guard as crash_report (POL-329).
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn kvm_diagnostics_never_leak_host_internals() {
+        let cases: Vec<(HostDiagnostic, &str)> = vec![
+            (kvm_missing(), "missing"),
+            (kvm_permission_denied(), "permission denied"),
+            (kvm_open_failed("EACCES".to_string()), "open failed"),
+            (kvm_smoke_failed(3, 5, "6.8.0"), "smoke failed"),
+        ];
+        for (diag, label) in cases {
+            crate::util::assert_client_safe(diag.client(), "test-box");
+            // The operator half is where the guidance belongs.
+            assert!(
+                diag.operator().contains("modprobe")
+                    || diag.operator().contains("lsmod")
+                    || diag.operator().contains("/dev/kvm")
+                    || diag.operator().contains("nested"),
+                "{label}: operator report lost the guidance"
+            );
         }
     }
 

--- a/src/boxlite/src/util/diagnostic.rs
+++ b/src/boxlite/src/util/diagnostic.rs
@@ -1,0 +1,127 @@
+//! Splitting a host-side failure into the part a client may see and the part
+//! only an operator may see.
+//!
+//! A box failure has two audiences with opposite needs. An engineer on their
+//! own machine wants the console path, the shim stderr, and the exact fix
+//! command. An API tenant must see none of it: the paths belong to someone
+//! else's host, the commands need a shell they will never have, and the
+//! component names describe internals they cannot act on.
+//!
+//! Both are served by routing, not by dropping: the operator half goes to
+//! `tracing::error!`, which reaches the CLI's stderr layer and the runner's
+//! `<home>/logs/boxlite.log`. Only the client half becomes a
+//! [`BoxliteError`](boxlite_shared::errors::BoxliteError) payload.
+
+/// A host-side failure carrying both of its audiences' messages.
+///
+/// Construct one wherever a failure is diagnosed, log [`operator`] at the call
+/// site, and pass [`into_client`] to the `BoxliteError` variant. Keeping the
+/// logging explicit at the call site — rather than hiding it in a method here —
+/// is deliberate: the side effect stays visible in the diff.
+///
+/// [`operator`]: HostDiagnostic::operator
+/// [`into_client`]: HostDiagnostic::into_client
+#[derive(Debug)]
+pub(crate) struct HostDiagnostic {
+    client: String,
+    operator: String,
+}
+
+impl HostDiagnostic {
+    /// `client` must survive [`assert_client_safe`]: no host paths, no commands
+    /// needing a host shell, no internal component names, no box identifier.
+    /// `operator` may carry all of it.
+    pub(crate) fn new(client: impl Into<String>, operator: impl Into<String>) -> Self {
+        Self {
+            client: client.into(),
+            operator: operator.into(),
+        }
+    }
+
+    /// The full diagnostic. Log this; never return it to a caller.
+    pub(crate) fn operator(&self) -> &str {
+        &self.operator
+    }
+
+    /// The only half allowed to cross the API boundary.
+    pub(crate) fn into_client(self) -> String {
+        self.client
+    }
+
+    /// Read-only view of the client half, for tests asserting it is safe.
+    #[cfg(test)]
+    pub(crate) fn client(&self) -> &str {
+        &self.client
+    }
+}
+
+/// Tokens that must never appear in a client-facing message.
+///
+/// Matched case-insensitively as substrings. Grouped by what they leak:
+/// host filesystem layout, on-disk artifacts, commands needing a host shell,
+/// and internal component names.
+#[cfg(test)]
+const CLIENT_FORBIDDEN_TOKENS: &[&str] = &[
+    // Host filesystem paths
+    "/var/",
+    "/dev/",
+    "/proc/",
+    "/sys/",
+    "/usr/",
+    "/etc/",
+    "/tmp/",
+    "/home/",
+    "/boxes/",
+    ".wslconfig",
+    // On-disk diagnostic artifacts
+    ".log",
+    "stderr",
+    "console output",
+    "debug files",
+    // Commands that need a shell on the host
+    "sudo",
+    "dmesg",
+    "strace",
+    "rust_log",
+    "modprobe",
+    "lsmod",
+    "usermod",
+    "sysctl",
+    "apparmor_parser",
+    "apt install",
+    "which boxlite",
+    "diagnostic commands",
+    // Internal component names
+    "shim",
+    "krun",
+    "gvproxy",
+    "bwrap",
+    "bubblewrap",
+    "apparmor",
+    "boxlite-guest",
+    "securityoptions",
+];
+
+/// Assert that `client` carries nothing only an operator may see.
+///
+/// This is the regression guard for POL-329: internal VMM diagnostics reaching
+/// the public API error body. Every producer of a client-facing failure string
+/// drives it, so a new leak of the same shape fails a test instead of shipping.
+///
+/// `box_id` is the identifier used to build the message under test; a
+/// client-facing message must not carry a box identifier at all, since the
+/// runtime's own id is not the one the control plane issued.
+#[cfg(test)]
+pub(crate) fn assert_client_safe(client: &str, box_id: &str) {
+    let haystack = client.to_ascii_lowercase();
+    for token in CLIENT_FORBIDDEN_TOKENS {
+        assert!(
+            !haystack.contains(&token.to_ascii_lowercase()),
+            "client message leaks operator-only token {token:?}:\n{client}"
+        );
+    }
+    assert!(
+        !client.contains(box_id),
+        "client message leaks box id {box_id:?}:\n{client}"
+    );
+}

--- a/src/boxlite/src/util/diagnostic.rs
+++ b/src/boxlite/src/util/diagnostic.rs
@@ -23,7 +23,11 @@
 /// [`into_client`]: HostDiagnostic::into_client
 #[derive(Debug)]
 pub(crate) struct HostDiagnostic {
-    client: String,
+    /// The only half allowed to cross the API boundary. `pub(crate)` so tests
+    /// can assert it is safe without a test-only accessor (which would be dead
+    /// code on macOS `--all-targets` builds, where the linux-gated tests that
+    /// read it are not compiled).
+    pub(crate) client: String,
     operator: String,
 }
 
@@ -46,12 +50,6 @@ impl HostDiagnostic {
     /// The only half allowed to cross the API boundary.
     pub(crate) fn into_client(self) -> String {
         self.client
-    }
-
-    /// Read-only view of the client half, for tests asserting it is safe.
-    #[cfg(test)]
-    pub(crate) fn client(&self) -> &str {
-        &self.client
     }
 }
 

--- a/src/boxlite/src/util/diagnostic.rs
+++ b/src/boxlite/src/util/diagnostic.rs
@@ -71,6 +71,13 @@ const CLIENT_FORBIDDEN_TOKENS: &[&str] = &[
     "/home/",
     "/boxes/",
     ".wslconfig",
+    // macOS host layout (this crate is a first-class macOS platform too).
+    // Only unambiguous home/system dirs — omitted /library/, /volumes/ and
+    // /network/, which collide with docker image refs and REST paths.
+    "/users/",
+    "/applications/",
+    "/system/",
+    "/private/",
     // On-disk diagnostic artifacts
     ".log",
     "stderr",

--- a/src/boxlite/src/util/mod.rs
+++ b/src/boxlite/src/util/mod.rs
@@ -1,8 +1,12 @@
 mod binary_finder;
+mod diagnostic;
 mod pid_file;
 pub mod process;
 
 pub use binary_finder::{RuntimeBinaryFinder, find_binary};
+pub(crate) use diagnostic::HostDiagnostic;
+#[cfg(test)]
+pub(crate) use diagnostic::assert_client_safe;
 pub use pid_file::{PidFileReader, PidRecord, ProcessIdentity};
 pub(crate) use pid_file::{PidFileWriter, ShimPidRecord};
 


### PR DESCRIPTION
## Summary
Internal VMM diagnostics — host paths (`/var/lib/boxlite/…`), shim/krun stderr, and `dmesg`-style fix commands — leaked into public API error bodies via `Box.errorReason`. Every host-failure message now splits into a terse client half (crosses the API) and a rich operator half (routed to `tracing::error!` → `boxlite.log` + CLI stderr). Nothing is dropped; the detail just stops crossing the wire.

## Call graph

Before
  wait_for_guest_ready    (GuestConnectTask · src/boxlite/src/litebox/init/tasks/guest_connect.rs:226)
    └─ CrashReport::from_exit_file   (CrashReport · src/boxlite/src/litebox/crash_report.rs:36)
         └─ user_message   (CrashReport · crash_report.rs:16)  ← BUG: embeds host paths, shim stderr, `dmesg`/`file $(which …)`
              └─ BoxliteError::Engine   (src/shared/src/errors.rs:13) — Display → CGO → runner → API 400 body

After
  wait_for_guest_ready    (GuestConnectTask · guest_connect.rs:226)
    └─ CrashReport::from_exit_file   (CrashReport · crash_report.rs:36)
         ├─ client_message   → BoxliteError::Engine   — terse, safe, crosses the API boundary
         └─ operator_report  → tracing::error!        — rich detail, stays in boxlite.log / CLI stderr

Fixes POL-329

## Changes
- `CrashReport`: `user_message` split into `client_message` + `operator_report`; `debug_info` folded into `operator_report`.
- New `HostDiagnostic` carrier (`util/diagnostic.rs`) with test-only `assert_client_safe` guard.
- Same split applied to: guest_connect timeout branch, vmm_attach, rt_impl recovery, jailer bwrap (incl. `can_create_user_namespace` → `Result<(), HostDiagnostic>`), system_check KVM/HVF producers (extracted as pure `kvm_*`/`hvf_*` builders).
- Regression guard: `test_client_message_never_leaks_host_diagnostics` + `kvm_diagnostics_never_leak_host_internals` assert no client message carries a host path, command, component name, or box id.

## How to verify
- `make test:unit:rust FILTER=crash_report` / `FILTER=system_check` / `FILTER=bwrap` / `FILTER=guest_connect`
- `make fmt:check && make lint:rust`

## Risks / rollout
- Rust-only; `apps/api` `sanitizeBoxError` and the runner boundary remain unhardened (follow-up).
- `ExitInfo::Error` with `error_kind=Unsupported` still forwards the shim message verbatim (curated capability statements today; latent, not active).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for startup, host validation, sandbox, and crash-recovery failures.
  * Client-facing errors now omit sensitive host details such as file paths, command output, and internal diagnostics.
  * Detailed troubleshooting information remains available in operator logs.
  * Added safeguards and tests to prevent internal information from appearing in client-visible messages.
  * Simplified several platform-specific failure messages for clearer guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->