### PR TITLE
feat(volumes): address managed volumes by id or name, drop volume://

### DIFF
--- a/apps/api/src/box/dto/create-volume.dto.spec.ts
+++ b/apps/api/src/box/dto/create-volume.dto.spec.ts
@@ -1,0 +1,33 @@
+import { plainToInstance } from 'class-transformer'
+import { validate } from 'class-validator'
+import { CreateVolumeDto } from './create-volume.dto'
+
+describe('CreateVolumeDto name', () => {
+  async function errorsFor(payload: Record<string, unknown>) {
+    return JSON.stringify(await validate(plainToInstance(CreateVolumeDto, payload)))
+  }
+
+  it('accepts an absent name', async () => {
+    expect(await validate(plainToInstance(CreateVolumeDto, {}))).toHaveLength(0)
+  })
+
+  it('accepts names a -v source can express', async () => {
+    for (const name of ['my-data', 'data_1', 'a.b', 'vol_01K2EXAMPLE', 'ab']) {
+      expect(await validate(plainToInstance(CreateVolumeDto, { name }))).toHaveLength(0)
+    }
+  })
+
+  // Each of these would be classified as a host path by the CLI's `-v` rule, or
+  // would break the colon split, leaving the volume unmountable by name.
+  it('rejects names that -v could never address', async () => {
+    for (const name of ['./data', '/data', '~data', 'a/b', 'a:b', 'a b', '-data', '_data']) {
+      expect(await errorsFor({ name })).toContain('matches')
+    }
+  })
+
+  // A single character is indistinguishable from a Windows drive letter in any
+  // `-v` parser, Docker's included.
+  it('rejects a one-character name', async () => {
+    expect(await errorsFor({ name: 'a' })).toContain('matches')
+  })
+})

--- a/apps/api/src/box/dto/create-volume.dto.ts
+++ b/apps/api/src/box/dto/create-volume.dto.ts
@@ -5,11 +5,37 @@
  */
 
 import { ApiProperty, ApiSchema } from '@nestjs/swagger'
-import { IsString } from 'class-validator'
+import { IsString, Matches, ValidateIf } from 'class-validator'
+
+/**
+ * A volume can be mounted by name in place of its id, so a name has to be
+ * expressible as a `-v` source. Two separate constraints, both enforced by the
+ * pattern below:
+ *
+ * - A name starting with `.`, `/` or `~` is classified as a *host path* by the
+ *   CLI, which looks at the first character only (Docker's rule), so it would
+ *   never reach the volume backend.
+ * - A name containing `:` would be split as a field separator, and one
+ *   containing `/` is not a path to the classifier but is still unusable -
+ *   both make the spec mean something other than what was written.
+ *
+ * The pattern is Docker's own (`RestrictedNameChars` in moby), including its
+ * two-character minimum: a single character cannot be told apart from a Windows
+ * drive letter by any `-v` parser, Docker's included.
+ */
+export const VOLUME_NAME_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_.-]+$/
 
 @ApiSchema({ name: 'CreateVolume' })
 export class CreateVolumeDto {
-  @ApiProperty()
+  @ApiProperty({ required: false, example: 'my-data' })
+  // ValidateIf, not IsOptional: IsOptional also waves through an explicit
+  // `null`, which would reach VolumeService.create as a non-undefined value.
+  @ValidateIf((_, value) => value !== undefined)
   @IsString()
+  @Matches(VOLUME_NAME_PATTERN, {
+    message:
+      'volume name must be at least two characters of [a-zA-Z0-9][a-zA-Z0-9_.-]. ' +
+      'If you intended to pass a host directory, use an absolute path.',
+  })
   name?: string
 }

--- a/apps/api/src/box/services/box.service.ts
+++ b/apps/api/src/box/services/box.service.ts
@@ -224,7 +224,22 @@ export class BoxService {
 
       if (createBoxDto.volumes && createBoxDto.volumes.length > 0) {
         const volumeIdOrNames = createBoxDto.volumes.map((v) => v.volumeId)
-        await this.volumeService.validateVolumes(organization.id, volumeIdOrNames)
+        const canonical = await this.volumeService.validateVolumes(organization.id, volumeIdOrNames)
+        // Replace the caller's selector with the id it resolved to inside this
+        // organization. A name is only unique per organization, but everything
+        // downstream (the runner, the `boxlite-volume-<id>` bucket) reads this
+        // field as a global id - see VolumeService.validateVolumes.
+        createBoxDto.volumes = createBoxDto.volumes.map((volume) => {
+          const canonicalId = canonical.get(volume.volumeId)
+          if (!canonicalId) {
+            // validateVolumes keys every selector or throws, so this is
+            // unreachable today. Fail closed anyway: the alternative fallback
+            // is silently persisting the caller's own string, which is exactly
+            // the tenant-controlled passthrough the resolution exists to stop.
+            throw new BadRequestError(`Volume '${volume.volumeId}' could not be resolved`)
+          }
+          return { ...volume, volumeId: canonicalId }
+        })
       } else if (image && !requiresFreshBoxForNetworkPolicy) {
         //  No volumes requested — try to claim a pre-warmed box matching this image/spec
         //  before creating a fresh one.

--- a/apps/api/src/box/services/volume.service.spec.ts
+++ b/apps/api/src/box/services/volume.service.spec.ts
@@ -72,3 +72,114 @@ describe('VolumeService waitForReady', () => {
     await expect(service.waitForReady('volume-1', 0)).rejects.toBeInstanceOf(RequestTimeoutException)
   })
 })
+
+describe('VolumeService validateVolumes canonicalization', () => {
+  function createService(volumes: Array<Record<string, unknown>>) {
+    const volumeRepository = {
+      find: jest.fn().mockResolvedValue(volumes),
+    }
+    const service = new VolumeService(volumeRepository as never, {} as never, {} as never, {} as never, {} as never)
+    return { service, volumeRepository }
+  }
+
+  it('resolves a name to the id of the volume that carries it', async () => {
+    const { service } = createService([{ id: 'uuid-mine', name: 'my-data', state: VolumeState.READY }])
+
+    const canonical = await service.validateVolumes('org-1', ['my-data'])
+
+    expect(canonical.get('my-data')).toBe('uuid-mine')
+  })
+
+  // The tenant-boundary case: a caller may name their own volume after another
+  // tenant's id. Validation passes because they do own a volume by that name,
+  // so the selector must resolve to THEIR volume's id - never be passed through
+  // as-is, which is the other tenant's id and the other tenant's bucket.
+  it('never passes through a name that impersonates another id', async () => {
+    const otherTenantId = 'uuid-belonging-to-someone-else'
+    const { service } = createService([{ id: 'uuid-mine', name: otherTenantId, state: VolumeState.READY }])
+
+    const canonical = await service.validateVolumes('org-1', [otherTenantId])
+
+    expect(canonical.get(otherTenantId)).toBe('uuid-mine')
+    expect(canonical.get(otherTenantId)).not.toBe(otherTenantId)
+  })
+
+  // When one volume's id equals another's name, the id must win: an id is
+  // globally unique, a name only unique per organization.
+  it('prefers an id match over a name match', async () => {
+    const { service } = createService([
+      { id: 'collide', name: 'by-id', state: VolumeState.READY },
+      { id: 'uuid-other', name: 'collide', state: VolumeState.READY },
+    ])
+
+    const canonical = await service.validateVolumes('org-1', ['collide'])
+
+    expect(canonical.get('collide')).toBe('collide')
+  })
+
+  it('returns an empty map for no selectors', async () => {
+    const { service, volumeRepository } = createService([])
+
+    await expect(service.validateVolumes('org-1', [])).resolves.toEqual(new Map())
+    expect(volumeRepository.find).not.toHaveBeenCalled()
+  })
+})
+
+describe('VolumeService validateVolumes query safety', () => {
+  const READY = { state: VolumeState.READY }
+
+  function createService(volumes: Array<Record<string, unknown>>) {
+    const volumeRepository = { find: jest.fn().mockResolvedValue(volumes) }
+    const service = new VolumeService(volumeRepository as never, {} as never, {} as never, {} as never, {} as never)
+    return { service, volumeRepository }
+  }
+
+  function whereOf(volumeRepository: { find: jest.Mock }) {
+    return volumeRepository.find.mock.calls[0][0].where as Array<Record<string, unknown>>
+  }
+
+  // `id` is a Postgres uuid column: comparing it to 'my-data' raises
+  // `invalid input syntax for type uuid` and kills the whole query, name
+  // branch included. A plain name must never reach that predicate.
+  it('keeps a non-uuid selector out of the id predicate', async () => {
+    const { service, volumeRepository } = createService([{ id: 'uuid-1', name: 'my-data', ...READY }])
+
+    await service.validateVolumes('org-1', ['my-data'])
+
+    const where = whereOf(volumeRepository)
+    expect(where.some((clause) => 'id' in clause)).toBe(false)
+    expect(where.some((clause) => 'name' in clause)).toBe(true)
+  })
+
+  it('uses the id predicate for a uuid-shaped selector', async () => {
+    const id = '3f2504e0-4f89-11d3-9a0c-0305e82c3301'
+    const { service, volumeRepository } = createService([{ id, name: 'my-data', ...READY }])
+
+    await service.validateVolumes('org-1', [id])
+
+    expect(whereOf(volumeRepository).some((clause) => 'id' in clause)).toBe(true)
+  })
+
+  // A stray non-ready volume whose name collides with a ready volume's id is
+  // not part of this request; judging it would fail a mount that is fine.
+  it('checks readiness only on the volumes actually selected', async () => {
+    const { service } = createService([
+      { id: 'wanted', name: 'by-id', ...READY },
+      { id: 'uuid-other', name: 'wanted', state: VolumeState.PENDING_CREATE },
+    ])
+
+    await expect(service.validateVolumes('org-1', ['wanted'])).resolves.toEqual(new Map([['wanted', 'wanted']]))
+  })
+
+  it('still rejects a selected volume that is not ready', async () => {
+    const { service } = createService([{ id: 'uuid-1', name: 'my-data', state: VolumeState.PENDING_CREATE }])
+
+    await expect(service.validateVolumes('org-1', ['my-data'])).rejects.toThrow('not in a ready state')
+  })
+
+  it('rejects a selector that matches nothing', async () => {
+    const { service } = createService([])
+
+    await expect(service.validateVolumes('org-1', ['missing'])).rejects.toThrow("Volume 'missing' not found")
+  })
+})

--- a/apps/api/src/box/services/volume.service.ts
+++ b/apps/api/src/box/services/volume.service.ts
@@ -13,7 +13,7 @@ import {
   ServiceUnavailableException,
 } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
-import { Repository, Not, In } from 'typeorm'
+import { Repository, Not, In, FindOptionsWhere } from 'typeorm'
 import { Volume } from '../entities/volume.entity'
 import { VolumeState } from '../enums/volume-state.enum'
 import { CreateVolumeDto } from '../dto/create-volume.dto'
@@ -29,6 +29,10 @@ import { RedisLockProvider } from '../common/redis-lock.provider'
 import { BoxRepository } from '../repositories/box.repository'
 import { BoxDesiredState } from '../enums/box-desired-state.enum'
 import { setTimeout as sleep } from 'timers/promises'
+
+// Shape Postgres accepts for a `uuid` column. Used to keep plain names out of
+// an id predicate, not to validate ids - the database is the authority.
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 @Injectable()
 export class VolumeService {
@@ -197,33 +201,61 @@ export class VolumeService {
     return volume
   }
 
-  async validateVolumes(organizationId: string, volumeIdOrNames: string[]): Promise<void> {
+  /**
+   * Resolve each selector to the volume it names, or throw.
+   *
+   * Returns a selector -> canonical id map rather than void: a selector may be
+   * a *name*, and a name is only unique within an organization. Everything
+   * downstream - the persisted box, the runner dispatch, the derived bucket
+   * `boxlite-volume-<id>` - treats the stored value as a globally canonical id.
+   * Persisting the caller's selector instead would let one tenant name a volume
+   * after another tenant's id and have the runner resolve it there.
+   */
+  async validateVolumes(organizationId: string, volumeIdOrNames: string[]): Promise<Map<string, string>> {
     if (!volumeIdOrNames.length) {
-      return
+      return new Map()
     }
 
-    const volumes = await this.volumeRepository.find({
-      where: [
-        { id: In(volumeIdOrNames), organizationId, state: Not(VolumeState.DELETED) },
-        { name: In(volumeIdOrNames), organizationId, state: Not(VolumeState.DELETED) },
-      ],
-    })
+    // `id` is a Postgres uuid column, so comparing it against a plain name
+    // raises `invalid input syntax for type uuid` and takes the whole query
+    // down - including the name branch that would have matched. Only
+    // uuid-shaped selectors reach the id predicate; every selector is safe
+    // against `name`, which is a varchar.
+    const uuidShaped = volumeIdOrNames.filter((selector) => UUID_PATTERN.test(selector))
 
-    // Check if all requested volumes were found and are in a READY state
-    const foundIds = new Set(volumes.map((v) => v.id))
-    const foundNames = new Set(volumes.map((v) => v.name))
+    const where: FindOptionsWhere<Volume>[] = [
+      { name: In(volumeIdOrNames), organizationId, state: Not(VolumeState.DELETED) },
+    ]
+    if (uuidShaped.length) {
+      where.push({ id: In(uuidShaped), organizationId, state: Not(VolumeState.DELETED) })
+    }
 
-    for (const idOrName of volumeIdOrNames) {
-      if (!foundIds.has(idOrName) && !foundNames.has(idOrName)) {
-        throw new NotFoundException(`Volume '${idOrName}' not found`)
+    const volumes = await this.volumeRepository.find({ where })
+
+    const byId = new Map(volumes.map((volume) => [volume.id, volume]))
+    const byName = new Map(volumes.map((volume) => [volume.name, volume]))
+
+    // Resolve every selector before judging any of them. Ids win over names: an
+    // id is globally unique, a name only unique per organization.
+    const selected = new Map<string, Volume>()
+    for (const selector of volumeIdOrNames) {
+      const volume = byId.get(selector) ?? byName.get(selector)
+      if (!volume) {
+        throw new NotFoundException(`Volume '${selector}' not found`)
       }
+      selected.set(selector, volume)
     }
 
-    for (const volume of volumes) {
+    // Readiness is checked on the volumes actually selected, not on every row
+    // the query returned: a non-ready volume whose *name* collides with a ready
+    // volume's id is not part of this request and must not fail it.
+    for (const volume of new Set(selected.values())) {
       if (volume.state !== VolumeState.READY) {
         throw new BadRequestError(`Volume '${volume.name}' is not in a ready state. Current state: ${volume.state}`)
       }
     }
+
+    return new Map(Array.from(selected, ([selector, volume]) => [selector, volume.id]))
   }
 
   async getOrganizationId(params: { id: string } | { name: string; organizationId: string }): Promise<string> {

--- a/apps/api/src/boxlite-rest/boxlite-volume.controller.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-volume.controller.spec.ts
@@ -53,6 +53,30 @@ describe('BoxliteVolumeController', () => {
     expect(volumeService.waitForReady).toHaveBeenCalledWith(volume.id, 30)
   })
 
+  // A name is what makes `-v my-data:/data` work, so it has to survive the
+  // controller rather than being dropped the way the empty `{}` body used to.
+  it('forwards a requested volume name to the service', async () => {
+    const { controller, volumeService } = createController()
+    const organization = { id: 'org-1' }
+
+    await controller.create({ organization, organizationId: organization.id } as never, {
+      name: 'my-data',
+    })
+
+    expect(volumeService.create).toHaveBeenCalledWith(organization, { name: 'my-data' })
+  })
+
+  // The body is optional in the spec, so an absent one must still create an
+  // unnamed volume instead of throwing on a missing property.
+  it('creates an unnamed volume when no body is sent', async () => {
+    const { controller, volumeService } = createController()
+    const organization = { id: 'org-1' }
+
+    await controller.create({ organization, organizationId: organization.id } as never, undefined)
+
+    expect(volumeService.create).toHaveBeenCalledWith(organization, {})
+  })
+
   it('lists volumes for the authenticated organization', async () => {
     const { controller, volumeService } = createController()
 

--- a/apps/api/src/boxlite-rest/boxlite-volume.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-volume.controller.ts
@@ -1,10 +1,11 @@
-import { Controller, Delete, Get, HttpCode, Param, Post, Query, UseGuards } from '@nestjs/common'
+import { Body, Controller, Delete, Get, HttpCode, Param, Post, Query, UseGuards } from '@nestjs/common'
 import { ApiExcludeController } from '@nestjs/swagger'
 import { CombinedAuthGuard } from '../auth/combined-auth.guard'
 import { OrganizationResourceActionGuard } from '../organization/guards/organization-resource-action.guard'
 import { AuthContext } from '../common/decorators/auth-context.decorator'
 import { OrganizationAuthContext } from '../common/interfaces/auth-context.interface'
 import { VolumeService } from '../box/services/volume.service'
+import { CreateVolumeDto } from '../box/dto/create-volume.dto'
 import { RequiredOrganizationResourcePermissions } from '../organization/decorators/required-organization-resource-permissions.decorator'
 import { OrganizationResourcePermission } from '../organization/enums/organization-resource-permission.enum'
 import { VolumeAccessGuard } from '../box/guards/volume-access.guard'
@@ -31,8 +32,12 @@ export class BoxliteVolumeController {
 
   @Post()
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_VOLUMES])
-  async create(@AuthContext() authContext: OrganizationAuthContext): Promise<RestVolumeResponse> {
-    const volume = await this.volumeService.create(authContext.organization, {})
+  async create(
+    @AuthContext() authContext: OrganizationAuthContext,
+    @Body() dto?: CreateVolumeDto,
+  ): Promise<RestVolumeResponse> {
+    // An absent body is an unnamed volume; VolumeService falls back to the id.
+    const volume = await this.volumeService.create(authContext.organization, dto ?? {})
     return this.toResponse(await this.volumeService.waitForReady(volume.id, 30))
   }
 

--- a/apps/api/src/boxlite-rest/dto/create-box.dto.spec.ts
+++ b/apps/api/src/boxlite-rest/dto/create-box.dto.spec.ts
@@ -221,72 +221,70 @@ describe('CreateBoxDto managed volumes', () => {
       ?.children?.[0]?.children?.find((error) => error.property === 'read_only')?.constraints
   }
 
-  it('accepts read-write managed volume mounts', async () => {
-    const errors = await validate(
-      plainToInstance(CreateBoxDto, {
-        volumes: [{ source: 'volume://volume-123', guest_path: '/data', read_only: false }],
-      }),
-    )
+  it('accepts a managed volume mount by id and by name', async () => {
+    for (const managed_volume of ['volume-123', 'customer-data']) {
+      const errors = await validate(
+        plainToInstance(CreateBoxDto, {
+          volumes: [{ managed_volume, guest_path: '/data', read_only: false }],
+        }),
+      )
 
-    expect(errors).toHaveLength(0)
+      expect(errors).toHaveLength(0)
+    }
   })
 
-  it('rejects volume mounts with neither source nor host_path', async () => {
+  it('rejects a volume mount with no managed_volume', async () => {
     const errors = await validate(
       plainToInstance(CreateBoxDto, {
         volumes: [{ guest_path: '/data', read_only: false }],
       }),
     )
 
-    expect(JSON.stringify(errors)).toContain('hasVolumeSource')
+    expect(JSON.stringify(errors)).toContain('isString')
   })
 
-  it('accepts the deprecated host_path in place of source', async () => {
+  it('rejects an empty managed_volume', async () => {
     const errors = await validate(
       plainToInstance(CreateBoxDto, {
-        volumes: [{ host_path: 'volume://volume-123', guest_path: '/data' }],
-      }),
-    )
-
-    expect(errors).toHaveLength(0)
-  })
-
-  it('rejects an empty source', async () => {
-    const errors = await validate(
-      plainToInstance(CreateBoxDto, {
-        volumes: [{ source: '', guest_path: '/data' }],
+        volumes: [{ managed_volume: '', guest_path: '/data' }],
       }),
     )
 
     expect(JSON.stringify(errors)).toContain('isNotEmpty')
   })
 
-  it('rejects an empty host_path', async () => {
-    const errors = await validate(
-      plainToInstance(CreateBoxDto, {
-        volumes: [{ host_path: '', guest_path: '/data' }],
-      }),
-    )
+  // This API mounts managed volumes only. A path here would name the server's
+  // filesystem, so it gets a message that says so rather than a "not found"
+  // for a volume the caller never meant to reference.
+  it.each(['/host/data', './data', '../data', '~/data', 'C:\\data', 'D:/data', '\\\\server\\share'])(
+    'rejects the host path %s with a host-bind message',
+    async (managed_volume) => {
+      const errors = await validate(
+        plainToInstance(CreateBoxDto, {
+          volumes: [{ managed_volume, guest_path: '/data' }],
+        }),
+      )
 
-    expect(JSON.stringify(errors)).toContain('isNotEmpty')
-  })
+      expect(JSON.stringify(errors)).toContain('host bind mounts are not supported')
+    },
+  )
 
-  it('rejects an empty source even with a valid host_path fallback available', async () => {
-    // An empty string is a malformed `source`, not an absent one - it must
-    // not be silently swapped for host_path in the mapper.
-    const errors = await validate(
-      plainToInstance(CreateBoxDto, {
-        volumes: [{ source: '', host_path: 'volume://volume-123', guest_path: '/data' }],
-      }),
-    )
+  it('still accepts a name that merely contains a dot or dash', async () => {
+    for (const managed_volume of ['my.data', 'my-data', 'a.b-c_d']) {
+      const errors = await validate(
+        plainToInstance(CreateBoxDto, {
+          volumes: [{ managed_volume, guest_path: '/data' }],
+        }),
+      )
 
-    expect(JSON.stringify(errors)).toContain('isNotEmpty')
+      expect(errors).toHaveLength(0)
+    }
   })
 
   it('rejects read-only cloud volume mounts until the backend supports them', async () => {
     const errors = await validate(
       plainToInstance(CreateBoxDto, {
-        volumes: [{ source: 'volume://volume-123', guest_path: '/data', read_only: true }],
+        volumes: [{ managed_volume: 'volume-123', guest_path: '/data', read_only: true }],
       }),
     )
 
@@ -296,7 +294,7 @@ describe('CreateBoxDto managed volumes', () => {
   it('rejects null read_only values', async () => {
     const errors = await validate(
       plainToInstance(CreateBoxDto, {
-        volumes: [{ source: 'volume://volume-123', guest_path: '/data', read_only: null }],
+        volumes: [{ managed_volume: 'volume-123', guest_path: '/data', read_only: null }],
       }),
     )
 

--- a/apps/api/src/boxlite-rest/dto/create-box.dto.ts
+++ b/apps/api/src/boxlite-rest/dto/create-box.dto.ts
@@ -20,7 +20,6 @@ import {
   Validate,
   ValidateIf,
   ValidateNested,
-  ValidationArguments,
   ValidatorConstraint,
   ValidatorConstraintInterface,
 } from 'class-validator'
@@ -36,21 +35,6 @@ class IsNetworkAllowEntryConstraint implements ValidatorConstraintInterface {
 
   defaultMessage(): string {
     return 'each allow_net entry must be an IPv4 address, IPv4 CIDR, hostname, or wildcard hostname'
-  }
-}
-
-// Attached to `guest_path` (always validated) rather than `source`, since
-// `@IsOptional()` on `source` would skip a validator stacked on that same
-// property whenever `source` is absent - exactly the case this needs to see.
-@ValidatorConstraint({ name: 'hasVolumeSource', async: false })
-class HasVolumeSourceConstraint implements ValidatorConstraintInterface {
-  validate(_value: unknown, args: ValidationArguments): boolean {
-    const volume = args.object as VolumeSpecDto
-    return typeof volume.source === 'string' || typeof volume.host_path === 'string'
-  }
-
-  defaultMessage(): string {
-    return 'volume requires source (or the deprecated host_path)'
   }
 }
 
@@ -149,29 +133,46 @@ function normalizeNetworkShape(value: unknown): NetworkSpecDto | unknown {
   return plainToInstance(NetworkSpecDto, { ...rest, outbound })
 }
 
+/**
+ * A host path reaching this API is always a mistake, not a mount: the path
+ * would name the *server's* filesystem, not the caller's, and this API mounts
+ * managed volumes only. Recognised by the same first-character rule the CLI
+ * classifies `-v` sources with, so the two agree on what a path looks like.
+ */
+const HOST_PATH_SELECTOR = /^(\.|\/|~|\\\\|[a-zA-Z]:[\\/])/
+
+@ValidatorConstraint({ name: 'isNotHostPath', async: false })
+class IsNotHostPathConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown): boolean {
+    return typeof value !== 'string' || !HOST_PATH_SELECTOR.test(value)
+  }
+
+  defaultMessage(): string {
+    return 'host bind mounts are not supported by this API; managed_volume takes a ' + 'volume id or name, not a path'
+  }
+}
+
 export class VolumeSpecDto {
-  // IsNotEmpty (not just IsOptional + IsString) so an explicit `source: ''`
-  // is a validation error on its own rather than being treated as "absent"
-  // and silently falling through to host_path in the mapper.
-  @IsOptional()
-  @IsString()
-  @IsNotEmpty()
-  source?: string
-
   /**
-   * @deprecated Use `source` with the `volume://<volume_id>` scheme instead.
-   * Accepted for backward compatibility with existing /v1 clients built
-   * against the pre-managed-volumes `VolumeSpec` schema; will be removed.
+   * The volume's server-assigned id or its name - the server resolves either.
+   *
+   * IsNotEmpty (not just IsString) so an explicit `managed_volume: ''` is a
+   * validation error on its own rather than reaching the mapper as a lookup
+   * that can never match.
    */
-  @IsOptional()
   @IsString()
   @IsNotEmpty()
-  host_path?: string
+  @Validate(IsNotHostPathConstraint)
+  managed_volume: string
 
   @IsString()
-  @Validate(HasVolumeSourceConstraint)
   guest_path: string
 
+  /**
+   * Read-only managed mounts are not implemented yet. Rejected rather than
+   * silently downgraded to read-write, which would hand the caller a writable
+   * mount they believe is protected.
+   */
   @ValidateIf((_, value) => value !== undefined)
   @IsIn([false])
   read_only?: false

--- a/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.spec.ts
+++ b/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.spec.ts
@@ -35,55 +35,20 @@ describe('BoxLite lifecycle policy mapper', () => {
 
   it('maps REST volume specs to managed volume mounts', () => {
     const mapped = createBoxToCreateBox({
-      volumes: [{ source: 'volume://volume-123', guest_path: '/data', read_only: false }],
+      volumes: [{ managed_volume: 'volume-123', guest_path: '/data', read_only: false }],
     })
 
     expect(mapped.volumes).toEqual([{ volumeId: 'volume-123', mountPath: '/data' }])
   })
 
-  it('maps the deprecated host_path field to managed volume mounts', () => {
+  // A name is as valid as an id here; VolumeService.validateVolumes resolves
+  // either, so the mapper must pass the value through untouched.
+  it('passes a volume name through as-is', () => {
     const mapped = createBoxToCreateBox({
-      volumes: [{ host_path: 'volume://volume-123', guest_path: '/data', read_only: false }],
+      volumes: [{ managed_volume: 'customer-data', guest_path: '/data', read_only: false }],
     })
 
-    expect(mapped.volumes).toEqual([{ volumeId: 'volume-123', mountPath: '/data' }])
-  })
-
-  it('does not fall back to host_path when source is an empty string', () => {
-    // DTO validation (IsNotEmpty) is the primary guard against this reaching
-    // the mapper at all; this locks in that the mapper itself also fails
-    // closed rather than treating '' as absent via `??`.
-    expect(() =>
-      createBoxToCreateBox({
-        volumes: [{ source: '', host_path: 'volume://volume-123', guest_path: '/data', read_only: false }],
-      }),
-    ).toThrow('volume source must use the volume:// scheme')
-  })
-
-  it('prefers source over host_path when both are present', () => {
-    const mapped = createBoxToCreateBox({
-      volumes: [
-        { source: 'volume://source-wins', host_path: 'volume://ignored', guest_path: '/data', read_only: false },
-      ],
-    })
-
-    expect(mapped.volumes).toEqual([{ volumeId: 'source-wins', mountPath: '/data' }])
-  })
-
-  it('rejects non-volume scheme sources on the remote managed-volume mapper', () => {
-    expect(() =>
-      createBoxToCreateBox({
-        volumes: [{ source: 'host:///tmp/data', guest_path: '/data', read_only: false }],
-      }),
-    ).toThrow('volume source must use the volume:// scheme')
-  })
-
-  it('rejects source values without a supported scheme', () => {
-    expect(() =>
-      createBoxToCreateBox({
-        volumes: [{ source: 'volume-123', guest_path: '/data', read_only: false }],
-      }),
-    ).toThrow('volume source must use the volume:// scheme')
+    expect(mapped.volumes).toEqual([{ volumeId: 'customer-data', mountPath: '/data' }])
   })
 
   it('returns the effective second-based policy', () => {

--- a/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.ts
+++ b/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { BadRequestException } from '@nestjs/common'
 import { BoxDto } from '../../box/dto/box.dto'
 import { BoxState } from '../../box/enums/box-state.enum'
 import {
@@ -47,7 +46,9 @@ export function createBoxToCreateBox(dto: RestCreateBoxDto, target?: string): Cr
   createDto.autoDelete = dto.auto_delete
   createDto.autoResume = dto.auto_resume
   createDto.volumes = dto.volumes?.map((volume) => ({
-    volumeId: resolveVolumeId(volume),
+    // `volumeId` is the internal DTO's name for what the volume service looks
+    // up by id *or* by name (see VolumeService.validateVolumes).
+    volumeId: volume.managed_volume,
     mountPath: volume.guest_path,
   }))
   if (dto.network) {
@@ -61,20 +62,6 @@ export function createBoxToCreateBox(dto: RestCreateBoxDto, target?: string): Cr
     createDto.public = dto.network.inbound?.mode ? dto.network.inbound.mode === 'enabled' : undefined
   }
   return createDto
-}
-
-function resolveVolumeId(volume: NonNullable<RestCreateBoxDto['volumes']>[number]): string {
-  // `host_path` is the deprecated pre-managed-volumes field name; DTO
-  // validation (HasVolumeSourceConstraint) already guarantees one of the two
-  // is present.
-  const source = volume.source ?? volume.host_path
-  if (source?.startsWith('volume://')) {
-    const volumeId = source.slice('volume://'.length)
-    if (volumeId) {
-      return volumeId
-    }
-  }
-  throw new BadRequestException('volume source must use the volume:// scheme')
 }
 
 function mapState(state: string | BoxState | undefined): string {

--- a/apps/dashboard/src/lib/cloudBox.test.ts
+++ b/apps/dashboard/src/lib/cloudBox.test.ts
@@ -53,24 +53,21 @@ describe('toBoxApiCreateRequest', () => {
     expect(toBoxApiCreateRequest().memory_mib).toBeUndefined()
   })
 
-  // The REST boundary takes {source, guest_path} — NOT the internal
-  // {volumeId, mountPath} pair it maps onto. `guest_path` is required and the
-  // source must carry the volume:// scheme, so sending the internal shape is a
-  // 400 (guest_path missing + "volume source must use the volume:// scheme"),
-  // not a silent no-op.
-  it('maps volume mounts to the REST volume:// source shape', () => {
+  // The REST boundary takes {managed_volume, guest_path} — NOT the internal
+  // {volumeId, mountPath} pair it maps onto. Both fields are required, so
+  // sending the internal shape is a 400, not a silent no-op.
+  it('maps volume mounts to the REST managed_volume shape', () => {
     const request = toBoxApiCreateRequest({
       volumes: [
         { volumeId: 'vol-a1b2c3d4', mountPath: '/models' },
-        // Names are accepted too: the API resolves id-or-name after stripping
-        // the scheme prefix.
+        // Names are accepted too: the API resolves id-or-name.
         { volumeId: 'customer-data', mountPath: '/data' },
       ],
     })
 
     expect(request.volumes).toEqual([
-      { source: 'volume://vol-a1b2c3d4', guest_path: '/models' },
-      { source: 'volume://customer-data', guest_path: '/data' },
+      { managed_volume: 'vol-a1b2c3d4', guest_path: '/models' },
+      { managed_volume: 'customer-data', guest_path: '/data' },
     ])
   })
 

--- a/apps/dashboard/src/lib/cloudBox.ts
+++ b/apps/dashboard/src/lib/cloudBox.ts
@@ -62,13 +62,10 @@ export type BoxApiCreateRequest = {
   auto_stop?: number
   auto_delete?: number
   auto_resume?: boolean
-  // The REST boundary takes a source URI + guest path, not the internal
+  // The REST boundary takes a managed volume + guest path, not the internal
   // {volumeId, mountPath} pair the API maps it onto (box-to-box.mapper.ts).
-  volumes?: { source: string; guest_path: string }[]
+  volumes?: { managed_volume: string; guest_path: string }[]
 }
-
-/** Scheme the REST boundary requires for a managed volume source. */
-const VOLUME_SOURCE_SCHEME = 'volume://'
 
 export type BoxApiBoxResponse = {
   box_id: string
@@ -102,9 +99,8 @@ export function toBoxApiCreateRequest(params?: CreateBoxParams): BoxApiCreateReq
     auto_resume: p.autoResume ?? true,
     volumes: p.volumes?.length
       ? p.volumes.map((mount) => ({
-          // `volumeId` may be an id or a name; the API resolves either once
-          // the scheme prefix is stripped.
-          source: `${VOLUME_SOURCE_SCHEME}${mount.volumeId}`,
+          // `volumeId` may be an id or a name; the API resolves either.
+          managed_volume: mount.volumeId,
           guest_path: mount.mountPath,
         }))
       : undefined,

--- a/apps/dashboard/src/pages/Volumes.tsx
+++ b/apps/dashboard/src/pages/Volumes.tsx
@@ -31,7 +31,11 @@ import { useQueryClient } from '@tanstack/react-query'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 
-const NAME_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/
+// Must match CreateVolumeDto.VOLUME_NAME_PATTERN on the server, including
+// its two-character minimum (`+`, not `*`): a one-character name is
+// indistinguishable from a Windows drive letter to any `-v` parser, so the
+// server rejects it and a `*` here would only turn that into a late 400.
+const NAME_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9._-]+$/
 
 // One definition shared by the header and every row. The header and the rows
 // are separate grid containers, so a content-sized (`auto`) last column made

--- a/apps/e2e/cases/test_volume_host_bind_mount.py
+++ b/apps/e2e/cases/test_volume_host_bind_mount.py
@@ -6,12 +6,12 @@ allowed"). A REST-mode `BoxOptions` carrying `volumes=[(host_path,
 guest_path, ...)]` must not produce a box with that host path
 mounted.
 
-The rejection is explicit, not silent. Managed volumes (#1192) made
-`volumes[].source` a `volume://<id>` reference and the mapper now
-400s anything else, rather than dropping it on the floor. Failing
-loud is the contract worth pinning: a silently ignored bind mount
-leaves the caller believing the guest can see a host directory it
-cannot.
+The rejection is explicit, not silent, and it now happens in the
+client: the wire's only mount field is `volumes[].managed_volume`,
+so a host bind has nothing to serialize into and never leaves the
+SDK. Failing loud is the contract worth pinning: a silently ignored
+bind mount leaves the caller believing the guest can see a host
+directory it cannot.
 
 Day-1 RO semantics for *managed* volumes are covered separately;
 the GHSA-g6ww-w5j2-r7x3 remount-RW attack and per-virtiofs RO
@@ -31,9 +31,8 @@ import pytest
 @pytest.mark.asyncio
 async def test_host_bind_mount_via_rest_is_rejected(rt, image):
     """`BoxOptions(volumes=[(host_dir, "/mnt/ro")])` over REST must be
-    rejected at the request boundary. The Python SDK sends a bare host
-    path as `volumes[].host_path`; the mapper requires a `volume://`
-    managed-volume reference, so the box is never created and no host
+    rejected. A tuple is a host bind, and the REST runtime refuses one
+    before the request is built, so the box is never created and no host
     path can reach the guest."""
     with tempfile.TemporaryDirectory(prefix="boxlite_e2e_hostmount_") as host_dir:
         with pytest.raises(Exception, match="volume") as exc_info:
@@ -48,5 +47,5 @@ async def test_host_bind_mount_via_rest_is_rejected(rt, image):
             )
 
     # The host path itself must not be echoed back; the rejection is
-    # about the missing volume:// reference, not about that directory.
+    # about the mount kind, not about that directory.
     assert host_dir not in str(exc_info.value)

--- a/apps/libs/api-client-go/api/openapi.yaml
+++ b/apps/libs/api-client-go/api/openapi.yaml
@@ -6273,12 +6273,11 @@ components:
       type: object
     CreateVolume:
       example:
-        name: name
+        name: my-data
       properties:
         name:
+          example: my-data
           type: string
-      required:
-      - name
       type: object
     JobStatus:
       enum:

--- a/apps/libs/api-client-go/model_create_volume.go
+++ b/apps/libs/api-client-go/model_create_volume.go
@@ -13,7 +13,6 @@ package apiclient
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 // checks if the CreateVolume type satisfies the MappedNullable interface at compile time
@@ -21,7 +20,7 @@ var _ MappedNullable = &CreateVolume{}
 
 // CreateVolume struct for CreateVolume
 type CreateVolume struct {
-	Name string `json:"name"`
+	Name *string `json:"name,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -31,9 +30,8 @@ type _CreateVolume CreateVolume
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewCreateVolume(name string) *CreateVolume {
+func NewCreateVolume() *CreateVolume {
 	this := CreateVolume{}
-	this.Name = name
 	return &this
 }
 
@@ -45,28 +43,36 @@ func NewCreateVolumeWithDefaults() *CreateVolume {
 	return &this
 }
 
-// GetName returns the Name field value
+// GetName returns the Name field value if set, zero value otherwise.
 func (o *CreateVolume) GetName() string {
-	if o == nil {
+	if o == nil || IsNil(o.Name) {
 		var ret string
 		return ret
 	}
-
-	return o.Name
+	return *o.Name
 }
 
-// GetNameOk returns a tuple with the Name field value
+// GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *CreateVolume) GetNameOk() (*string, bool) {
-	if o == nil {
+	if o == nil || IsNil(o.Name) {
 		return nil, false
 	}
-	return &o.Name, true
+	return o.Name, true
 }
 
-// SetName sets field value
+// HasName returns a boolean if a field has been set.
+func (o *CreateVolume) HasName() bool {
+	if o != nil && !IsNil(o.Name) {
+		return true
+	}
+
+	return false
+}
+
+// SetName gets a reference to the given string and assigns it to the Name field.
 func (o *CreateVolume) SetName(v string) {
-	o.Name = v
+	o.Name = &v
 }
 
 func (o CreateVolume) MarshalJSON() ([]byte, error) {
@@ -79,7 +85,9 @@ func (o CreateVolume) MarshalJSON() ([]byte, error) {
 
 func (o CreateVolume) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	toSerialize["name"] = o.Name
+	if !IsNil(o.Name) {
+		toSerialize["name"] = o.Name
+	}
 
 	for key, value := range o.AdditionalProperties {
 		toSerialize[key] = value
@@ -89,27 +97,6 @@ func (o CreateVolume) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *CreateVolume) UnmarshalJSON(data []byte) (err error) {
-	// This validates that all required properties are included in the JSON object
-	// by unmarshalling the object into a generic map with string keys and checking
-	// that every required field exists as a key in the generic map.
-	requiredProperties := []string{
-		"name",
-	}
-
-	allProperties := make(map[string]interface{})
-
-	err = json.Unmarshal(data, &allProperties)
-
-	if err != nil {
-		return err;
-	}
-
-	for _, requiredProperty := range(requiredProperties) {
-		if _, exists := allProperties[requiredProperty]; !exists {
-			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-
 	varCreateVolume := _CreateVolume{}
 
 	err = json.Unmarshal(data, &varCreateVolume)

--- a/apps/libs/api-client/src/docs/CreateVolume.md
+++ b/apps/libs/api-client/src/docs/CreateVolume.md
@@ -5,7 +5,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**name** | **string** |  | [default to undefined]
+**name** | **string** |  | [optional] [default to undefined]
 
 ## Example
 

--- a/apps/libs/api-client/src/models/create-volume.ts
+++ b/apps/libs/api-client/src/models/create-volume.ts
@@ -15,6 +15,6 @@
 
 
 export interface CreateVolume {
-    'name': string;
+    'name'?: string;
 }
 

--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -253,7 +253,9 @@ func (c *Client) Create(ctx context.Context, boxDto dto.CreateBoxDTO) (string, s
 		return "", "", err
 	}
 	for _, vol := range volumeMounts {
-		opts = append(opts, boxlite.WithVolume(vol.hostPath, vol.mountPath))
+		// The bucket is already FUSE-mounted on this host, so the runner is a
+		// host-bind consumer even though the box is mounting a managed volume.
+		opts = append(opts, boxlite.WithHostPath(vol.hostPath, vol.mountPath))
 	}
 
 	if len(volumeMounts) > 0 {

--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -255,7 +255,7 @@ func (c *Client) Create(ctx context.Context, boxDto dto.CreateBoxDTO) (string, s
 	for _, vol := range volumeMounts {
 		// The bucket is already FUSE-mounted on this host, so the runner is a
 		// host-bind consumer even though the box is mounting a managed volume.
-		opts = append(opts, boxlite.WithHostPath(vol.hostPath, vol.mountPath))
+		opts = append(opts, boxlite.WithBindMount(vol.hostPath, vol.mountPath))
 	}
 
 	if len(volumeMounts) > 0 {

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -297,7 +297,7 @@ See [Configuring Networking](./guides/README.md#configuring-networking) for deta
 **Alternatives:**
 1. **Share data via volumes:**
    ```python
-   volumes=[("/host/shared", "/mnt/shared", "rw")]
+   volumes=[("/host/shared", "/mnt/shared", False)]
    ```
 
 2. **Use host network:**

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -214,7 +214,7 @@ async with boxlite.SimpleBox(
 ```python
 async with boxlite.SimpleBox(
     image="python:slim",
-    volumes=[("/host/data", "/mnt/data", "ro")]
+    volumes=[("/host/data", "/mnt/data", True)]
 ) as box:
     # ...
 ```
@@ -402,8 +402,8 @@ Mount host directories into boxes for data input/output.
 
 ```python
 volumes=[
-    ("/host/config", "/etc/app/config", "ro"),
-    ("/host/datasets", "/mnt/data", "ro"),
+    ("/host/config", "/etc/app/config", True),
+    ("/host/datasets", "/mnt/data", True),
 ]
 ```
 
@@ -411,8 +411,8 @@ volumes=[
 
 ```python
 volumes=[
-    ("/host/output", "/mnt/output", "rw"),
-    ("/host/logs", "/var/log/app", "rw"),
+    ("/host/output", "/mnt/output", False),
+    ("/host/logs", "/var/log/app", False),
 ]
 ```
 
@@ -428,7 +428,7 @@ import boxlite
 async with boxlite.SimpleBox(
     image="python:slim",
     volumes=[
-        (os.path.expanduser("~/.config/myapp"), "/etc/myapp", "ro")
+        (os.path.expanduser("~/.config/myapp"), "/etc/myapp", True)
     ]
 ) as box:
     result = await box.exec("cat", "/etc/myapp/config.yaml")
@@ -442,8 +442,8 @@ async with boxlite.SimpleBox(
 async with boxlite.SimpleBox(
     image="python:slim",
     volumes=[
-        ("/data/input", "/mnt/input", "ro"),
-        ("/data/output", "/mnt/output", "rw"),
+        ("/data/input", "/mnt/input", True),
+        ("/data/output", "/mnt/output", False),
     ]
 ) as box:
     await box.exec("python", "process.py", "--input", "/mnt/input", "--output", "/mnt/output")
@@ -456,7 +456,7 @@ async with boxlite.SimpleBox(
 async with boxlite.SimpleBox(
     image="python:slim",
     volumes=[
-        (os.getcwd(), "/workspace", "rw")
+        (os.getcwd(), "/workspace", False)
     ],
     working_dir="/workspace"
 ) as box:

--- a/docs/guides/ai-agent-integration.md
+++ b/docs/guides/ai-agent-integration.md
@@ -191,8 +191,8 @@ Use read-only volumes to provide data to the sandbox without risk of modificatio
 options = boxlite.BoxOptions(
     image="python:slim",
     volumes=[
-        ("/host/datasets", "/mnt/data", "ro"),     # Agent can read but not write
-        ("/host/config", "/etc/app/config", "ro"),  # Configuration files
+        ("/host/datasets", "/mnt/data", True),     # Agent can read but not write
+        ("/host/config", "/etc/app/config", True),  # Configuration files
     ],
 )
 ```
@@ -300,8 +300,8 @@ For datasets or configuration that should be available immediately:
 options = boxlite.BoxOptions(
     image="python:slim",
     volumes=[
-        ("/host/datasets", "/mnt/data", "ro"),   # Input data
-        ("/host/results", "/mnt/results", "rw"),  # Output directory
+        ("/host/datasets", "/mnt/data", True),   # Input data
+        ("/host/results", "/mnt/results", False),  # Output directory
     ],
 )
 ```
@@ -371,7 +371,7 @@ async def main():
         memory_mib=1024,
         working_dir="/workspace",
         volumes=[
-            ("/host/datasets", "/mnt/data", "ro"),
+            ("/host/datasets", "/mnt/data", True),
         ],
         security=boxlite.SecurityOptions.maximum(),
     ))

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -311,11 +311,12 @@ env=[
 - Use to override image defaults (e.g., `PATH`)
 - Sensitive values (API keys, passwords) are visible in box metadata
 
-#### `volumes: List[Tuple[str, str, str]]`
+#### `volumes: List[Tuple | Dict]`
 
-Volume mounts as (host_path, guest_path, mode) tuples.
+Volume mounts. A tuple is always a host bind; a dict takes either
+`managed_volume` (a volume's id or name) or `host_path`, never both.
 
-**Format:** `(host_path, guest_path, "ro"|"rw")`
+**Format:** `(host_path, guest_path[, read_only])` - `read_only` is a bool, default `False`.
 
 **Default:** `[]` (no mounts)
 
@@ -323,13 +324,13 @@ Volume mounts as (host_path, guest_path, mode) tuples.
 ```python
 volumes=[
     # Read-only mount (data input)
-    ("/host/config", "/etc/app/config", "ro"),
+    ("/host/config", "/etc/app/config", True),
 
     # Read-write mount (data output)
-    ("/host/data", "/mnt/data", "rw"),
+    ("/host/data", "/mnt/data", False),
 
     # Home directory mount
-    (os.path.expanduser("~/Documents"), "/mnt/docs", "ro"),
+    (os.path.expanduser("~/Documents"), "/mnt/docs", True),
 ]
 ```
 

--- a/docs/reference/cli/README.md
+++ b/docs/reference/cli/README.md
@@ -34,6 +34,7 @@ For a quick start, see [`src/cli/README.md`](../../../src/cli/README.md).
   - [`boxlite stats`](#boxlite-stats)
   - [`boxlite network tunnel`](#boxlite-network-tunnel)
   - [`boxlite serve`](#boxlite-serve)
+  - [`boxlite volume`](#boxlite-volume)
   - [`boxlite completion`](#boxlite-completion)
 - [Shared Flag Groups](#shared-flag-groups)
 - [Volume Mount Syntax](#volume-mount-syntax)
@@ -596,6 +597,42 @@ boxlite serve --host 127.0.0.1 --port 9000
 
 ---
 
+### `boxlite volume`
+
+**Synopsis:** `boxlite volume <create|ls|get|rm>`
+
+Manage managed persistent volumes. Volumes are a REST-runtime capability — the
+local runtime has no volume backend, so every subcommand returns
+`named volumes are not supported yet` against it. See
+[Connecting to the cloud](#connecting-to-the-cloud).
+
+| Subcommand | Synopsis | Notes |
+|---|---|---|
+| `create` | `boxlite volume create [--name NAME]` | Prints the new id |
+| `ls` (`list`) | `boxlite volume ls [-q] [--format FORMAT]` | Columns: ID, NAME, CREATED, SIZE |
+| `get` (`inspect`) | `boxlite volume get ID [--format FORMAT]` | By id |
+| `rm` (`delete`) | `boxlite volume rm ID... [--force]` | By id |
+
+**`--name`** is mountable in place of the id, so a box can ask for the volume it
+wants without knowing the id:
+
+```bash
+boxlite volume create --name my-data       # prints e.g. vol_01K2EXAMPLE
+boxlite run -v my-data:/data alpine        # by name
+boxlite run -v vol_01K2EXAMPLE:/data alpine # or by id
+```
+
+Names must be at least two characters of `[a-zA-Z0-9][a-zA-Z0-9_.-]` — Docker's
+rule, and for the same reason: the name has to survive
+[`-v` parsing](#volume-mount-syntax). A leading `.`, `/` or `~` would classify
+the source as a host path; a `:` would split the spec into the wrong fields.
+Neither name could ever be mounted. Without `--name` the server names the
+volume after its id, which stays mountable.
+
+`get` and `rm` take an id only; mounting is what accepts either.
+
+---
+
 ### `boxlite completion`
 
 **Synopsis:** `boxlite completion <SHELL>`
@@ -691,22 +728,51 @@ Used by `run` and `create` (defined at `src/cli/src/cli.rs:584-604`).
 
 ## Volume Mount Syntax
 
-`-v`/`--volume` accepts the grammar implemented at `src/cli/src/cli.rs:442-519`:
+`-v`/`--volume` accepts the grammar implemented in `src/cli/src/volumespec.rs`:
 
 ```
-VOLUME := HOST_PATH ':' BOX_PATH [':' OPTIONS]          # bind mount
+VOLUME := SOURCE ':' BOX_PATH [':' OPTIONS]             # managed volume or bind mount
         | BOX_PATH [':' OPTIONS]                         # anonymous volume
 ```
+
+`SOURCE` is classified by its **first character**, the same rule Docker uses
+(`docker/cli/internal/volumespec`). Nothing inspects the filesystem, so a spec
+means the same thing on every machine:
+
+| `SOURCE` starts with | Meaning |
+|---|---|
+| `/`, `./`, `../`, `~` | Host path |
+| `\\` (UNC / named pipe) | Host path |
+| A drive letter, e.g. `C:\` or `D:/` | Host path |
+| Anything else | **Managed volume**, by id or by name |
 
 | Form | Example | Behavior |
 |------|---------|----------|
 | `BOX_PATH` | `/data` | Anonymous volume stored under `{home}/volumes/anonymous/<ulid>` |
 | `BOX_PATH:ro` / `BOX_PATH:rw` | `/data:ro` | Anonymous volume with explicit mode |
+| `VOLUME:BOX_PATH` | `my-data:/data` | Managed volume by name |
+| `VOLUME:BOX_PATH` | `vol_01K2EXAMPLE:/data` | Managed volume by server-assigned id |
 | `HOST_PATH:BOX_PATH` | `/host/data:/data` | Bind mount (host directory must exist) |
-| `HOST_PATH:BOX_PATH:OPTIONS` | `/host/data:/data:ro` | Bind mount with options |
+| `HOST_PATH:BOX_PATH:OPTIONS` | `./data:/data:ro` | Bind mount with options |
 | `C:\HOST\PATH:/BOX_PATH[:OPTIONS]` | `C:\data:/app/data:ro` | Windows drive paths are handled — the drive-letter colon is not treated as a separator |
 
 **Options:** `ro` (read-only) or `rw` (read-write, default). Other options are ignored. Relative host paths are canonicalized at parse time; missing host paths fail with `volume host path ...`.
+
+**Runtime support.** Managed volumes require a REST runtime — the local runtime
+has no volume backend and rejects them at create. Host binds are the mirror
+image: they name a path on the machine running the box, so a REST runtime
+refuses them. Manage volumes with [`boxlite volume`](#boxlite-volume).
+
+> **Behavior change.** A bare relative source is no longer a bind mount:
+> `-v data:/app` now means the managed volume `data`, not `./data`. Write
+> `./data:/app` for the bind. Unlike Docker, a mistyped name cannot silently
+> create an empty volume — boxlite never auto-creates, so an unknown reference
+> fails with "Volume 'data' not found".
+
+**Single-character names are not addressable via `-v`.** The parser cannot
+distinguish `a:` from a drive letter, so `-v a:/data` is read as one field and
+fails. Docker has the same limitation and rejects one-character volume names
+outright.
 
 The anonymous-volume base directory is resolved as: `--home`, else `$BOXLITE_HOME`, else `~/.boxlite`, else the system temp dir.
 

--- a/docs/reference/nodejs/README.md
+++ b/docs/reference/nodejs/README.md
@@ -147,13 +147,33 @@ interface JsEnvVar {
 
 #### `JsVolumeSpec`
 
+A mount has exactly one origin — a managed volume or a host bind path:
+
 ```typescript
-interface JsVolumeSpec {
-  hostPath: string;    // Path on host
-  guestPath: string;   // Path in container
-  readOnly?: boolean;  // Default: false
-}
+type JsVolumeSpec =
+  | {
+      // The volume's server-assigned id or its name - the server resolves either.
+      managedVolume: string;
+      guestPath: string;
+      // Read-only managed mounts are not implemented yet; `true` is rejected.
+      readOnly?: false;
+    }
+  | {
+      hostPath: string;    // Path on host
+      guestPath: string;   // Path in container
+      readOnly?: boolean;  // Default: false
+    };
 ```
+
+```typescript
+volumes: [
+  { managedVolume: "my-data", guestPath: "/data" },
+  { managedVolume: "vol_01K2EXAMPLE", guestPath: "/cache" },
+];
+```
+
+Setting both origins, or neither, is rejected. Host bind mounts are
+local-runtime only; a REST runtime refuses them.
 
 #### `JsPortSpec`
 
@@ -387,7 +407,7 @@ interface SimpleBoxOptions {
   detach?: boolean;       // Default: false
   workingDir?: string;    // Working directory
   env?: Record<string, string>;  // Environment variables
-  volumes?: VolumeSpec[]; // Volume mounts
+  volumes?: JsVolumeSpec[]; // Volume mounts (managedVolume or hostPath)
   network?: NetworkSpec;
   ports?: PortSpec[];     // Port mappings
   secrets?: Secret[];

--- a/docs/reference/python/README.md
+++ b/docs/reference/python/README.md
@@ -130,7 +130,7 @@ Configuration options for creating a box.
 | `disk_size_gb` | `int \| None` | `None` | Persistent disk size in GB (None = ephemeral) |
 | `working_dir` | `str` | `"/root"` | Working directory inside container |
 | `env` | `List[Tuple[str, str]]` | `[]` | Environment variables as (key, value) pairs |
-| `volumes` | `List[Tuple[str, str, str]]` | `[]` | Volume mounts as (host_path, guest_path, mode) |
+| `volumes` | `List[Tuple \| Dict]` | `[]` | Volume mounts; tuple = host bind, dict = `managed_volume` or `host_path` |
 | `network` | `NetworkSpec \| None` | `None` | Structured network configuration. Omit for default enabled networking. |
 | `ports` | `List[Tuple \| Dict]` | `[]` | Local TCP forwarding; omit `host_port` in a dict for automatic allocation |
 | `secrets` | `List[Secret]` | `[]` | Outbound HTTP(S) secret substitution rules |
@@ -174,12 +174,28 @@ network = NetworkSpec(
 
 #### Volume Mount Format
 
+A mount has exactly one origin. A tuple is always a host bind:
+
 ```python
 volumes=[
-    ("/host/config", "/etc/app/config", "ro"),  # Read-only
-    ("/host/data", "/mnt/data", "rw"),          # Read-write
+    ("/host/config", "/etc/app/config", True),  # Read-only
+    ("/host/data", "/mnt/data", False),         # Read-write
 ]
 ```
+
+A dict takes `managed_volume` — the volume's server-assigned id **or** its
+name, the server resolves either — or `host_path`, never both:
+
+```python
+volumes=[
+    {"managed_volume": "my-data", "guest_path": "/data"},
+    {"managed_volume": "vol_01K2EXAMPLE", "guest_path": "/cache"},
+    {"host_path": "/host/config", "guest_path": "/etc/app/config"},
+]
+```
+
+Managed volumes require a REST runtime; host binds are local-runtime only.
+`read_only` is rejected on a managed mount - only host binds may be read-only.
 
 #### Port Forwarding Format
 

--- a/docs/reference/rust/README.md
+++ b/docs/reference/rust/README.md
@@ -614,11 +614,7 @@ let options = BoxOptions {
         ("PYTHONPATH".to_string(), "/app".to_string()),
     ],
     volumes: vec![
-        VolumeSpec {
-            host_path: "/home/user/project".to_string(),
-            guest_path: "/app".to_string(),
-            read_only: false,
-        },
+        VolumeSpec::host_path("/home/user/project", "/app"),
     ],
     ports: vec![
         PortSpec {
@@ -683,11 +679,15 @@ impl Default for RootfsSpec {
 
 ### VolumeSpec
 
-Filesystem mount specification.
+Filesystem mount specification. A mount has exactly one origin: a managed
+volume, or a host bind path.
 
 ```rust
 pub struct VolumeSpec {
-    /// Path on host
+    /// Managed volume, by server-assigned id or by name.
+    pub managed_volume: Option<String>,
+
+    /// Path on host. Empty when `managed_volume` is set.
     pub host_path: String,
 
     /// Path inside guest
@@ -697,6 +697,31 @@ pub struct VolumeSpec {
     pub read_only: bool,
 }
 ```
+
+Build one with a constructor rather than by hand:
+
+```rust
+use boxlite::runtime::options::VolumeSpec;
+
+// Managed volume, addressed by name — `"vol_01K2EXAMPLE"` works the same way.
+let by_name = VolumeSpec::managed_volume("my-data", "/data");
+
+// Host bind mount, read-only.
+let bind = VolumeSpec {
+    read_only: true,
+    ..VolumeSpec::host_path("/tmp/data", "/data")
+};
+```
+
+The reference is taken verbatim and reaches the wire unchanged — nothing
+decorates or narrows it.
+
+The two origins are not interchangeable across runtimes:
+
+| Origin | Local runtime | REST runtime |
+| --- | --- | --- |
+| `VolumeSpec::managed_volume` | rejected — no volume backend | mounted |
+| `VolumeSpec::host_path` | mounted | rejected — the path is the server's, not yours |
 
 ### NetworkSpec
 
@@ -1167,9 +1192,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         rootfs: RootfsSpec::Image("python:3.11-slim".to_string()),
         volumes: vec![
             VolumeSpec {
-                host_path: "/home/user/code".to_string(),
-                guest_path: "/app".to_string(),
                 read_only: true,
+                ..VolumeSpec::host_path("/home/user/code", "/app")
             },
         ],
         advanced: AdvancedBoxOptions {

--- a/docs/reference/rust/README.md
+++ b/docs/reference/rust/README.md
@@ -614,7 +614,7 @@ let options = BoxOptions {
         ("PYTHONPATH".to_string(), "/app".to_string()),
     ],
     volumes: vec![
-        VolumeSpec::host_path("/home/user/project", "/app"),
+        VolumeSpec::bind_mount("/home/user/project", "/app"),
     ],
     ports: vec![
         PortSpec {
@@ -698,6 +698,11 @@ pub struct VolumeSpec {
 }
 ```
 
+The constructor names the operation; the `host_path` field names what it holds.
+The field keeps its name because it is persisted box config: boxes on disk carry
+a `host_path` key, so renaming the field would strand every box written before
+such a rename. Renaming the constructor, as here, does not touch what is stored.
+
 Build one with a constructor rather than by hand:
 
 ```rust
@@ -709,7 +714,7 @@ let by_name = VolumeSpec::managed_volume("my-data", "/data");
 // Host bind mount, read-only.
 let bind = VolumeSpec {
     read_only: true,
-    ..VolumeSpec::host_path("/tmp/data", "/data")
+    ..VolumeSpec::bind_mount("/tmp/data", "/data")
 };
 ```
 
@@ -721,7 +726,7 @@ The two origins are not interchangeable across runtimes:
 | Origin | Local runtime | REST runtime |
 | --- | --- | --- |
 | `VolumeSpec::managed_volume` | rejected — no volume backend | mounted |
-| `VolumeSpec::host_path` | mounted | rejected — the path is the server's, not yours |
+| `VolumeSpec::bind_mount` | mounted | rejected — the path is the server's, not yours |
 
 ### NetworkSpec
 
@@ -1193,7 +1198,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         volumes: vec![
             VolumeSpec {
                 read_only: true,
-                ..VolumeSpec::host_path("/home/user/code", "/app")
+                ..VolumeSpec::bind_mount("/home/user/code", "/app")
             },
         ],
         advanced: AdvancedBoxOptions {

--- a/make/quality.mk
+++ b/make/quality.mk
@@ -163,13 +163,13 @@ lint\:c:
 	@echo "🔍 Linting C SDK..."
 	@# Banned unsafe C functions — platform-independent check.
 	@# macOS clang-tidy skips DeprecatedOrUnsafeBufferHandling (no Annex K),
-	@# so this grep catches memcpy/sprintf/strcpy etc. on all platforms.
-	@if grep -rn 'memcpy\|memmove\|sprintf\b\|strcat\|strcpy\|gets\b\|strtok' \
+	@# so this grep catches memcpy/memset/sprintf/strcpy etc. on all platforms.
+	@if grep -rn 'memcpy\|memmove\|memset\|sprintf\b\|strcat\|strcpy\|gets\b\|strtok' \
 		--include='*.c' sdks/c/tests/ sdks/c/src/ 2>/dev/null | \
 		grep -v '// NOLINT' ; then \
 		echo ""; \
 		echo "❌ Banned unsafe C functions found above."; \
-		echo "   Use bounded alternatives (char loops, strlcpy, snprintf)."; \
+		echo "   Use bounded alternatives (= {0} init, char loops, strlcpy, snprintf)."; \
 		echo "   Add '// NOLINT' comment to suppress if intentional."; \
 		exit 1; \
 	fi

--- a/make/test.mk
+++ b/make/test.mk
@@ -379,6 +379,10 @@ test\:stress\:disk: $(if $(SETUP_DONE),,runtime\:debug)
 test\:unit\:python: _ensure-python-deps
 	@echo "🧪 Running Python SDK unit tests..."
 	@. .venv/bin/activate && cd sdks/python && python -m pytest tests/ -v -m "not integration" $(PYTEST_FILTER)
+	@echo "🧪 Running Python binding (Rust) unit tests..."
+	@# --no-default-features drops pyo3's extension-module so the test binary can
+	@# link libpython; see sdks/python/Cargo.toml.
+	@cargo test -p boxlite-python --no-default-features --lib $(CARGOTEST_FILTER)
 
 # Python SDK integration tests.
 test\:integration\:python:
@@ -396,6 +400,8 @@ test\:all\:python:
 test\:unit\:node: _ensure-node-deps
 	@echo "🧪 Running Node.js SDK unit tests..."
 	@cd sdks/node && npm test -- $(VITEST_FILTER)
+	@echo "🧪 Running Node.js binding (Rust) unit tests..."
+	@cargo test -p boxlite-node --lib $(CARGOTEST_FILTER)
 
 # Node.js SDK integration tests (requires VM environment).
 test\:integration\:node:

--- a/openapi/box.openapi.yaml
+++ b/openapi/box.openapi.yaml
@@ -194,6 +194,12 @@ paths:
       summary: Create a managed persistent volume
       description: Creates a volume and waits until its backing object storage is ready.
       tags: [Volumes]
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateVolumeRequest"
       responses:
         "201":
           description: Volume created and ready for use
@@ -1821,31 +1827,30 @@ components:
     VolumeSpec:
       type: object
       description: |
-        Filesystem mount attached to a box. One of `source` or the deprecated
-        `host_path` is required.
-      required: [guest_path]
+        Managed volume mounted into a box. Host bind mounts have no
+        representation here: the path would name the server's filesystem, not
+        the caller's, so the only mount source this API accepts is a managed
+        volume.
+      additionalProperties: false
+      required: [managed_volume, guest_path]
       properties:
-        source:
+        managed_volume:
           type: string
+          minLength: 1
           description: |
-            Scheme-qualified mount source. Use `volume://<volume_id>` for managed
-            volumes.
-          example: volume://vol_01K2EXAMPLE
-        host_path:
-          type: string
-          deprecated: true
-          description: |
-            Deprecated alias for `source`, kept for backward compatibility with
-            existing /v1 clients built against the pre-managed-volumes schema.
-            Use `source` with the `volume://<volume_id>` scheme instead; this
-            field will be removed in a future API version.
-          example: volume://vol_01K2EXAMPLE
+            The volume's server-assigned `id` or its `name` — both resolve to
+            the same volume, and a name is unique within the owning scope.
+          example: vol_01K2EXAMPLE
         guest_path:
           type: string
           description: Mount point inside the container
         read_only:
           type: boolean
           default: false
+          enum: [false]
+          description: |
+            Read-only managed mounts are not implemented yet; `true` is
+            rejected rather than silently downgraded to read-write.
 
     VolumeState:
       type: string
@@ -1870,6 +1875,20 @@ components:
           type: string
           format: date-time
           description: Volume creation timestamp (UTC)
+
+    CreateVolumeRequest:
+      type: object
+      description: Body for volume creation. Omit entirely to create an unnamed volume.
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          description: |
+            Volume name, unique within the owning scope. Mountable in place of
+            the volume's id. Defaults to the server-assigned id when omitted.
+          pattern: "^[a-zA-Z0-9][a-zA-Z0-9_.-]+$"
+          minLength: 2
+          example: my-data
 
     Volume:
       type: object

--- a/openapi/reference-server/server.py
+++ b/openapi/reference-server/server.py
@@ -432,8 +432,15 @@ def build_box_options(req: CreateBoxRequest) -> boxlite.BoxOptions:
     if req.detach is not None:
         kwargs["detach"] = req.detach
     if req.volumes:
+        # The wire carries managed volumes only; a host path would name this
+        # server's filesystem rather than the caller's. Dict form, because a
+        # tuple is always a host bind in the Python SDK.
         kwargs["volumes"] = [
-            (v["host_path"], v["guest_path"], v.get("read_only", False))
+            {
+                "managed_volume": v["managed_volume"],
+                "guest_path": v["guest_path"],
+                "read_only": v.get("read_only", False),
+            }
             for v in req.volumes
         ]
     if req.security:

--- a/sdks/c/README.md
+++ b/sdks/c/README.md
@@ -894,7 +894,7 @@ Callbacks are invoked on the **calling thread**. Do not block in callbacks.
 ### Unreleased
 
 **Breaking Changes:**
-- `boxlite_options_add_volume` is renamed `boxlite_options_add_host_path`, and
+- `boxlite_options_add_volume` is renamed `boxlite_options_add_bind_mount`, and
   the new `boxlite_options_add_managed_volume` mounts a managed volume by its
   server-assigned id or its name. The two mount origins are distinct: a host
   path is local-runtime only, a managed volume REST-runtime only.
@@ -927,7 +927,7 @@ boxlite_volume_create(handle, on_created, user_data, &err);
 After:
 ```c
 /* host bind (local runtime) */
-boxlite_options_add_host_path(opts, "/host/data", "/data", 0);
+boxlite_options_add_bind_mount(opts, "/host/data", "/data", 0);
 /* managed volume by id or name (REST runtime) */
 boxlite_options_add_managed_volume(opts, "my-data", "/data", 0);
 

--- a/sdks/c/README.md
+++ b/sdks/c/README.md
@@ -894,6 +894,18 @@ Callbacks are invoked on the **calling thread**. Do not block in callbacks.
 ### Unreleased
 
 **Breaking Changes:**
+- `boxlite_options_add_volume` is renamed `boxlite_options_add_host_path`, and
+  the new `boxlite_options_add_managed_volume` mounts a managed volume by its
+  server-assigned id or its name. The two mount origins are distinct: a host
+  path is local-runtime only, a managed volume REST-runtime only.
+- `boxlite_volume_create` takes a new `const char *name` as its second
+  argument, before the callback. Pass `NULL` for an unnamed volume. A non-NULL
+  name that is not valid UTF-8 returns `InvalidArgument` rather than silently
+  creating an unnamed volume.
+- `CVolumeInfo` gains a `name` field between `id` and `created_at`, changing
+  the struct layout. Recompile any consumer that reads it; the field is a
+  heap-owned string released by the existing
+  `boxlite_free_volume_info` / `boxlite_free_volume_info_list`.
 - `boxlite_options_add_port` signature changed. Parameters are now host-first
   (matching `PortSpec`, the other SDKs, and Docker's `host:guest` convention),
   ports are `uint16_t`, the new `BoxlitePortProtocol` enum and a nullable
@@ -905,6 +917,23 @@ Callbacks are invoked on the **calling thread**. Do not block in callbacks.
   queued; call `boxlite_runtime_drain()` to dispatch the callback. On success,
   the callback owns the `CBoxInfo *` and must release it with
   `boxlite_free_box_info()`.
+
+Before:
+```c
+boxlite_options_add_volume(opts, "/host/data", "/data", 0);
+boxlite_volume_create(handle, on_created, user_data, &err);
+```
+
+After:
+```c
+/* host bind (local runtime) */
+boxlite_options_add_host_path(opts, "/host/data", "/data", 0);
+/* managed volume by id or name (REST runtime) */
+boxlite_options_add_managed_volume(opts, "my-data", "/data", 0);
+
+boxlite_volume_create(handle, "my-data", on_created, user_data, &err);
+boxlite_volume_create(handle, NULL, on_created, user_data, &err);  /* unnamed */
+```
 
 Before:
 ```c

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -421,6 +421,8 @@ typedef void (*CRuntimeShutdownCb)(CBoxliteError*, void*);
 // meaningful only when `has_size` is non-zero.
 typedef struct CVolumeInfo {
   char *id;
+  // Volume name, mountable in place of the id. Defaults to the id.
+  char *name;
   char *created_at;
   uint64_t size_bytes;
   int has_size;
@@ -799,10 +801,28 @@ void boxlite_options_set_workdir(CBoxliteOptions *opts, const char *workdir);
 
 void boxlite_options_add_env(CBoxliteOptions *opts, const char *key, const char *val);
 
-void boxlite_options_add_volume(CBoxliteOptions *opts,
-                                const char *host_path,
-                                const char *guest_path,
-                                int read_only);
+// Bind a host directory or file into the box.
+//
+// Host bind mounts are local-runtime only; a REST runtime rejects them at
+// create. Use [`boxlite_options_add_managed_volume`] against a REST runtime.
+void boxlite_options_add_host_path(CBoxliteOptions *opts,
+                                   const char *host_path,
+                                   const char *guest_path,
+                                   int read_only);
+
+// Mount a managed volume, addressed by its server-assigned id **or** by its
+// name — the server resolves either.
+//
+// `managed_volume` is the volume's id or name (`"my-data"`, `"vol_01K2…"`).
+// Managed volumes need a REST runtime; the local runtime has no volume backend
+// and rejects one at create.
+//
+// A NULL `opts`, `managed_volume`, or `guest_path` is ignored, matching
+// [`boxlite_options_add_host_path`].
+void boxlite_options_add_managed_volume(CBoxliteOptions *opts,
+                                        const char *managed_volume,
+                                        const char *guest_path,
+                                        int read_only);
 
 // Forward `host_port` on the host to `guest_port` inside the box.
 //
@@ -1021,6 +1041,7 @@ void boxlite_free_string(char *s);
 // remain valid until this function returns. A successful callback must release
 // its metadata with `boxlite_free_volume_info`; the error pointer is borrowed.
 enum BoxliteErrorCode boxlite_volume_create(CBoxliteVolumeHandle *handle,
+                                            const char *name,
                                             CBoxVolumeCreateCb cb,
                                             void *user_data,
                                             CBoxliteError *out_error);

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -805,10 +805,10 @@ void boxlite_options_add_env(CBoxliteOptions *opts, const char *key, const char 
 //
 // Host bind mounts are local-runtime only; a REST runtime rejects them at
 // create. Use [`boxlite_options_add_managed_volume`] against a REST runtime.
-void boxlite_options_add_host_path(CBoxliteOptions *opts,
-                                   const char *host_path,
-                                   const char *guest_path,
-                                   int read_only);
+void boxlite_options_add_bind_mount(CBoxliteOptions *opts,
+                                    const char *host_path,
+                                    const char *guest_path,
+                                    int read_only);
 
 // Mount a managed volume, addressed by its server-assigned id **or** by its
 // name — the server resolves either.
@@ -818,7 +818,7 @@ void boxlite_options_add_host_path(CBoxliteOptions *opts,
 // and rejects one at create.
 //
 // A NULL `opts`, `managed_volume`, or `guest_path` is ignored, matching
-// [`boxlite_options_add_host_path`].
+// [`boxlite_options_add_bind_mount`].
 void boxlite_options_add_managed_volume(CBoxliteOptions *opts,
                                         const char *managed_volume,
                                         const char *guest_path,

--- a/sdks/c/src/options.rs
+++ b/sdks/c/src/options.rs
@@ -75,13 +75,13 @@ pub unsafe extern "C" fn boxlite_options_add_env(
 /// Host bind mounts are local-runtime only; a REST runtime rejects them at
 /// create. Use [`boxlite_options_add_managed_volume`] against a REST runtime.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn boxlite_options_add_host_path(
+pub unsafe extern "C" fn boxlite_options_add_bind_mount(
     opts: *mut CBoxliteOptions,
     host_path: *const c_char,
     guest_path: *const c_char,
     read_only: c_int,
 ) {
-    options_add_host_path(opts, host_path, guest_path, read_only)
+    options_add_bind_mount(opts, host_path, guest_path, read_only)
 }
 
 /// Mount a managed volume, addressed by its server-assigned id **or** by its
@@ -92,7 +92,7 @@ pub unsafe extern "C" fn boxlite_options_add_host_path(
 /// and rejects one at create.
 ///
 /// A NULL `opts`, `managed_volume`, or `guest_path` is ignored, matching
-/// [`boxlite_options_add_host_path`].
+/// [`boxlite_options_add_bind_mount`].
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_options_add_managed_volume(
     opts: *mut CBoxliteOptions,
@@ -366,7 +366,7 @@ pub unsafe fn options_add_env(handle: *mut OptionsHandle, key: *const c_char, va
     }
 }
 
-pub unsafe fn options_add_host_path(
+pub unsafe fn options_add_bind_mount(
     handle: *mut OptionsHandle,
     host_path: *const c_char,
     guest_path: *const c_char,
@@ -379,7 +379,7 @@ pub unsafe fn options_add_host_path(
         if let (Ok(h), Ok(g)) = (c_str_to_string(host_path), c_str_to_string(guest_path)) {
             (*handle).options.volumes.push(VolumeSpec {
                 read_only: read_only != 0,
-                ..VolumeSpec::host_path(h, g)
+                ..VolumeSpec::bind_mount(h, g)
             });
         }
     }

--- a/sdks/c/src/options.rs
+++ b/sdks/c/src/options.rs
@@ -70,14 +70,37 @@ pub unsafe extern "C" fn boxlite_options_add_env(
     options_add_env(opts, key, val)
 }
 
+/// Bind a host directory or file into the box.
+///
+/// Host bind mounts are local-runtime only; a REST runtime rejects them at
+/// create. Use [`boxlite_options_add_managed_volume`] against a REST runtime.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn boxlite_options_add_volume(
+pub unsafe extern "C" fn boxlite_options_add_host_path(
     opts: *mut CBoxliteOptions,
     host_path: *const c_char,
     guest_path: *const c_char,
     read_only: c_int,
 ) {
-    options_add_volume(opts, host_path, guest_path, read_only)
+    options_add_host_path(opts, host_path, guest_path, read_only)
+}
+
+/// Mount a managed volume, addressed by its server-assigned id **or** by its
+/// name — the server resolves either.
+///
+/// `managed_volume` is the volume's id or name (`"my-data"`, `"vol_01K2…"`).
+/// Managed volumes need a REST runtime; the local runtime has no volume backend
+/// and rejects one at create.
+///
+/// A NULL `opts`, `managed_volume`, or `guest_path` is ignored, matching
+/// [`boxlite_options_add_host_path`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_options_add_managed_volume(
+    opts: *mut CBoxliteOptions,
+    managed_volume: *const c_char,
+    guest_path: *const c_char,
+    read_only: c_int,
+) {
+    options_add_managed_volume(opts, managed_volume, guest_path, read_only)
 }
 
 /// Transport protocol for a port forwarding rule.
@@ -343,7 +366,7 @@ pub unsafe fn options_add_env(handle: *mut OptionsHandle, key: *const c_char, va
     }
 }
 
-pub unsafe fn options_add_volume(
+pub unsafe fn options_add_host_path(
     handle: *mut OptionsHandle,
     host_path: *const c_char,
     guest_path: *const c_char,
@@ -355,9 +378,27 @@ pub unsafe fn options_add_volume(
         }
         if let (Ok(h), Ok(g)) = (c_str_to_string(host_path), c_str_to_string(guest_path)) {
             (*handle).options.volumes.push(VolumeSpec {
-                host_path: h,
-                guest_path: g,
                 read_only: read_only != 0,
+                ..VolumeSpec::host_path(h, g)
+            });
+        }
+    }
+}
+
+pub unsafe fn options_add_managed_volume(
+    handle: *mut OptionsHandle,
+    managed_volume: *const c_char,
+    guest_path: *const c_char,
+    read_only: c_int,
+) {
+    unsafe {
+        if handle.is_null() || managed_volume.is_null() || guest_path.is_null() {
+            return;
+        }
+        if let (Ok(v), Ok(g)) = (c_str_to_string(managed_volume), c_str_to_string(guest_path)) {
+            (*handle).options.volumes.push(VolumeSpec {
+                read_only: read_only != 0,
+                ..VolumeSpec::managed_volume(v, g)
             });
         }
     }

--- a/sdks/c/src/volumes.rs
+++ b/sdks/c/src/volumes.rs
@@ -44,6 +44,8 @@ pub struct VolumeHandle {
 #[repr(C)]
 pub struct CVolumeInfo {
     pub id: *mut c_char,
+    /// Volume name, mountable in place of the id. Defaults to the id.
+    pub name: *mut c_char,
     pub created_at: *mut c_char,
     pub size_bytes: u64,
     pub has_size: c_int,
@@ -76,6 +78,7 @@ impl CVolumeInfo {
 
         CVolumeInfo {
             id: to_c_str(&info.id),
+            name: to_c_str(&info.name),
             created_at: to_c_str(&info.created_at.to_rfc3339()),
             size_bytes,
             has_size,
@@ -90,6 +93,7 @@ pub unsafe fn free_volume_info(info: *mut CVolumeInfo) {
         }
         let info_ref = &mut *info;
         free_str(info_ref.id);
+        free_str(info_ref.name);
         free_str(info_ref.created_at);
         drop(Box::from_raw(info));
     }
@@ -104,6 +108,7 @@ pub unsafe fn free_volume_info_list(list: *mut CVolumeInfoList) {
         for idx in 0..list_ref.count {
             let item = &mut *list_ref.items.add(idx as usize);
             free_str(item.id);
+            free_str(item.name);
             free_str(item.created_at);
         }
         if !list_ref.items.is_null() {
@@ -143,11 +148,12 @@ unsafe fn free_str(s: *mut c_char) {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_volume_create(
     handle: *mut CBoxliteVolumeHandle,
+    name: *const c_char,
     cb: CBoxVolumeCreateCb,
     user_data: *mut c_void,
     out_error: *mut CBoxliteError,
 ) -> BoxliteErrorCode {
-    volume_create(handle, cb, user_data, out_error)
+    unsafe { volume_create(handle, name, cb, user_data, out_error) }
 }
 
 /// Queue asynchronous volume listing with the same dispatch, concurrency, and
@@ -245,6 +251,7 @@ pub unsafe extern "C" fn boxlite_free_volume_info_list(list: *mut CVolumeInfoLis
 
 unsafe fn volume_create(
     handle: *mut VolumeHandle,
+    name: *const c_char,
     cb: CBoxVolumeCreateCb,
     user_data: *mut c_void,
     out_error: *mut FFIError,
@@ -266,9 +273,25 @@ unsafe fn volume_create(
         let core_handle = handle_ref.handle.clone();
         let queue = handle_ref.queue.clone();
         let user_data_addr = user_data as usize;
+        // Copied before the spawn: the caller owns the string only until this
+        // function returns. Invalid UTF-8 is refused rather than dropped —
+        // swallowing it would silently create an *unnamed* volume, and the
+        // caller would never learn the name they asked for was discarded.
+        let name = if name.is_null() {
+            None
+        } else {
+            match crate::util::c_str_to_string(name) {
+                Ok(name) => Some(name),
+                Err(e) => {
+                    let code = error_to_code(&e);
+                    write_error(out_error, e);
+                    return code;
+                }
+            }
+        };
 
         handle_ref.tokio_rt.spawn(async move {
-            let result = core_handle.create().await.map(|info| {
+            let result = core_handle.create(name.as_deref()).await.map(|info| {
                 crate::event_queue::OwnedFfiPtr::new_with(
                     Box::new(CVolumeInfo::from_volume_info(&info)),
                     free_volume_info,

--- a/sdks/c/tests/CMakeLists.txt
+++ b/sdks/c/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ include_directories(${BOXLITE_INCLUDE_DIR})
 set(TEST_TARGETS
     test_simple_api
     test_null_callback
+    test_volume_ffi
     test_rest
     test_info
 )
@@ -73,6 +74,9 @@ set_tests_properties(test_simple_api PROPERTIES LABELS "integration")
 # test_null_callback only exercises the FFI argument-validation path;
 # no VM is required, but we still link the runtime dylib.
 set_tests_properties(test_null_callback PROPERTIES LABELS "unit;ffi")
+# test_volume_ffi only exercises signatures and argument validation, so it
+# needs no VM either.
+set_tests_properties(test_volume_ffi PROPERTIES LABELS "unit;ffi")
 # REST runtime construction does no I/O (lazy connect), so it is a
 # true unit test — runs under `make test:unit:c` (ctest -L unit).
 set_tests_properties(test_rest PROPERTIES LABELS "unit")

--- a/sdks/c/tests/test_volume_ffi.c
+++ b/sdks/c/tests/test_volume_ffi.c
@@ -1,0 +1,81 @@
+/**
+ * BoxLite C SDK — managed-volume FFI surface.
+ *
+ * Covers the three ABI breaks recorded in the README migration guide, from a
+ * real C consumer rather than from Rust:
+ *
+ *   1. `boxlite_options_add_volume` split into `boxlite_options_add_host_path`
+ *      (a path on this machine) and `boxlite_options_add_managed_volume`
+ *      (a server-side volume, by id or name).
+ *   2. `boxlite_volume_create` gained a `const char *name` second parameter.
+ *   3. `CVolumeInfo` gained a `name` member, changing the struct layout.
+ *
+ * Compiling this file is itself most of the test: a consumer built against the
+ * old header would not link. The runtime assertions cover the argument
+ * validation that a signature change alone cannot prove.
+ */
+
+#include "boxlite.h"
+#include <assert.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+
+static void on_volume_created(struct CVolumeInfo *info, CBoxliteError *error,
+                              void *user_data) {
+  (void)info;
+  (void)error;
+  (void)user_data;
+}
+
+/* (3) The struct carries a name, and it sits between id and created_at. */
+static void test_volume_info_layout(void) {
+  struct CVolumeInfo info;
+  memset(&info, 0, sizeof(info));
+
+  info.id = NULL;
+  info.name = NULL;
+  info.created_at = NULL;
+
+  assert(offsetof(struct CVolumeInfo, id) < offsetof(struct CVolumeInfo, name));
+  assert(offsetof(struct CVolumeInfo, name) <
+         offsetof(struct CVolumeInfo, created_at));
+  printf("  ok: CVolumeInfo carries a name field\n");
+}
+
+/* (1) Both mount origins are reachable, and neither crashes on a NULL handle.
+ */
+static void test_mount_origin_entrypoints(void) {
+  boxlite_options_add_host_path(NULL, "/host/data", "/data", 0);
+  boxlite_options_add_managed_volume(NULL, "my-data", "/data", 0);
+  printf(
+      "  ok: host-path and managed-volume entrypoints accept a NULL handle\n");
+}
+
+/* (2) The name parameter exists, and a NULL handle is still rejected
+ * synchronously rather than queueing work against nothing. */
+static void test_volume_create_rejects_null_handle(void) {
+  CBoxliteError error;
+  memset(&error, 0, sizeof(error));
+
+  enum BoxliteErrorCode named =
+      boxlite_volume_create(NULL, "my-data", on_volume_created, NULL, &error);
+  assert(named == InvalidArgument);
+
+  memset(&error, 0, sizeof(error));
+  enum BoxliteErrorCode unnamed =
+      boxlite_volume_create(NULL, NULL, on_volume_created, NULL, &error);
+  assert(unnamed == InvalidArgument);
+
+  printf(
+      "  ok: boxlite_volume_create takes a name and rejects a NULL handle\n");
+}
+
+int main(void) {
+  printf("test_volume_ffi\n");
+  test_volume_info_layout();
+  test_mount_origin_entrypoints();
+  test_volume_create_rejects_null_handle();
+  printf("PASS\n");
+  return 0;
+}

--- a/sdks/c/tests/test_volume_ffi.c
+++ b/sdks/c/tests/test_volume_ffi.c
@@ -4,7 +4,7 @@
  * Covers the three ABI breaks recorded in the README migration guide, from a
  * real C consumer rather than from Rust:
  *
- *   1. `boxlite_options_add_volume` split into `boxlite_options_add_host_path`
+ *   1. `boxlite_options_add_volume` split into `boxlite_options_add_bind_mount`
  *      (a path on this machine) and `boxlite_options_add_managed_volume`
  *      (a server-side volume, by id or name).
  *   2. `boxlite_volume_create` gained a `const char *name` second parameter.
@@ -19,7 +19,6 @@
 #include <assert.h>
 #include <stddef.h>
 #include <stdio.h>
-#include <string.h>
 
 static void on_volume_created(struct CVolumeInfo *info, CBoxliteError *error,
                               void *user_data) {
@@ -30,8 +29,7 @@ static void on_volume_created(struct CVolumeInfo *info, CBoxliteError *error,
 
 /* (3) The struct carries a name, and it sits between id and created_at. */
 static void test_volume_info_layout(void) {
-  struct CVolumeInfo info;
-  memset(&info, 0, sizeof(info));
+  struct CVolumeInfo info = {0};
 
   info.id = NULL;
   info.name = NULL;
@@ -46,26 +44,26 @@ static void test_volume_info_layout(void) {
 /* (1) Both mount origins are reachable, and neither crashes on a NULL handle.
  */
 static void test_mount_origin_entrypoints(void) {
-  boxlite_options_add_host_path(NULL, "/host/data", "/data", 0);
+  boxlite_options_add_bind_mount(NULL, "/host/data", "/data", 0);
   boxlite_options_add_managed_volume(NULL, "my-data", "/data", 0);
   printf(
-      "  ok: host-path and managed-volume entrypoints accept a NULL handle\n");
+      "  ok: bind-mount and managed-volume entrypoints accept a NULL handle\n");
 }
 
 /* (2) The name parameter exists, and a NULL handle is still rejected
  * synchronously rather than queueing work against nothing. */
 static void test_volume_create_rejects_null_handle(void) {
-  CBoxliteError error;
-  memset(&error, 0, sizeof(error));
+  CBoxliteError error = {0};
 
   enum BoxliteErrorCode named =
       boxlite_volume_create(NULL, "my-data", on_volume_created, NULL, &error);
   assert(named == InvalidArgument);
+  boxlite_error_free(&error);
 
-  memset(&error, 0, sizeof(error));
   enum BoxliteErrorCode unnamed =
       boxlite_volume_create(NULL, NULL, on_volume_created, NULL, &error);
   assert(unnamed == InvalidArgument);
+  boxlite_error_free(&error);
 
   printf(
       "  ok: boxlite_volume_create takes a name and rejects a NULL handle\n");

--- a/sdks/go/boxlite_test.go
+++ b/sdks/go/boxlite_test.go
@@ -194,14 +194,44 @@ func TestExecutionSignalAcceptsBoundarySignals(t *testing.T) {
 // Options
 // ============================================================================
 
+// A managed volume and a host bind are different origins, not two spellings of
+// one. WithManagedVolume must not land in hostPath, or the mount would be sent
+// to a REST runtime as a server-side path and refused.
+func TestWithManagedVolumeKeepsOriginsApart(t *testing.T) {
+	// By id and by name alike: the server resolves either, so the SDK stores
+	// whatever the caller passed without trying to tell them apart.
+	for _, reference := range []string{"vol_01K2EXAMPLE", "my-data"} {
+		cfg := &boxConfig{}
+		WithManagedVolume(reference, "/data")(cfg)
+		WithHostPath("/tmp/data", "/host-data")(cfg)
+
+		if len(cfg.volumes) != 2 {
+			t.Fatalf("volumes: got %d", len(cfg.volumes))
+		}
+		if cfg.volumes[0].managedVolume != reference || cfg.volumes[0].hostPath != "" {
+			t.Errorf("managed volume: got managedVolume=%q hostPath=%q",
+				cfg.volumes[0].managedVolume, cfg.volumes[0].hostPath)
+		}
+		// There is no read-only counterpart: the server rejects read_only on a
+		// managed mount, so a managed volume is always read-write here.
+		if cfg.volumes[0].readOnly {
+			t.Error("WithManagedVolume should be read-write")
+		}
+		if cfg.volumes[1].hostPath != "/tmp/data" || cfg.volumes[1].managedVolume != "" {
+			t.Errorf("host bind: got managedVolume=%q hostPath=%q",
+				cfg.volumes[1].managedVolume, cfg.volumes[1].hostPath)
+		}
+	}
+}
+
 func TestBoxOptions(t *testing.T) {
 	cfg := &boxConfig{}
 	WithName("test-box")(cfg)
 	WithCPUs(4)(cfg)
 	WithMemory(1024)(cfg)
 	WithEnv("FOO", "bar")(cfg)
-	WithVolume("/host", "/guest")(cfg)
-	WithVolumeReadOnly("/ro-host", "/ro-guest")(cfg)
+	WithHostPath("/host", "/guest")(cfg)
+	WithHostPathReadOnly("/ro-host", "/ro-guest")(cfg)
 	WithPort(PortSpec{Host: 8080, Guest: 3000})(cfg)
 	WithWorkDir("/app")(cfg)
 	WithEntrypoint("/bin/sh")(cfg)

--- a/sdks/go/boxlite_test.go
+++ b/sdks/go/boxlite_test.go
@@ -203,7 +203,7 @@ func TestWithManagedVolumeKeepsOriginsApart(t *testing.T) {
 	for _, reference := range []string{"vol_01K2EXAMPLE", "my-data"} {
 		cfg := &boxConfig{}
 		WithManagedVolume(reference, "/data")(cfg)
-		WithHostPath("/tmp/data", "/host-data")(cfg)
+		WithBindMount("/tmp/data", "/host-data")(cfg)
 
 		if len(cfg.volumes) != 2 {
 			t.Fatalf("volumes: got %d", len(cfg.volumes))
@@ -230,8 +230,8 @@ func TestBoxOptions(t *testing.T) {
 	WithCPUs(4)(cfg)
 	WithMemory(1024)(cfg)
 	WithEnv("FOO", "bar")(cfg)
-	WithHostPath("/host", "/guest")(cfg)
-	WithHostPathReadOnly("/ro-host", "/ro-guest")(cfg)
+	WithBindMount("/host", "/guest")(cfg)
+	WithBindMountReadOnly("/ro-host", "/ro-guest")(cfg)
 	WithPort(PortSpec{Host: 8080, Guest: 3000})(cfg)
 	WithWorkDir("/app")(cfg)
 	WithEntrypoint("/bin/sh")(cfg)

--- a/sdks/go/options.go
+++ b/sdks/go/options.go
@@ -242,18 +242,18 @@ func WithEnv(key, value string) BoxOption {
 	}
 }
 
-// WithHostPath binds a host path into the box.
+// WithBindMount binds a host path into the box.
 //
 // Host binds are local-runtime only; a REST runtime rejects them at create.
 // Use [WithManagedVolume] against a REST runtime.
-func WithHostPath(hostPath, guestPath string) BoxOption {
+func WithBindMount(hostPath, guestPath string) BoxOption {
 	return func(c *boxConfig) {
 		c.volumes = append(c.volumes, volumeEntry{hostPath: hostPath, guestPath: guestPath})
 	}
 }
 
-// WithHostPathReadOnly binds a host path into the box as read-only.
-func WithHostPathReadOnly(hostPath, guestPath string) BoxOption {
+// WithBindMountReadOnly binds a host path into the box as read-only.
+func WithBindMountReadOnly(hostPath, guestPath string) BoxOption {
 	return func(c *boxConfig) {
 		c.volumes = append(c.volumes, volumeEntry{hostPath: hostPath, guestPath: guestPath, readOnly: true})
 	}
@@ -274,7 +274,7 @@ func WithManagedVolume(managedVolume, guestPath string) BoxOption {
 
 // Read-only managed volumes have no WithManagedVolumeReadOnly counterpart:
 // the server rejects read_only on a managed mount, so the option could only
-// ever produce an error. Host binds keep WithHostPathReadOnly.
+// ever produce an error. Host binds keep WithBindMountReadOnly.
 
 // WithPort publishes a guest port on a host port.
 //
@@ -448,7 +448,7 @@ func buildCOptions(image string, cfg *boxConfig) (*C.CBoxliteOptions, error) {
 			C.free(unsafe.Pointer(cVolume))
 		} else {
 			cHost := toCString(volume.hostPath)
-			C.boxlite_options_add_host_path(cOpts, cHost, cGuest, readOnly)
+			C.boxlite_options_add_bind_mount(cOpts, cHost, cGuest, readOnly)
 			C.free(unsafe.Pointer(cHost))
 		}
 		C.free(unsafe.Pointer(cGuest))

--- a/sdks/go/options.go
+++ b/sdks/go/options.go
@@ -191,10 +191,13 @@ type boxConfig struct {
 	advanced   *AdvancedBoxOptions // nil = runtime defaults; non-nil = caller-owned advanced opts applied via boxlite_options_set_advanced
 }
 
+// volumeEntry is one mount. Exactly one origin is set: managedVolume for a
+// server-side managed volume, hostPath for a bind from the local filesystem.
 type volumeEntry struct {
-	hostPath  string
-	guestPath string
-	readOnly  bool
+	managedVolume string
+	hostPath      string
+	guestPath     string
+	readOnly      bool
 }
 
 // WithName sets a human-readable name for the box.
@@ -239,19 +242,39 @@ func WithEnv(key, value string) BoxOption {
 	}
 }
 
-// WithVolume mounts a host path into the box.
-func WithVolume(hostPath, containerPath string) BoxOption {
+// WithHostPath binds a host path into the box.
+//
+// Host binds are local-runtime only; a REST runtime rejects them at create.
+// Use [WithManagedVolume] against a REST runtime.
+func WithHostPath(hostPath, guestPath string) BoxOption {
 	return func(c *boxConfig) {
-		c.volumes = append(c.volumes, volumeEntry{hostPath, containerPath, false})
+		c.volumes = append(c.volumes, volumeEntry{hostPath: hostPath, guestPath: guestPath})
 	}
 }
 
-// WithVolumeReadOnly mounts a host path into the box as read-only.
-func WithVolumeReadOnly(hostPath, containerPath string) BoxOption {
+// WithHostPathReadOnly binds a host path into the box as read-only.
+func WithHostPathReadOnly(hostPath, guestPath string) BoxOption {
 	return func(c *boxConfig) {
-		c.volumes = append(c.volumes, volumeEntry{hostPath, containerPath, true})
+		c.volumes = append(c.volumes, volumeEntry{hostPath: hostPath, guestPath: guestPath, readOnly: true})
 	}
 }
+
+// WithManagedVolume mounts a managed volume into the box.
+//
+// managedVolume is the volume's server-assigned id or its name — the server
+// resolves either.
+//
+// Managed volumes need a REST runtime; the local runtime has no volume backend
+// and rejects one at create.
+func WithManagedVolume(managedVolume, guestPath string) BoxOption {
+	return func(c *boxConfig) {
+		c.volumes = append(c.volumes, volumeEntry{managedVolume: managedVolume, guestPath: guestPath})
+	}
+}
+
+// Read-only managed volumes have no WithManagedVolumeReadOnly counterpart:
+// the server rejects read_only on a managed mount, so the option could only
+// ever produce an error. Host binds keep WithHostPathReadOnly.
 
 // WithPort publishes a guest port on a host port.
 //
@@ -414,14 +437,20 @@ func buildCOptions(image string, cfg *boxConfig) (*C.CBoxliteOptions, error) {
 		C.free(unsafe.Pointer(cValue))
 	}
 	for _, volume := range cfg.volumes {
-		cHost := toCString(volume.hostPath)
 		cGuest := toCString(volume.guestPath)
 		readOnly := C.int(0)
 		if volume.readOnly {
 			readOnly = 1
 		}
-		C.boxlite_options_add_volume(cOpts, cHost, cGuest, readOnly)
-		C.free(unsafe.Pointer(cHost))
+		if volume.managedVolume != "" {
+			cVolume := toCString(volume.managedVolume)
+			C.boxlite_options_add_managed_volume(cOpts, cVolume, cGuest, readOnly)
+			C.free(unsafe.Pointer(cVolume))
+		} else {
+			cHost := toCString(volume.hostPath)
+			C.boxlite_options_add_host_path(cOpts, cHost, cGuest, readOnly)
+			C.free(unsafe.Pointer(cHost))
+		}
 		C.free(unsafe.Pointer(cGuest))
 	}
 	for _, port := range cfg.ports {

--- a/sdks/go/security_readonly_volume_remount_integration_test.go
+++ b/sdks/go/security_readonly_volume_remount_integration_test.go
@@ -2,7 +2,7 @@
 
 // Regression test for GHSA-g6ww-w5j2-r7x3 (read-only volume remount bypass).
 //
-// A host directory mounted via WithVolumeReadOnly must stay read-only even
+// A host directory mounted via WithHostPathReadOnly must stay read-only even
 // against a malicious guest that runs `mount -o remount,rw`. Before v0.9.0
 // the guest could remount the virtiofs share read-write (it had
 // CAP_SYS_ADMIN) and write through to the host.
@@ -42,7 +42,7 @@ func TestSecurityReadonlyVolumeRemountBypass(t *testing.T) {
 	rt := newTestRuntime(t)
 	box := createStartedBoxOrSkip(t, rt, "alpine:latest",
 		WithAutoRemove(false),
-		WithVolumeReadOnly(hostDir, roGuestMount),
+		WithHostPathReadOnly(hostDir, roGuestMount),
 	)
 
 	ctx := context.Background()

--- a/sdks/go/security_readonly_volume_remount_integration_test.go
+++ b/sdks/go/security_readonly_volume_remount_integration_test.go
@@ -2,7 +2,7 @@
 
 // Regression test for GHSA-g6ww-w5j2-r7x3 (read-only volume remount bypass).
 //
-// A host directory mounted via WithHostPathReadOnly must stay read-only even
+// A host directory mounted via WithBindMountReadOnly must stay read-only even
 // against a malicious guest that runs `mount -o remount,rw`. Before v0.9.0
 // the guest could remount the virtiofs share read-write (it had
 // CAP_SYS_ADMIN) and write through to the host.
@@ -42,7 +42,7 @@ func TestSecurityReadonlyVolumeRemountBypass(t *testing.T) {
 	rt := newTestRuntime(t)
 	box := createStartedBoxOrSkip(t, rt, "alpine:latest",
 		WithAutoRemove(false),
-		WithHostPathReadOnly(hostDir, roGuestMount),
+		WithBindMountReadOnly(hostDir, roGuestMount),
 	)
 
 	ctx := context.Background()

--- a/sdks/go/volumes.go
+++ b/sdks/go/volumes.go
@@ -19,7 +19,9 @@ import (
 // time as a string, mirroring the Node/Python SDKs). SizeBytes is nil when the
 // payload size could not be computed.
 type VolumeInfo struct {
-	Id        string
+	Id string
+	// Name is mountable in place of Id. The server defaults it to Id.
+	Name      string
 	CreatedAt string
 	SizeBytes *uint64
 }
@@ -52,7 +54,10 @@ func (r *Runtime) Volumes() (*Volumes, error) {
 }
 
 // Create creates a volume and returns its metadata.
-func (v *Volumes) Create(ctx context.Context) (*VolumeInfo, error) {
+//
+// name may be mounted in place of the volume's id; pass "" to let the server
+// name the volume after its id.
+func (v *Volumes) Create(ctx context.Context, name string) (*VolumeInfo, error) {
 	if v == nil {
 		return nil, closedVolumesError()
 	}
@@ -66,8 +71,14 @@ func (v *Volumes) Create(ctx context.Context) (*VolumeInfo, error) {
 	ch := make(chan volumeResult, 1)
 	h := registerHandleForDispatch(cgo.NewHandle(ch))
 
+	var cName *C.char
+	if name != "" {
+		cName = toCString(name)
+		defer C.free(unsafe.Pointer(cName))
+	}
+
 	var cerr C.CBoxliteError
-	code := C.boxlite_volume_create(v.handle, C.cbVolumeCreate(), handleToPtr(h), &cerr)
+	code := C.boxlite_volume_create(v.handle, cName, C.cbVolumeCreate(), handleToPtr(h), &cerr)
 	v.mu.RUnlock()
 	if code != C.Ok {
 		deleteHandleForDispatch(h)
@@ -225,6 +236,7 @@ func cVolumeInfoToGo(info *C.CVolumeInfo) VolumeInfo {
 	}
 	return VolumeInfo{
 		Id:        cString(info.id),
+		Name:      cString(info.name),
 		CreatedAt: cString(info.created_at),
 		SizeBytes: size,
 	}

--- a/sdks/node/README.md
+++ b/sdks/node/README.md
@@ -190,7 +190,10 @@ const box = new SimpleBox({
   },
   env: { FOO: 'bar' },
   volumes: [
-    { hostPath: '/tmp/data', guestPath: '/data', readOnly: false }
+    // A host bind (local runtimes only)...
+    { hostPath: '/tmp/data', guestPath: '/data', readOnly: false },
+    // ...or a managed volume, by id or by name (REST runtimes).
+    { managedVolume: 'my-data', guestPath: '/cache' }
   ],
   ports: [
     { hostPort: 8080, guestPort: 80 }

--- a/sdks/node/lib/native-contracts.ts
+++ b/sdks/node/lib/native-contracts.ts
@@ -27,10 +27,12 @@ export interface ImageHandle {
   list(): Promise<ImageInfo[]>;
 }
 
-/** Metadata for a named volume returned by the native runtime. */
+/** Metadata for a managed volume returned by the native runtime. */
 export interface VolumeInfo {
   /** Server-assigned volume id used by get and remove operations. */
   id: string;
+  /** Volume name, mountable in place of the id. Defaults to the id. */
+  name: string;
   /** Creation timestamp formatted as an RFC 3339 string. */
   createdAt: string;
   /** Volume size in bytes when the backend can report it. */
@@ -40,13 +42,15 @@ export interface VolumeInfo {
 /** Runtime-scoped handle for named-volume operations. */
 export interface VolumeHandle {
   /**
-   * Creates a new named volume.
+   * Creates a new managed volume.
    *
+   * @param name Optional volume name, mountable in place of the returned id.
+   * The server names the volume after its id when omitted.
    * @returns Metadata for the created volume.
    * @throws A native BoxLite error when the backend does not support volumes or
    * the volume cannot be created.
    */
-  create(): Promise<VolumeInfo>;
+  create(name?: string): Promise<VolumeInfo>;
   /**
    * Lists named volumes visible to this runtime.
    *
@@ -77,29 +81,21 @@ export interface JsEnvVar {
   value: string;
 }
 
-export type JsVolumeSpec =
-  | {
-      /** Scheme-qualified managed volume source, e.g. volume://vol_123. */
-      source: string;
-      guestPath: string;
-      readOnly?: boolean;
-    }
-  | {
-      /** Path on the local host for host-path mounts. */
-      hostPath: string;
-      guestPath: string;
-      readOnly?: boolean;
-    };
+export type JsVolumeSpec = JsManagedVolumeSpec | JsHostPathVolumeSpec;
 
-export interface JsVolumeSourceSpec {
-  /** Scheme-qualified managed volume source, e.g. volume://vol_123. */
-  source: string;
+export interface JsManagedVolumeSpec {
+  /** Managed volume, by server-assigned id or by name — the server resolves either. */
+  managedVolume: string;
   guestPath: string;
-  readOnly?: boolean;
+  /**
+   * Read-only managed mounts are not implemented yet; `true` is rejected
+   * rather than silently downgraded to read-write.
+   */
+  readOnly?: false;
 }
 
 export interface JsHostPathVolumeSpec {
-  /** Path on the local host for host-path mounts. */
+  /** Path on the local host for host-path mounts. Local runtimes only. */
   hostPath: string;
   guestPath: string;
   readOnly?: boolean;

--- a/sdks/node/lib/simplebox.ts
+++ b/sdks/node/lib/simplebox.ts
@@ -216,7 +216,7 @@ export interface SimpleBoxOptions {
   /** Environment variables */
   env?: Record<string, string>;
 
-  /** Volume mounts: local hostPath or managed source such as volume://vol_123. */
+  /** Volume mounts: a local hostPath, or a managedVolume by id or name. */
   volumes?: JsVolumeSpec[];
 
   /** Port mappings */

--- a/sdks/node/src/options.rs
+++ b/sdks/node/src/options.rs
@@ -290,7 +290,7 @@ impl TryFrom<JsVolumeSpec> for VolumeSpec {
             (Some(managed_volume), None) => {
                 VolumeSpec::managed_volume(managed_volume, v.guest_path)
             }
-            (None, Some(host_path)) => VolumeSpec::host_path(host_path, v.guest_path),
+            (None, Some(host_path)) => VolumeSpec::bind_mount(host_path, v.guest_path),
             (None, None) => {
                 return Err(Self::Error::InvalidArgument(
                     "volume requires managedVolume or hostPath".into(),

--- a/sdks/node/src/options.rs
+++ b/sdks/node/src/options.rs
@@ -258,12 +258,14 @@ pub struct JsEnvVar {
 
 /// Volume mount specification.
 ///
-/// Maps a host directory to a guest path inside the container.
+/// Maps either a managed volume or a host directory to a guest path inside the
+/// container. Exactly one origin may be set.
 #[napi(object)]
 #[derive(Clone, Debug)]
 pub struct JsVolumeSpec {
-    /// Scheme-qualified source such as `volume://vol_123`.
-    pub source: Option<String>,
+    /// Managed volume, by server-assigned id **or** by name — the server
+    /// resolves either.
+    pub managed_volume: Option<String>,
 
     /// Path on host machine for local host-path mounts.
     pub host_path: Option<String>,
@@ -279,27 +281,26 @@ impl TryFrom<JsVolumeSpec> for VolumeSpec {
     type Error = boxlite_shared::errors::BoxliteError;
 
     fn try_from(v: JsVolumeSpec) -> Result<Self, Self::Error> {
-        let host_path = match (v.source, v.host_path) {
-            (Some(source), _) => {
-                if !source.starts_with("volume://") {
-                    return Err(Self::Error::InvalidArgument(
-                        "volume source must use the volume:// scheme".into(),
-                    ));
-                }
-                source
+        let spec = match (v.managed_volume, v.host_path) {
+            (Some(_), Some(_)) => {
+                return Err(Self::Error::InvalidArgument(
+                    "volume takes managedVolume or hostPath, not both".into(),
+                ));
             }
-            (None, Some(host_path)) => host_path,
+            (Some(managed_volume), None) => {
+                VolumeSpec::managed_volume(managed_volume, v.guest_path)
+            }
+            (None, Some(host_path)) => VolumeSpec::host_path(host_path, v.guest_path),
             (None, None) => {
                 return Err(Self::Error::InvalidArgument(
-                    "volume source or hostPath is required".into(),
+                    "volume requires managedVolume or hostPath".into(),
                 ));
             }
         };
 
         Ok(VolumeSpec {
-            host_path,
-            guest_path: v.guest_path,
             read_only: v.read_only.unwrap_or(false),
+            ..spec
         })
     }
 }
@@ -722,39 +723,50 @@ mod tests {
         }
     }
 
+    /// A managed volume is taken verbatim — by id or by name, no scheme, no
+    /// rewriting. Whatever the caller wrote is what the server resolves.
     #[test]
-    fn js_volume_source_requires_volume_scheme() {
-        let volume = VolumeSpec::try_from(JsVolumeSpec {
-            source: Some("volume://vol_123".into()),
-            host_path: None,
+    fn js_managed_volume_is_taken_verbatim() {
+        for reference in ["vol_01K2EXAMPLE", "my-data"] {
+            let volume = VolumeSpec::try_from(JsVolumeSpec {
+                managed_volume: Some(reference.into()),
+                host_path: None,
+                guest_path: "/data".into(),
+                read_only: None,
+            })
+            .unwrap();
+
+            assert_eq!(volume.managed_volume.as_deref(), Some(reference));
+            assert_eq!(volume.host_path, "");
+            assert_eq!(volume.guest_path, "/data");
+            assert!(!volume.read_only);
+        }
+    }
+
+    #[test]
+    fn js_volume_requires_exactly_one_origin() {
+        let err = VolumeSpec::try_from(JsVolumeSpec {
+            managed_volume: Some("my-data".into()),
+            host_path: Some("/tmp/data".into()),
             guest_path: "/data".into(),
             read_only: None,
         })
-        .unwrap();
+        .unwrap_err();
 
-        assert_eq!(volume.host_path, "volume://vol_123");
-        assert_eq!(volume.guest_path, "/data");
-        assert!(!volume.read_only);
+        assert!(err.to_string().contains("not both"), "{err}");
 
         let err = VolumeSpec::try_from(JsVolumeSpec {
-            source: Some("vol_123".into()),
+            managed_volume: None,
             host_path: None,
             guest_path: "/data".into(),
             read_only: None,
         })
         .unwrap_err();
 
-        assert!(err.to_string().contains("volume:// scheme"));
-
-        let err = VolumeSpec::try_from(JsVolumeSpec {
-            source: None,
-            host_path: None,
-            guest_path: "/data".into(),
-            read_only: None,
-        })
-        .unwrap_err();
-
-        assert!(err.to_string().contains("source or hostPath is required"));
+        assert!(
+            err.to_string().contains("managedVolume or hostPath"),
+            "{err}"
+        );
     }
 
     #[test]

--- a/sdks/node/src/volumes.rs
+++ b/sdks/node/src/volumes.rs
@@ -12,6 +12,8 @@ use crate::util::map_err;
 #[derive(Clone, Debug)]
 pub struct JsVolumeInfo {
     pub id: String,
+    /// Volume name, mountable in place of the id. Defaults to the id.
+    pub name: String,
     #[napi(js_name = "createdAt")]
     pub created_at: String,
     #[napi(js_name = "sizeBytes")]
@@ -22,6 +24,7 @@ impl From<&VolumeInfo> for JsVolumeInfo {
     fn from(info: &VolumeInfo) -> Self {
         Self {
             id: info.id.clone(),
+            name: info.name.clone(),
             created_at: info.created_at.to_rfc3339(),
             // Saturating cast preserves a stable JS number surface if a future
             // backend ever reports a value beyond signed 64-bit range.
@@ -47,10 +50,13 @@ pub struct JsVolumeHandle {
 #[napi]
 impl JsVolumeHandle {
     /// Create a volume and return its metadata.
+    ///
+    /// `name` is optional and can be mounted in place of the volume's id. The
+    /// server names the volume after its id when omitted.
     #[napi]
-    pub async fn create(&self) -> Result<JsVolumeInfo> {
+    pub async fn create(&self, name: Option<String>) -> Result<JsVolumeInfo> {
         let handle = Arc::clone(&self.handle);
-        let info = handle.create().await.map_err(map_err)?;
+        let info = handle.create(name.as_deref()).await.map_err(map_err)?;
         Ok(JsVolumeInfo::from(&info))
     }
 

--- a/sdks/node/tests/options.test.ts
+++ b/sdks/node/tests/options.test.ts
@@ -190,15 +190,19 @@ describe("SimpleBoxOptions", () => {
     expect(opts.network?.mode).toBe("disabled");
   });
 
-  test("accepts managed volume source mounts", async () => {
+  test("accepts managed volume mounts by id and by name", async () => {
     const { SimpleBox } = await import("../lib/simplebox.js");
     const box = new SimpleBox({
-      volumes: [{ source: "volume://vol_123", guestPath: "/data" }],
+      volumes: [
+        { managedVolume: "vol_01K2EXAMPLE", guestPath: "/data" },
+        { managedVolume: "my-data", guestPath: "/cache" },
+      ],
     });
     const nativeOptions = (box as any)._boxOpts;
 
     expect(nativeOptions.volumes).toEqual([
-      { source: "volume://vol_123", guestPath: "/data" },
+      { managedVolume: "vol_01K2EXAMPLE", guestPath: "/data" },
+      { managedVolume: "my-data", guestPath: "/cache" },
     ]);
   });
 

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -12,13 +12,24 @@ name = "boxlite_python"
 crate-type = ["cdylib"]
 
 [features]
-default = []
+# `extension-module` tells pyo3 not to link libpython, which is right for the
+# wheel maturin builds but makes `cargo test` unlinkable. Gating it lets the
+# binding's own unit tests run with --no-default-features while every normal
+# build keeps the wheel behaviour.
+default = ["extension-module"]
+extension-module = ["pyo3/extension-module"]
 
 [dependencies]
 boxlite = { path = "../../src/boxlite", features = ["rest"] }
-pyo3 = { version = "0.27.1", features = ["extension-module"] }
+pyo3 = { version = "0.27.1" }
 pyo3-async-runtimes = { version = "0.27", features = ["tokio-runtime"] }
 tokio = { version = "1.37", features = ["io-util", "net", "sync"] }
 futures = "0.3.31"
 tracing = "0.1.44"
 serde_json = "1.0"
+
+[dev-dependencies]
+# `cargo test --no-default-features` links libpython but does not start an
+# interpreter; auto-initialize does that on first use so the binding's own
+# tests can build Python objects.
+pyo3 = { version = "0.27.1", features = ["auto-initialize"] }

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -239,8 +239,8 @@ Configuration options for creating a box.
 - `disk_size_gb: int | None` - Persistent disk size in GB (default: None)
 - `working_dir: str` - Working directory in container (default: `"/root"`)
 - `env: List[Tuple[str, str]]` - Environment variables as (key, value) pairs
-- `volumes: List[Tuple[str, str, str]]` - Volume mounts as (host_path, guest_path, mode)
-  - Mode: `"ro"` (read-only) or `"rw"` (read-write)
+- `volumes: List[Tuple | Dict]` - Volume mounts; a tuple is a host bind, a dict takes `managed_volume` (id or name) or `host_path`
+  - `read_only` is a bool and defaults to `False`
 - `network: NetworkSpec | None` - Structured network configuration
 - `ports: List[Tuple | Dict]` - Local TCP forwarding; omit `host_port` in a dict for automatic allocation
   - Protocol: `"tcp"`; UDP is rejected
@@ -277,7 +277,7 @@ options = boxlite.BoxOptions(
         ("POSTGRES_DB", "mydb"),
     ],
     volumes=[
-        ("/host/data", "/mnt/data", "ro"),  # Read-only mount
+        ("/host/data", "/mnt/data", True),  # Read-only mount
     ],
     ports=[
         (5432, 5432, "tcp"),  # PostgreSQL
@@ -639,9 +639,9 @@ boxlite.BoxOptions(
 boxlite.BoxOptions(
     volumes=[
         # Read-only mount
-        ("/host/config", "/etc/app/config", "ro"),
+        ("/host/config", "/etc/app/config", True),
         # Read-write mount
-        ("/host/data", "/mnt/data", "rw"),
+        ("/host/data", "/mnt/data", False),
     ]
 )
 ```

--- a/sdks/python/src/options.rs
+++ b/sdks/python/src/options.rs
@@ -605,7 +605,7 @@ impl From<PyVolumeSpec> for VolumeSpec {
     fn from(v: PyVolumeSpec) -> Self {
         let spec = match v.managed_volume {
             Some(managed_volume) => VolumeSpec::managed_volume(managed_volume, v.guest_path),
-            None => VolumeSpec::host_path(v.host_path, v.guest_path),
+            None => VolumeSpec::bind_mount(v.host_path, v.guest_path),
         };
 
         VolumeSpec {

--- a/sdks/python/src/options.rs
+++ b/sdks/python/src/options.rs
@@ -587,19 +587,30 @@ impl TryFrom<PyBoxOptions> for BoxOptions {
     }
 }
 
+/// One entry of the `volumes=` argument, before it becomes a [`VolumeSpec`].
+///
+/// `managed_volume` holds a volume id or name from the `managed_volume` key;
+/// `host_path` holds a bind path from a tuple or the `host_path` key. Exactly
+/// one is set. The dict keys are the core field names verbatim, so one
+/// vocabulary spans Python, the Rust core and the wire.
 #[derive(Clone, Debug)]
 pub(crate) struct PyVolumeSpec {
-    host: String,
-    guest: String,
+    managed_volume: Option<String>,
+    host_path: String,
+    guest_path: String,
     read_only: bool,
 }
 
 impl From<PyVolumeSpec> for VolumeSpec {
     fn from(v: PyVolumeSpec) -> Self {
+        let spec = match v.managed_volume {
+            Some(managed_volume) => VolumeSpec::managed_volume(managed_volume, v.guest_path),
+            None => VolumeSpec::host_path(v.host_path, v.guest_path),
+        };
+
         VolumeSpec {
-            host_path: v.host,
-            guest_path: v.guest,
             read_only: v.read_only,
+            ..spec
         }
     }
 }
@@ -610,75 +621,94 @@ impl<'a, 'py> pyo3::FromPyObject<'a, 'py> for PyVolumeSpec {
     fn extract(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
         let obj = ob.to_owned();
 
+        // Tuple form is a host bind, and only a host bind: it predates managed
+        // volumes and has no slot to say which origin it means.
         if let Ok(t) = obj.cast::<PyTuple>() {
             let len = t.len();
-            let err =
-                || PyRuntimeError::new_err("volumes tuples must be (host, guest[, read_only])");
-            let host: String;
-            let guest: String;
+            let err = || {
+                PyRuntimeError::new_err(
+                    "volumes tuples must be (host_path, guest_path[, read_only])",
+                )
+            };
+            let host_path: String;
+            let guest_path: String;
             let read_only: bool;
 
             match len {
                 2 => {
-                    host = t.get_item(0)?.extract()?;
-                    guest = t.get_item(1)?.extract()?;
+                    host_path = t.get_item(0)?.extract()?;
+                    guest_path = t.get_item(1)?.extract()?;
                     read_only = false;
                 }
                 3 => {
-                    host = t.get_item(0)?.extract()?;
-                    guest = t.get_item(1)?.extract()?;
+                    host_path = t.get_item(0)?.extract()?;
+                    guest_path = t.get_item(1)?.extract()?;
                     read_only = t.get_item(2)?.extract()?;
                 }
                 _ => return Err(err()),
             }
 
             return Ok(PyVolumeSpec {
-                host,
-                guest,
+                managed_volume: None,
+                host_path,
+                guest_path,
                 read_only,
             });
         }
 
         if let Ok(d) = obj.cast::<PyDict>() {
-            let host: String = if let Ok(Some(v)) = d.get_item("source") {
-                let source: String = v.extract()?;
-                if !source.starts_with("volume://") {
+            // Unknown keys are an error, not noise. `ro` and `guest` used to be
+            // accepted aliases; ignoring them now would silently hand back a
+            // read-write mount to a caller who asked for read-only.
+            const KEYS: [&str; 4] = ["managed_volume", "host_path", "guest_path", "read_only"];
+            for key in d.keys() {
+                let key: String = key.extract()?;
+                if !KEYS.contains(&key.as_str()) {
+                    return Err(PyRuntimeError::new_err(format!(
+                        "unknown volume dict key {key:?}; expected one of {}",
+                        KEYS.join(", ")
+                    )));
+                }
+            }
+
+            let managed_volume: Option<String> = match d.get_item("managed_volume") {
+                Ok(Some(v)) => Some(v.extract()?),
+                _ => None,
+            };
+            let host_path: Option<String> = match d.get_item("host_path") {
+                Ok(Some(v)) => Some(v.extract()?),
+                _ => None,
+            };
+
+            let (managed_volume, host_path) = match (managed_volume, host_path) {
+                (Some(_), Some(_)) => {
                     return Err(PyRuntimeError::new_err(
-                        "volume source must use the volume:// scheme",
+                        "volume dict takes managed_volume or host_path, not both",
                     ));
                 }
-                source
-            } else if let Ok(Some(v)) = d.get_item("host") {
-                v.extract()?
-            } else if let Ok(Some(v)) = d.get_item("host_path") {
-                v.extract()?
-            } else {
-                return Err(PyRuntimeError::new_err(
-                    "volume dict missing source/host/host_path",
-                ));
+                (Some(managed_volume), None) => (Some(managed_volume), String::new()),
+                (None, Some(host_path)) => (None, host_path),
+                (None, None) => {
+                    return Err(PyRuntimeError::new_err(
+                        "volume dict requires managed_volume or host_path",
+                    ));
+                }
             };
 
-            let guest: String = if let Ok(Some(v)) = d.get_item("guest") {
-                v.extract()?
-            } else if let Ok(Some(v)) = d.get_item("guest_path") {
-                v.extract()?
-            } else {
-                return Err(PyRuntimeError::new_err(
-                    "volume dict missing guest/guest_path",
-                ));
+            let guest_path: String = match d.get_item("guest_path") {
+                Ok(Some(v)) => v.extract()?,
+                _ => return Err(PyRuntimeError::new_err("volume dict missing guest_path")),
             };
 
-            let read_only: bool = if let Ok(Some(v)) = d.get_item("read_only") {
-                v.extract()?
-            } else if let Ok(Some(v)) = d.get_item("ro") {
-                v.extract()?
-            } else {
-                false
+            let read_only: bool = match d.get_item("read_only") {
+                Ok(Some(v)) => v.extract()?,
+                _ => false,
             };
 
             return Ok(PyVolumeSpec {
-                host,
-                guest,
+                managed_volume,
+                host_path,
+                guest_path,
                 read_only,
             });
         }
@@ -1062,24 +1092,80 @@ mod tests {
         assert_eq!(capabilities.add, ["SYS_ADMIN"]);
     }
 
+    /// A managed volume is taken verbatim — by id or by name alike. The server
+    /// resolves either, so the SDK must not narrow it or rewrite it.
     #[test]
-    fn py_volume_source_requires_volume_scheme() {
+    fn py_managed_volume_is_taken_verbatim() {
         Python::attach(|py| {
-            let valid = PyDict::new(py);
-            valid.set_item("source", "volume://vol_123").unwrap();
-            valid.set_item("guest_path", "/data").unwrap();
+            for reference in ["vol_01K2EXAMPLE", "my-data"] {
+                let dict = PyDict::new(py);
+                dict.set_item("managed_volume", reference).unwrap();
+                dict.set_item("guest_path", "/data").unwrap();
+                dict.set_item("read_only", true).unwrap();
 
-            let volume = valid.extract::<PyVolumeSpec>().unwrap();
-            assert_eq!(volume.host, "volume://vol_123");
-            assert_eq!(volume.guest, "/data");
-            assert!(!volume.read_only);
+                let spec = VolumeSpec::from(dict.extract::<PyVolumeSpec>().unwrap());
+                assert_eq!(spec.managed_volume.as_deref(), Some(reference));
+                assert_eq!(spec.host_path, "");
+                assert_eq!(spec.guest_path, "/data");
+                assert!(spec.read_only);
+            }
+        });
+    }
 
-            let invalid = PyDict::new(py);
-            invalid.set_item("source", "vol_123").unwrap();
-            invalid.set_item("guest_path", "/data").unwrap();
+    /// A dropped alias must fail loudly. `ro` was accepted before the rename;
+    /// ignoring it as an unknown key would silently turn a read-only mount
+    /// into a read-write one — a permission downgrade the caller never sees.
+    #[test]
+    fn py_volume_dict_rejects_unknown_keys() {
+        Python::attach(|py| {
+            for (key, value) in [("ro", "true"), ("guest", "/d"), ("source", "my-data")] {
+                let dict = PyDict::new(py);
+                dict.set_item("host_path", "/tmp/data").unwrap();
+                dict.set_item("guest_path", "/data").unwrap();
+                dict.set_item(key, value).unwrap();
 
-            let err = invalid.extract::<PyVolumeSpec>().unwrap_err();
-            assert!(err.to_string().contains("volume:// scheme"));
+                let err = dict.extract::<PyVolumeSpec>().unwrap_err();
+                let message = err.to_string();
+                assert!(message.contains("unknown volume dict key"), "{message}");
+                assert!(message.contains(key), "{message}");
+            }
+        });
+    }
+
+    #[test]
+    fn py_volume_dict_requires_exactly_one_origin() {
+        Python::attach(|py| {
+            let both = PyDict::new(py);
+            both.set_item("managed_volume", "my-data").unwrap();
+            both.set_item("host_path", "/tmp/data").unwrap();
+            both.set_item("guest_path", "/data").unwrap();
+
+            let err = both.extract::<PyVolumeSpec>().unwrap_err();
+            assert!(err.to_string().contains("not both"), "{err}");
+
+            let neither = PyDict::new(py);
+            neither.set_item("guest_path", "/data").unwrap();
+
+            let err = neither.extract::<PyVolumeSpec>().unwrap_err();
+            assert!(
+                err.to_string().contains("managed_volume or host_path"),
+                "{err}"
+            );
+        });
+    }
+
+    /// Tuples stay host binds. They predate managed volumes and have no slot
+    /// to say which origin they mean, so a first element that merely looks
+    /// like a volume name must not be promoted to a managed volume.
+    #[test]
+    fn py_volume_tuple_stays_a_host_bind() {
+        Python::attach(|py| {
+            let tuple = PyTuple::new(py, ["/tmp/data", "/data"]).unwrap();
+            let spec = VolumeSpec::from(tuple.extract::<PyVolumeSpec>().unwrap());
+
+            assert_eq!(spec.managed_volume, None);
+            assert_eq!(spec.host_path, "/tmp/data");
+            assert_eq!(spec.guest_path, "/data");
         });
     }
 }

--- a/sdks/python/src/volumes.rs
+++ b/sdks/python/src/volumes.rs
@@ -6,13 +6,16 @@ use pyo3::prelude::*;
 
 use crate::util::map_err;
 
-/// Metadata for a named volume.
+/// Metadata for a managed volume.
 #[pyclass(name = "VolumeInfo")]
 #[derive(Clone)]
 pub(crate) struct PyVolumeInfo {
     /// Server-assigned volume id used by get and remove operations.
     #[pyo3(get)]
     pub(crate) id: String,
+    /// Volume name, mountable in place of the id. Defaults to the id.
+    #[pyo3(get)]
+    pub(crate) name: String,
     /// Creation timestamp formatted as an RFC 3339 string.
     #[pyo3(get)]
     pub(crate) created_at: String,
@@ -25,8 +28,8 @@ pub(crate) struct PyVolumeInfo {
 impl PyVolumeInfo {
     fn __repr__(&self) -> String {
         format!(
-            "VolumeInfo(id={:?}, created_at={:?})",
-            self.id, self.created_at
+            "VolumeInfo(id={:?}, name={:?}, created_at={:?})",
+            self.id, self.name, self.created_at
         )
     }
 }
@@ -35,6 +38,7 @@ impl From<VolumeInfo> for PyVolumeInfo {
     fn from(info: VolumeInfo) -> Self {
         Self {
             id: info.id,
+            name: info.name,
             created_at: info.created_at.to_rfc3339(),
             size_bytes: info.size_bytes,
         }
@@ -49,14 +53,17 @@ pub(crate) struct PyVolumeHandle {
 
 #[pymethods]
 impl PyVolumeHandle {
-    /// Create a named volume.
+    /// Create a volume.
     ///
-    /// Returns an awaitable that resolves to the new `VolumeInfo`. Backend
-    /// failures are raised when the awaitable is awaited.
-    fn create<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+    /// `name` is optional and can be mounted in place of the volume's id; the
+    /// server names the volume after its id when omitted. Returns an awaitable
+    /// that resolves to the new `VolumeInfo`. Backend failures are raised when
+    /// the awaitable is awaited.
+    #[pyo3(signature = (name=None))]
+    fn create<'py>(&self, py: Python<'py>, name: Option<String>) -> PyResult<Bound<'py, PyAny>> {
         let handle = Arc::clone(&self.handle);
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let info = handle.create().await.map_err(map_err)?;
+            let info = handle.create(name.as_deref()).await.map_err(map_err)?;
             Ok(PyVolumeInfo::from(info))
         })
     }

--- a/src/boxlite/src/jailer/builder.rs
+++ b/src/boxlite/src/jailer/builder.rs
@@ -419,11 +419,13 @@ mod tests {
             .with_box_id("test-box")
             .with_layout(test_layout("/tmp/box"))
             .with_volume(VolumeSpec {
+                managed_volume: None,
                 host_path: "/data".to_string(),
                 guest_path: "/mnt/data".to_string(),
                 read_only: true,
             })
             .with_volume(VolumeSpec {
+                managed_volume: None,
                 host_path: "/output".to_string(),
                 guest_path: "/mnt/output".to_string(),
                 read_only: false,

--- a/src/boxlite/src/jailer/command.rs
+++ b/src/boxlite/src/jailer/command.rs
@@ -183,6 +183,7 @@ mod tests {
             .with_layout(test_layout("/tmp/ctx-test"))
             .with_security(security)
             .with_volume(VolumeSpec {
+                managed_volume: None,
                 host_path: "/data".to_string(),
                 guest_path: "/mnt/data".to_string(),
                 read_only: true,

--- a/src/boxlite/src/jailer/mod.rs
+++ b/src/boxlite/src/jailer/mod.rs
@@ -332,7 +332,12 @@ fn build_path_access(layout: &BoxFilesystemLayout, volumes: &[VolumeSpec]) -> Ve
     // User volumes. Directories are shared directly, so grant the VMM access.
     // Single files are staged under shared_dir (granted above), so they need no
     // grant here — this also keeps the file's host siblings out of the sandbox.
+    // A managed volume names no host path, so there is nothing to grant; the
+    // local runtime rejects one before boot anyway (`resolve_user_volumes`).
     for vol in volumes {
+        if vol.managed_volume.is_some() {
+            continue;
+        }
         let p = PathBuf::from(&vol.host_path);
         if let Some(VolumeShare::Dir(dir)) = classify_volume_share(&p) {
             paths.push(PathAccess {
@@ -873,11 +878,13 @@ mod tests {
 
         let volumes = vec![
             VolumeSpec {
+                managed_volume: None,
                 host_path: vol_ro.to_string_lossy().to_string(),
                 guest_path: "/mnt/input".to_string(),
                 read_only: true,
             },
             VolumeSpec {
+                managed_volume: None,
                 host_path: vol_rw.to_string_lossy().to_string(),
                 guest_path: "/mnt/output".to_string(),
                 read_only: false,
@@ -905,6 +912,7 @@ mod tests {
         let layout = test_layout(dir.path().to_path_buf());
 
         let volumes = vec![VolumeSpec {
+            managed_volume: None,
             host_path: "/does/not/exist".to_string(),
             guest_path: "/mnt/data".to_string(),
             read_only: true,
@@ -929,6 +937,7 @@ mod tests {
         std::fs::write(&file, "k=v\n").unwrap();
 
         let volumes = vec![VolumeSpec {
+            managed_volume: None,
             host_path: file.to_string_lossy().to_string(),
             guest_path: "/etc/app.conf".to_string(),
             read_only: true,
@@ -1066,6 +1075,7 @@ mod tests {
             .with_layout(layout.clone())
             .with_security(security)
             .with_volumes(vec![VolumeSpec {
+                managed_volume: None,
                 host_path: vol_dir.to_string_lossy().to_string(),
                 guest_path: "/mnt/data".to_string(),
                 read_only: false,

--- a/src/boxlite/src/litebox/init/types.rs
+++ b/src/boxlite/src/litebox/init/types.rs
@@ -396,7 +396,7 @@ mod tests {
 
     #[test]
     fn resolve_volume_nonexistent_path_errors() {
-        let volumes = vec![VolumeSpec::host_path("/nonexistent/path/12345", "/data")];
+        let volumes = vec![VolumeSpec::bind_mount("/nonexistent/path/12345", "/data")];
 
         let result = resolve_user_volumes(&volumes);
         assert!(result.is_err());

--- a/src/boxlite/src/litebox/init/types.rs
+++ b/src/boxlite/src/litebox/init/types.rs
@@ -51,6 +51,18 @@ pub fn resolve_user_volumes(volumes: &[VolumeSpec]) -> BoxliteResult<Vec<Resolve
     let mut resolved = Vec::with_capacity(volumes.len());
 
     for (i, vol) in volumes.iter().enumerate() {
+        // Managed volumes live on the server that owns the volume backend.
+        // Without this the reference falls through to the host-path checks
+        // below and surfaces as "host path does not exist: my-data", which
+        // points the caller at their own filesystem instead of at the
+        // runtime they used.
+        if let Some(reference) = &vol.managed_volume {
+            return Err(BoxliteError::Unsupported(format!(
+                "managed volume {reference:?} requires a REST runtime; the local runtime has no \
+                 volume backend to resolve it against"
+            )));
+        }
+
         let host_path = PathBuf::from(&vol.host_path);
 
         if !host_path.exists() {
@@ -362,6 +374,7 @@ mod tests {
     fn resolve_volume_gets_owner_uid() {
         let tmp = tempfile::tempdir().unwrap();
         let volumes = vec![VolumeSpec {
+            managed_volume: None,
             host_path: tmp.path().to_str().unwrap().to_string(),
             guest_path: "/data".to_string(),
             read_only: false,
@@ -383,14 +396,34 @@ mod tests {
 
     #[test]
     fn resolve_volume_nonexistent_path_errors() {
-        let volumes = vec![VolumeSpec {
-            host_path: "/nonexistent/path/12345".to_string(),
-            guest_path: "/data".to_string(),
-            read_only: false,
-        }];
+        let volumes = vec![VolumeSpec::host_path("/nonexistent/path/12345", "/data")];
 
         let result = resolve_user_volumes(&volumes);
         assert!(result.is_err());
+    }
+
+    /// The local runtime has no volume backend, so a managed volume has to say
+    /// so. Without the guard the reference falls through to the host-path
+    /// checks and reports "host path does not exist: my-data", which sends the
+    /// caller looking for a directory they never asked for.
+    #[test]
+    fn resolve_managed_volume_reports_the_missing_backend() {
+        let volumes = vec![VolumeSpec::managed_volume("my-data", "/data")];
+
+        let error = resolve_user_volumes(&volumes)
+            .expect_err("the local runtime cannot resolve a managed volume");
+
+        assert!(
+            matches!(error, BoxliteError::Unsupported(_)),
+            "{error:?} should be Unsupported, not a config error about a path"
+        );
+        let message = error.to_string();
+        assert!(message.contains("my-data"), "{message}");
+        assert!(message.contains("REST runtime"), "{message}");
+        assert!(
+            !message.contains("host path"),
+            "the error must not blame a host path: {message}"
+        );
     }
 
     #[test]
@@ -400,6 +433,7 @@ mod tests {
         std::fs::write(&file_path, "key=value\n").unwrap();
 
         let volumes = vec![VolumeSpec {
+            managed_volume: None,
             host_path: file_path.to_str().unwrap().to_string(),
             guest_path: "/etc/app.conf".to_string(),
             read_only: true,

--- a/src/boxlite/src/rest/runtime.rs
+++ b/src/boxlite/src/rest/runtime.rs
@@ -592,7 +592,7 @@ mod tests {
         let options = BoxliteRestOptions::new("http://localhost:1");
         let runtime = RestRuntime::new(&options).expect("failed to create REST runtime");
         let box_options = BoxOptions {
-            volumes: vec![VolumeSpec::host_path("/tmp/secrets", "/mnt/ro")],
+            volumes: vec![VolumeSpec::bind_mount("/tmp/secrets", "/mnt/ro")],
             ..Default::default()
         };
 

--- a/src/boxlite/src/rest/runtime.rs
+++ b/src/boxlite/src/rest/runtime.rs
@@ -52,11 +52,11 @@ impl AuthBackend for RestRuntime {
 
 #[async_trait::async_trait]
 impl VolumeBackend for RestRuntime {
-    async fn create_volume(&self) -> BoxliteResult<VolumeInfo> {
-        let resp: VolumeResponse = self
-            .client
-            .post("/volumes", &CreateVolumeRequest {})
-            .await?;
+    async fn create_volume(&self, name: Option<&str>) -> BoxliteResult<VolumeInfo> {
+        let request = CreateVolumeRequest {
+            name: name.map(str::to_string),
+        };
+        let resp: VolumeResponse = self.client.post("/volumes", &request).await?;
         Ok(resp.to_volume_info())
     }
 
@@ -108,11 +108,57 @@ fn reject_remote_experimental_options(options: &BoxOptions) -> BoxliteResult<()>
     Ok(())
 }
 
+/// Check the mounts a REST runtime was asked for.
+///
+/// Two things happen here, and neither happens anywhere else on this path:
+/// `BoxOptions::sanitize` is local-only, so `VolumeSpec::validate` — the
+/// "exactly one origin" invariant that C and Go callers can violate by setting
+/// the fields directly — has no other chance to run before the request goes out.
+///
+/// A host bind then has no meaning against a REST runtime: the path names the
+/// *server's* filesystem, not the caller's. The rejected path is deliberately
+/// not quoted back — the caller already knows what they asked for, and echoing
+/// a server-side path into a client error is a leak, not a diagnostic.
+fn validate_remote_volumes(options: &BoxOptions) -> BoxliteResult<()> {
+    for volume in &options.volumes {
+        volume.validate()?;
+    }
+
+    if options
+        .volumes
+        .iter()
+        .any(|volume| volume.managed_volume.is_none())
+    {
+        return Err(BoxliteError::Unsupported(
+            "host bind mounts are only supported by the local runtime; mount a managed volume \
+             by id or name instead"
+                .to_string(),
+        ));
+    }
+
+    // The server rejects `read_only: true` on a managed mount. Refusing here
+    // says so plainly instead of surfacing a field-level 400, and — more to the
+    // point — never lets a caller believe a writable mount is protected.
+    if let Some(volume) = options
+        .volumes
+        .iter()
+        .find(|volume| volume.read_only)
+        .and_then(|volume| volume.managed_volume.as_deref())
+    {
+        return Err(BoxliteError::Unsupported(format!(
+            "read-only managed volumes are not supported yet; mount {volume:?} read-write"
+        )));
+    }
+
+    Ok(())
+}
+
 #[async_trait::async_trait]
 impl RuntimeBackend for RestRuntime {
     async fn create(&self, options: BoxOptions, name: Option<String>) -> BoxliteResult<LiteBox> {
         validate_remote_box_options(&options)?;
         reject_remote_experimental_options(&options)?;
+        validate_remote_volumes(&options)?;
 
         // Validate only the caller's requested policy. An unset auto_stop means
         // "no auto-stop", so it must not borrow the server's default here —
@@ -148,6 +194,7 @@ impl RuntimeBackend for RestRuntime {
     ) -> BoxliteResult<(LiteBox, bool)> {
         validate_remote_box_options(&options)?;
         reject_remote_experimental_options(&options)?;
+        validate_remote_volumes(&options)?;
 
         // Try to get existing box by name first
         if let Some(ref box_name) = name
@@ -532,6 +579,88 @@ mod tests {
 
         assert!(matches!(error, BoxliteError::Unsupported(_)));
         assert!(error.to_string().contains("local runtime"));
+    }
+
+    /// A host path has no meaning against a REST runtime — the server's
+    /// filesystem is not the caller's. The path must not leave the client at
+    /// all: it is the caller's own business, and a server-side "not found"
+    /// naming it would leak it into logs on the way back.
+    #[tokio::test]
+    async fn create_rejects_host_bind_mount_in_rest_mode() {
+        use crate::runtime::options::VolumeSpec;
+
+        let options = BoxliteRestOptions::new("http://localhost:1");
+        let runtime = RestRuntime::new(&options).expect("failed to create REST runtime");
+        let box_options = BoxOptions {
+            volumes: vec![VolumeSpec::host_path("/tmp/secrets", "/mnt/ro")],
+            ..Default::default()
+        };
+
+        let error = RuntimeBackend::create(&runtime, box_options, None)
+            .await
+            .err()
+            .expect("REST host bind mounts must be rejected before network I/O");
+
+        assert!(matches!(error, BoxliteError::Unsupported(_)), "{error:?}");
+        assert!(error.to_string().contains("host bind mounts"));
+        assert!(
+            !error.to_string().contains("/tmp/secrets"),
+            "the rejected host path must not be echoed back: {error}"
+        );
+    }
+
+    /// The server rejects `read_only: true` on a managed mount. Refusing it
+    /// here keeps a caller from believing a writable mount is protected — the
+    /// failure mode that matters is the silent downgrade, not the 400.
+    #[tokio::test]
+    async fn create_rejects_read_only_managed_volume() {
+        use crate::runtime::options::VolumeSpec;
+
+        let options = BoxliteRestOptions::new("http://localhost:1");
+        let runtime = RestRuntime::new(&options).expect("failed to create REST runtime");
+        let box_options = BoxOptions {
+            volumes: vec![VolumeSpec {
+                read_only: true,
+                ..VolumeSpec::managed_volume("my-data", "/data")
+            }],
+            ..Default::default()
+        };
+
+        let error = RuntimeBackend::create(&runtime, box_options, None)
+            .await
+            .err()
+            .expect("read-only managed volumes must be rejected before network I/O");
+
+        assert!(matches!(error, BoxliteError::Unsupported(_)), "{error:?}");
+        assert!(error.to_string().contains("read-only"), "{error}");
+    }
+
+    /// The guard is about host paths, not about mounts: a managed volume gets
+    /// past it and on to the request, addressed by id or by name alike.
+    #[tokio::test]
+    async fn create_accepts_managed_volume_by_id_or_name() {
+        use crate::runtime::options::VolumeSpec;
+
+        for reference in ["vol_01K2EXAMPLE", "my-data"] {
+            let options = BoxliteRestOptions::new("http://localhost:1");
+            let runtime = RestRuntime::new(&options).expect("failed to create REST runtime");
+            let box_options = BoxOptions {
+                volumes: vec![VolumeSpec::managed_volume(reference, "/data")],
+                ..Default::default()
+            };
+
+            // localhost:1 refuses the connection, so reaching *any* transport
+            // error is the proof that the mount cleared client-side validation.
+            let error = RuntimeBackend::create(&runtime, box_options, None)
+                .await
+                .err()
+                .expect("no server is listening on localhost:1");
+
+            assert!(
+                !matches!(error, BoxliteError::Unsupported(_)),
+                "managed volume {reference:?} must not be refused client-side: {error:?}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -220,9 +220,12 @@ pub(crate) struct CreateBoxAdvancedOptions {
     pub capabilities: ContainerCapabilities,
 }
 
+/// A mount on the wire. Only managed volumes exist here — a REST server has no
+/// host filesystem to bind from, so `validate_remote_volumes` refuses a host
+/// bind at create and this type has no field for one.
 #[derive(Debug, Serialize)]
 pub(crate) struct CreateBoxVolumeSpec {
-    pub source: String,
+    pub managed_volume: String,
     pub guest_path: String,
     pub read_only: bool,
 }
@@ -230,18 +233,15 @@ pub(crate) struct CreateBoxVolumeSpec {
 impl From<&crate::runtime::options::VolumeSpec> for CreateBoxVolumeSpec {
     fn from(volume: &crate::runtime::options::VolumeSpec) -> Self {
         Self {
-            source: managed_volume_source(&volume.host_path),
+            // `validate_remote_volumes` runs first and refuses any mount whose
+            // `managed_volume` is unset, so the default is unreachable rather
+            // than a fallback: an empty string would be a selector the server
+            // can never resolve. `From` cannot report that, which is why the
+            // check lives at create instead of here.
+            managed_volume: volume.managed_volume.clone().unwrap_or_default(),
             guest_path: volume.guest_path.clone(),
             read_only: volume.read_only,
         }
-    }
-}
-
-fn managed_volume_source(source: &str) -> String {
-    if source.starts_with("volume://") {
-        source.to_string()
-    } else {
-        format!("volume://{source}")
     }
 }
 
@@ -385,15 +385,23 @@ pub(crate) struct ListBoxesResponse {
 // Named volumes (`/v1/volumes`)
 // ============================================================================
 
-/// Body for `POST /v1/volumes`. Volume creation takes no parameters — the
-/// server assigns the id — so the body is empty.
+/// Body for `POST /v1/volumes`.
+///
+/// `name` is omitted from the wire when unset, so an unnamed create still sends
+/// `{}` and the server falls back to the assigned id.
 #[derive(Debug, Serialize)]
-pub(crate) struct CreateVolumeRequest {}
+pub(crate) struct CreateVolumeRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
 
 /// A single volume as returned by the REST API.
 #[derive(Debug, Deserialize)]
 pub(crate) struct VolumeResponse {
     pub id: String,
+    /// Required by the spec, but defaulted so a pre-name server still parses.
+    #[serde(default)]
+    pub name: String,
     pub created_at: String,
     #[serde(default)]
     pub size_bytes: Option<u64>,
@@ -407,6 +415,13 @@ impl VolumeResponse {
 
         crate::volumes::VolumeInfo {
             id: self.id.clone(),
+            // A server that predates the name field leaves it blank; fall back
+            // to the id, which is what an unnamed volume is called anyway.
+            name: if self.name.is_empty() {
+                self.id.clone()
+            } else {
+                self.name.clone()
+            },
             created_at,
             size_bytes: self.size_bytes,
         }
@@ -686,11 +701,7 @@ mod tests {
                 hosts: vec!["api.openai.com".into()],
                 placeholder: "<BOXLITE_SECRET:openai>".into(),
             }],
-            volumes: vec![VolumeSpec {
-                host_path: "volume-123".into(),
-                guest_path: "/data".into(),
-                read_only: false,
-            }],
+            volumes: vec![VolumeSpec::managed_volume("volume-123", "/data")],
             auto_stop: Some(1800),
             auto_delete: Some(604800),
             ..Default::default()
@@ -711,14 +722,14 @@ mod tests {
         );
         assert_eq!(req.secrets.as_ref().map(Vec::len), Some(1));
         let volume = &req.volumes.as_ref().unwrap()[0];
-        assert_eq!(volume.source, "volume://volume-123");
+        assert_eq!(volume.managed_volume, "volume-123");
         assert_eq!(volume.guest_path, "/data");
         assert!(!volume.read_only);
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(
             json["volumes"],
             serde_json::json!([{
-                "source": "volume://volume-123",
+                "managed_volume": "volume-123",
                 "guest_path": "/data",
                 "read_only": false
             }])
@@ -785,22 +796,64 @@ mod tests {
         assert!(json.get("advanced").is_some());
     }
 
+    /// An unnamed create must not put `"name": null` on the wire — the spec
+    /// marks the body optional and its schema `additionalProperties: false`.
     #[test]
-    fn test_create_box_request_preserves_scheme_volume_source() {
+    fn unnamed_volume_create_omits_the_name_key() {
+        let json = serde_json::to_value(CreateVolumeRequest { name: None }).unwrap();
+        assert_eq!(json, serde_json::json!({}));
+
+        let named = serde_json::to_value(CreateVolumeRequest {
+            name: Some("my-data".into()),
+        })
+        .unwrap();
+        assert_eq!(named, serde_json::json!({"name": "my-data"}));
+    }
+
+    /// A server that predates the name field sends no `name`. Falling back to
+    /// the id keeps `VolumeInfo.name` mountable rather than empty — an unnamed
+    /// volume is called by its id server-side anyway.
+    #[test]
+    fn volume_response_without_a_name_falls_back_to_the_id() {
+        let response: VolumeResponse =
+            serde_json::from_str(r#"{"id":"vol_01K2EXAMPLE","created_at":"2026-08-26T00:00:00Z"}"#)
+                .expect("a pre-name server response must still parse");
+        assert_eq!(response.to_volume_info().name, "vol_01K2EXAMPLE");
+
+        let named: VolumeResponse = serde_json::from_str(
+            r#"{"id":"vol_01K2EXAMPLE","name":"my-data","created_at":"2026-08-26T00:00:00Z"}"#,
+        )
+        .unwrap();
+        assert_eq!(named.to_volume_info().name, "my-data");
+    }
+
+    /// The reference reaches the wire byte-for-byte as the caller wrote it,
+    /// whether it is a server-assigned id or a name. The server resolves both,
+    /// so the client neither narrows nor decorates it — there is no scheme to
+    /// add, and nothing here may rewrite the value.
+    #[test]
+    fn managed_volume_reaches_wire_verbatim_by_id_or_by_name() {
         use crate::runtime::options::{BoxOptions, VolumeSpec};
 
-        let opts = BoxOptions {
-            volumes: vec![VolumeSpec {
-                host_path: "volume://volume-123".into(),
-                guest_path: "/data".into(),
-                read_only: false,
-            }],
-            ..Default::default()
-        };
+        for reference in ["vol_01K2EXAMPLE", "my-data"] {
+            let opts = BoxOptions {
+                volumes: vec![VolumeSpec::managed_volume(reference, "/data")],
+                ..Default::default()
+            };
 
-        let req = CreateBoxRequest::from_options(&opts, None);
-        let volume = &req.volumes.as_ref().unwrap()[0];
-        assert_eq!(volume.source, "volume://volume-123");
+            let req = CreateBoxRequest::from_options(&opts, None);
+            let volume = &req.volumes.as_ref().unwrap()[0];
+            assert_eq!(volume.managed_volume, reference);
+            assert_eq!(volume.guest_path, "/data");
+
+            let json = serde_json::to_value(&req).unwrap();
+            assert_eq!(json["volumes"][0]["managed_volume"], reference);
+            assert!(
+                json["volumes"][0].get("source").is_none(),
+                "the wire has no `source` field any more: {}",
+                json["volumes"][0]
+            );
+        }
     }
 
     #[test]

--- a/src/boxlite/src/runtime/core.rs
+++ b/src/boxlite/src/runtime/core.rs
@@ -471,7 +471,7 @@ impl BoxliteRuntime {
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let runtime = BoxliteRuntime::with_defaults()?;
     /// let volumes = runtime.volumes()?;
-    /// let info = volumes.create().await?;
+    /// let info = volumes.create(Some("my-data")).await?;
     /// println!("created volume {}", info.id);
     /// # Ok(())
     /// # }

--- a/src/boxlite/src/runtime/import.rs
+++ b/src/boxlite/src/runtime/import.rs
@@ -116,8 +116,10 @@ fn options_from_manifest(
     if matches!(options.rootfs, RootfsSpec::RootfsPath(_)) {
         return Err(rejected_upload("host rootfs paths"));
     }
+    // Every mount, not just a host bind: a managed volume reference in an
+    // uploaded archive would also select storage the uploader does not own.
     if !options.volumes.is_empty() {
-        return Err(rejected_upload("host volume mounts"));
+        return Err(rejected_upload("volume mounts"));
     }
     options.advanced.security = SecurityOptions::default();
 
@@ -328,18 +330,37 @@ mod tests {
     #[test]
     fn untrusted_import_rejects_host_volumes() {
         let mut options = BoxOptions::default();
-        options.volumes.push(crate::runtime::options::VolumeSpec {
-            host_path: "/".to_string(),
-            guest_path: "/host".to_string(),
-            read_only: false,
-        });
+        options
+            .volumes
+            .push(crate::runtime::options::VolumeSpec::host_path("/", "/host"));
 
         let error =
             options_from_manifest(&v3_manifest(options), ArchiveImportPolicy::UntrustedRemote)
                 .expect_err("untrusted archives must not select server host paths");
 
         assert!(matches!(error, BoxliteError::Unsupported(_)), "{error:?}");
-        assert!(error.to_string().contains("host volume mounts"));
+        assert!(error.to_string().contains("volume mounts"));
+    }
+
+    /// The second mount kind is refused by the same gate. A managed volume
+    /// names storage the uploader does not necessarily own, so an archive
+    /// arriving over REST must not be able to select one either.
+    #[test]
+    fn untrusted_import_rejects_managed_volumes() {
+        let mut options = BoxOptions::default();
+        options
+            .volumes
+            .push(crate::runtime::options::VolumeSpec::managed_volume(
+                "someone-elses-data",
+                "/data",
+            ));
+
+        let error =
+            options_from_manifest(&v3_manifest(options), ArchiveImportPolicy::UntrustedRemote)
+                .expect_err("untrusted archives must not select managed volumes");
+
+        assert!(matches!(error, BoxliteError::Unsupported(_)), "{error:?}");
+        assert!(error.to_string().contains("volume mounts"));
     }
 
     #[test]

--- a/src/boxlite/src/runtime/import.rs
+++ b/src/boxlite/src/runtime/import.rs
@@ -332,7 +332,9 @@ mod tests {
         let mut options = BoxOptions::default();
         options
             .volumes
-            .push(crate::runtime::options::VolumeSpec::host_path("/", "/host"));
+            .push(crate::runtime::options::VolumeSpec::bind_mount(
+                "/", "/host",
+            ));
 
         let error =
             options_from_manifest(&v3_manifest(options), ArchiveImportPolicy::UntrustedRemote)

--- a/src/boxlite/src/runtime/options.rs
+++ b/src/boxlite/src/runtime/options.rs
@@ -660,8 +660,12 @@ impl Default for RootfsSpec {
 ///
 /// A mount has exactly one origin: `managed_volume` for a server-side managed
 /// volume, or `host_path` for a bind mount from the machine running the box.
-/// Build one with [`VolumeSpec::managed_volume`] or [`VolumeSpec::host_path`] instead of
-/// filling the fields by hand.
+/// Build one with [`VolumeSpec::managed_volume`] or [`VolumeSpec::bind_mount`]
+/// instead of filling the fields by hand.
+///
+/// The `host_path` field keeps its name because it is persisted box config:
+/// boxes on disk carry a `host_path` key, so renaming the field — not the
+/// constructor — would strand every box written before such a rename.
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct VolumeSpec {
     /// Managed volume to mount, addressed by its server-assigned id **or** by
@@ -686,7 +690,7 @@ pub struct VolumeSpec {
 
 impl VolumeSpec {
     /// Bind a host directory or file into the box.
-    pub fn host_path(host_path: impl Into<String>, guest_path: impl Into<String>) -> Self {
+    pub fn bind_mount(host_path: impl Into<String>, guest_path: impl Into<String>) -> Self {
         Self {
             managed_volume: None,
             host_path: host_path.into(),
@@ -1609,7 +1613,7 @@ mod tests {
         assert!(err.contains("not supported yet"));
     }
 
-    /// `VolumeSpec::managed_volume` and `VolumeSpec::host_path` cannot produce a mount
+    /// `VolumeSpec::managed_volume` and `VolumeSpec::bind_mount` cannot produce a mount
     /// with two origins or none, but a struct literal and the C/Go FFI both
     /// can, so sanitize() is the create-time backstop for those paths.
     #[test]
@@ -1666,7 +1670,7 @@ mod tests {
     #[test]
     fn host_volume_omits_managed_volume_key() {
         let opts = BoxOptions {
-            volumes: vec![VolumeSpec::host_path("/tmp/data", "/data")],
+            volumes: vec![VolumeSpec::bind_mount("/tmp/data", "/data")],
             ..Default::default()
         };
 

--- a/src/boxlite/src/runtime/options.rs
+++ b/src/boxlite/src/runtime/options.rs
@@ -614,6 +614,10 @@ impl BoxOptions {
             port.validate_publishable()?;
         }
 
+        for volume in &self.volumes {
+            volume.validate()?;
+        }
+
         Ok(())
     }
 
@@ -653,11 +657,83 @@ impl Default for RootfsSpec {
 }
 
 /// Filesystem mount specification.
+///
+/// A mount has exactly one origin: `managed_volume` for a server-side managed
+/// volume, or `host_path` for a bind mount from the machine running the box.
+/// Build one with [`VolumeSpec::managed_volume`] or [`VolumeSpec::host_path`] instead of
+/// filling the fields by hand.
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct VolumeSpec {
+    /// Managed volume to mount, addressed by its server-assigned id **or** by
+    /// its name — the server resolves either.
+    ///
+    /// Managed volumes need a REST runtime, since the local runtime has no
+    /// volume backend to resolve a reference against.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub managed_volume: Option<String>,
+
+    /// Host directory or file to bind into the box. Empty when
+    /// `managed_volume` is set.
+    #[serde(default)]
     pub host_path: String,
+
+    /// Mount point inside the box.
     pub guest_path: String,
+
+    /// Mount without write access.
     pub read_only: bool,
+}
+
+impl VolumeSpec {
+    /// Bind a host directory or file into the box.
+    pub fn host_path(host_path: impl Into<String>, guest_path: impl Into<String>) -> Self {
+        Self {
+            managed_volume: None,
+            host_path: host_path.into(),
+            guest_path: guest_path.into(),
+            read_only: false,
+        }
+    }
+
+    /// Mount a managed volume, addressed by server-assigned id or by name.
+    pub fn managed_volume(volume: impl Into<String>, guest_path: impl Into<String>) -> Self {
+        Self {
+            managed_volume: Some(volume.into()),
+            host_path: String::new(),
+            guest_path: guest_path.into(),
+            read_only: false,
+        }
+    }
+
+    /// Reject a mount that names no origin, both origins, or an empty one.
+    ///
+    /// FFI callers (C/Go) and hand-built literals can reach either invalid
+    /// shape, so this runs at create rather than only in the constructors.
+    pub fn validate(&self) -> BoxliteResult<()> {
+        let guest_path = &self.guest_path;
+        match &self.managed_volume {
+            Some(volume) if !self.host_path.is_empty() => {
+                Err(boxlite_shared::errors::BoxliteError::Config(format!(
+                    "volume mount {guest_path:?} sets both managed_volume ({volume:?}) and \
+                     host_path; use exactly one"
+                )))
+            }
+            Some(volume) if volume.trim().is_empty() => {
+                Err(boxlite_shared::errors::BoxliteError::Config(format!(
+                    "volume mount {guest_path:?} has an empty managed_volume; pass a volume id \
+                     or name"
+                )))
+            }
+            Some(_) => Ok(()),
+            None if self.host_path.is_empty() => {
+                Err(boxlite_shared::errors::BoxliteError::Config(format!(
+                    "volume mount {guest_path:?} needs a managed_volume (volume id or name) or \
+                     a host_path"
+                )))
+            }
+            None => Ok(()),
+        }
+    }
 }
 
 /// Network mode for public box configuration surfaces.
@@ -1531,6 +1607,77 @@ mod tests {
         };
         let err = opts.sanitize().unwrap_err().to_string();
         assert!(err.contains("not supported yet"));
+    }
+
+    /// `VolumeSpec::managed_volume` and `VolumeSpec::host_path` cannot produce a mount
+    /// with two origins or none, but a struct literal and the C/Go FFI both
+    /// can, so sanitize() is the create-time backstop for those paths.
+    #[test]
+    fn test_sanitize_rejects_ambiguous_volume_origin() {
+        let both = BoxOptions {
+            volumes: vec![VolumeSpec {
+                managed_volume: Some("my-data".into()),
+                host_path: "/tmp/data".into(),
+                guest_path: "/data".into(),
+                read_only: false,
+            }],
+            ..Default::default()
+        };
+        let err = both.sanitize().unwrap_err().to_string();
+        assert!(err.contains("exactly one"), "{err}");
+
+        let neither = BoxOptions {
+            volumes: vec![VolumeSpec {
+                guest_path: "/data".into(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let err = neither.sanitize().unwrap_err().to_string();
+        assert!(err.contains("volume id or name"), "{err}");
+
+        let empty_reference = BoxOptions {
+            volumes: vec![VolumeSpec::managed_volume("   ", "/data")],
+            ..Default::default()
+        };
+        let err = empty_reference.sanitize().unwrap_err().to_string();
+        assert!(err.contains("empty managed_volume"), "{err}");
+    }
+
+    /// A box persisted before `managed_volume` existed carries only
+    /// `host_path`; it must still load, as a host bind, without a migration.
+    #[test]
+    fn legacy_volume_json_without_managed_volume_still_loads() {
+        let opts: BoxOptions = serde_json::from_str(
+            r#"{"volumes":[{"host_path":"/tmp/data","guest_path":"/data","read_only":true}]}"#,
+        )
+        .expect("pre-managed_volume box config must still deserialize");
+
+        let volume = &opts.volumes[0];
+        assert_eq!(volume.managed_volume, None);
+        assert_eq!(volume.host_path, "/tmp/data");
+        assert!(volume.read_only);
+        opts.sanitize().expect("a legacy host bind is still valid");
+    }
+
+    /// An ordinary host bind must not start writing a `managed_volume` key
+    /// into persisted configs and archives — an older reader has no field for
+    /// it. Same reasoning as `box_options_omits_capabilities_key_when_unspecified`.
+    #[test]
+    fn host_volume_omits_managed_volume_key() {
+        let opts = BoxOptions {
+            volumes: vec![VolumeSpec::host_path("/tmp/data", "/data")],
+            ..Default::default()
+        };
+
+        let json: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&opts).unwrap()).unwrap();
+        let volume = &json["volumes"][0];
+
+        assert!(
+            !volume.as_object().unwrap().contains_key("managed_volume"),
+            "a host bind must omit the key, not serialize null: {volume}"
+        );
     }
 
     #[test]

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -1765,6 +1765,7 @@ async fn sanitize_local_options(
     features: &ExperimentalFeatures,
     options: BoxOptions,
 ) -> BoxliteResult<BoxOptions> {
+    reject_local_unsupported_options(&options)?;
     features.require_for_options(&options)?;
     tokio::task::spawn_blocking(move || {
         options.sanitize()?;
@@ -1781,7 +1782,6 @@ async fn sanitize_local_options(
 #[async_trait::async_trait]
 impl super::backend::RuntimeBackend for LocalRuntime {
     async fn create(&self, options: BoxOptions, name: Option<String>) -> BoxliteResult<LiteBox> {
-        reject_local_unsupported_options(&options)?;
         let options = sanitize_local_options(&self.0.experimental_features, options).await?;
         self.0.create(options, name).await
     }
@@ -1791,7 +1791,6 @@ impl super::backend::RuntimeBackend for LocalRuntime {
         options: BoxOptions,
         name: Option<String>,
     ) -> BoxliteResult<(LiteBox, bool)> {
-        reject_local_unsupported_options(&options)?;
         let options = sanitize_local_options(&self.0.experimental_features, options).await?;
         self.0.get_or_create(options, name).await
     }
@@ -1944,22 +1943,31 @@ mod tests {
         );
     }
 
-    #[test]
-    fn local_runtime_rejects_explicit_lifecycle_policy() {
+    #[tokio::test]
+    async fn local_runtime_rejects_explicit_lifecycle_policy() {
+        let features = ExperimentalFeatures::default();
         let mut options = BoxOptions::default();
-        assert!(reject_local_unsupported_options(&options).is_ok());
+        assert!(
+            sanitize_local_options(&features, options.clone())
+                .await
+                .is_ok()
+        );
 
         options.auto_stop = Some(0);
-        assert!(reject_local_unsupported_options(&options).is_ok());
+        assert!(
+            sanitize_local_options(&features, options.clone())
+                .await
+                .is_ok()
+        );
 
         options.auto_stop = Some(1);
         assert!(matches!(
-            reject_local_unsupported_options(&options),
+            sanitize_local_options(&features, options.clone()).await,
             Err(BoxliteError::Unsupported(_))
         ));
         options.auto_stop = None;
         options.auto_delete = Some(3600);
-        assert!(reject_local_unsupported_options(&options).is_ok());
+        assert!(sanitize_local_options(&features, options).await.is_ok());
     }
 
     /// The local runtime has no volume backend. `resolve_user_volumes` also
@@ -1967,21 +1975,23 @@ mod tests {
     /// image is pulled and the box record exists. This guard is the whole
     /// reason the failure is cheap, so it needs its own test: without it every
     /// suite still passes and the rejection silently moves back to boot time.
-    #[test]
-    fn local_runtime_rejects_managed_volumes_before_boot() {
+    #[tokio::test]
+    async fn local_runtime_rejects_managed_volumes_before_boot() {
         use crate::runtime::options::VolumeSpec;
 
+        let features = ExperimentalFeatures::default();
         let host_bind = BoxOptions {
-            volumes: vec![VolumeSpec::host_path("/tmp/data", "/data")],
+            volumes: vec![VolumeSpec::bind_mount("/tmp/data", "/data")],
             ..Default::default()
         };
-        assert!(reject_local_unsupported_options(&host_bind).is_ok());
+        assert!(sanitize_local_options(&features, host_bind).await.is_ok());
 
         let managed = BoxOptions {
             volumes: vec![VolumeSpec::managed_volume("my-data", "/data")],
             ..Default::default()
         };
-        let error = reject_local_unsupported_options(&managed)
+        let error = sanitize_local_options(&features, managed)
+            .await
             .expect_err("a managed volume has no local backend to resolve against");
 
         assert!(matches!(error, BoxliteError::Unsupported(_)), "{error:?}");

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -1735,7 +1735,7 @@ impl std::fmt::Debug for RuntimeImpl {
 /// Trait methods use `&self`. This newtype holds the Arc as a field to bridge the gap.
 pub(crate) struct LocalRuntime(pub(crate) SharedRuntimeImpl);
 
-fn reject_local_lifecycle_policy(options: &BoxOptions) -> BoxliteResult<()> {
+fn reject_local_unsupported_options(options: &BoxOptions) -> BoxliteResult<()> {
     // Local runtimes support auto_delete as a remove-on-stop policy, but AutoStop
     // needs a sweeper that the local runtime does not have, so it stays REST-only.
     if options.auto_stop.is_some_and(|seconds| seconds > 0) {
@@ -1743,6 +1743,21 @@ fn reject_local_lifecycle_policy(options: &BoxOptions) -> BoxliteResult<()> {
             "AutoStop is only supported by REST runtimes".into(),
         ));
     }
+
+    // `resolve_user_volumes` catches this too, but only once boot is under way
+    // — after the image is pulled and the box record exists. Fail here instead,
+    // mirroring `validate_remote_volumes` on the REST side.
+    if let Some(volume) = options
+        .volumes
+        .iter()
+        .find_map(|volume| volume.managed_volume.as_deref())
+    {
+        return Err(BoxliteError::Unsupported(format!(
+            "managed volume {volume:?} is only supported by REST runtimes; the local runtime has \
+             no volume backend to resolve it against"
+        )));
+    }
+
     Ok(())
 }
 
@@ -1766,7 +1781,7 @@ async fn sanitize_local_options(
 #[async_trait::async_trait]
 impl super::backend::RuntimeBackend for LocalRuntime {
     async fn create(&self, options: BoxOptions, name: Option<String>) -> BoxliteResult<LiteBox> {
-        reject_local_lifecycle_policy(&options)?;
+        reject_local_unsupported_options(&options)?;
         let options = sanitize_local_options(&self.0.experimental_features, options).await?;
         self.0.create(options, name).await
     }
@@ -1776,7 +1791,7 @@ impl super::backend::RuntimeBackend for LocalRuntime {
         options: BoxOptions,
         name: Option<String>,
     ) -> BoxliteResult<(LiteBox, bool)> {
-        reject_local_lifecycle_policy(&options)?;
+        reject_local_unsupported_options(&options)?;
         let options = sanitize_local_options(&self.0.experimental_features, options).await?;
         self.0.get_or_create(options, name).await
     }
@@ -1849,7 +1864,10 @@ impl super::images::ImageBackend for LocalRuntime {
 // future managed volume backend, so every operation returns `Unsupported`.
 #[async_trait::async_trait]
 impl super::volumes::VolumeBackend for LocalRuntime {
-    async fn create_volume(&self) -> BoxliteResult<crate::volumes::VolumeInfo> {
+    async fn create_volume(
+        &self,
+        _name: Option<&str>,
+    ) -> BoxliteResult<crate::volumes::VolumeInfo> {
         Err(volumes_unsupported())
     }
 
@@ -1929,19 +1947,47 @@ mod tests {
     #[test]
     fn local_runtime_rejects_explicit_lifecycle_policy() {
         let mut options = BoxOptions::default();
-        assert!(reject_local_lifecycle_policy(&options).is_ok());
+        assert!(reject_local_unsupported_options(&options).is_ok());
 
         options.auto_stop = Some(0);
-        assert!(reject_local_lifecycle_policy(&options).is_ok());
+        assert!(reject_local_unsupported_options(&options).is_ok());
 
         options.auto_stop = Some(1);
         assert!(matches!(
-            reject_local_lifecycle_policy(&options),
+            reject_local_unsupported_options(&options),
             Err(BoxliteError::Unsupported(_))
         ));
         options.auto_stop = None;
         options.auto_delete = Some(3600);
-        assert!(reject_local_lifecycle_policy(&options).is_ok());
+        assert!(reject_local_unsupported_options(&options).is_ok());
+    }
+
+    /// The local runtime has no volume backend. `resolve_user_volumes` also
+    /// refuses a managed volume, but only once boot is under way — after the
+    /// image is pulled and the box record exists. This guard is the whole
+    /// reason the failure is cheap, so it needs its own test: without it every
+    /// suite still passes and the rejection silently moves back to boot time.
+    #[test]
+    fn local_runtime_rejects_managed_volumes_before_boot() {
+        use crate::runtime::options::VolumeSpec;
+
+        let host_bind = BoxOptions {
+            volumes: vec![VolumeSpec::host_path("/tmp/data", "/data")],
+            ..Default::default()
+        };
+        assert!(reject_local_unsupported_options(&host_bind).is_ok());
+
+        let managed = BoxOptions {
+            volumes: vec![VolumeSpec::managed_volume("my-data", "/data")],
+            ..Default::default()
+        };
+        let error = reject_local_unsupported_options(&managed)
+            .expect_err("a managed volume has no local backend to resolve against");
+
+        assert!(matches!(error, BoxliteError::Unsupported(_)), "{error:?}");
+        let message = error.to_string();
+        assert!(message.contains("my-data"), "{message}");
+        assert!(message.contains("REST runtime"), "{message}");
     }
 
     #[test]

--- a/src/boxlite/src/runtime/volumes.rs
+++ b/src/boxlite/src/runtime/volumes.rs
@@ -25,7 +25,8 @@ use crate::volumes::VolumeInfo;
 #[async_trait]
 pub(crate) trait VolumeBackend: Send + Sync {
     /// Create a volume, returning its server-assigned metadata (including id).
-    async fn create_volume(&self) -> BoxliteResult<VolumeInfo>;
+    /// `name` is optional; the server names the volume after its id without one.
+    async fn create_volume(&self, name: Option<&str>) -> BoxliteResult<VolumeInfo>;
 
     /// List all volumes.
     async fn list_volumes(&self) -> BoxliteResult<Vec<VolumeInfo>>;
@@ -52,8 +53,11 @@ impl VolumeHandle {
     }
 
     /// Create a volume, returning its metadata (including the assigned id).
-    pub async fn create(&self) -> BoxliteResult<VolumeInfo> {
-        self.backend.create_volume().await
+    ///
+    /// A named volume can be mounted by that name instead of its id. Without
+    /// a name the server uses the id, so the volume is still mountable.
+    pub async fn create(&self, name: Option<&str>) -> BoxliteResult<VolumeInfo> {
+        self.backend.create_volume(name).await
     }
 
     /// List all volumes.

--- a/src/boxlite/src/volumes/store.rs
+++ b/src/boxlite/src/volumes/store.rs
@@ -19,6 +19,11 @@ pub struct VolumeInfo {
     /// Server-assigned volume id — the addressing key for get/remove.
     pub id: String,
 
+    /// Volume name, unique within the owning scope. Mountable in place of the
+    /// id, so a box can name the volume it wants without knowing the id. The
+    /// server defaults it to the id when the caller supplies none.
+    pub name: String,
+
     /// When the volume was created.
     pub created_at: DateTime<Utc>,
 

--- a/src/boxlite/tests/mount_security.rs
+++ b/src/boxlite/tests/mount_security.rs
@@ -81,6 +81,7 @@ async fn mount_security_integration() {
         .create(
             BoxOptions {
                 volumes: vec![VolumeSpec {
+                    managed_volume: None,
                     host_path: tmp.path().to_str().unwrap().into(),
                     guest_path: "/workspace/data".into(),
                     read_only: false,

--- a/src/boxlite/tests/security_enforcement.rs
+++ b/src/boxlite/tests/security_enforcement.rs
@@ -77,11 +77,13 @@ async fn virtiofs_readonly_and_capabilities() {
             BoxOptions {
                 volumes: vec![
                     VolumeSpec {
+                        managed_volume: None,
                         host_path: ro_dir.path().to_str().unwrap().into(),
                         guest_path: "/data/readonly".into(),
                         read_only: true,
                     },
                     VolumeSpec {
+                        managed_volume: None,
                         host_path: rw_dir.path().to_str().unwrap().into(),
                         guest_path: "/data/writable".into(),
                         read_only: false,

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -328,7 +328,7 @@ silently restarting it, because restarting would run the command a second time.
 | `--env KEY=VALUE` | `-e` | Set environment variables (repeatable) |
 | `--workdir PATH` | `-w` | Working directory in the box |
 | `--publish PORT` | `-p` | Publish a TCP box port locally (`80` = automatic host port, `8080:80` = fixed) |
-| `--volume VOLUME` | `-v` | Mount a volume (e.g. `hostPath:boxPath`, `boxPath` for anonymous) |
+| `--volume VOLUME` | `-v` | Mount a volume: `name:/box` for a managed volume, `./path:/box` for a host bind, `/box` for anonymous |
 | `--cpus N` | | CPU limit |
 | `--memory MiB` | | Memory limit (MiB) |
 | `--cap-add CAPABILITY` | | Add a Linux capability (repeatable; accepts `CAP_` prefix or `ALL`) |
@@ -373,7 +373,7 @@ default, and `exec` still starts it on demand.
 | `--env KEY=VALUE` | `-e` | Environment variables |
 | `--workdir PATH` | `-w` | Working directory |
 | `--publish PORT` | `-p` | Publish a TCP box port locally (`80` = automatic host port, `8080:80` = fixed) |
-| `--volume VOLUME` | `-v` | Mount a volume (e.g. `hostPath:boxPath`, or box path for anonymous) |
+| `--volume VOLUME` | `-v` | Mount a volume: `name:/box` for a managed volume, `./path:/box` for a host bind, `/box` for anonymous |
 | `--cpus N` | | CPU limit |
 | `--memory MiB` | | Memory limit (MiB) |
 | `--cap-add CAPABILITY` | | Add a Linux capability (repeatable; accepts `CAP_` prefix or `ALL`) |

--- a/src/cli/src/cli.rs
+++ b/src/cli/src/cli.rs
@@ -817,8 +817,8 @@ impl VolumeFlags {
                     VolumeSpec::managed_volume(volume, mount.guest_path)
                 }
 
-                crate::volumespec::MountOrigin::HostPath(path) => {
-                    VolumeSpec::host_path(resolve_host_path(path)?, mount.guest_path)
+                crate::volumespec::MountOrigin::BindMount(path) => {
+                    VolumeSpec::bind_mount(resolve_host_path(path)?, mount.guest_path)
                 }
 
                 crate::volumespec::MountOrigin::Anonymous => {
@@ -829,7 +829,7 @@ impl VolumeFlags {
                     std::fs::create_dir_all(&dir).map_err(|e| {
                         anyhow::anyhow!("failed to create anonymous volume dir {:?}: {}", dir, e)
                     })?;
-                    VolumeSpec::host_path(dir.to_string_lossy().into_owned(), mount.guest_path)
+                    VolumeSpec::bind_mount(dir.to_string_lossy().into_owned(), mount.guest_path)
                 }
             };
 

--- a/src/cli/src/cli.rs
+++ b/src/cli/src/cli.rs
@@ -746,125 +746,13 @@ fn parse_port(s: &str) -> anyhow::Result<u16> {
 // VOLUME FLAGS
 // ============================================================================
 
-/// Result of parsing a volume spec. Anonymous volumes have host_path = None.
-struct ParsedVolumeSpec {
-    host_path: Option<String>,
-    guest_path: String,
-    read_only: bool,
-}
-
 #[derive(Args, Debug, Clone)]
 pub struct VolumeFlags {
-    /// Mount a volume (format: hostPath:boxPath[:options], or boxPath for anonymous volume, e.g. /data:/app/data, /data:ro)
+    /// Mount a volume: VOLUME:BOX_PATH for a managed volume, HOST_PATH:BOX_PATH[:options]
+    /// for a host bind (host paths start with `/`, `./`, `~` or a drive letter), or
+    /// BOX_PATH[:options] for an anonymous volume
     #[arg(short = 'v', long = "volume", value_name = "VOLUME")]
     pub volume: Vec<String>,
-}
-
-/// True if the segment is a single ASCII letter (Windows drive, e.g. "C" in "C:\path").
-fn is_windows_drive(segment: &str) -> bool {
-    let s = segment.trim();
-    s.len() == 1
-        && s.chars()
-            .next()
-            .map(|c| c.is_ascii_alphabetic())
-            .unwrap_or(false)
-}
-
-/// True if path looks like a Windows absolute path (e.g. `C:\foo` or `D:/bar`).
-fn is_windows_absolute_path(path: &str) -> bool {
-    let b = path.as_bytes();
-    b.len() >= 3 && b[0].is_ascii_alphabetic() && b[1] == b':' && (b[2] == b'\\' || b[2] == b'/')
-}
-
-/// Parse options string (e.g. "ro" or "rw,nocopy") and return read_only. Other options are ignored.
-fn parse_volume_read_only(opts: &str) -> bool {
-    opts.split(',').any(|o| o.trim().eq_ignore_ascii_case("ro"))
-}
-
-/// Parse a single volume spec.
-/// - Anonymous : `boxPath` or `boxPath:ro` (e.g. `/data`, `/data:ro`).
-/// - Bind mount: `hostPath:boxPath[:options]` (e.g. `/data:/app/data`, `/data:/app/data:ro`).
-///
-/// Options: `ro` (read-only), `rw` (read-write, default). Other options are ignored.
-///   Windows: host path may be a drive path like `C:\data`; the colon after the drive letter is not
-///   treated as a separator (e.g. `C:\data:/app/data` → host=`C:\data`, guest=`/app/data`).
-fn parse_volume_spec(s: &str) -> anyhow::Result<ParsedVolumeSpec> {
-    let s = s.trim();
-    if s.is_empty() {
-        anyhow::bail!("empty volume spec");
-    }
-    let parts: Vec<&str> = s.split(':').map(str::trim).collect();
-
-    let (host_path, guest_path, read_only) = match parts.len() {
-        1 => {
-            // Anonymous volume: box path only (e.g. /data)
-            let guest = parts[0].to_string();
-            if guest.is_empty() {
-                anyhow::bail!("volume box path must be non-empty");
-            }
-            if !guest.starts_with('/') && !is_windows_drive(parts[0]) {
-                anyhow::bail!(
-                    "anonymous volume box path must be absolute (e.g. /data), got {:?}",
-                    guest
-                );
-            }
-            (None, guest, false)
-        }
-        2 => {
-            // Either anonymous with options (guest:ro) or bind (host:guest)
-            let second = parts[1];
-            if second.eq_ignore_ascii_case("ro") || second.eq_ignore_ascii_case("rw") {
-                let guest = parts[0].to_string();
-                if guest.is_empty() {
-                    anyhow::bail!("volume box path must be non-empty");
-                }
-                (None, guest, second.eq_ignore_ascii_case("ro"))
-            } else {
-                (Some(parts[0].to_string()), parts[1].to_string(), false)
-            }
-        }
-        3 => {
-            if is_windows_drive(parts[0]) {
-                let host = format!("{}:{}", parts[0], parts[1]);
-                (Some(host), parts[2].to_string(), false)
-            } else {
-                let ro = parse_volume_read_only(parts[2]);
-                (Some(parts[0].to_string()), parts[1].to_string(), ro)
-            }
-        }
-        4.. => {
-            if is_windows_drive(parts[0]) {
-                let host = format!("{}:{}", parts[0], parts[1]);
-                let ro = parse_volume_read_only(parts[3]);
-                (Some(host), parts[2].to_string(), ro)
-            } else {
-                anyhow::bail!(
-                    "invalid volume spec {:?}; use hostPath:boxPath[:options] (e.g. /data:/app/data or C:\\data:/app/data:ro)",
-                    s
-                );
-            }
-        }
-        _ => {
-            anyhow::bail!(
-                "invalid volume spec {:?}; use hostPath:boxPath[:options] or boxPath[:options] for anonymous volume",
-                s
-            );
-        }
-    };
-
-    if let Some(ref host) = host_path
-        && host.is_empty()
-    {
-        anyhow::bail!("volume host path must be non-empty");
-    }
-    if guest_path.is_empty() {
-        anyhow::bail!("volume box path must be non-empty");
-    }
-    Ok(ParsedVolumeSpec {
-        host_path,
-        guest_path,
-        read_only,
-    })
 }
 
 /// Resolve base directory for anonymous volumes: explicit home, or BOXLITE_HOME, or ~/.boxlite, or temp dir.
@@ -884,6 +772,26 @@ fn anonymous_volume_base(home: Option<&std::path::Path>) -> std::path::PathBuf {
         .unwrap_or_else(std::env::temp_dir)
 }
 
+/// Make a host bind path absolute.
+///
+/// `volumespec` classified this as a path without touching the filesystem, so a
+/// relative one is resolved here — the same split Docker uses, where the client
+/// absolutizes and only the resolved path travels on.
+fn resolve_host_path(path: String) -> anyhow::Result<String> {
+    // A Windows path is absolute even where `Path::is_relative` says otherwise:
+    // on Unix `C:\data` has no leading `/`, so without this it would be
+    // canonicalized against the working directory and fail.
+    if !std::path::Path::new(&path).is_relative()
+        || crate::volumespec::is_windows_drive_prefix(&path)
+    {
+        return Ok(path);
+    }
+
+    let absolute = std::fs::canonicalize(&path)
+        .map_err(|e| anyhow::anyhow!("volume host path {:?}: {}", path, e))?;
+    Ok(absolute.to_string_lossy().into_owned())
+}
+
 impl VolumeFlags {
     /// Apply volume flags to options. Pass `home` for anonymous volume storage (e.g. from GlobalFlags).
     pub fn apply_to(
@@ -892,39 +800,42 @@ impl VolumeFlags {
         home: Option<&std::path::Path>,
     ) -> anyhow::Result<()> {
         let base = anonymous_volume_base(home);
-        for s in self.volume.iter() {
-            let spec = parse_volume_spec(s)?;
-            let host_path = match spec.host_path {
-                // TODO(#942): when the host side of a `-v <src>:<guest>` spec is a
-                // bare name (not a path) that matches a named volume, resolve it
-                // to the volume's mountpoint here (via the volume backend) and
-                // bind that payload dir instead of treating the name as a literal
-                // host path.
-                Some(host) => {
-                    let mut path = host;
-                    if std::path::Path::new(&path).is_relative() && !is_windows_absolute_path(&path)
-                    {
-                        let abs = std::fs::canonicalize(&path)
-                            .map_err(|e| anyhow::anyhow!("volume host path {:?}: {}", path, e))?;
-                        path = abs.to_string_lossy().into_owned();
+        for value in self.volume.iter() {
+            let mount = crate::volumespec::parse(value)?;
+
+            let spec = match mount.origin {
+                // Held as written; the server resolves an id or a name.
+                crate::volumespec::MountOrigin::ManagedVolume(volume) => {
+                    // Neither the server nor the REST client accepts one yet;
+                    // saying so here beats a downgrade the caller never sees.
+                    if mount.read_only {
+                        anyhow::bail!(
+                            "read-only managed volumes are not supported yet; \
+                             mount {volume:?} read-write"
+                        );
                     }
-                    path
+                    VolumeSpec::managed_volume(volume, mount.guest_path)
                 }
-                None => {
-                    // Anonymous volume: use a random ID for the directory name (same approach as
-                    // Podman: cryptographically random ID to avoid collisions under any load).
+
+                crate::volumespec::MountOrigin::HostPath(path) => {
+                    VolumeSpec::host_path(resolve_host_path(path)?, mount.guest_path)
+                }
+
+                crate::volumespec::MountOrigin::Anonymous => {
+                    // Random id for the directory name (same approach as Podman:
+                    // cryptographically random to avoid collisions under any load).
                     let unique = ulid::Ulid::new().to_string();
                     let dir = base.join("volumes").join("anonymous").join(unique);
                     std::fs::create_dir_all(&dir).map_err(|e| {
                         anyhow::anyhow!("failed to create anonymous volume dir {:?}: {}", dir, e)
                     })?;
-                    dir.to_string_lossy().into_owned()
+                    VolumeSpec::host_path(dir.to_string_lossy().into_owned(), mount.guest_path)
                 }
             };
+
             opts.volumes.push(VolumeSpec {
-                host_path,
-                guest_path: spec.guest_path,
-                read_only: spec.read_only,
+                read_only: mount.read_only,
+                ..spec
             });
         }
         Ok(())
@@ -1531,111 +1442,6 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_volume_spec_host_guest() {
-        let spec = super::parse_volume_spec("/data:/app/data").unwrap();
-        assert_eq!(spec.host_path.as_deref(), Some("/data"));
-        assert_eq!(spec.guest_path, "/app/data");
-        assert!(!spec.read_only);
-    }
-
-    #[test]
-    fn test_parse_volume_spec_read_only() {
-        let spec = super::parse_volume_spec("/data:/app/data:ro").unwrap();
-        assert_eq!(spec.host_path.as_deref(), Some("/data"));
-        assert_eq!(spec.guest_path, "/app/data");
-        assert!(spec.read_only);
-    }
-
-    #[test]
-    fn test_parse_volume_spec_rw_explicit() {
-        let spec = super::parse_volume_spec("/data:/app/data:rw").unwrap();
-        assert_eq!(spec.host_path.as_deref(), Some("/data"));
-        assert_eq!(spec.guest_path, "/app/data");
-        assert!(!spec.read_only);
-    }
-
-    #[test]
-    fn test_parse_volume_spec_anonymous() {
-        let spec = super::parse_volume_spec("/data").unwrap();
-        assert!(spec.host_path.is_none());
-        assert_eq!(spec.guest_path, "/data");
-        assert!(!spec.read_only);
-    }
-
-    #[test]
-    fn test_parse_volume_spec_anonymous_ro() {
-        let spec = super::parse_volume_spec("/data:ro").unwrap();
-        assert!(spec.host_path.is_none());
-        assert_eq!(spec.guest_path, "/data");
-        assert!(spec.read_only);
-    }
-
-    #[test]
-    fn test_parse_volume_spec_anonymous_relative_invalid() {
-        assert!(super::parse_volume_spec("data").is_err());
-    }
-
-    #[test]
-    fn test_parse_volume_spec_invalid_empty_parts() {
-        assert!(super::parse_volume_spec(":/app").is_err());
-        assert!(super::parse_volume_spec("/data:").is_err());
-    }
-
-    // --- Windows drive compatibility ---
-
-    #[test]
-    fn test_parse_volume_spec_windows_drive_two_parts() {
-        // "C:\data:/app/data" → host=C:\data, guest=/app/data (3 segments after split)
-        let spec = super::parse_volume_spec(r"C:\data:/app/data").unwrap();
-        assert_eq!(spec.host_path.as_deref(), Some(r"C:\data"));
-        assert_eq!(spec.guest_path, "/app/data");
-        assert!(!spec.read_only);
-    }
-
-    #[test]
-    fn test_parse_volume_spec_windows_drive_with_ro() {
-        // "C:\data:/app/data:ro" → 4 segments
-        let spec = super::parse_volume_spec(r"C:\data:/app/data:ro").unwrap();
-        assert_eq!(spec.host_path.as_deref(), Some(r"C:\data"));
-        assert_eq!(spec.guest_path, "/app/data");
-        assert!(spec.read_only);
-    }
-
-    #[test]
-    fn test_parse_volume_spec_windows_drive_with_rw() {
-        let spec = super::parse_volume_spec(r"D:\path:/mnt:rw").unwrap();
-        assert_eq!(spec.host_path.as_deref(), Some(r"D:\path"));
-        assert_eq!(spec.guest_path, "/mnt");
-        assert!(!spec.read_only);
-    }
-
-    #[test]
-    fn test_parse_volume_spec_windows_drive_long_path() {
-        // "D:\host\path:/app" → host=D:\host\path, guest=/app
-        let spec = super::parse_volume_spec(r"D:\host\path:/app").unwrap();
-        assert_eq!(spec.host_path.as_deref(), Some(r"D:\host\path"));
-        assert_eq!(spec.guest_path, "/app");
-    }
-
-    #[test]
-    fn test_parse_volume_spec_unix_three_colons_invalid() {
-        // Unix path with 4+ segments and no Windows drive → error
-        assert!(super::parse_volume_spec("/a:b:c:d").is_err());
-    }
-
-    #[test]
-    fn test_parse_volume_spec_linux_unchanged() {
-        // Linux/macOS style must still work
-        let spec = super::parse_volume_spec("/data:/app/data").unwrap();
-        assert_eq!(spec.host_path.as_deref(), Some("/data"));
-        assert_eq!(spec.guest_path, "/app/data");
-        let spec2 = super::parse_volume_spec("/data:/app/data:ro").unwrap();
-        assert_eq!(spec2.host_path.as_deref(), Some("/data"));
-        assert_eq!(spec2.guest_path, "/app/data");
-        assert!(spec2.read_only);
-    }
-
-    #[test]
     fn test_volume_flags_apply_to() {
         let flags = VolumeFlags {
             volume: vec![
@@ -1671,6 +1477,80 @@ mod tests {
         assert_eq!(opts.volumes[1].host_path, r"D:\readonly");
         assert_eq!(opts.volumes[1].guest_path, "/ro");
         assert!(opts.volumes[1].read_only);
+    }
+
+    /// `-v my-data:/data` reaches `BoxOptions` as a managed volume, not a host
+    /// bind — the whole point of adopting Docker's rule. It must not touch the
+    /// filesystem on the way: no canonicalize, no "path does not exist".
+    #[test]
+    fn test_volume_flags_apply_to_managed_volume() {
+        let flags = VolumeFlags {
+            volume: vec![
+                "my-data:/data".to_string(),
+                "vol_01K2EXAMPLE:/cache".to_string(),
+            ],
+        };
+        let mut opts = BoxOptions::default();
+        flags.apply_to(&mut opts, None).unwrap();
+
+        assert_eq!(opts.volumes.len(), 2);
+        assert_eq!(opts.volumes[0].managed_volume.as_deref(), Some("my-data"));
+        assert_eq!(opts.volumes[0].host_path, "");
+        assert_eq!(opts.volumes[0].guest_path, "/data");
+        assert!(!opts.volumes[0].read_only);
+        assert_eq!(
+            opts.volumes[1].managed_volume.as_deref(),
+            Some("vol_01K2EXAMPLE")
+        );
+        assert_eq!(opts.volumes[1].guest_path, "/cache");
+    }
+
+    /// `:ro` on a managed volume is refused, not quietly downgraded. Neither
+    /// the server nor the REST client accepts one, and a caller who believes a
+    /// mount is protected when it is writable is the failure worth preventing.
+    #[test]
+    fn test_volume_flags_reject_read_only_managed_volume() {
+        let flags = VolumeFlags {
+            volume: vec!["my-data:/data:ro".to_string()],
+        };
+        let mut opts = BoxOptions::default();
+
+        let error = flags
+            .apply_to(&mut opts, None)
+            .expect_err("read-only managed volumes must be refused")
+            .to_string();
+
+        assert!(error.contains("read-only"), "{error}");
+        assert!(error.contains("my-data"), "{error}");
+        assert!(opts.volumes.is_empty());
+    }
+
+    /// A host bind may still be read-only — the restriction is specific to
+    /// managed volumes, not to `:ro`.
+    #[test]
+    fn test_volume_flags_still_allow_read_only_host_binds() {
+        let flags = VolumeFlags {
+            volume: vec!["/host/data:/data:ro".to_string()],
+        };
+        let mut opts = BoxOptions::default();
+        flags.apply_to(&mut opts, None).unwrap();
+
+        assert_eq!(opts.volumes[0].host_path, "/host/data");
+        assert!(opts.volumes[0].read_only);
+    }
+
+    /// A host bind keeps `managed_volume` unset, so the two `-v` forms stay
+    /// distinguishable all the way to the wire.
+    #[test]
+    fn test_volume_flags_apply_to_leaves_host_binds_unmanaged() {
+        let flags = VolumeFlags {
+            volume: vec!["/host/data:/guest/data".to_string()],
+        };
+        let mut opts = BoxOptions::default();
+        flags.apply_to(&mut opts, None).unwrap();
+
+        assert_eq!(opts.volumes[0].managed_volume, None);
+        assert_eq!(opts.volumes[0].host_path, "/host/data");
     }
 
     #[test]
@@ -1807,14 +1687,28 @@ mod tests {
     use crate::commands::volume::VolumeCommand;
 
     #[test]
-    fn volume_create_takes_no_args() {
-        // `create` takes no arguments — the id is server-assigned and printed.
+    fn volume_create_takes_an_optional_name() {
+        // Without --name the server names the volume after its id.
         let cli = Cli::try_parse_from(["boxlite", "volume", "create"]).expect("parse");
         let Commands::Volume(args) = cli.command else {
             panic!("expected Commands::Volume");
         };
-        assert!(matches!(args.command, VolumeCommand::Create(_)));
-        // A positional argument must be rejected.
+        let VolumeCommand::Create(create) = args.command else {
+            panic!("expected VolumeCommand::Create");
+        };
+        assert_eq!(create.name, None);
+
+        let cli = Cli::try_parse_from(["boxlite", "volume", "create", "--name", "my-data"])
+            .expect("parse");
+        let Commands::Volume(args) = cli.command else {
+            panic!("expected Commands::Volume");
+        };
+        let VolumeCommand::Create(create) = args.command else {
+            panic!("expected VolumeCommand::Create");
+        };
+        assert_eq!(create.name.as_deref(), Some("my-data"));
+
+        // The name is a flag, not a positional: a bare argument is still rejected.
         assert!(Cli::try_parse_from(["boxlite", "volume", "create", "data"]).is_err());
     }
 

--- a/src/cli/src/commands/serve/handlers/volumes.rs
+++ b/src/cli/src/commands/serve/handlers/volumes.rs
@@ -11,17 +11,20 @@ use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 
-use super::super::types::{ListVolumesResponse, RemoveQuery};
+use super::super::types::{CreateVolumeRequest, ListVolumesResponse, RemoveQuery};
 use super::super::{AppState, error_from_boxlite, volume_info_to_response};
 
 pub(in crate::commands::serve) async fn create_volume(
     State(state): State<Arc<AppState>>,
+    // Optional so a caller may POST with no body at all, which the spec allows.
+    body: Option<Json<CreateVolumeRequest>>,
 ) -> Response {
     let handle = match state.runtime.volumes() {
         Ok(h) => h,
         Err(e) => return error_from_boxlite(&e),
     };
-    match handle.create().await {
+    let name = body.and_then(|Json(request)| request.name);
+    match handle.create(name.as_deref()).await {
         Ok(info) => (StatusCode::CREATED, Json(volume_info_to_response(&info))).into_response(),
         Err(e) => error_from_boxlite(&e),
     }

--- a/src/cli/src/commands/serve/mod.rs
+++ b/src/cli/src/commands/serve/mod.rs
@@ -720,6 +720,7 @@ fn box_info_to_response(info: &BoxInfo) -> BoxResponse {
 fn volume_info_to_response(info: &boxlite::runtime::types::VolumeInfo) -> types::VolumeResponse {
     types::VolumeResponse {
         id: info.id.clone(),
+        name: info.name.clone(),
         created_at: info.created_at.to_rfc3339(),
         size_bytes: info.size_bytes,
     }
@@ -1686,7 +1687,25 @@ mod tests {
                     "read_only": false
                 }]
             }),
-            "host volume mounts",
+            "volume mounts",
+        )
+        .await;
+    }
+
+    /// The managed-volume shape is refused by the same gate, and reaches it
+    /// through the same deserialization — an archive naming someone else's
+    /// volume must not provision a box either.
+    #[tokio::test]
+    async fn serve_import_rejects_managed_volume_archive_before_provisioning() {
+        assert_uploaded_archive_rejected_before_provisioning(
+            serde_json::json!({
+                "volumes": [{
+                    "managed_volume": "someone-elses-data",
+                    "guest_path": "/data",
+                    "read_only": false
+                }]
+            }),
+            "volume mounts",
         )
         .await;
     }

--- a/src/cli/src/commands/serve/types.rs
+++ b/src/cli/src/commands/serve/types.rs
@@ -146,8 +146,16 @@ pub(super) struct ListBoxesResponse {
 #[derive(Serialize)]
 pub(super) struct VolumeResponse {
     pub id: String,
+    pub name: String,
     pub created_at: String,
     pub size_bytes: Option<u64>,
+}
+
+/// Body for `POST /v1/volumes`. An absent body means an unnamed volume.
+#[derive(Deserialize, Default)]
+pub(super) struct CreateVolumeRequest {
+    #[serde(default)]
+    pub name: Option<String>,
 }
 
 #[derive(Serialize)]

--- a/src/cli/src/commands/volume/create.rs
+++ b/src/cli/src/commands/volume/create.rs
@@ -3,14 +3,20 @@ use clap::Args;
 
 /// Create a volume.
 ///
-/// Takes no arguments — the server assigns the id, which is printed on success
-/// (mirroring `boxlite create`).
+/// The server assigns the id, which is printed on success (mirroring
+/// `boxlite create`). A `--name` can be mounted in place of that id.
 #[derive(Args, Debug)]
-pub struct CreateArgs {}
+pub struct CreateArgs {
+    /// Volume name, mountable in place of the id (e.g. `-v my-data:/data`).
+    /// At least two characters of `[a-zA-Z0-9][a-zA-Z0-9_.-]`.
+    /// Defaults to the server-assigned id.
+    #[arg(long)]
+    pub name: Option<String>,
+}
 
-pub async fn run(_args: CreateArgs, global: &GlobalFlags) -> anyhow::Result<()> {
+pub async fn run(args: CreateArgs, global: &GlobalFlags) -> anyhow::Result<()> {
     let rt = global.create_runtime()?;
-    let info = rt.volumes()?.create().await?;
+    let info = rt.volumes()?.create(args.name.as_deref()).await?;
     // Like `boxlite create`, print the new id on success.
     println!("{}", info.id);
     Ok(())

--- a/src/cli/src/commands/volume/ls.rs
+++ b/src/cli/src/commands/volume/ls.rs
@@ -26,6 +26,9 @@ pub struct VolumePresenter {
     #[tabled(rename = "ID")]
     #[serde(rename = "Id")]
     pub id: String,
+    #[tabled(rename = "NAME")]
+    #[serde(rename = "Name")]
+    pub name: String,
     #[tabled(rename = "CREATED")]
     #[serde(rename = "CreatedAt")]
     pub created: String,
@@ -38,6 +41,7 @@ impl From<&VolumeInfo> for VolumePresenter {
     fn from(info: &VolumeInfo) -> Self {
         Self {
             id: info.id.clone(),
+            name: info.name.clone(),
             created: formatter::format_time(&info.created_at),
             size: format_size(info.size_bytes),
         }

--- a/src/cli/src/commands/volume/mod.rs
+++ b/src/cli/src/commands/volume/mod.rs
@@ -1,10 +1,13 @@
 //! `boxlite volume {create,ls,get,rm}` — manage volumes.
 //!
-//! Volumes are addressed by a server-assigned id (like boxes): `create` takes
-//! no arguments and prints the new id, and get/rm operate on ids. Each leaf
-//! module owns its own `Args` struct and `run()`; this module holds the
-//! subcommand enum and dispatches. The backend is not implemented yet, so every
-//! command currently returns "not supported".
+//! Volumes carry a server-assigned id and a name; `create` prints the new id
+//! and takes an optional `--name`, while get/rm operate on ids. A name is
+//! mountable in place of the id (`-v my-data:/data`).
+//!
+//! Each leaf module owns its own `Args` struct and `run()`; this module holds
+//! the subcommand enum and dispatches. Volumes are a REST-runtime capability:
+//! the local runtime has no volume backend and every command returns
+//! "not supported" against it.
 
 use clap::{Args, Subcommand};
 
@@ -23,7 +26,7 @@ pub struct VolumeArgs {
 
 #[derive(Subcommand, Debug)]
 pub enum VolumeCommand {
-    /// Create a volume (prints the new id).
+    /// Create a volume, optionally named (prints the new id).
     Create(create::CreateArgs),
 
     /// List volumes.

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -6,6 +6,7 @@ mod defaults;
 mod formatter;
 pub mod terminal;
 pub mod util;
+mod volumespec;
 
 use std::path::{Path, PathBuf};
 use std::process;

--- a/src/cli/src/volumespec.rs
+++ b/src/cli/src/volumespec.rs
@@ -30,7 +30,7 @@ pub enum MountOrigin {
     /// A managed volume, by server-assigned id or by name.
     ManagedVolume(String),
     /// A host directory or file. Relative paths are resolved by the caller.
-    HostPath(String),
+    BindMount(String),
     /// No source given — the caller wants scratch space at `guest_path`.
     Anonymous,
 }
@@ -140,7 +140,7 @@ fn classify(source: &str) -> anyhow::Result<MountOrigin> {
     };
 
     Ok(if host_path {
-        MountOrigin::HostPath(source.to_string())
+        MountOrigin::BindMount(source.to_string())
     } else {
         MountOrigin::ManagedVolume(source.to_string())
     })
@@ -196,7 +196,7 @@ mod tests {
 
     fn host(spec: &str) -> String {
         match parse(spec).unwrap().origin {
-            MountOrigin::HostPath(path) => path,
+            MountOrigin::BindMount(path) => path,
             other => panic!("{spec:?} should be a host path, got {other:?}"),
         }
     }
@@ -241,7 +241,7 @@ mod tests {
     #[test]
     fn windows_drive_path_still_takes_options() {
         let mount = parse(r"C:\data:/data:ro").unwrap();
-        assert_eq!(mount.origin, MountOrigin::HostPath(r"C:\data".to_string()));
+        assert_eq!(mount.origin, MountOrigin::BindMount(r"C:\data".to_string()));
         assert_eq!(mount.guest_path, "/data");
         assert!(mount.read_only);
     }

--- a/src/cli/src/volumespec.rs
+++ b/src/cli/src/volumespec.rs
@@ -1,0 +1,281 @@
+//! Parsing for `-v`/`--volume` mount specs.
+//!
+//! One token has to say which of three things the caller meant, so the rule is
+//! Docker's, character for character
+//! (`docker/cli/internal/volumespec/volumespec.go:33-49` for the scanner,
+//! `:96-124` for the classification):
+//!
+//! - The spec is split by scanning, not by `split(':')`. A colon preceded by
+//!   exactly one letter is a Windows drive letter and is absorbed into the
+//!   field rather than ending it, so `C:\data:/app` splits into two fields and
+//!   not three.
+//! - The source field is then classified by its **first character**: `.`, `/`,
+//!   `~`, a `\\` prefix, or `X:` mean a host path. Anything else is a managed
+//!   volume, addressed by id or by name.
+//!
+//! Docker's own failure mode does not carry over. There, a mistyped source
+//! silently creates an empty volume and the caller's data appears to vanish;
+//! boxlite never auto-creates, so an unknown reference is a loud "not found"
+//! from the server (`VolumeService.validateVolumes`).
+//!
+//! Unlike Docker this classification happens exactly once. Docker re-derives it
+//! daemon-side from an untyped string (`moby/daemon/volume/mounts/linux_parser.go`,
+//! `ParseMountRaw` re-testing `path.IsAbs`); `VolumeSpec` carries
+//! `managed_volume` and `host_path` as separate fields, so the decision made
+//! here survives all the way to the wire.
+
+/// Where a parsed mount's contents come from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MountOrigin {
+    /// A managed volume, by server-assigned id or by name.
+    ManagedVolume(String),
+    /// A host directory or file. Relative paths are resolved by the caller.
+    HostPath(String),
+    /// No source given — the caller wants scratch space at `guest_path`.
+    Anonymous,
+}
+
+/// One `-v` spec, resolved into an origin plus its mount point.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedMount {
+    pub origin: MountOrigin,
+    pub guest_path: String,
+    pub read_only: bool,
+}
+
+/// Parse one `-v` value.
+///
+/// Grammar, after the drive-aware split:
+/// - `BOX_PATH` / `BOX_PATH:ro` — anonymous volume
+/// - `SOURCE:BOX_PATH[:OPTIONS]` — managed volume or host bind, per `classify`
+pub fn parse(spec: &str) -> anyhow::Result<ParsedMount> {
+    let spec = spec.trim();
+    if spec.is_empty() {
+        anyhow::bail!("empty volume spec");
+    }
+
+    let fields = split_fields(spec);
+    let fields: Vec<&str> = fields.iter().map(|f| f.trim()).collect();
+
+    match fields.as_slice() {
+        [guest] => Ok(ParsedMount {
+            origin: MountOrigin::Anonymous,
+            guest_path: absolute_box_path(guest)?,
+            read_only: false,
+        }),
+
+        // `BOX_PATH:ro` is an anonymous volume with a mode, not a source named
+        // "ro". Checked before the source form so the shorthand keeps working.
+        [guest, mode] if is_mode(mode) => Ok(ParsedMount {
+            origin: MountOrigin::Anonymous,
+            guest_path: absolute_box_path(guest)?,
+            read_only: mode.eq_ignore_ascii_case("ro"),
+        }),
+
+        [source, guest] => Ok(ParsedMount {
+            origin: classify(source)?,
+            guest_path: absolute_box_path(guest)?,
+            read_only: false,
+        }),
+
+        [source, guest, options] => Ok(ParsedMount {
+            origin: classify(source)?,
+            guest_path: absolute_box_path(guest)?,
+            read_only: parse_read_only(options),
+        }),
+
+        _ => anyhow::bail!(
+            "invalid volume spec {spec:?}; use VOLUME:BOX_PATH, HOST_PATH:BOX_PATH[:OPTIONS], \
+             or BOX_PATH[:OPTIONS] for an anonymous volume"
+        ),
+    }
+}
+
+/// Split on `:`, except where the colon is a Windows drive separator.
+///
+/// Mirrors the scanner in `volumespec.go`: a colon terminates a field unless
+/// the field so far is exactly one letter, in which case it belongs to the
+/// field. That is what keeps `C:\data` whole without counting colons.
+///
+/// Upstream: `docker/cli/internal/volumespec/volumespec.go:33-49`.
+fn split_fields(spec: &str) -> Vec<String> {
+    let mut fields = Vec::new();
+    let mut buffer = String::new();
+
+    for ch in spec.chars() {
+        if ch == ':' && !is_drive_letter(&buffer) {
+            fields.push(std::mem::take(&mut buffer));
+        } else {
+            buffer.push(ch);
+        }
+    }
+    fields.push(buffer);
+
+    fields
+}
+
+/// A field holding exactly one ASCII letter — the left half of `C:`.
+fn is_drive_letter(buffer: &str) -> bool {
+    let mut chars = buffer.chars();
+    matches!((chars.next(), chars.next()), (Some(c), None) if c.is_ascii_alphabetic())
+}
+
+/// Decide whether a source names a host path or a managed volume.
+///
+/// First character only, as `isFilePath` does
+/// (`docker/cli/internal/volumespec/volumespec.go:108-124`). Nothing here
+/// inspects the filesystem:
+/// a spec must mean the same thing on every machine, whether or not the path
+/// happens to exist.
+fn classify(source: &str) -> anyhow::Result<MountOrigin> {
+    if source.is_empty() {
+        anyhow::bail!("volume source must be non-empty");
+    }
+
+    let host_path = match source.chars().next() {
+        Some('.') | Some('/') | Some('~') => true,
+        // UNC path or Windows named pipe.
+        _ if source.starts_with(r"\\") => true,
+        _ => is_windows_drive_prefix(source),
+    };
+
+    Ok(if host_path {
+        MountOrigin::HostPath(source.to_string())
+    } else {
+        MountOrigin::ManagedVolume(source.to_string())
+    })
+}
+
+/// `C:\data` or `C:/data` — a drive letter, a colon, then a separator.
+///
+/// Public to the crate so the host-path resolver shares this one definition:
+/// on Unix `Path::is_relative` calls `C:\data` relative and would canonicalize
+/// it against the working directory.
+pub fn is_windows_drive_prefix(source: &str) -> bool {
+    let bytes = source.as_bytes();
+    bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && (bytes[2] == b'\\' || bytes[2] == b'/')
+}
+
+fn is_mode(field: &str) -> bool {
+    field.eq_ignore_ascii_case("ro") || field.eq_ignore_ascii_case("rw")
+}
+
+/// Read `ro` out of an options list (`ro`, `rw,nocopy`). Other options are
+/// ignored, matching the behaviour this replaces.
+fn parse_read_only(options: &str) -> bool {
+    options
+        .split(',')
+        .any(|option| option.trim().eq_ignore_ascii_case("ro"))
+}
+
+/// The mount point inside the box. Always POSIX-absolute: guests are Linux, so
+/// unlike Docker there is no Windows-destination case to allow for.
+fn absolute_box_path(guest: &str) -> anyhow::Result<String> {
+    if guest.is_empty() {
+        anyhow::bail!("volume box path must be non-empty");
+    }
+    if !guest.starts_with('/') {
+        anyhow::bail!("volume box path must be absolute (e.g. /data), got {guest:?}");
+    }
+    Ok(guest.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn managed(spec: &str) -> String {
+        match parse(spec).unwrap().origin {
+            MountOrigin::ManagedVolume(volume) => volume,
+            other => panic!("{spec:?} should be a managed volume, got {other:?}"),
+        }
+    }
+
+    fn host(spec: &str) -> String {
+        match parse(spec).unwrap().origin {
+            MountOrigin::HostPath(path) => path,
+            other => panic!("{spec:?} should be a host path, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bare_source_is_a_managed_volume() {
+        assert_eq!(managed("my-data:/data"), "my-data");
+        assert_eq!(managed("vol_01K2EXAMPLE:/data"), "vol_01K2EXAMPLE");
+        assert_eq!(managed("data:/data"), "data");
+    }
+
+    /// A one-letter source is unreachable, and deliberately so: the scanner
+    /// cannot tell `a:` from a drive letter, so it absorbs the colon and the
+    /// whole spec becomes a single field — which then fails as a non-absolute
+    /// box path. Docker's scanner behaves identically (`isWindowsDrive` tests
+    /// only that the buffer is one letter). Single-character volume names are
+    /// therefore not addressable via `-v`; Docker rejects them outright with
+    /// "volume name is too short".
+    #[test]
+    fn single_letter_source_is_swallowed_as_a_drive_letter() {
+        let error = parse("a:/data").unwrap_err().to_string();
+        assert!(error.contains("must be absolute"), "{error}");
+    }
+
+    #[test]
+    fn leading_dot_slash_or_tilde_is_a_host_path() {
+        assert_eq!(host("/host/data:/data"), "/host/data");
+        assert_eq!(host("./data:/data"), "./data");
+        assert_eq!(host("../data:/data"), "../data");
+        assert_eq!(host("~/data:/data"), "~/data");
+    }
+
+    /// The case that broke an earlier attempt at this: the drive colon must not
+    /// end the field, or `C` is read as a volume named "C".
+    #[test]
+    fn windows_drive_paths_survive_the_split() {
+        assert_eq!(host(r"C:\data:/data"), r"C:\data");
+        assert_eq!(host(r"D:/host/path:/data"), r"D:/host/path");
+        assert_eq!(host(r"\\server\share:/data"), r"\\server\share");
+    }
+
+    #[test]
+    fn windows_drive_path_still_takes_options() {
+        let mount = parse(r"C:\data:/data:ro").unwrap();
+        assert_eq!(mount.origin, MountOrigin::HostPath(r"C:\data".to_string()));
+        assert_eq!(mount.guest_path, "/data");
+        assert!(mount.read_only);
+    }
+
+    #[test]
+    fn anonymous_forms() {
+        assert_eq!(parse("/data").unwrap().origin, MountOrigin::Anonymous);
+        let read_only = parse("/data:ro").unwrap();
+        assert_eq!(read_only.origin, MountOrigin::Anonymous);
+        assert!(read_only.read_only);
+        assert!(!parse("/data:rw").unwrap().read_only);
+    }
+
+    #[test]
+    fn read_only_option_is_parsed_for_both_origins() {
+        assert!(parse("my-data:/data:ro").unwrap().read_only);
+        assert!(parse("/host:/data:ro").unwrap().read_only);
+        assert!(!parse("/host:/data:rw,nocopy").unwrap().read_only);
+        assert!(!parse("/host:/data:rw").unwrap().read_only);
+    }
+
+    #[test]
+    fn box_path_must_be_absolute() {
+        for spec in ["my-data:data", "/host:data", "data"] {
+            let error = parse(spec).unwrap_err().to_string();
+            assert!(error.contains("must be absolute"), "{spec}: {error}");
+        }
+    }
+
+    #[test]
+    fn rejects_empty_and_overlong_specs() {
+        assert!(parse("").unwrap_err().to_string().contains("empty"));
+        assert!(parse("   ").unwrap_err().to_string().contains("empty"));
+        let error = parse("a:/b:ro:extra:more").unwrap_err().to_string();
+        assert!(error.contains("invalid volume spec"), "{error}");
+    }
+}


### PR DESCRIPTION
Managed volumes were reachable only through a `volume://` prefix inside the wire's polymorphic `source` string. `VolumeSpec` now carries `managed_volume` and `host_path` as separate typed fields, so the scheme has no remaining job and is gone from the tree — `git grep 'volume://'` returns zero hits.

This also lands the CLI half that #1216 deferred, using Docker's classification rule instead of the scheme, and closes #1208.

## Call graph

Before

```
apply_to               (VolumeFlags · src/cli/src/cli.rs:795)
  └─ parse_volume_spec (fn · src/cli/src/cli.rs:791)                      ← BUG: every source is a host bind; no CLI path to a managed volume
       └─ managed_volume_source (fn · src/boxlite/src/rest/types.rs:240)  ← BUG: blindly prefixes volume://, so /tmp/x becomes volume:///tmp/x
            └─ resolveVolumeId (fn · apps/api/src/boxlite-rest/mappers/box-to-box.mapper.ts:66)
                 └─ validateVolumes (VolumeService · apps/api/src/box/services/volume.service.ts:200)  ← BUG: returns void, so the caller's own selector is persisted; also binds plain names into a uuid id predicate
                      └─ toRunnerDto (RunnerAdapter · apps/api/src/box/runner-adapter/runnerAdapter.v2.ts:131)  ← BUG: resolves boxlite-volume-<selector>, another tenant's bucket
```

After

```
apply_to               (VolumeFlags · src/cli/src/cli.rs:795)
  └─ parse             (fn · src/cli/src/volumespec.rs:51)                — one classification, Docker's rule
       ├─ split_fields (fn · src/cli/src/volumespec.rs:101)               — char scanner; a drive colon is absorbed, not split
       └─ classify     (fn · src/cli/src/volumespec.rs:130)               — first char `.` `/` `~` UNC or `X:` is a host path, else a managed volume
            ├─ sanitize_local_options (fn · src/boxlite/src/runtime/rt_impl.rs:1764)  — one local gate; refuses a managed volume before boot
            └─ validate_remote_volumes (fn · src/boxlite/src/rest/runtime.rs:122)               — refuses a host bind and a read-only managed mount
                 └─ from             (CreateBoxVolumeSpec · src/boxlite/src/rest/types.rs:233)  — sends the reference verbatim, no scheme
                      └─ createBoxToCreateBox (fn · apps/api/src/boxlite-rest/mappers/box-to-box.mapper.ts:35)  — reads managed_volume, no scheme parsing
                           └─ validateVolumes (VolumeService · apps/api/src/box/services/volume.service.ts:214)  — returns selector to canonical id; uuid-shaped selectors only reach the id predicate
                                └─ create      (BoxService · apps/api/src/box/services/box.service.ts:227)      — stores the canonical id, throws if unresolved
                                     └─ toRunnerDto (RunnerAdapter · apps/api/src/box/runner-adapter/runnerAdapter.v2.ts:131)  — always a real uuid
```

## Surface

| Concept | Rust | Go | C | Node | Python | Wire |
|---|---|---|---|---|---|---|
| managed volume | `VolumeSpec::managed_volume` | `WithManagedVolume` | `..._add_managed_volume` | `managedVolume` | `managed_volume` | `managed_volume` |
| host bind | `VolumeSpec::bind_mount` | `WithBindMount` | `..._add_bind_mount` | `hostPath` | `host_path` | *(none — REST has no host binds)* |

```bash
boxlite volume create --name my-data     # NAME column now in ls/get
boxlite run -v my-data:/data alpine      # by name
boxlite run -v vol_01K2… :/data alpine   # or by id
boxlite run -v ./data:/data alpine       # host bind
```

`-v` classification follows `docker/cli/internal/volumespec/volumespec.go:33-49` (scanner) and `:108-124` (first-character rule). Docker's failure mode does not carry over: a mistyped source there silently creates an empty volume, while boxlite never auto-creates, so an unknown reference is a loud "not found".

## Breaking

- `-v data:/app` now mounts the managed volume `data` instead of binding `./data`. Write `./data:/app` for the bind.
- Wire `volumes[].source` and `volumes[].host_path` → `volumes[].managed_volume`. **Client and server must ship together.**
- Go `WithVolume`/`WithVolumeReadOnly` → `WithBindMount`/`WithBindMountReadOnly`; `Volumes.Create(ctx, name)`.
- C `boxlite_options_add_volume` → `boxlite_options_add_bind_mount`; `boxlite_volume_create` gains a `name` parameter; `CVolumeInfo` gains a `name` field, changing the struct layout. Migration guide in `sdks/c/README.md`.
- Rust `VolumeHandle::create(Option<&str>)`; `VolumeSpec::host`/`::managed` → `::bind_mount`/`::managed_volume`.
- Python volume dicts reject unknown keys — `host`, `guest`, `ro`, `source` were honoured aliases and now hard-error.
- Read-only managed mounts are rejected at all four boundaries rather than silently downgraded to read-write.

`bind_mount` names the *operation* — Docker's and the OCI runtime-spec's term for binding a host path in, and already this repo's own vocabulary at `src/boxlite/src/fs/bind_mount/`. The *data* keeps `host_path`: the Node/Python volume keys and the `VolumeSpec.host_path` field are unchanged. That field is persisted box config, so renaming it would strand every box created before this change.

## Test plan

- [x] core `cargo test -p boxlite --lib` — 1048/1048
- [x] CLI `cargo test -p boxlite-cli --bin boxlite` — 187/187
- [x] Node 78 vitest + 23 binding; Python 135 pytest + 8 binding; Go; C 75
- [x] `apps/api` — volume.service 18, create-box.dto 49, box.service 28, mapper 7, volume controller 9, create-volume.dto 4
- [x] `make fmt` + `make lint` clean (`lint:c` clang-tidy re-run with `--warnings-as-errors='*'`, which macOS skips)
- [x] Generated API clients regenerated — `CreateVolume.name` required → optional in the TS and Go clients
- [x] `local_runtime_rejects_managed_volumes_before_boot` two-side checked through the real entry point: call deleted from `sanitize_local_options` → FAILED (managed volume flowed straight through), restored → passed
- [ ] VM-backed integration suites — not run locally (no built guest in this worktree)

`make/test.mk` now runs the Node and Python binding tests, which had never executed; `sdks/python/Cargo.toml` gates pyo3's `extension-module` so `cargo test` can link libpython.

## Note for reviewers

Both pushes on this branch used `--no-verify`, each after an explicit one-off approval, because the pre-push `make test` cannot pass in this worktree:

- The first push was blocked by `rest::client::tests::control_request_keeps_total_timeout`. Confirmed pre-existing: an isolated `git worktree add --detach` at `f05312e34` reproduces the same panic at `rest/client.rs:769`, and this branch does not touch `rest/client.rs` or `rest/litebox.rs`.
- The second was blocked by 17 VM-backed integration tests (`test_exec_*`, `test_init_semantics_*`, `box_full_user_journey_birth_to_death`, `exec_does_not_grow_proc_mounts`), all failing with `Container init process exited - cannot exec ... container status: Created`. Boxes do not boot in this worktree. The same code is green in CI: `Rust Tests` passed on all three platforms and `Test (conclusion)` passed on the parent commit, whose only red checks were the three this PR fixes.

Both blockers want their own fix and are out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Create optionally named managed volumes through the CLI, REST API, and SDKs.
  * Mount managed volumes by name or ID and display their names in volume listings.
  * Added Docker-compatible volume syntax for bind mounts, managed volumes, anonymous mounts, Windows paths, and read-only options.
* **Breaking Changes**
  * Use `managed_volume` instead of legacy source or `volume://` references.
  * SDK APIs now distinguish managed volumes from bind mounts.
  * Read-only managed-volume mounts are no longer supported.
* **Documentation**
  * Updated examples and runtime-specific volume guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->