### PR TITLE
fix(security): sync aarch64 seccomp filter for disabled-network boot

### DIFF
--- a/src/boxlite/resources/seccomp/aarch64-unknown-linux-gnu.json
+++ b/src/boxlite/resources/seccomp/aarch64-unknown-linux-gnu.json
@@ -508,6 +508,269 @@
             {
                 "syscall": "restart_syscall",
                 "comment": "automatically issued by the kernel when specific timing-related syscalls (e.g. nanosleep) get interrupted by SIGSTOP"
+            },
+            {
+                "syscall": "ioctl",
+                "args": [{"index": 1, "type": "dword", "op": "eq", "val": 3255348834, "comment": "KVM_GET_IRQCHIP"}]
+            },
+            {
+                "syscall": "ioctl",
+                "args": [{"index": 1, "type": "dword", "op": "eq", "val": 2150674044, "comment": "KVM_GET_CLOCK"}]
+            },
+            {
+                "syscall": "ioctl",
+                "args": [{"index": 1, "type": "dword", "op": "eq", "val": 2154868383, "comment": "KVM_GET_PIT2"}]
+            },
+            {
+                "syscall": "statx",
+                "comment": "libkrun: modern file stat (glibc 2.38+). Required at steady-state."
+            },
+            {
+                "syscall": "readlinkat",
+                "comment": "libkrun: modern readlink (glibc uses readlinkat). TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "unlinkat",
+                "comment": "libkrun: modern unlink (glibc uses unlinkat). TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "clone3",
+                "comment": "libkrun: vCPU thread creation (glibc 2.34+ uses clone3). Required at steady-state."
+            },
+            {
+                "syscall": "clone",
+                "comment": "libkrun: vCPU thread creation (legacy clone, fallback for older glibc). Required at steady-state."
+            },
+            {
+                "syscall": "close_range",
+                "comment": "libkrun: close range of file descriptors (glibc 2.34+). Required at steady-state."
+            },
+            {
+                "syscall": "epoll_create1",
+                "comment": "libkrun: create epoll instance for I/O multiplexing. Required at steady-state."
+            },
+            {
+                "syscall": "mprotect",
+                "comment": "libkrun: memory protection changes for guest RAM regions. Required at steady-state."
+            },
+            {
+                "syscall": "bind",
+                "comment": "libkrun: bind socket for tonic gRPC vsock server. Required at steady-state."
+            },
+            {
+                "syscall": "listen",
+                "comment": "libkrun: listen on socket for tonic gRPC vsock server. Required at steady-state."
+            },
+            {
+                "syscall": "getsockname",
+                "comment": "libkrun: get socket address for tonic gRPC vsock server. Required at steady-state."
+            },
+            {
+                "syscall": "setsockopt",
+                "comment": "libkrun: set socket options for tonic gRPC vsock server. Required at steady-state."
+            },
+            {
+                "syscall": "sendto",
+                "comment": "libkrun: send data on socket for networking. Required at steady-state."
+            },
+            {
+                "syscall": "ppoll",
+                "comment": "libkrun: I/O multiplexing for event loop. Required at steady-state."
+            },
+            {
+                "syscall": "pread64",
+                "comment": "libkrun: positioned read for block device I/O. Required at steady-state."
+            },
+            {
+                "syscall": "pwrite64",
+                "comment": "libkrun: positioned write for block device I/O. Required at steady-state."
+            },
+            {
+                "syscall": "preadv",
+                "comment": "libkrun: vectorized positioned read for block device I/O. Required at steady-state."
+            },
+            {
+                "syscall": "dup",
+                "comment": "libkrun: file descriptor duplication. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "dup3",
+                "comment": "libkrun: file descriptor duplication. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "kill",
+                "comment": "libkrun: signal delivery for VM lifecycle management. Required at steady-state."
+            },
+            {
+                "syscall": "capget",
+                "comment": "libkrun: query process capabilities during setup. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "prctl",
+                "comment": "libkrun: thread setup (PR_SET_NAME, etc.). Required at steady-state for vCPU thread naming."
+            },
+            {
+                "syscall": "pipe2",
+                "comment": "libkrun: pipe creation for internal IPC. Required at steady-state."
+            },
+            {
+                "syscall": "tgkill",
+                "comment": "libkrun: thread-group signal delivery for VM lifecycle. Required at steady-state."
+            },
+            {
+                "syscall": "nanosleep",
+                "comment": "libkrun: sleep operations for timing. Required at steady-state."
+            },
+            {
+                "syscall": "clock_nanosleep",
+                "comment": "libkrun: precise sleep (glibc maps nanosleep to clock_nanosleep). Required at steady-state."
+            },
+            {
+                "syscall": "getpid",
+                "comment": "libkrun: get process ID. Required at steady-state."
+            },
+            {
+                "syscall": "gettid",
+                "comment": "libkrun: get thread ID for vCPU thread init. Required at steady-state."
+            },
+            {
+                "syscall": "getuid",
+                "comment": "libkrun: get user ID. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "getgid",
+                "comment": "libkrun: get group ID. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "faccessat",
+                "comment": "libkrun: check file access permissions. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "set_robust_list",
+                "comment": "libkrun: pthread robust futex list (called by new threads). TODO(seccomp): needed per-thread, but only during thread init."
+            },
+            {
+                "syscall": "set_tid_address",
+                "comment": "libkrun: set thread ID pointer (called by new threads). TODO(seccomp): needed per-thread, but only during thread init."
+            },
+            {
+                "syscall": "rseq",
+                "comment": "libkrun: restartable sequences (glibc 2.35+). TODO(seccomp): needed per-thread, but only during thread init."
+            },
+            {
+                "syscall": "prlimit64",
+                "comment": "libkrun: get/set resource limits. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "sched_getaffinity",
+                "comment": "libkrun: CPU affinity query for vCPU scheduling. Required at steady-state."
+            },
+            {
+                "syscall": "umask",
+                "comment": "libkrun: set file creation mask (used by libcontainer). TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "accept",
+                "comment": "libkrun: accept connections (older variant without flags). Required at steady-state for tonic gRPC."
+            },
+            {
+                "syscall": "capset",
+                "comment": "libkrun: set process capabilities during setup. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "copy_file_range",
+                "comment": "libkrun: efficient file copy. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "fchmod",
+                "comment": "libkrun: change file permissions. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "flock",
+                "comment": "libkrun: file locking. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "getcwd",
+                "comment": "libkrun: get current working directory. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "getdents64",
+                "comment": "libkrun: read directory entries. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "geteuid",
+                "comment": "libkrun: get effective user ID. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "getsockopt",
+                "comment": "libkrun: get socket options for tonic gRPC vsock server. Required at steady-state."
+            },
+            {
+                "syscall": "mkdirat",
+                "comment": "libkrun: create directory relative to fd. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "pwritev",
+                "comment": "libkrun: vectorized positioned write for block device I/O. Required at steady-state."
+            },
+            {
+                "syscall": "shutdown",
+                "comment": "libkrun: shutdown socket for tonic gRPC. Required at steady-state."
+            },
+            {
+                "syscall": "signalfd4",
+                "comment": "libkrun: create signalfd for signal handling. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "socketpair",
+                "comment": "libkrun: create connected socket pair for internal IPC. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "uname",
+                "comment": "libkrun: get system info. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "wait4",
+                "comment": "libkrun: wait for child process. Required at steady-state."
+            },
+            {
+                "syscall": "waitid",
+                "comment": "libkrun: wait for child process (extended). Required at steady-state."
+            },
+            {
+                "syscall": "ioctl",
+                "comment": "TODO(seccomp): overly broad \u2014 replace with explicit KVM ioctl codes once libkrun's full set is audited. Firecracker enumerates each KVM_* code individually. Currently catch-all because libkrun uses 28+ distinct KVM ioctls during VM setup and runtime.",
+                "args": [{"index": 1, "type": "dword", "op": "ge", "val": 0, "comment": "any ioctl request code"}]
+            },
+            {
+                "syscall": "mmap",
+                "comment": "TODO(seccomp): overly broad \u2014 replace with explicit MAP_* flag combinations once libkrun's mmap usage is audited. Currently catch-all because libkrun uses MAP_SHARED, MAP_PRIVATE|MAP_ANONYMOUS, MAP_FIXED, and more for guest RAM, balloon, and I/O regions.",
+                "args": [{"index": 3, "type": "dword", "op": "ge", "val": 0, "comment": "any mmap flags"}]
+            },
+            {
+                "syscall": "socket",
+                "comment": "TODO(seccomp): overly broad \u2014 replace with explicit AF_UNIX/AF_INET/AF_INET6 rules once libkrun's socket usage is audited. Currently catch-all because libkrun uses various domain/type/protocol combinations for vsock and networking.",
+                "args": [{"index": 0, "type": "dword", "op": "ge", "val": 0, "comment": "any socket domain"}]
+            },
+            {
+                "syscall": "fcntl",
+                "comment": "TODO(seccomp): overly broad \u2014 replace with explicit F_GETFD/F_SETFD/F_GETFL/F_SETFL rules. Currently catch-all because libkrun uses multiple fcntl commands for FD management.",
+                "args": [{"index": 1, "type": "dword", "op": "ge", "val": 0, "comment": "any fcntl command"}]
+            },
+            {
+                "syscall": "futex",
+                "comment": "TODO(seccomp): overly broad \u2014 replace with explicit FUTEX_WAIT/WAKE/WAIT_PRIVATE/WAKE_PRIVATE/WAIT_BITSET_PRIVATE rules once libkrun's futex ops are audited. Currently catch-all because seccompiler silently drops unconditional entries when conditional entries exist for the same syscall.",
+                "args": [{"index": 1, "type": "dword", "op": "ge", "val": 0, "comment": "any futex op"}]
+            },
+            {
+                "syscall": "rt_sigaction",
+                "comment": "TODO(seccomp): overly broad \u2014 replace with explicit signal numbers (SIGABRT, SIGSEGV, SIGBUS, etc.) once libkrun's signal set is known. Currently catch-all because libkrun registers handlers for multiple signals during VM setup.",
+                "args": [{"index": 0, "type": "dword", "op": "ge", "val": 0, "comment": "any signal number"}]
+            },
+            {
+                "syscall": "accept4",
+                "comment": "TODO(seccomp): overly broad \u2014 replace with explicit SOCK_CLOEXEC rule once libkrun's accept4 flags are confirmed. Currently catch-all for compatibility.",
+                "args": [{"index": 3, "type": "dword", "op": "ge", "val": 0, "comment": "any accept4 flags"}]
             }
         ]
     },

--- a/src/boxlite/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/src/boxlite/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -508,6 +508,269 @@
             {
                 "syscall": "restart_syscall",
                 "comment": "automatically issued by the kernel when specific timing-related syscalls (e.g. nanosleep) get interrupted by SIGSTOP"
+            },
+            {
+                "syscall": "ioctl",
+                "args": [{"index": 1, "type": "dword", "op": "eq", "val": 3255348834, "comment": "KVM_GET_IRQCHIP"}]
+            },
+            {
+                "syscall": "ioctl",
+                "args": [{"index": 1, "type": "dword", "op": "eq", "val": 2150674044, "comment": "KVM_GET_CLOCK"}]
+            },
+            {
+                "syscall": "ioctl",
+                "args": [{"index": 1, "type": "dword", "op": "eq", "val": 2154868383, "comment": "KVM_GET_PIT2"}]
+            },
+            {
+                "syscall": "statx",
+                "comment": "libkrun: modern file stat (glibc 2.38+). Required at steady-state."
+            },
+            {
+                "syscall": "readlinkat",
+                "comment": "libkrun: modern readlink (glibc uses readlinkat). TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "unlinkat",
+                "comment": "libkrun: modern unlink (glibc uses unlinkat). TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "clone3",
+                "comment": "libkrun: vCPU thread creation (glibc 2.34+ uses clone3). Required at steady-state."
+            },
+            {
+                "syscall": "clone",
+                "comment": "libkrun: vCPU thread creation (legacy clone, fallback for older glibc). Required at steady-state."
+            },
+            {
+                "syscall": "close_range",
+                "comment": "libkrun: close range of file descriptors (glibc 2.34+). Required at steady-state."
+            },
+            {
+                "syscall": "epoll_create1",
+                "comment": "libkrun: create epoll instance for I/O multiplexing. Required at steady-state."
+            },
+            {
+                "syscall": "mprotect",
+                "comment": "libkrun: memory protection changes for guest RAM regions. Required at steady-state."
+            },
+            {
+                "syscall": "bind",
+                "comment": "libkrun: bind socket for tonic gRPC vsock server. Required at steady-state."
+            },
+            {
+                "syscall": "listen",
+                "comment": "libkrun: listen on socket for tonic gRPC vsock server. Required at steady-state."
+            },
+            {
+                "syscall": "getsockname",
+                "comment": "libkrun: get socket address for tonic gRPC vsock server. Required at steady-state."
+            },
+            {
+                "syscall": "setsockopt",
+                "comment": "libkrun: set socket options for tonic gRPC vsock server. Required at steady-state."
+            },
+            {
+                "syscall": "sendto",
+                "comment": "libkrun: send data on socket for networking. Required at steady-state."
+            },
+            {
+                "syscall": "ppoll",
+                "comment": "libkrun: I/O multiplexing for event loop. Required at steady-state."
+            },
+            {
+                "syscall": "pread64",
+                "comment": "libkrun: positioned read for block device I/O. Required at steady-state."
+            },
+            {
+                "syscall": "pwrite64",
+                "comment": "libkrun: positioned write for block device I/O. Required at steady-state."
+            },
+            {
+                "syscall": "preadv",
+                "comment": "libkrun: vectorized positioned read for block device I/O. Required at steady-state."
+            },
+            {
+                "syscall": "dup",
+                "comment": "libkrun: file descriptor duplication. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "dup3",
+                "comment": "libkrun: file descriptor duplication. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "kill",
+                "comment": "libkrun: signal delivery for VM lifecycle management. Required at steady-state."
+            },
+            {
+                "syscall": "capget",
+                "comment": "libkrun: query process capabilities during setup. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "prctl",
+                "comment": "libkrun: thread setup (PR_SET_NAME, etc.). Required at steady-state for vCPU thread naming."
+            },
+            {
+                "syscall": "pipe2",
+                "comment": "libkrun: pipe creation for internal IPC. Required at steady-state."
+            },
+            {
+                "syscall": "tgkill",
+                "comment": "libkrun: thread-group signal delivery for VM lifecycle. Required at steady-state."
+            },
+            {
+                "syscall": "nanosleep",
+                "comment": "libkrun: sleep operations for timing. Required at steady-state."
+            },
+            {
+                "syscall": "clock_nanosleep",
+                "comment": "libkrun: precise sleep (glibc maps nanosleep to clock_nanosleep). Required at steady-state."
+            },
+            {
+                "syscall": "getpid",
+                "comment": "libkrun: get process ID. Required at steady-state."
+            },
+            {
+                "syscall": "gettid",
+                "comment": "libkrun: get thread ID for vCPU thread init. Required at steady-state."
+            },
+            {
+                "syscall": "getuid",
+                "comment": "libkrun: get user ID. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "getgid",
+                "comment": "libkrun: get group ID. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "faccessat",
+                "comment": "libkrun: check file access permissions. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "set_robust_list",
+                "comment": "libkrun: pthread robust futex list (called by new threads). TODO(seccomp): needed per-thread, but only during thread init."
+            },
+            {
+                "syscall": "set_tid_address",
+                "comment": "libkrun: set thread ID pointer (called by new threads). TODO(seccomp): needed per-thread, but only during thread init."
+            },
+            {
+                "syscall": "rseq",
+                "comment": "libkrun: restartable sequences (glibc 2.35+). TODO(seccomp): needed per-thread, but only during thread init."
+            },
+            {
+                "syscall": "prlimit64",
+                "comment": "libkrun: get/set resource limits. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "sched_getaffinity",
+                "comment": "libkrun: CPU affinity query for vCPU scheduling. Required at steady-state."
+            },
+            {
+                "syscall": "umask",
+                "comment": "libkrun: set file creation mask (used by libcontainer). TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "accept",
+                "comment": "libkrun: accept connections (older variant without flags). Required at steady-state for tonic gRPC."
+            },
+            {
+                "syscall": "capset",
+                "comment": "libkrun: set process capabilities during setup. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "copy_file_range",
+                "comment": "libkrun: efficient file copy. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "fchmod",
+                "comment": "libkrun: change file permissions. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "flock",
+                "comment": "libkrun: file locking. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "getcwd",
+                "comment": "libkrun: get current working directory. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "getdents64",
+                "comment": "libkrun: read directory entries. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "geteuid",
+                "comment": "libkrun: get effective user ID. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "getsockopt",
+                "comment": "libkrun: get socket options for tonic gRPC vsock server. Required at steady-state."
+            },
+            {
+                "syscall": "mkdirat",
+                "comment": "libkrun: create directory relative to fd. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "pwritev",
+                "comment": "libkrun: vectorized positioned write for block device I/O. Required at steady-state."
+            },
+            {
+                "syscall": "shutdown",
+                "comment": "libkrun: shutdown socket for tonic gRPC. Required at steady-state."
+            },
+            {
+                "syscall": "signalfd4",
+                "comment": "libkrun: create signalfd for signal handling. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "socketpair",
+                "comment": "libkrun: create connected socket pair for internal IPC. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "uname",
+                "comment": "libkrun: get system info. TODO(seccomp): likely setup-only, may be removable after audit."
+            },
+            {
+                "syscall": "wait4",
+                "comment": "libkrun: wait for child process. Required at steady-state."
+            },
+            {
+                "syscall": "waitid",
+                "comment": "libkrun: wait for child process (extended). Required at steady-state."
+            },
+            {
+                "syscall": "ioctl",
+                "comment": "TODO(seccomp): overly broad \u2014 replace with explicit KVM ioctl codes once libkrun's full set is audited. Firecracker enumerates each KVM_* code individually. Currently catch-all because libkrun uses 28+ distinct KVM ioctls during VM setup and runtime.",
+                "args": [{"index": 1, "type": "dword", "op": "ge", "val": 0, "comment": "any ioctl request code"}]
+            },
+            {
+                "syscall": "mmap",
+                "comment": "TODO(seccomp): overly broad \u2014 replace with explicit MAP_* flag combinations once libkrun's mmap usage is audited. Currently catch-all because libkrun uses MAP_SHARED, MAP_PRIVATE|MAP_ANONYMOUS, MAP_FIXED, and more for guest RAM, balloon, and I/O regions.",
+                "args": [{"index": 3, "type": "dword", "op": "ge", "val": 0, "comment": "any mmap flags"}]
+            },
+            {
+                "syscall": "socket",
+                "comment": "TODO(seccomp): overly broad \u2014 replace with explicit AF_UNIX/AF_INET/AF_INET6 rules once libkrun's socket usage is audited. Currently catch-all because libkrun uses various domain/type/protocol combinations for vsock and networking.",
+                "args": [{"index": 0, "type": "dword", "op": "ge", "val": 0, "comment": "any socket domain"}]
+            },
+            {
+                "syscall": "fcntl",
+                "comment": "TODO(seccomp): overly broad \u2014 replace with explicit F_GETFD/F_SETFD/F_GETFL/F_SETFL rules. Currently catch-all because libkrun uses multiple fcntl commands for FD management.",
+                "args": [{"index": 1, "type": "dword", "op": "ge", "val": 0, "comment": "any fcntl command"}]
+            },
+            {
+                "syscall": "futex",
+                "comment": "TODO(seccomp): overly broad \u2014 replace with explicit FUTEX_WAIT/WAKE/WAIT_PRIVATE/WAKE_PRIVATE/WAIT_BITSET_PRIVATE rules once libkrun's futex ops are audited. Currently catch-all because seccompiler silently drops unconditional entries when conditional entries exist for the same syscall.",
+                "args": [{"index": 1, "type": "dword", "op": "ge", "val": 0, "comment": "any futex op"}]
+            },
+            {
+                "syscall": "rt_sigaction",
+                "comment": "TODO(seccomp): overly broad \u2014 replace with explicit signal numbers (SIGABRT, SIGSEGV, SIGBUS, etc.) once libkrun's signal set is known. Currently catch-all because libkrun registers handlers for multiple signals during VM setup.",
+                "args": [{"index": 0, "type": "dword", "op": "ge", "val": 0, "comment": "any signal number"}]
+            },
+            {
+                "syscall": "accept4",
+                "comment": "TODO(seccomp): overly broad \u2014 replace with explicit SOCK_CLOEXEC rule once libkrun's accept4 flags are confirmed. Currently catch-all for compatibility.",
+                "args": [{"index": 3, "type": "dword", "op": "ge", "val": 0, "comment": "any accept4 flags"}]
             }
         ]
     },

--- a/src/boxlite/src/jailer/seccomp.rs
+++ b/src/boxlite/src/jailer/seccomp.rs
@@ -464,4 +464,70 @@ mod tests {
             "vcpu filter is empty"
         );
     }
+
+    /// The aarch64 VMM seccomp filter must cover the syscalls libkrun's
+    /// no-gvproxy (`network.mode=disabled`) boot path calls. It was once a
+    /// stale subset of the x86_64 filter (57 vs 118 names) and was missing
+    /// `clone`/`clone3` (vCPU/vsock threads), `epoll_create1` (event loop),
+    /// `bind`/`listen`/`accept` (vsock unix backend), etc., so a disabled box
+    /// SIGSYS-killed during `krun_start_enter` on ARM. Pin the boot-critical
+    /// set so the aarch64 filter can never silently drift back (POL-203).
+    #[test]
+    fn aarch64_vmm_filter_covers_network_disabled_boot_syscalls() {
+        // Boot-critical syscalls for libkrun's no-gvproxy path, derived from
+        // static analysis of src/deps/libkrun-sys/vendor/libkrun (thread
+        // creation, event loop, vsock unix backend, glibc startup) — not
+        // reverse-derived from the filter itself, so the assertion is meaningful.
+        const REQUIRED: &[&str] = &[
+            "clone",
+            "clone3",        // vCPU + vsock muxer threads
+            "epoll_create1", // event manager
+            "bind",
+            "listen",
+            "accept",   // vsock unix backend (gRPC/ready sockets)
+            "prctl",    // thread name / no_new_privs
+            "rseq",     // glibc startup
+            "mprotect", // memory protection
+            "wait4",
+            "waitid", // process wait
+            "pipe2",
+            "socketpair", // fd creation
+            "getpid",
+            "gettid", // identity
+            "set_tid_address",
+            "set_robust_list", // thread startup
+        ];
+
+        for variant in ["aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl"] {
+            let path = format!(
+                "{}/resources/seccomp/{variant}.json",
+                env!("CARGO_MANIFEST_DIR")
+            );
+            let json: serde_json::Value = serde_json::from_str(
+                &std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}")),
+            )
+            .unwrap_or_else(|e| panic!("parse {path}: {e}"));
+
+            let have: std::collections::HashSet<String> = json["vmm"]["filter"]
+                .as_array()
+                .unwrap_or_else(|| panic!("{variant}: vmm.filter is not an array"))
+                .iter()
+                .filter_map(|e| {
+                    e.get("syscall")
+                        .and_then(|s| s.as_str())
+                        .map(str::to_string)
+                })
+                .collect();
+
+            let missing: Vec<&str> = REQUIRED
+                .iter()
+                .filter(|s| !have.contains(**s))
+                .copied()
+                .collect();
+            assert!(
+                missing.is_empty(),
+                "{variant}: aarch64 VMM seccomp filter is missing boot-critical syscalls: {missing:?}"
+            );
+        }
+    }
 }

--- a/src/boxlite/src/litebox/crash_report.rs
+++ b/src/boxlite/src/litebox/crash_report.rs
@@ -185,10 +185,13 @@ impl CrashReport {
             Some(code) if code > 128 => {
                 let signal = code - 128;
                 let signal_name = match signal {
+                    4 => "SIGILL",
                     6 => "SIGABRT",
+                    7 => "SIGBUS",
                     9 => "SIGKILL",
                     11 => "SIGSEGV",
                     15 => "SIGTERM",
+                    31 => "SIGSYS",
                     _ => "unknown signal",
                 };
                 msg.push_str(&format!("Exit code: {code} ({signal_name})\n"));
@@ -339,6 +342,27 @@ mod tests {
         );
 
         assert!(report.user_message.contains("Exit code: 134 (SIGABRT)"));
+    }
+
+    #[test]
+    fn test_no_exit_file_with_sigsys_exit_code() {
+        // A seccomp `trap` (blocked syscall) kills the shim with SIGSYS (31);
+        // decode_wait_status encodes it as 128 + 31 = 159. The fallback table
+        // must not collapse it to "unknown signal" (POL-203).
+        let dir = tempfile::tempdir().unwrap();
+        let exit_file = dir.path().join("nonexistent");
+        let console_log = dir.path().join("console.log");
+        let stderr_file = dir.path().join("stderr");
+
+        let report = CrashReport::from_exit_file(
+            &exit_file,
+            &console_log,
+            &stderr_file,
+            "test-box",
+            Some(159), // 128 + 31 (SIGSYS)
+        );
+
+        assert!(report.user_message.contains("Exit code: 159 (SIGSYS)"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`network.mode=disabled` boxes SIGSYS-killed during `krun_start_enter` on ARM: the aarch64 VMM seccomp filter was a stale subset of the x86_64 filter. Sync it and pin the boot-critical set with a parity test; also report SIGSYS in the no-exit-file crash fallback instead of "unknown signal".

## Call graph

Before
  run_shim             (shim · src/shim/src/main.rs:159)  — network disabled ⇒ apply VMM seccomp
    └─ apply_vmm_filter (seccomp · src/boxlite/src/jailer/seccomp.rs:243)  ← BUG: aarch64 filter missing clone/clone3/epoll_create1/bind/listen/accept, plus socket/futex/ioctl/mmap/fcntl/rt_sigaction/accept4 arg catch-alls
         └─ start_enter (KrunContext · src/boxlite/src/vmm/krun/context.rs:605)  — SIGSYS (exit 159), guest never boots

After
  run_shim             (shim · src/shim/src/main.rs:159)
    └─ apply_vmm_filter (seccomp · src/boxlite/src/jailer/seccomp.rs:243)  — aarch64 filter synced to x86_64 (111 names / 135 entries)
         └─ start_enter (KrunContext · src/boxlite/src/vmm/krun/context.rs:605)  — VM boots, vsock control channel works, no egress

Fixes POL-203

## Changes

- Sync the aarch64 VMM seccomp filter to x86_64 parity: +64 entries (54 syscall names + 10 arg catch-all rules), mapping arch-mismatched names to their aarch64 equivalents (`access→faccessat`, `dup2→dup3`, `poll→ppoll`).
- Add `aarch64_vmm_filter_covers_network_disabled_boot_syscalls`, a parity test that fails if the aarch64 filter drops a boot-critical syscall.
- Report SIGSYS (and complete the table with SIGILL/SIGBUS) in the crash-report no-exit-file fallback.

## How to verify

- `make test:unit:rust` — runs the new parity test and the crash-report suite.
- On an `ubuntu-24.04-arm` runner: boot a `network.mode=disabled` box; `echo`/`ls` work and `test ! -e /sys/class/net/eth0` exits 0 (`src/boxlite/tests/network_spec.rs`).
