### PR TITLE
fix(api): stop fencing runner assignment on box creation

### DIFF
--- a/apps/api/src/box/repositories/box.repository.ts
+++ b/apps/api/src/box/repositories/box.repository.ts
@@ -23,6 +23,10 @@ import { BoxPublicStatusUpdatedEvent } from '../events/box-public-status-updated
 import { BoxOrganizationUpdatedEvent } from '../events/box-organization-updated.event'
 import { BoxLookupCacheInvalidationService } from '../services/box-lookup-cache-invalidation.service'
 
+// SQLSTATE lock_not_available — a statement waited longer than lock_timeout to
+// acquire a lock.
+const PG_LOCK_TIMEOUT_CODE = '55P03'
+
 // Cap how long the proxy auto-start UPDATE waits to acquire the box row's
 // write lock. Concurrent start/stop/sync go through updateWhere(), which holds
 // a pessimistic_write lock on the same row; there is no global statement/lock
@@ -32,10 +36,6 @@ import { BoxLookupCacheInvalidationService } from '../services/box-lookup-cache-
 // race-lost no-op. Aligned with the caller-side wait cap in
 // boxlite-proxy.controller.ts (PROXY_START_HINT_TIMEOUT_MS).
 const PROXY_START_LOCK_TIMEOUT_MS = 2000
-
-// SQLSTATE for `lock_not_available` — raised when a statement waits longer than
-// lock_timeout to acquire a lock.
-const PG_LOCK_TIMEOUT_CODE = '55P03'
 
 // A box the migration marker may claim, with the stamp its claim copies.
 type ParkedBox = { id: string; updatedAt: Date }

--- a/apps/api/src/box/services/box.service.runner-assignment.integration.spec.ts
+++ b/apps/api/src/box/services/box.service.runner-assignment.integration.spec.ts
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { randomUUID } from 'node:crypto'
+import Redis from 'ioredis'
+import { DataSource, Repository } from 'typeorm'
+import { CustomNamingStrategy } from '../../common/utils/naming-strategy.util'
+import { RedisLockProvider } from '../common/redis-lock.provider'
+import { Box } from '../entities/box.entity'
+import { BoxLastActivity } from '../entities/box-last-activity.entity'
+import { BoxMigration } from '../entities/box-migration.entity'
+import { Runner } from '../entities/runner.entity'
+import { BoxClass } from '../enums/box-class.enum'
+import { RunnerState } from '../enums/runner-state.enum'
+import { BoxRepository } from '../repositories/box.repository'
+import { BoxService } from './box.service'
+import { RunnerService } from './runner.service'
+
+const describeIfDatabase = process.env.DB_HOST ? describe : describe.skip
+
+// Its own database, not a schema in the shared one. The Runner entity's
+// `@PrimaryGeneratedColumn('uuid')` makes TypeORM issue
+// `CREATE EXTENSION IF NOT EXISTS "uuid-ossp"` on connect, and that statement is
+// not atomic — a sibling suite doing the same concurrently collides on
+// pg_extension_name_index. usage.service.integration.spec.ts also drops and
+// recreates schema public wholesale, which would take the extension with it. A
+// private database removes both couplings.
+const databaseName = `runner_assignment_${process.pid}_${randomUUID().replaceAll('-', '')}`
+const schemaName = 'public'
+const organizationId = '00000000-0000-4000-8000-0000000000ff'
+const region = 'us'
+
+// Enough concurrent creates to make the collision structural rather than a
+// timing coincidence: every caller resolves its candidate query before any of
+// them reaches the assignment step, so all of them target the single runner.
+const BURST = 8
+
+describeIfDatabase('BoxService runner assignment under concurrency (integration, real Postgres)', () => {
+  let dataSource: DataSource
+  let boxes: Repository<Box>
+  let runners: Repository<Runner>
+  let boxRepository: BoxRepository
+  let redis: Redis
+  let service: BoxService
+  let ownsDatabase = false
+
+  function readyRunner(): Runner {
+    const runner = new Runner({
+      region,
+      name: `runner-${randomUUID().slice(0, 8)}`,
+      apiKey: 'test-key',
+      apiVersion: '2',
+      cpu: 64,
+      memoryGiB: 256,
+      diskGiB: 2048,
+    })
+    runner.class = BoxClass.SMALL
+    runner.state = RunnerState.READY
+    runner.availabilityScore = 100
+    runner.lastChecked = new Date()
+    return runner
+  }
+
+  function pendingBox(name: string): Box {
+    const box = new Box(region, name)
+    box.organizationId = organizationId
+    box.osUser = 'boxlite'
+    box.class = BoxClass.SMALL
+    box.pending = true
+    return box
+  }
+
+  // Drives the same private assignment the create path uses, so the assertions
+  // cover production runner selection + assignment rather than a
+  // re-implementation.
+  function assignBox(name: string): Promise<Box> {
+    const box = pendingBox(name)
+    return (service as any).persistOnAvailableRunner(box, { regions: [region], boxClass: BoxClass.SMALL }, () =>
+      boxRepository.insert(box),
+    )
+  }
+
+  beforeAll(async () => {
+    const connection = {
+      type: 'postgres' as const,
+      host: process.env.DB_HOST,
+      port: Number(process.env.DB_PORT || 5432),
+      username: process.env.DB_USERNAME,
+      password: process.env.DB_PASSWORD,
+    }
+
+    // Entity-free so no uuid column exists to trigger the extension on this
+    // connection; CREATE DATABASE cannot run inside a transaction, and
+    // dataSource.query is autocommit.
+    const admin = await new DataSource({ ...connection, database: process.env.DB_DATABASE }).initialize()
+    try {
+      await admin.query(`CREATE DATABASE "${databaseName}"`)
+      ownsDatabase = true
+    } finally {
+      await admin.destroy()
+    }
+
+    dataSource = await new DataSource({
+      ...connection,
+      database: databaseName,
+      entities: [Box, BoxLastActivity, BoxMigration, Runner],
+      namingStrategy: new CustomNamingStrategy(),
+      entitySkipConstructor: true,
+      synchronize: false,
+    }).initialize()
+
+    await dataSource.synchronize()
+
+    boxes = dataSource.getRepository(Box)
+    runners = dataSource.getRepository(Runner)
+    redis = new Redis({
+      host: process.env.REDIS_HOST || '127.0.0.1',
+      port: Number(process.env.REDIS_PORT || 6379),
+    })
+
+    boxRepository = new BoxRepository(
+      dataSource,
+      { emit: jest.fn() } as any,
+      { invalidate: jest.fn(), invalidateOrgId: jest.fn() } as any,
+    )
+
+    // Real candidate selection: findAvailableRunners / getRandomAvailableRunner /
+    // findOneUncachedOrFail all read through this repository, so the score gate
+    // and the `excludedRunnerIds` filter are the production ones.
+    const runnerService = Object.create(RunnerService.prototype) as RunnerService
+    Object.assign(runnerService as any, {
+      runnerRepository: runners,
+      configService: { getOrThrow: jest.fn().mockReturnValue(10) },
+      dataSource,
+    })
+
+    service = Object.create(BoxService.prototype) as BoxService
+    Object.assign(service as any, {
+      logger: { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+      boxRepository,
+      runnerService,
+      dataSource,
+      // Wired even though assignment reaches for neither: a fixture that omits
+      // a collaborator the code under test could use cannot tell an unlocked
+      // assignment from a mis-assembled one — if production started opening a
+      // transaction or taking a lease again, these are what it would find.
+      redisLockProvider: new RedisLockProvider(redis),
+      redis,
+    })
+  })
+
+  afterAll(async () => {
+    redis?.disconnect()
+    if (!dataSource?.isInitialized) {
+      return
+    }
+
+    await dataSource.destroy()
+
+    if (!ownsDatabase) {
+      return
+    }
+
+    const admin = await new DataSource({
+      type: 'postgres',
+      host: process.env.DB_HOST,
+      port: Number(process.env.DB_PORT || 5432),
+      username: process.env.DB_USERNAME,
+      password: process.env.DB_PASSWORD,
+      database: process.env.DB_DATABASE,
+    }).initialize()
+    try {
+      // A failed test can leave a row-lock waiter holding a connection open, and
+      // DROP DATABASE refuses while any session is attached — it would report
+      // that instead of the assertion that actually failed.
+      await admin.query(`SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1`, [databaseName])
+      await admin.query(`DROP DATABASE IF EXISTS "${databaseName}"`)
+    } finally {
+      await admin.destroy()
+    }
+  })
+
+  beforeEach(async () => {
+    await dataSource.query(`DELETE FROM "${schemaName}"."box_last_activity"`)
+    await dataSource.query(`DELETE FROM "${schemaName}"."box"`)
+    await dataSource.query(`DELETE FROM "${schemaName}"."runner"`)
+    await redis.flushdb()
+  })
+
+  it('assigns every box in a concurrent burst to the only schedulable runner', async () => {
+    const runner = readyRunner()
+    await runners.insert(runner)
+
+    const settled = await Promise.allSettled(Array.from({ length: BURST }, (_, i) => assignBox(`burst-${i}`)))
+
+    // Surfacing the messages rather than a bare count: `No available runners`
+    // is the spurious capacity error this guards against, and it must not
+    // appear when the fleet was never out of capacity.
+    expect(
+      settled.filter((r) => r.status === 'rejected').map((r) => (r as PromiseRejectedResult).reason?.message),
+    ).toEqual([])
+    expect(await boxes.countBy({ runnerId: runner.id })).toBe(BURST)
+  })
+
+  it('assigns onto a runner a drain is mid-commit instead of waiting for it', async () => {
+    const runner = readyRunner()
+    await runners.insert(runner)
+
+    // The exact lock strength updateDrainingStatus and the decommission
+    // verification take, held from an independent connection with the flag
+    // already written but not yet committed.
+    const drain = dataSource.createQueryRunner()
+    await drain.connect()
+    await drain.startTransaction()
+    await drain.query(`SELECT "id" FROM "${schemaName}"."runner" WHERE "id" = $1 FOR UPDATE`, [runner.id])
+    await drain.query(`UPDATE "${schemaName}"."runner" SET "draining" = true WHERE "id" = $1`, [runner.id])
+
+    try {
+      const box = await assignBox('drained-under-us')
+
+      // Resolved while the drain still owns the row: assignment takes no lock
+      // on it, so it never queues behind a lifecycle writer.
+      expect(drain.isTransactionActive).toBe(true)
+      expect(box.runnerId).toBe(runner.id)
+
+      await drain.commitTransaction()
+    } finally {
+      if (drain.isTransactionActive) {
+        await drain.rollbackTransaction()
+      }
+      await drain.release()
+    }
+
+    // The accepted outcome: a box sitting on a runner that is now draining.
+    // Nothing is lost — the drain waits this box out instead of decommissioning
+    // past it.
+    expect(await runners.findOneByOrFail({ id: runner.id })).toMatchObject({ draining: true })
+    expect(await boxes.countBy({ runnerId: runner.id })).toBe(1)
+  }, 20_000)
+
+  it('excludes a runner that is genuinely draining and reports no candidate remains', async () => {
+    const runner = readyRunner()
+    runner.draining = true
+    await runners.insert(runner)
+
+    // No contention here — the runner is simply unschedulable, so the 400 that
+    // says "nowhere to put this" is the honest answer.
+    await expect(assignBox('draining-target')).rejects.toMatchObject({ status: 400 })
+    expect(await boxes.countBy({ runnerId: runner.id })).toBe(0)
+  })
+})

--- a/apps/api/src/box/services/box.service.spec.ts
+++ b/apps/api/src/box/services/box.service.spec.ts
@@ -8,6 +8,7 @@ import { BoxService } from './box.service'
 import { BoxState } from '../enums/box-state.enum'
 import { BoxDesiredState } from '../enums/box-desired-state.enum'
 import { RunnerState } from '../enums/runner-state.enum'
+import { BadRequestError } from '../../exceptions/bad-request.exception'
 import { BoxEvents } from '../constants/box-events.constants'
 
 // ensureStartedForProxy only touches boxRepository + eventEmitter +
@@ -38,7 +39,6 @@ function makeService() {
     eventEmitter, // eventEmitter
     organizationService, // organizationService
     noop, // runnerAdapterFactory
-    noop, // redisLockProvider
     noop, // redis
     noop, // regionService
     noop, // boxLookupCacheInvalidationService
@@ -80,7 +80,6 @@ function makePreviewUrlService() {
     noop, // eventEmitter
     noop, // organizationService
     noop, // runnerAdapterFactory
-    noop, // redisLockProvider
     redis, // redis
     regionService, // regionService
     noop, // boxLookupCacheInvalidationService
@@ -231,7 +230,6 @@ function makeNetworkTunnelService() {
     noop,
     noop,
     noop,
-    noop,
     regionService,
     noop,
     noop,
@@ -262,13 +260,6 @@ describe('BoxService public defaults', () => {
     const runner = { id: 'runner-1', draining: false, state: RunnerState.READY }
     const runnerService = {
       getRandomAvailableRunner: jest.fn().mockResolvedValue(runner),
-      findOneUncachedOrFail: jest.fn().mockResolvedValue(runner),
-    }
-    const redisLockProvider = {
-      acquireLease: jest.fn().mockResolvedValue({
-        signal: new AbortController().signal,
-        release: jest.fn().mockResolvedValue(undefined),
-      }),
     }
     const service = Object.create(BoxService.prototype) as BoxService
     Object.assign(service as any, {
@@ -276,14 +267,14 @@ describe('BoxService public defaults', () => {
       getValidatedOrDefaultClass: jest.fn().mockReturnValue('small'),
       organizationService: { assertOrganizationIsNotSuspended: jest.fn() },
       redis: { exists: jest.fn().mockResolvedValue(1) },
+      logger: { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
       warmPoolService,
       runnerService,
-      redisLockProvider,
       boxRepository,
       eventEmitter: { emitAsync: jest.fn().mockResolvedValue(undefined) },
       toBoxDto: jest.fn((box) => box),
     })
-    return { service, boxRepository, runnerService, redisLockProvider, warmPoolService }
+    return { service, boxRepository, runnerService, warmPoolService }
   }
 
   it.each([
@@ -342,36 +333,6 @@ describe('BoxService public defaults', () => {
     expect(boxRepository.insert).toHaveBeenCalled()
   })
 
-  it('rechecks runner eligibility under the assignment fence before inserting', async () => {
-    const { service, boxRepository, runnerService, redisLockProvider } = makeCreateService()
-    runnerService.findOneUncachedOrFail
-      .mockResolvedValueOnce({ id: 'runner-1', draining: true, state: RunnerState.READY })
-      .mockResolvedValueOnce({ id: 'runner-1', draining: false, state: RunnerState.READY })
-
-    await service.create({ name: 'fenced-box' } as any, { id: 'org-1' } as any)
-
-    expect(redisLockProvider.acquireLease).toHaveBeenCalledWith('runner:runner-1:box-assignment', 30)
-    expect(runnerService.findOneUncachedOrFail).toHaveBeenCalledTimes(2)
-    expect(boxRepository.insert).toHaveBeenCalledTimes(1)
-  })
-
-  it('returns a committed box when the assignment lease aborts immediately after insert', async () => {
-    const { service, boxRepository, redisLockProvider } = makeCreateService()
-    const controller = new AbortController()
-    redisLockProvider.acquireLease.mockResolvedValue({
-      signal: controller.signal,
-      release: jest.fn().mockResolvedValue(undefined),
-    })
-    boxRepository.insert.mockImplementation(async (box: any) => {
-      controller.abort(new Error('lease lost after commit'))
-      return box
-    })
-
-    await expect(service.create({ name: 'committed-box' } as any, { id: 'org-1' } as any)).resolves.toEqual(
-      expect.objectContaining({ name: 'committed-box' }),
-    )
-  })
-
   it.each([
     [undefined, true],
     [false, false],
@@ -396,5 +357,59 @@ describe('BoxService public defaults', () => {
       'warm-box',
       expect.objectContaining({ updateData: expect.objectContaining({ public: expectedPublic }) }),
     )
+  })
+})
+
+// Assignment is what turns a chosen runner into a committed box row. The only
+// seams it crosses are the candidate query and the insert — no transaction of
+// its own, and no lock on the runner row.
+describe('BoxService runner assignment', () => {
+  function makeAssignment() {
+    const runner = { id: 'runner-1', draining: false, state: RunnerState.READY }
+    const boxRepository = { insert: jest.fn(async (box: any) => box) } as any
+    const runnerService = { getRandomAvailableRunner: jest.fn().mockResolvedValue(runner) }
+    // Wired even though assignment no longer reaches for it: a fixture that
+    // omits a collaborator the code under test could use cannot tell an
+    // unlocked assignment from a mis-assembled one.
+    const dataSource = { transaction: jest.fn() }
+    const service = Object.create(BoxService.prototype) as BoxService
+    Object.assign(service as any, {
+      logger: { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+      runnerService,
+      dataSource,
+      boxRepository,
+    })
+
+    // Drives the private assignment directly rather than through create(),
+    // whose quota / region / warm-pool preamble only obscures it.
+    const assign = (name = 'box-1') => {
+      const box = { id: name, runnerId: undefined as string | undefined }
+      return (service as any).persistOnAvailableRunner(box, { regions: ['us'] }, () => boxRepository.insert(box))
+    }
+    return { assign, boxRepository, runnerService, dataSource }
+  }
+
+  it('commits the box on the chosen runner without locking its row', async () => {
+    const { assign, boxRepository, dataSource } = makeAssignment()
+
+    const box = await assign()
+
+    expect(box.runnerId).toBe('runner-1')
+    expect(boxRepository.insert).toHaveBeenCalledWith(expect.objectContaining({ runnerId: 'runner-1' }))
+    // No transaction of its own means no row lock on the runner: a drain never
+    // waits for this insert, and this insert never waits for a drain — so it can
+    // land on a runner that goes draining in between, which is the accepted
+    // trade.
+    expect(dataSource.transaction).not.toHaveBeenCalled()
+  })
+
+  it('leaves an empty candidate set as the 400 it already is', async () => {
+    const { assign, boxRepository, runnerService } = makeAssignment()
+    runnerService.getRandomAvailableRunner.mockRejectedValue(new BadRequestError('No available runners'))
+
+    // Nothing in that region and class can take this box. With no contention
+    // left to mistake it for, there is no retryable reading of this failure.
+    await expect(assign()).rejects.toMatchObject({ status: 400, message: 'No available runners' })
+    expect(boxRepository.insert).not.toHaveBeenCalled()
   })
 })

--- a/apps/api/src/box/services/box.service.ts
+++ b/apps/api/src/box/services/box.service.ts
@@ -12,7 +12,6 @@ import { persistWithGeneratedBoxName } from '../utils/box-name-generator'
 import { CreateBoxDto } from '../dto/create-box.dto'
 import { BoxState } from '../enums/box-state.enum'
 import { BoxClass } from '../enums/box-class.enum'
-import { RunnerState } from '../enums/runner-state.enum'
 import { BoxDesiredState } from '../enums/box-desired-state.enum'
 import { GetRunnerParams, RunnerService } from './runner.service'
 import { BoxError } from '../../exceptions/box-error.exception'
@@ -50,12 +49,10 @@ import {
 } from '../dto/list-boxes-query.dto'
 import { createRangeFilter } from '../../common/utils/range-filter'
 import { LogExecution } from '../../common/decorators/log-execution.decorator'
-import { RedisLockProvider, withRedisLockLease } from '../common/redis-lock.provider'
 import { customAlphabet as customNanoid, nanoid, urlAlphabet } from 'nanoid'
 import { WithInstrumentation } from '../../common/decorators/otel.decorator'
 import { validateMountPaths, validateSubpaths } from '../utils/volume-mount-path-validation.util'
 import { BoxRepository } from '../repositories/box.repository'
-import { getRunnerAssignmentLockKey } from '../utils/lock-key.util'
 import { Job } from '../entities/job.entity'
 import { JobService } from './job.service'
 import { JobStatus, JobType, ResourceType } from '../dto/job.dto'
@@ -109,7 +106,6 @@ export class BoxService {
     private readonly eventEmitter: EventEmitter2,
     private readonly organizationService: OrganizationService,
     private readonly runnerAdapterFactory: RunnerAdapterFactory,
-    private readonly redisLockProvider: RedisLockProvider,
     @InjectRedis() private readonly redis: Redis,
     private readonly regionService: RegionService,
     private readonly boxLookupCacheInvalidationService: BoxLookupCacheInvalidationService,
@@ -123,49 +119,36 @@ export class BoxService {
     return `box:${id}:state-change`
   }
 
-  private async persistWithRunnerAssignmentFence(
+  /**
+   * Assigns `box` to a schedulable runner, then persists it.
+   *
+   * Nothing locks the runner row across the gap between the candidate query —
+   * which already filters out draining, unschedulable and non-READY runners —
+   * and the insert. A drain landing inside that gap therefore wins the row but
+   * not the box: the runner ends up marked draining with this box assigned to
+   * it. That is the deliberate trade, and it is how schedulers usually settle
+   * it: Nomad re-checks node eligibility only when the plan is applied
+   * (`evaluateNodePlan`, nomad/plan_apply.go:837-861, over a read-only memdb
+   * snapshot), and Kubernetes lets the kubelet reject a pod the scheduler
+   * already bound (`predicateAdmitHandler.Admit`,
+   * pkg/kubelet/lifecycle/predicate.go:118-207). A lock here buys a fence over
+   * milliseconds and charges every create for it — waiting behind runner
+   * lifecycle writers, and unable to tell "busy" from "unusable" when it loses.
+   *
+   * Draining is not a hard exclusion, it is "no new work, wait out the boxes
+   * already here". A box that slips in is one more box to wait out:
+   * `handleCheckDecommissionRunners` counts assignments before each transition
+   * and resets its counter while any remain, so the runner keeps draining and
+   * the box keeps running.
+   */
+  private async persistOnAvailableRunner(
     box: Box,
     runnerParams: GetRunnerParams,
     persist: () => Promise<Box>,
   ): Promise<Box> {
-    const excludedRunnerIds = [...(runnerParams.excludedRunnerIds ?? [])]
-    for (let attempt = 0; attempt < 3; attempt++) {
-      const runner = await this.runnerService.getRandomAvailableRunner({ ...runnerParams, excludedRunnerIds })
-      const lockKey = getRunnerAssignmentLockKey(runner.id)
-      const lease = await this.redisLockProvider.acquireLease(lockKey, 30)
-      if (!lease) {
-        excludedRunnerIds.push(runner.id)
-        continue
-      }
-
-      let committed: Box | null = null
-      try {
-        const inserted = await withRedisLockLease(lease, async (signal) => {
-          const currentRunner = await this.runnerService.findOneUncachedOrFail(runner.id)
-          if (currentRunner.draining || currentRunner.state !== RunnerState.READY) {
-            excludedRunnerIds.push(runner.id)
-            return null
-          }
-
-          signal.throwIfAborted()
-          box.runnerId = currentRunner.id
-          committed = await persist()
-          return committed
-        })
-        if (inserted) {
-          return inserted
-        }
-      } catch (error) {
-        // Once insert committed, returning the entity keeps CREATED event handling
-        // consistent even if the lease is lost while releasing.
-        if (committed) {
-          return committed
-        }
-        throw error
-      }
-    }
-
-    throw new BadRequestError('No runner remained available while assigning the box')
+    const runner = await this.runnerService.getRandomAvailableRunner(runnerParams)
+    box.runnerId = runner.id
+    return persist()
   }
 
   private assertBoxNotErrored(box: Box): void {
@@ -192,7 +175,7 @@ export class BoxService {
 
     box.pending = true
 
-    return this.persistWithRunnerAssignmentFence(box, { regions: [box.region], boxClass: box.class }, () =>
+    return this.persistOnAvailableRunner(box, { regions: [box.region], boxClass: box.class }, () =>
       this.boxRepository.insert(box),
     )
   }
@@ -317,8 +300,9 @@ export class BoxService {
 
       // No caller-provided name -> assign a fun default (e.g. "cozy-otter"),
       // falling back to "cozy-otter-{boxId}" if it collides with the per-org
-      // @Unique(['organizationId', 'name']) constraint.
-      const insertedBox = await this.persistWithRunnerAssignmentFence(box, { regions: [region.id], boxClass }, () =>
+      // @Unique(['organizationId', 'name']) constraint. Only the insert retries:
+      // the chosen runner is still fine, it was the name that collided.
+      const insertedBox = await this.persistOnAvailableRunner(box, { regions: [region.id], boxClass }, () =>
         createBoxDto.name
           ? this.boxRepository.insert(box)
           : persistWithGeneratedBoxName(box.id, (name) => {

--- a/apps/api/src/box/services/runner.service.decommission.spec.ts
+++ b/apps/api/src/box/services/runner.service.decommission.spec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
+import { Runner } from '../entities/runner.entity'
 import { RunnerState } from '../enums/runner-state.enum'
 import { RunnerService } from './runner.service'
 
@@ -18,17 +19,12 @@ describe('RunnerService decommission verification', () => {
       update: jest.fn().mockResolvedValue({ affected: 1 }),
     }
     const boxRepository = { count: jest.fn().mockResolvedValue(boxCount) }
+    // Only the singleton cron guards still take a Redis lock; the two runner
+    // state writers serialise against each other with a FOR UPDATE row lock
+    // inside `dataSource.transaction`.
     const redisLockProvider = {
       lock: jest.fn().mockResolvedValue(true),
       unlock: jest.fn().mockResolvedValue(undefined),
-      acquireLease: jest.fn().mockResolvedValue({
-        signal: new AbortController().signal,
-        release: jest.fn().mockResolvedValue(undefined),
-      }),
-      waitForLease: jest.fn().mockResolvedValue({
-        signal: new AbortController().signal,
-        release: jest.fn().mockResolvedValue(undefined),
-      }),
     }
     const configService = { getOrThrow: jest.fn().mockReturnValue(1) }
     const redis = {
@@ -36,7 +32,19 @@ describe('RunnerService decommission verification', () => {
       set: jest.fn().mockResolvedValue('OK'),
       del: jest.fn().mockResolvedValue(1),
     }
-    const dataSource = { queryResultCache: undefined }
+    // Stands in for the locked read + write the two writers do; `count` here is
+    // the transactional re-count, distinct from boxRepository.count outside it.
+    const entityManager = {
+      findOne: jest.fn().mockResolvedValue(runner),
+      count: jest.fn().mockResolvedValue(boxCount),
+      update: jest.fn().mockResolvedValue({ affected: 1 }),
+      save: jest.fn(async (_entity: unknown, value: unknown) => value),
+      query: jest.fn().mockResolvedValue(undefined),
+    }
+    const dataSource = {
+      queryResultCache: undefined,
+      transaction: jest.fn(async (cb: (em: typeof entityManager) => Promise<unknown>) => cb(entityManager)),
+    }
     const eventEmitter = { emit: jest.fn() }
     const service = new RunnerService(
       runnerRepository as any,
@@ -50,7 +58,16 @@ describe('RunnerService decommission verification', () => {
       redis as any,
     )
 
-    return { service, runnerRepository, boxRepository, redisLockProvider, redis, eventEmitter }
+    return {
+      service,
+      runnerRepository,
+      boxRepository,
+      redisLockProvider,
+      redis,
+      eventEmitter,
+      entityManager,
+      dataSource,
+    }
   }
 
   it('resets verification while any box is still assigned to the draining runner', async () => {
@@ -64,11 +81,11 @@ describe('RunnerService decommission verification', () => {
   })
 
   it('decommissions only after three checks with no remaining runner assignments', async () => {
-    const { service, runnerRepository, redis } = createService(0, '2')
+    const { service, redis, entityManager } = createService(0, '2')
 
     await (service as any).handleCheckDecommissionRunners()
 
-    expect(runnerRepository.update).toHaveBeenCalledWith('runner-1', { state: RunnerState.DECOMMISSIONED })
+    expect(entityManager.update).toHaveBeenCalledWith(Runner, 'runner-1', { state: RunnerState.DECOMMISSIONED })
     expect(redis.del).toHaveBeenCalledWith('runner:draining-check:runner-1')
   })
 
@@ -90,37 +107,41 @@ describe('RunnerService decommission verification', () => {
     expect(redis.del).toHaveBeenCalledWith('runner:draining-check:runner-1')
   })
 
-  it('does not publish decommission when an assignment appears after taking the assignment fence', async () => {
-    const { service, runnerRepository, boxRepository, redis, redisLockProvider } = createService(0, '2')
-    boxRepository.count.mockResolvedValueOnce(0).mockResolvedValueOnce(1)
+  it('does not publish decommission when the transactional re-count still finds a box', async () => {
+    const { service, redis, entityManager } = createService(0, '2')
+    entityManager.count.mockResolvedValue(1)
 
     await (service as any).handleCheckDecommissionRunners()
 
-    expect(runnerRepository.update).not.toHaveBeenCalled()
+    expect(entityManager.update).not.toHaveBeenCalled()
     expect(redis.set).toHaveBeenCalledWith('runner:draining-check:runner-1', '0', 'EX', 600)
-    expect(redisLockProvider.acquireLease).toHaveBeenCalledWith('runner:runner-1:box-assignment', 30)
+    // The re-count has to happen under the same exclusive lock as the write.
+    expect(entityManager.findOne).toHaveBeenCalledWith(
+      Runner,
+      expect.objectContaining({ lock: { mode: 'pessimistic_write' } }),
+    )
   })
 
   it('does not decommission when draining is cleared before final verification', async () => {
-    const { service, runnerRepository, boxRepository } = createService(0, '2')
-    runnerRepository.findOne.mockResolvedValue({ id: 'runner-1', draining: false, state: RunnerState.READY })
+    const { service, entityManager } = createService(0, '2')
+    entityManager.findOne.mockResolvedValue({ id: 'runner-1', draining: false, state: RunnerState.READY })
 
     await (service as any).handleCheckDecommissionRunners()
 
-    expect(boxRepository.count).toHaveBeenCalledTimes(1)
-    expect(runnerRepository.update).not.toHaveBeenCalled()
+    expect(entityManager.count).not.toHaveBeenCalled()
+    expect(entityManager.update).not.toHaveBeenCalled()
   })
 
-  it('updates draining while holding the runner assignment lease', async () => {
-    const { service, redisLockProvider } = createService(0)
+  it('updates draining under an exclusive lock on the runner row', async () => {
+    const { service, entityManager } = createService(0)
 
     await service.updateDrainingStatus('runner-1', false)
 
-    expect(redisLockProvider.waitForLease).toHaveBeenCalledWith(
-      'runner:runner-1:box-assignment',
-      30,
-      expect.any(AbortSignal),
+    expect(entityManager.findOne).toHaveBeenCalledWith(
+      Runner,
+      expect.objectContaining({ where: { id: 'runner-1' }, lock: { mode: 'pessimistic_write' } }),
     )
+    expect(entityManager.save).toHaveBeenCalledWith(Runner, expect.objectContaining({ draining: false }))
   })
 
   it('keeps a runner decommissioned when an in-flight health write completes later', async () => {
@@ -145,6 +166,18 @@ describe('RunnerService decommission verification', () => {
     await service.updateRunnerHealth('runner-1')
 
     expect(eventEmitter.emit).not.toHaveBeenCalled()
+  })
+
+  it('waits out the row lock rather than capping it', async () => {
+    const { service, entityManager } = createService(0, '2')
+
+    await (service as any).handleCheckDecommissionRunners()
+    await service.updateDrainingStatus('runner-1', true)
+
+    // No `SET LOCAL lock_timeout`: the only holder either can wait on is the
+    // other one, for a single read-modify-write. Assignments take no lock on
+    // the runner row, so no create is queued behind this either way.
+    expect(entityManager.query).not.toHaveBeenCalled()
   })
 
   it('translates a missing uncached runner into NotFoundException', async () => {

--- a/apps/api/src/box/services/runner.service.ts
+++ b/apps/api/src/box/services/runner.service.ts
@@ -17,6 +17,7 @@ import {
 import { InjectRepository } from '@nestjs/typeorm'
 import { Cron, CronExpression } from '@nestjs/schedule'
 import { DataSource, FindOptionsWhere, In, MoreThanOrEqual, Not, Repository, UpdateResult } from 'typeorm'
+import { Box } from '../entities/box.entity'
 import { Runner } from '../entities/runner.entity'
 import { CreateRunnerInternalDto } from '../dto/create-runner-internal.dto'
 import { BoxClass } from '../enums/box-class.enum'
@@ -25,7 +26,7 @@ import { BadRequestError } from '../../exceptions/bad-request.exception'
 import { EventEmitter2 } from '@nestjs/event-emitter'
 import { BoxState } from '../enums/box-state.enum'
 import { RunnerAdapterFactory, RunnerInfo } from '../runner-adapter/runnerAdapter'
-import { RedisLockProvider, withRedisLockLease } from '../common/redis-lock.provider'
+import { RedisLockProvider } from '../common/redis-lock.provider'
 import { TypedConfigService } from '../../config/typed-config.service'
 import { LogExecution } from '../../common/decorators/log-execution.decorator'
 import { WithInstrumentation } from '../../common/decorators/otel.decorator'
@@ -43,7 +44,6 @@ import Redis from 'ioredis'
 import { runnerLookupCacheKeyById, RUNNER_LOOKUP_CACHE_TTL_MS } from '../utils/runner-lookup-cache.util'
 import { BoxRepository } from '../repositories/box.repository'
 import { RunnerServiceInfo } from '../common/runner-service-info'
-import { getRunnerAssignmentLockKey } from '../utils/lock-key.util'
 
 @Injectable()
 export class RunnerService {
@@ -681,37 +681,52 @@ export class RunnerService {
               const count = currentCount ? parseInt(currentCount, 10) + 1 : 1
 
               if (count >= 3) {
-                const assignmentLockKey = getRunnerAssignmentLockKey(runner.id)
-                const assignmentLease = await this.redisLockProvider.acquireLease(assignmentLockKey, 30)
-                if (!assignmentLease) {
-                  return
-                }
-
-                await withRedisLockLease(assignmentLease, async (signal) => {
-                  const currentRunner = await this.findOneUncachedOrFail(runner.id)
-                  if (!currentRunner.draining || currentRunner.state === RunnerState.DECOMMISSIONED) {
-                    await this.redis.del(redisKey)
-                    return
+                // FOR UPDATE serialises this against updateDrainingStatus,
+                // whose full-entity save would otherwise write a stale `state`
+                // back over this one.
+                //
+                // Box assignment takes no lock on this row (see
+                // BoxService.persistOnAvailableRunner), so the re-count is a
+                // snapshot rather than a fence. It still catches every box the
+                // drain is waiting out: a create commits its insert
+                // milliseconds after picking a runner, and this transition sits
+                // three 10s checks behind the drain that started it.
+                //
+                // Unbounded on purpose: the only conflicting holder is that one
+                // other writer, holding for a single read-modify-write.
+                const decommissioned = await this.dataSource.transaction(async (entityManager) => {
+                  const currentRunner = await entityManager.findOne(Runner, {
+                    where: { id: runner.id },
+                    lock: { mode: 'pessimistic_write' },
+                    loadEagerRelations: false,
+                  })
+                  if (!currentRunner || !currentRunner.draining || currentRunner.state === RunnerState.DECOMMISSIONED) {
+                    return 'abandoned'
                   }
 
-                  const finalAssignedBoxCount = await this.boxRepository.count({
+                  const finalAssignedBoxCount = await entityManager.count(Box, {
                     where: { runnerId: runner.id },
                   })
                   if (finalAssignedBoxCount > 0) {
-                    await this.redis.set(redisKey, '0', 'EX', 600)
                     this.logger.warn(
                       `Runner ${runner.id} received ${finalAssignedBoxCount} box assignments during decommission verification`,
                     )
-                    return
+                    return 'reset'
                   }
 
-                  signal.throwIfAborted()
-                  await this.updateRunner(runner.id, {
-                    state: RunnerState.DECOMMISSIONED,
-                  })
-                  await this.redis.del(redisKey)
-                  this.logger.log(`Runner ${runner.id} has been decommissioned after 3 successful draining checks`)
+                  await entityManager.update(Runner, runner.id, { state: RunnerState.DECOMMISSIONED })
+                  return 'decommissioned'
                 })
+
+                if (decommissioned === 'reset') {
+                  await this.redis.set(redisKey, '0', 'EX', 600)
+                } else {
+                  await this.redis.del(redisKey)
+                }
+                if (decommissioned === 'decommissioned') {
+                  this.invalidateRunnerCache(runner.id)
+                  this.logger.log(`Runner ${runner.id} has been decommissioned after 3 successful draining checks`)
+                }
               } else {
                 await this.redis.set(redisKey, count.toString(), 'EX', 600) // 10 minute TTL
                 this.logger.debug(`Runner ${runner.id} draining check passed (${count}/3), no boxes remain assigned`)
@@ -735,28 +750,36 @@ export class RunnerService {
   }
 
   async updateDrainingStatus(id: string, draining: boolean): Promise<Runner> {
-    const lease = await this.redisLockProvider.waitForLease(
-      getRunnerAssignmentLockKey(id),
-      30,
-      new AbortController().signal,
-    )
-    return withRedisLockLease(lease, async (signal) => {
-      const runner = await this.findOneUncachedOrFail(id)
-      if (runner.state === RunnerState.DECOMMISSIONED) {
+    // FOR UPDATE against the decommission transition: the save below writes the
+    // whole entity, so without it the `state` read here could be written back
+    // over a DECOMMISSIONED that landed in between. Assignments hold no lock on
+    // this row, so nothing else waits on this.
+    const runner = await this.dataSource.transaction(async (entityManager) => {
+      const current = await entityManager.findOne(Runner, {
+        where: { id },
+        lock: { mode: 'pessimistic_write' },
+        loadEagerRelations: false,
+      })
+      if (!current) {
+        throw new NotFoundException(`Runner with ID ${id} not found`)
+      }
+      if (current.state === RunnerState.DECOMMISSIONED) {
         throw new ConflictException('Cannot update draining status of a decommissioned runner')
       }
-      signal.throwIfAborted()
-      await this.redis.del(`runner:draining-check:${id}`)
-      runner.draining = draining
-      return this.runnerRepository.save(runner)
+      current.draining = draining
+      return entityManager.save(Runner, current)
     })
+
+    await this.redis.del(`runner:draining-check:${id}`)
+    this.invalidateRunnerCache(id)
+    return runner
   }
 
   async getRandomAvailableRunner(params: GetRunnerParams): Promise<Runner> {
     const availableRunners = await this.findAvailableRunners(params)
 
     if (availableRunners.length === 0) {
-      throw new BadRequestError('No available runners')
+      throw new BadRequestError(NO_AVAILABLE_RUNNERS)
     }
 
     // Get random runner from the best available runners
@@ -950,6 +973,13 @@ export class RunnerService {
     }
   }
 }
+
+/**
+ * The message `getRandomAvailableRunner` raises when the candidate query comes
+ * back empty. Exported because callers key retry semantics off exactly this
+ * condition, and must not re-spell the string to recognise it.
+ */
+export const NO_AVAILABLE_RUNNERS = 'No available runners'
 
 export class GetRunnerParams {
   regions?: string[]

--- a/apps/api/src/box/utils/lock-key.util.ts
+++ b/apps/api/src/box/utils/lock-key.util.ts
@@ -10,10 +10,6 @@ export function getStateChangeLockKey(id: string): string {
   return `box:${id}:state-change`
 }
 
-export function getRunnerAssignmentLockKey(id: string): string {
-  return `runner:${id}:box-assignment`
-}
-
 /**
  * The lock that marks one migration job as in flight for a box.
  *


### PR DESCRIPTION
## Summary

Concurrent box creation aimed at the same runner contended a non-blocking Redis `SET NX` lease; the loser could not tell "busy" from "unusable", excluded the runner, and — with one schedulable runner in that region and class — emptied the candidate set and answered `400 No available runners` while the fleet still had capacity. The per-runner interlock is removed rather than replaced: creation picks a candidate and inserts, and a drain that commits in that window leaves the box on a runner already marked draining.

## Call graph

Before
  BoxService.create                     (BoxService · apps/api/src/box/services/box.service.ts:200)
    └─ persistWithRunnerAssignmentFence (BoxService · apps/api/src/box/services/box.service.ts:126)
         ├─ getRandomAvailableRunner    (RunnerService · apps/api/src/box/services/runner.service.ts:755)
         ├─ acquireLease                (RedisLockProvider · apps/api/src/box/common/redis-lock.provider.ts:167)  ← BUG: non-blocking, so a lost race excludes a healthy runner
         ├─ findOneUncachedOrFail       (RunnerService · apps/api/src/box/services/runner.service.ts:213)         — re-read under the lease
         └─ boxRepository.insert        (BoxRepository · apps/api/src/box/repositories/box.repository.ts:55)
  …
  updateDrainingStatus                  (RunnerService · apps/api/src/box/services/runner.service.ts:737)         — waitForLease on the same per-runner key
  handleCheckDecommissionRunners        (RunnerService · apps/api/src/box/services/runner.service.ts:643)         — acquireLease, same key

After
  BoxService.create                     (BoxService · apps/api/src/box/services/box.service.ts:183)
    └─ persistOnAvailableRunner         (BoxService · apps/api/src/box/services/box.service.ts:144)
         ├─ getRandomAvailableRunner    (RunnerService · apps/api/src/box/services/runner.service.ts:778)         — the only eligibility check
         └─ boxRepository.insert        (BoxRepository · apps/api/src/box/repositories/box.repository.ts:55)      — own transaction, no runner-row lock
  …
  updateDrainingStatus                  (RunnerService · apps/api/src/box/services/runner.service.ts:752)         — FOR UPDATE, vs the decommission transition only
  handleCheckDecommissionRunners        (RunnerService · apps/api/src/box/services/runner.service.ts:643)         — FOR UPDATE, count then transition

Fixes #1353

## Changes

- `runner:<id>:box-assignment` and its three holders are gone, and nothing takes their place: `getRunnerAssignmentLockKey` is deleted, and `RedisLockProvider` stays in `RunnerService` only for the singleton cron guards (`check-runners`, `check-decommission-runners`), which are unrelated to per-runner exclusion.
- `persistOnAvailableRunner` is the whole assignment: pick a candidate, stamp `runnerId`, persist. No transaction wrapping the pair, no re-read, no candidate-exclusion retry loop. `findAvailableRunners` already filters out draining, unschedulable and non-READY rows, so it is the only eligibility check.
- **The accepted race.** A drain committing between the candidate query and the insert wins the row but not the box. Draining is soft — it stops new scheduling and waits out the boxes already there — and `handleCheckDecommissionRunners` counts assignments before every transition and resets its counter while any remain, so a box that slips in delays the drain instead of being orphaned. Nomad settles the same race the same way, re-checking node eligibility only at plan apply; Kubernetes lets the kubelet reject a pod the scheduler already bound.
- The two writers of runner state keep an interlock, but only against each other: `updateDrainingStatus` saves a whole `Runner`, so without `FOR UPDATE` its `state` read could be written back over a concurrent `DECOMMISSIONED`. Neither excludes assignment any more, so neither carries a `lock_timeout` — no create is queued behind them.
- **Status codes.** `400 No available runners` is again the only answer to an exhausted candidate set. The `408` paths and the contention reclassification are gone with the contention that motivated them; a `BadRequestError` from `getRandomAvailableRunner` propagates unchanged.
- `BoxRepository.insert` keeps its own transaction and takes no `EntityManager`; `BoxService` no longer injects `DataSource`. The generated-name retry wraps only the insert, so a name collision keeps the runner it already chose.
- Tests: `box.service.runner-assignment.integration.spec.ts` (real Postgres) covers the concurrent burst, a drain holding the runner row mid-commit, and a genuinely draining runner; the unit cases live in a `BoxService runner assignment` block and drive the assignment directly rather than through `create()`.

## How to verify

    cd apps
    DB_HOST=<host> DB_PORT=<port> DB_USERNAME=<user> DB_PASSWORD=<pass> DB_DATABASE=<db> \
    REDIS_HOST=<host> REDIS_PORT=<port> \
      npx jest --config api/jest.config.ts --rootDir api

`box.service.runner-assignment.integration.spec.ts` needs real Postgres and creates its own database; it skips when `DB_HOST` is unset. Against `main` its burst case fails with `No available runners`. Its drain case discriminates the other direction: reinstate a `pessimistic_read` read on the runner row inside an assignment transaction and `assigns onto a runner a drain is mid-commit instead of waiting for it` parks on the lock until the 20s test timeout.

## Risks / rollout

- The decommission re-count is now a snapshot rather than a fence. An insert that commits after it would leave a box on a `DECOMMISSIONED` runner. That needs a create stalled past three 10s checks between picking a runner and inserting — where the shared lock made it impossible.
- A box that lands on a draining runner holds the drain open for its own lifetime; auto-stop and auto-delete still apply, so the runner drains once the box goes away.
- `updateDrainingStatus` still resets its Redis counter and invalidates cache after the transaction commits (unchanged). A crash in that window leaves a stale `runner:draining-check:<id>`, so a later cycle can reach three checks early; the transition still re-verifies `draining` and a zero box count under `FOR UPDATE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrent box assignment reliability and distribution across available runners.
  * Prevented new assignments to runners that are actively draining.
  * Improved runner decommissioning and status updates during concurrent activity.
  * Reduced contention during runner state changes.
  * Standardized the error shown when no runners are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->