### PR TITLE
fix(rest): classify transport faults, unblock two red tests

### DIFF
--- a/src/boxlite/src/db/base_disk.rs
+++ b/src/boxlite/src/db/base_disk.rs
@@ -174,7 +174,7 @@ impl BaseDiskStore {
                 "SELECT id, source_box_id, name, kind, base_path, \
                  created_at, json FROM base_disk \
                  WHERE source_box_id = ?1 AND kind = ?2 \
-                 ORDER BY created_at DESC"
+                 ORDER BY created_at DESC, rowid DESC"
                     .to_string(),
                 vec![
                     Box::new(source_box_id.to_string()),
@@ -185,7 +185,7 @@ impl BaseDiskStore {
                 "SELECT id, source_box_id, name, kind, base_path, \
                  created_at, json FROM base_disk \
                  WHERE source_box_id = ?1 \
-                 ORDER BY created_at DESC"
+                 ORDER BY created_at DESC, rowid DESC"
                     .to_string(),
                 vec![Box::new(source_box_id.to_string())],
             ),
@@ -449,6 +449,10 @@ mod tests {
 
         let all = store.list_by_box("box-1", None).unwrap();
         assert_eq!(all.len(), 2);
+        // Both disks are stamped in the same whole second, so newest-first has
+        // to come from the insertion tiebreaker rather than `created_at`.
+        let listed: Vec<&str> = all.iter().map(|d| d.id().as_str()).collect();
+        assert_eq!(listed, ["base0001", "snap0001"]);
     }
 
     #[test]

--- a/src/boxlite/src/db/boxes.rs
+++ b/src/boxlite/src/db/boxes.rs
@@ -191,7 +191,7 @@ impl BoxStore {
             SELECT c.json as config_json, s.json as state_json
             FROM box_config c
             JOIN box_state s ON c.id = s.id
-            ORDER BY c.created_at DESC
+            ORDER BY c.created_at DESC, c.rowid DESC
             "#
         ))?;
 
@@ -226,7 +226,7 @@ impl BoxStore {
             FROM box_config c
             JOIN box_state s ON c.id = s.id
             WHERE s.status IN ('starting', 'running', 'detached')
-            ORDER BY c.created_at DESC
+            ORDER BY c.created_at DESC, c.rowid DESC
             "#
         ))?;
 
@@ -482,6 +482,11 @@ mod tests {
 
         let all = store.list_all().unwrap();
         assert_eq!(all.len(), 3);
+        // `create_test_config` stamps `Utc::now()` and the column is
+        // whole-second, so all three tie — the documented newest-first order
+        // has to survive that, not fall back to insertion order.
+        let listed: Vec<&str> = all.iter().map(|(c, _)| c.id.as_str()).collect();
+        assert_eq!(listed, [TEST_ID_3, TEST_ID_2, TEST_ID_1]);
     }
 
     #[test]

--- a/src/boxlite/src/db/snapshot.rs
+++ b/src/boxlite/src/db/snapshot.rs
@@ -55,9 +55,10 @@ impl SnapshotStore {
     /// List all snapshots for a box. Newest first.
     pub(crate) fn list(&self, box_id: &str) -> BoxliteResult<Vec<SnapshotInfo>> {
         let conn = self.db.conn();
-        let mut stmt = db_err!(
-            conn.prepare("SELECT json FROM snapshot WHERE box_id = ?1 ORDER BY created_at DESC")
-        )?;
+        let mut stmt = db_err!(conn.prepare(
+            "SELECT json FROM snapshot WHERE box_id = ?1 \
+             ORDER BY created_at DESC, rowid DESC"
+        ))?;
         let rows =
             db_err!(stmt.query_map(rusqlite::params![box_id], |row| { row.get::<_, String>(0) }))?;
 
@@ -180,6 +181,34 @@ mod tests {
         assert_eq!(list[0].name, "snap-c");
         assert_eq!(list[1].name, "snap-b");
         assert_eq!(list[2].name, "snap-a");
+    }
+
+    /// Snapshots taken inside one second share a `created_at` (the column is
+    /// whole-second), so ordering on it alone leaves them in an order SQLite
+    /// does not define — in practice insertion order, the exact inverse of the
+    /// documented "newest first".
+    #[test]
+    fn test_list_breaks_created_at_ties_newest_first() {
+        let db = test_db();
+        let store = SnapshotStore::new(db);
+
+        for (id, name) in [("s1", "v1"), ("s2", "v2"), ("s3", "v3")] {
+            let mut snap = make_snapshot(id, "box-1", name);
+            snap.created_at = 1000;
+            store.save(&snap).unwrap();
+        }
+
+        let names: Vec<String> = store
+            .list("box-1")
+            .unwrap()
+            .into_iter()
+            .map(|s| s.name)
+            .collect();
+        assert_eq!(
+            names,
+            ["v3", "v2", "v1"],
+            "same-second snapshots must still list newest first"
+        );
     }
 
     #[test]

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -145,18 +145,6 @@ pub(crate) struct BoxImpl {
     /// reattach to a box whose init is already running.
     container_start: Arc<OnceCell<()>>,
 
-    /// Cancels the *spawned* container-start alone, and only from `stop()`.
-    ///
-    /// Deliberately not descended from `shutdown_token`: that one is a child of
-    /// the runtime's, so runtime shutdown cancels it — and runtime shutdown is
-    /// exactly when a detached box must be left alone
-    /// (`RuntimeImpl::shutdown_sync` skips detached boxes for that reason).
-    /// Cancelling its init anyway strands the container created-but-never-
-    /// started: the box never runs, never exits, and is reported Running
-    /// forever. Caller-owned starts keep using `shutdown_token` — their caller
-    /// is going away too.
-    container_start_cancel: CancellationToken,
-
     #[cfg(test)]
     background_starts_finished: Arc<std::sync::atomic::AtomicUsize>,
     #[cfg(test)]
@@ -200,7 +188,6 @@ impl BoxImpl {
             live: OnceCell::new(),
             watcher: std::sync::OnceLock::new(),
             container_start: Arc::new(OnceCell::new()),
-            container_start_cancel: CancellationToken::new(),
             #[cfg(test)]
             background_starts_finished: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             #[cfg(test)]
@@ -317,7 +304,7 @@ impl BoxImpl {
         let live = self.ensure_booted().await?;
         let guest_session = live.guest_session.clone();
         let container_start = Arc::clone(&self.container_start);
-        let shutdown_token = self.container_start_cancel.child_token();
+        let shutdown_token = self.shutdown_token.child_token();
         let container_id = self.container_id().to_owned();
         let box_id = self.config.id.clone();
         let event_listeners = self.event_listeners.clone();
@@ -711,7 +698,6 @@ impl BoxImpl {
 
         // Cancel the token - signals all in-flight operations to abort
         self.shutdown_token.cancel();
-        self.container_start_cancel.cancel();
 
         // Only attempt graceful shutdown for boxes that should have a live
         // shim. Calling live_state() on Configured/Failed would route

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -145,6 +145,18 @@ pub(crate) struct BoxImpl {
     /// reattach to a box whose init is already running.
     container_start: Arc<OnceCell<()>>,
 
+    /// Cancels the *spawned* container-start alone, and only from `stop()`.
+    ///
+    /// Deliberately not descended from `shutdown_token`: that one is a child of
+    /// the runtime's, so runtime shutdown cancels it — and runtime shutdown is
+    /// exactly when a detached box must be left alone
+    /// (`RuntimeImpl::shutdown_sync` skips detached boxes for that reason).
+    /// Cancelling its init anyway strands the container created-but-never-
+    /// started: the box never runs, never exits, and is reported Running
+    /// forever. Caller-owned starts keep using `shutdown_token` — their caller
+    /// is going away too.
+    container_start_cancel: CancellationToken,
+
     #[cfg(test)]
     background_starts_finished: Arc<std::sync::atomic::AtomicUsize>,
     #[cfg(test)]
@@ -188,6 +200,7 @@ impl BoxImpl {
             live: OnceCell::new(),
             watcher: std::sync::OnceLock::new(),
             container_start: Arc::new(OnceCell::new()),
+            container_start_cancel: CancellationToken::new(),
             #[cfg(test)]
             background_starts_finished: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             #[cfg(test)]
@@ -304,7 +317,7 @@ impl BoxImpl {
         let live = self.ensure_booted().await?;
         let guest_session = live.guest_session.clone();
         let container_start = Arc::clone(&self.container_start);
-        let shutdown_token = self.shutdown_token.child_token();
+        let shutdown_token = self.container_start_cancel.child_token();
         let container_id = self.container_id().to_owned();
         let box_id = self.config.id.clone();
         let event_listeners = self.event_listeners.clone();
@@ -698,6 +711,7 @@ impl BoxImpl {
 
         // Cancel the token - signals all in-flight operations to abort
         self.shutdown_token.cancel();
+        self.container_start_cancel.cancel();
 
         // Only attempt graceful shutdown for boxes that should have a live
         // shim. Calling live_state() on Configured/Failed would route

--- a/src/boxlite/src/rest/client.rs
+++ b/src/boxlite/src/rest/client.rs
@@ -167,11 +167,10 @@ impl ApiClient {
         }
         // Read the body as bytes once, then parse; this is what lets us
         // include the body in a parse-failure error without re-issuing the
-        // request.
-        let bytes = resp
-            .bytes()
-            .await
-            .map_err(|e| BoxliteError::Internal(format!("reading response body: {}", e)))?;
+        // request. A failure at this point is a transport fault — this client's
+        // own total timeout expiring after the headers landed, a reset
+        // connection, a corrupt compressed body — never an internal bug.
+        let bytes = resp.bytes().await.map_err(transport_error)?;
         serde_json::from_slice::<T>(&bytes).map_err(|e| {
             let preview = String::from_utf8_lossy(&bytes);
             let preview = if preview.len() > 4096 {
@@ -420,25 +419,11 @@ impl ApiClient {
             uri: String,
         }
         let path = format!("/boxes/{}/network/tunnel?port={port}", box_id.as_ref());
-        let request = self
-            .authorize(
-                self.http
-                    .post(self.url(&path))
-                    .header(reqwest::header::ACCEPT, "application/json"),
-            )
-            .await?;
-        let response = request
-            .send()
-            .await
-            .map_err(|e| BoxliteError::Network(e.to_string()))?;
-        let status = response.status();
-        if !status.is_success() {
-            return self.handle_error(status, response).await;
-        }
-        let descriptor: TunnelDescriptor = response
-            .json()
-            .await
-            .map_err(|e| BoxliteError::Internal(format!("invalid tunnel descriptor: {e}")))?;
+        let builder = self
+            .http
+            .post(self.url(&path))
+            .header(reqwest::header::ACCEPT, "application/json");
+        let descriptor: TunnelDescriptor = self.send_json(builder).await?;
         Ok(descriptor.uri)
     }
 
@@ -565,7 +550,7 @@ impl ApiClient {
 /// invaluable for diagnosing transparent-proxy regressions like the
 /// Clash `:7890` interception that produced bare 502s in
 /// production.
-fn transport_error(err: reqwest::Error) -> BoxliteError {
+pub(super) fn transport_error(err: reqwest::Error) -> BoxliteError {
     let url_hint = err.url().map(|u| u.as_str().to_string());
     let kind = if err.is_connect() {
         "connect failed"
@@ -821,6 +806,50 @@ mod tests {
             "unexpected error: {error}"
         );
 
+        server.await.unwrap();
+    }
+
+    /// `prepare_box_tunnel` sends its descriptor request through the shared
+    /// control-request path, so this pins the wire contract that path owes it:
+    /// POST to the prefixed tunnel URL, JSON accepted, descriptor parsed back.
+    #[tokio::test]
+    async fn prepare_box_tunnel_posts_descriptor_request_and_parses_uri() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut headers = Vec::new();
+            while !headers.ends_with(b"\r\n\r\n") {
+                headers.push(socket.read_u8().await.unwrap());
+            }
+            let headers = String::from_utf8(headers).unwrap().to_lowercase();
+            assert!(
+                headers.starts_with("post /v1/boxes/box1/network/tunnel?port=8080 http/1.1"),
+                "unexpected request line: {headers}"
+            );
+            assert!(
+                headers.contains("accept: application/json"),
+                "descriptor request must ask for json: {headers}"
+            );
+            let body = r#"{"uri":"http://127.0.0.1:9/tunnel"}"#;
+            socket
+                .write_all(
+                    format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+        });
+
+        let client =
+            ApiClient::new(&BoxliteRestOptions::new(format!("http://127.0.0.1:{port}"))).unwrap();
+        let uri = client.prepare_box_tunnel("box1", 8080).await.unwrap();
+
+        assert_eq!(uri, "http://127.0.0.1:9/tunnel");
         server.await.unwrap();
     }
 

--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -21,7 +21,7 @@ use crate::runtime::backend::{BoxBackend, BoxNetworkBackend, SnapshotBackend};
 use crate::runtime::id::BoxID;
 use crate::runtime::options::{CloneOptions, ExportOptions, SnapshotOptions};
 
-use super::client::{ApiClient, WsStream};
+use super::client::{ApiClient, WsStream, transport_error};
 use super::exec::RestExecControl;
 use super::types::{
     BoxMetricsResponse, BoxResponse, CloneBoxRequest, CreateSnapshotRequest, ExecRequest,
@@ -308,10 +308,7 @@ impl BoxBackend for RestBox {
             .header("Content-Type", "application/x-tar")
             .body(tar_bytes);
 
-        let resp = builder
-            .send()
-            .await
-            .map_err(|e| BoxliteError::Internal(format!("copy_into upload failed: {}", e)))?;
+        let resp = builder.send().await.map_err(transport_error)?;
 
         if !resp.status().is_success() {
             let status = resp.status();
@@ -341,10 +338,7 @@ impl BoxBackend for RestBox {
             .await?
             .header("Accept", "application/x-tar");
 
-        let resp = builder
-            .send()
-            .await
-            .map_err(|e| BoxliteError::Internal(format!("copy_out download failed: {}", e)))?;
+        let resp = builder.send().await.map_err(transport_error)?;
 
         if !resp.status().is_success() {
             let status = resp.status();
@@ -355,10 +349,7 @@ impl BoxBackend for RestBox {
             )));
         }
 
-        let tar_bytes = resp
-            .bytes()
-            .await
-            .map_err(|e| BoxliteError::Internal(format!("copy_out read body failed: {}", e)))?;
+        let tar_bytes = resp.bytes().await.map_err(transport_error)?;
 
         // Extract tar to host path
         extract_tar_to_path(&tar_bytes, host_dst)
@@ -1477,6 +1468,46 @@ mod tests {
             vec!["/v1/boxes/box1".to_string()]
         );
         server.abort();
+    }
+
+    /// A download whose connection dies mid-body is a transport fault, not a
+    /// client bug — `copy_out` must classify it as such so a caller can retry
+    /// instead of filing one.
+    #[tokio::test]
+    async fn copy_out_reports_a_truncated_download_as_network() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut head = Vec::new();
+            while !head.ends_with(b"\r\n\r\n") {
+                head.push(socket.read_u8().await.unwrap());
+            }
+            // Promise 4 KiB of tar, deliver two bytes, then hang up.
+            socket
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\n\
+                      Content-Type: application/x-tar\r\n\
+                      Content-Length: 4096\r\n\
+                      Connection: close\r\n\r\nhi",
+                )
+                .await
+                .unwrap();
+        });
+
+        let rest_box = rest_box_for(port, "box1");
+        let host_dst = std::env::temp_dir().join("boxlite-copy-out-truncated");
+
+        let error = rest_box
+            .copy_out("/tmp/archive", &host_dst, CopyOptions::default())
+            .await
+            .expect_err("a truncated download must fail");
+
+        assert!(
+            matches!(&error, BoxliteError::Network(_)),
+            "a severed download must classify as transport, got {error:?}"
+        );
+        server.await.unwrap();
     }
 
     #[tokio::test]

--- a/src/boxlite/tests/run_main_command.rs
+++ b/src/boxlite/tests/run_main_command.rs
@@ -471,6 +471,20 @@ async fn an_adopted_running_box_is_followed_to_its_exit() {
             .await
             .expect("create box");
         handle.start().await.expect("start box");
+        // `start()` only *spawns* the container start — boot creates the
+        // container, running its init is the separate step (docker's create →
+        // attach → start), and `start()` returns as soon as the VM is up.
+        // Leaving the block here would drop the runtime mid-spawn and race it,
+        // testing that race instead of the adoption below. `exec` single-flights
+        // on the same `container_start` cell, so it both performs and awaits
+        // that step: past this point the main command is genuinely running.
+        handle
+            .exec(BoxCommand::new("true"))
+            .await
+            .expect("run the container init before abandoning the runtime")
+            .wait()
+            .await
+            .expect("await the probe exec");
     }
 
     // A second runtime adopts it: `get()` hands out a handle, which is where the


### PR DESCRIPTION
## Summary

Four REST call sites reported a network fault as an internal bug, and every
newest-first list query fell back to insertion order when its whole-second
`created_at` tied.

## Call graph

Before
```
send_json            (ApiClient · src/boxlite/src/rest/client.rs:172)   — resp.bytes() -> Internal        ← BUG: a total-timeout expiry reads as a client bug
prepare_box_tunnel   (ApiClient · src/boxlite/src/rest/client.rs:411)   — hand-rolled authorize/send/status/parse, same mis-mapping
copy_into / copy_out (RestBox   · src/boxlite/src/rest/litebox.rs:314)  — send()/bytes() -> Internal      ← BUG: same class, file transfers

list                 (SnapshotStore · src/boxlite/src/db/snapshot.rs:56) — ORDER BY created_at DESC       ← BUG: same-second rows tie, order undefined
list_all/list_active (BoxStore      · src/boxlite/src/db/boxes.rs:194)   — same shape
list_by_box          (BaseDiskStore · src/boxlite/src/db/base_disk.rs:177) — same shape
```

After
```
send_json            (ApiClient · src/boxlite/src/rest/client.rs:173)   — resp.bytes() -> transport_error
prepare_box_tunnel   (ApiClient · src/boxlite/src/rest/client.rs:411)   — delegates to send_json
copy_into / copy_out (RestBox   · src/boxlite/src/rest/litebox.rs:311)  — send()/bytes() -> transport_error

list                 (SnapshotStore · src/boxlite/src/db/snapshot.rs:56) — ORDER BY created_at DESC, rowid DESC
list_all/list_active (BoxStore      · src/boxlite/src/db/boxes.rs:194)   — ORDER BY c.created_at DESC, c.rowid DESC
list_by_box          (BaseDiskStore · src/boxlite/src/db/base_disk.rs:177) — ORDER BY created_at DESC, rowid DESC
```

## Changes

- `transport_error` now classifies every reqwest failure in the `rest` module,
  including body reads; it is `pub(super)` so `litebox.rs` shares it.
  `prepare_box_tunnel` drops its duplicate of `send_json`.
- `an_adopted_running_box_is_followed_to_its_exit` now runs an `exec` between
  `start()` and dropping its first runtime. `start()` only *spawns* the
  container start, so the old shape raced that spawn and measured the race
  instead of the watcher arming it exists to cover.
- Newest-first queries break `created_at` ties with `rowid`.

## How to verify

- `make test:unit:rust FILTER="rest::client::tests:: rest::litebox::tests::copy_out"`
- `make test:unit:rust`
- `SETUP_DONE=1 make test:integration:rust`
- `make fmt:check:rust`

## Risks / rollout

- `copy_into` and `copy_out` transport errors lose their operation label; the
  reqwest URL still identifies the box and path.
- The assertion added to `db::boxes::tests::test_list_all` passes with and
  without the tiebreaker — `idx_box_config_created_at` makes SQLite walk the
  index in reverse, masking the tie there. It pins the contract, not the fix.
- The `boxlite-guest` cross-target leg of `make clippy` was not run.
- Clippy is red on this PR because origin/main's own tip is red: #1231 changed
  `BoxOptions::sanitize` to take `&mut self` and missed four bindings in tests
  #1350 had just added. Not from this branch; rebase once main is green.

## Known gap, deliberately not fixed here

A detached box whose runtime is dropped while its container start is still in
flight can be left created but never run — reported `Running` with no exit code
forever. Two independent mechanisms kill that spawned start: the runtime
shutdown token, and dropping the tokio runtime itself. A token-scoping fix was
written and reverted here because it closed only the first. Closing both wants
`shutdown_sync` to drain in-flight starts before cancelling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Base disks, boxes, and snapshots now consistently display newest items first, including when records share the same timestamp.
  * REST requests and file transfers now provide clearer, more consistent network error reporting.
  * File downloads that end unexpectedly are correctly identified as network failures.
  * Container adoption and tunnel setup now use more reliable request and startup handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->