### PR TITLE
fix(import): reject link archive members and fail closed on bad disks

### DIFF
--- a/src/boxlite/src/litebox/archive.rs
+++ b/src/boxlite/src/litebox/archive.rs
@@ -173,27 +173,73 @@ pub(crate) fn extract_archive(archive_path: &Path, dest_dir: &Path) -> BoxliteRe
     })?;
 
     if magic == ZSTD_MAGIC {
-        extract_zstd_tar(file, dest_dir)
+        let decoder = zstd::Decoder::new(file)
+            .map_err(|e| BoxliteError::Storage(format!("Failed to create zstd decoder: {}", e)))?;
+        unpack_file_members(decoder, dest_dir)
     } else {
-        extract_plain_tar(file, dest_dir)
+        unpack_file_members(file, dest_dir)
     }
 }
 
-fn extract_zstd_tar(file: std::fs::File, dest_dir: &Path) -> BoxliteResult<()> {
-    let decoder = zstd::Decoder::new(file)
-        .map_err(|e| BoxliteError::Storage(format!("Failed to create zstd decoder: {}", e)))?;
-    let mut archive = tar::Archive::new(decoder);
-    archive
-        .unpack(dest_dir)
-        .map_err(|e| BoxliteError::Storage(format!("Failed to extract zstd tar: {}", e)))?;
-    Ok(())
+/// Member types that carry their own contents rather than a reference to
+/// something else.
+///
+/// `Regular` is the common case. `Continuous` is its rarely used contiguous
+/// variant. `GNUSparse` is what `tar::Builder` emits for a file with holes —
+/// which on Linux is every exported qcow2 disk, since the builder reads sparse
+/// information from disk by default. All three unpack as ordinary files.
+///
+/// The OCI layer extractor pairs the same two types for the same reason — see
+/// the `EntryType::Regular | EntryType::GNUSparse` arm in
+/// `images/archive/extractor.rs`.
+fn carries_file_contents(entry_type: tar::EntryType) -> bool {
+    matches!(
+        entry_type,
+        tar::EntryType::Regular | tar::EntryType::Continuous | tar::EntryType::GNUSparse
+    )
 }
 
-fn extract_plain_tar(file: std::fs::File, dest_dir: &Path) -> BoxliteResult<()> {
-    let mut archive = tar::Archive::new(file);
-    archive
-        .unpack(dest_dir)
-        .map_err(|e| BoxliteError::Storage(format!("Failed to extract archive: {}", e)))?;
+/// Unpack an archive, accepting only members that carry their own contents.
+///
+/// tar checks where a member is *written* but copies a link's target verbatim,
+/// so a link member lands in `dest_dir` pointing anywhere on the host and every
+/// later step — exists, checksum, the backing-file scan, the rename that makes
+/// it a box's disk — follows it there. Deciding on the member's own type is the
+/// only point where the archive itself, rather than whatever it resolves to, is
+/// what gets judged.
+///
+/// This costs no compatibility: `tar::Builder` dereferences symlinks by default
+/// and boxlite has never turned that off, so no export has ever produced a link
+/// member. Member *names* are deliberately not filtered — archives written
+/// before the guest rootfs became a shared base image carry a third member that
+/// the importer ignores, and rejecting it would strand them.
+fn unpack_file_members<R: std::io::Read>(reader: R, dest_dir: &Path) -> BoxliteResult<()> {
+    let mut archive = tar::Archive::new(reader);
+    let entries = archive
+        .entries()
+        .map_err(|e| BoxliteError::Storage(format!("Failed to read archive: {}", e)))?;
+
+    for entry in entries {
+        let mut entry = entry
+            .map_err(|e| BoxliteError::Storage(format!("Failed to read archive member: {}", e)))?;
+
+        let entry_type = entry.header().entry_type();
+        if !carries_file_contents(entry_type) {
+            let name = entry
+                .path()
+                .map(|path| path.display().to_string())
+                .unwrap_or_else(|_| "<unreadable>".to_string());
+            return Err(BoxliteError::Storage(format!(
+                "Invalid archive: member '{}' is {:?}, only files are allowed",
+                name, entry_type
+            )));
+        }
+
+        entry
+            .unpack_in(dest_dir)
+            .map_err(|e| BoxliteError::Storage(format!("Failed to extract archive: {}", e)))?;
+    }
+
     Ok(())
 }
 
@@ -497,5 +543,200 @@ mod tests {
             !extract_dir.join(disk_filenames::GUEST_ROOTFS_DISK).exists(),
             "the archive must not contain a guest rootfs member"
         );
+    }
+
+    /// A `.boxlite` archive is untrusted input, and tar validates only where an
+    /// entry is *written* — a symlink's target is copied verbatim. Without an
+    /// entry-type check an archive can plant `disk.qcow2` as a link to any host
+    /// path, and every later step (exists, checksum, backing-file scan, rename)
+    /// follows it. The link must never reach the filesystem at all.
+    #[test]
+    fn extract_archive_rejects_symlink_entry() {
+        let dir = tempdir().unwrap();
+        let archive_path = dir.path().join("evil.boxlite");
+        let extract_dir = dir.path().join("extracted");
+        std::fs::create_dir_all(&extract_dir).unwrap();
+
+        let victim = dir.path().join("victim-disk.qcow2");
+        std::fs::write(&victim, b"victim bytes").unwrap();
+
+        {
+            let file = std::fs::File::create(&archive_path).unwrap();
+            let mut builder = tar::Builder::new(file);
+            let mut header = tar::Header::new_gnu();
+            header.set_entry_type(tar::EntryType::Symlink);
+            header.set_size(0);
+            header.set_mode(0o777);
+            builder
+                .append_link(&mut header, disk_filenames::CONTAINER_DISK, &victim)
+                .unwrap();
+            builder.finish().unwrap();
+        }
+
+        let error = extract_archive(&archive_path, &extract_dir)
+            .expect_err("a symlink archive member must be rejected");
+        assert!(
+            error.to_string().contains(disk_filenames::CONTAINER_DISK),
+            "the error must name the offending member, got: {error}"
+        );
+        assert!(
+            extract_dir
+                .join(disk_filenames::CONTAINER_DISK)
+                .symlink_metadata()
+                .is_err(),
+            "the link must never reach the filesystem"
+        );
+    }
+
+    /// The same rule covers hard links. `symlink_metadata` reports a hard link
+    /// as a regular file, so a check written against that would let this
+    /// through; only the archive member's own type tells the truth.
+    #[test]
+    fn extract_archive_rejects_hardlink_entry() {
+        let dir = tempdir().unwrap();
+        let archive_path = dir.path().join("evil.boxlite");
+        let extract_dir = dir.path().join("extracted");
+        std::fs::create_dir_all(&extract_dir).unwrap();
+
+        let manifest = dir.path().join(MANIFEST_FILENAME);
+        std::fs::write(&manifest, br#"{"version":3}"#).unwrap();
+
+        {
+            let file = std::fs::File::create(&archive_path).unwrap();
+            let mut builder = tar::Builder::new(file);
+            builder
+                .append_path_with_name(&manifest, MANIFEST_FILENAME)
+                .unwrap();
+            let mut header = tar::Header::new_gnu();
+            header.set_entry_type(tar::EntryType::Link);
+            header.set_size(0);
+            header.set_mode(0o644);
+            builder
+                .append_link(
+                    &mut header,
+                    disk_filenames::CONTAINER_DISK,
+                    MANIFEST_FILENAME,
+                )
+                .unwrap();
+            builder.finish().unwrap();
+        }
+
+        let error = extract_archive(&archive_path, &extract_dir)
+            .expect_err("a hard link archive member must be rejected");
+        assert!(
+            error.to_string().contains(disk_filenames::CONTAINER_DISK),
+            "the error must name the offending member, got: {error}"
+        );
+        assert!(
+            extract_dir
+                .join(disk_filenames::CONTAINER_DISK)
+                .symlink_metadata()
+                .is_err(),
+            "the link must never reach the filesystem"
+        );
+    }
+
+    /// Archives written before the guest rootfs became a shared base image
+    /// carry a third member. The importer ignores it, but extraction must
+    /// still accept it — rejecting unknown *names* would strand every archive
+    /// exported by a released build.
+    #[test]
+    fn extract_archive_accepts_legacy_guest_rootfs_member() {
+        let dir = tempdir().unwrap();
+        let archive_path = dir.path().join("legacy.boxlite");
+        let extract_dir = dir.path().join("extracted");
+        std::fs::create_dir_all(&extract_dir).unwrap();
+
+        let manifest = dir.path().join(MANIFEST_FILENAME);
+        let container = dir.path().join("container-src");
+        let guest = dir.path().join("guest-src");
+        std::fs::write(&manifest, br#"{"version":2}"#).unwrap();
+        std::fs::write(&container, b"container-disk").unwrap();
+        std::fs::write(&guest, b"guest-rootfs-disk").unwrap();
+
+        {
+            let file = std::fs::File::create(&archive_path).unwrap();
+            let mut builder = tar::Builder::new(file);
+            builder
+                .append_path_with_name(&manifest, MANIFEST_FILENAME)
+                .unwrap();
+            builder
+                .append_path_with_name(&container, disk_filenames::CONTAINER_DISK)
+                .unwrap();
+            builder
+                .append_path_with_name(&guest, disk_filenames::GUEST_ROOTFS_DISK)
+                .unwrap();
+            builder.finish().unwrap();
+        }
+
+        extract_archive(&archive_path, &extract_dir)
+            .expect("a legacy 3-member archive must import");
+        assert_eq!(
+            std::fs::read_to_string(extract_dir.join(disk_filenames::CONTAINER_DISK)).unwrap(),
+            "container-disk"
+        );
+        assert_eq!(
+            std::fs::read_to_string(extract_dir.join(disk_filenames::GUEST_ROOTFS_DISK)).unwrap(),
+            "guest-rootfs-disk"
+        );
+    }
+    /// Every exported disk is a sparse qcow2, and on Linux `tar::Builder`
+    /// encodes a file with holes as a `GNUSparse` member rather than a plain
+    /// regular one. A member-type check written against `Regular` alone reads
+    /// as correct against small dense fixtures and rejects every real export,
+    /// so the fixture here has to have a hole in it.
+    #[test]
+    fn extract_archive_accepts_sparse_disk_member() {
+        use std::io::{Seek, SeekFrom, Write};
+
+        const HOLE_END: u64 = 8 * 1024 * 1024;
+
+        let dir = tempdir().unwrap();
+        let archive_path = dir.path().join("sparse.boxlite");
+        let extract_dir = dir.path().join("extracted");
+        std::fs::create_dir_all(&extract_dir).unwrap();
+
+        let manifest = dir.path().join(MANIFEST_FILENAME);
+        std::fs::write(&manifest, br#"{"version":3}"#).unwrap();
+
+        let disk = dir.path().join("sparse-disk");
+        {
+            let mut file = std::fs::File::create(&disk).unwrap();
+            file.write_all(b"head").unwrap();
+            file.seek(SeekFrom::Start(HOLE_END)).unwrap();
+            file.write_all(b"tail").unwrap();
+            file.sync_all().unwrap();
+        }
+
+        build_zstd_tar_archive(&archive_path, &manifest, &disk, 3).unwrap();
+
+        // Where the builder reads hole information, assert the fixture really
+        // did reproduce a real export's encoding — otherwise this test would
+        // quietly stop covering the case it exists for.
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
+        {
+            let file = std::fs::File::open(&archive_path).unwrap();
+            let decoder = zstd::Decoder::new(file).unwrap();
+            let mut probe = tar::Archive::new(decoder);
+            let mut disk_member_type = None;
+            for entry in probe.entries().unwrap() {
+                let entry = entry.unwrap();
+                if entry.path().unwrap().to_string_lossy() == disk_filenames::CONTAINER_DISK {
+                    disk_member_type = Some(entry.header().entry_type());
+                }
+            }
+            assert_eq!(
+                disk_member_type,
+                Some(tar::EntryType::GNUSparse),
+                "the fixture must be encoded the way a real exported disk is"
+            );
+        }
+
+        extract_archive(&archive_path, &extract_dir).expect("a sparse disk member must extract");
+
+        let extracted = std::fs::read(extract_dir.join(disk_filenames::CONTAINER_DISK)).unwrap();
+        assert_eq!(extracted.len() as u64, HOLE_END + 4);
+        assert_eq!(&extracted[..4], b"head");
+        assert_eq!(&extracted[HOLE_END as usize..], b"tail");
     }
 }

--- a/src/boxlite/src/runtime/import.rs
+++ b/src/boxlite/src/runtime/import.rs
@@ -192,10 +192,12 @@ fn extract_and_validate(
 
 /// Validate disk security and move disks into box_home/disks/.
 fn install_disks(temp_dir: &Path, box_home: &Path) -> BoxliteResult<()> {
-    // Security: Reject imported disks that reference backing files.
-    // A crafted archive could include a qcow2 with a backing reference to
-    // /etc/shadow or another box's disk, leaking data on first read.
+    // Security: the disk about to become a box's own must be a file this
+    // extraction produced, and must not reach any further on its own. A
+    // crafted archive would otherwise point it at /etc/shadow or another
+    // box's disk, leaking data on first read.
     let extracted_container = temp_dir.join(disk_filenames::CONTAINER_DISK);
+    ensure_within_extraction_dir(&extracted_container, temp_dir)?;
     validate_no_backing_references(&extracted_container)?;
 
     let disks_dir = box_home.join("disks");
@@ -215,17 +217,54 @@ fn install_disks(temp_dir: &Path, box_home: &Path) -> BoxliteResult<()> {
     Ok(())
 }
 
+/// Reject an imported disk that resolves outside the extraction directory.
+///
+/// Extraction already refuses link members, so this is the assertion rather
+/// than the control — but it is the last look before the rename turns this
+/// path into a box's own disk, and a path that escaped would hand the new box
+/// someone else's.
+fn ensure_within_extraction_dir(disk_path: &Path, extraction_dir: &Path) -> BoxliteResult<()> {
+    let resolve = |path: &Path| -> BoxliteResult<std::path::PathBuf> {
+        path.canonicalize().map_err(|e| {
+            BoxliteError::Storage(format!("Failed to resolve {}: {}", path.display(), e))
+        })
+    };
+
+    // Both sides are resolved: the extraction directory itself can sit under a
+    // symlinked home, and comparing a resolved disk against an unresolved root
+    // would reject every such install.
+    let resolved_disk = resolve(disk_path)?;
+    let resolved_root = resolve(extraction_dir)?;
+
+    if !resolved_disk.starts_with(&resolved_root) {
+        return Err(BoxliteError::InvalidState(format!(
+            "Imported disk '{}' resolves outside the extraction directory. \
+             This is not allowed for security reasons.",
+            disk_path.display()
+        )));
+    }
+
+    Ok(())
+}
+
 /// Reject qcow2 disks with backing file references (security check).
 pub(crate) fn validate_no_backing_references(disk_path: &Path) -> BoxliteResult<()> {
-    if let Ok(Some(backing)) = crate::disk::read_backing_file_path(disk_path) {
-        return Err(BoxliteError::InvalidState(format!(
+    match crate::disk::read_backing_file_path(disk_path) {
+        Ok(None) => Ok(()),
+        Ok(Some(backing)) => Err(BoxliteError::InvalidState(format!(
             "Imported disk '{}' has backing file reference '{}'. \
              This is not allowed for security reasons.",
             disk_path.display(),
             backing
-        )));
+        ))),
+        // A disk the parser cannot read is a disk this check cannot clear.
+        // Reading the error as "no backing reference" hands the verdict to
+        // whatever the file happens to be.
+        Err(error) => Err(BoxliteError::InvalidState(format!(
+            "Imported disk '{}' is not a readable qcow2 image: {error}",
+            disk_path.display()
+        ))),
     }
-    Ok(())
 }
 
 #[cfg(test)]
@@ -512,5 +551,23 @@ mod tests {
 
         let result = validate_no_backing_references(&disk);
         assert!(result.is_ok());
+    }
+
+    /// The backing-file scan is the import path's only disk-level security
+    /// decision, so it has to fail closed. A disk it cannot parse is a disk it
+    /// cannot clear — treating the parse error as "no backing reference" hands
+    /// the verdict to whatever the file happens to be.
+    #[test]
+    fn test_validate_no_backing_references_rejects_unparsable_disk() {
+        let dir = TempDir::new_in("/tmp").unwrap();
+        let disk = dir.path().join("not-a-qcow2.qcow2");
+        std::fs::write(&disk, b"this is not a qcow2 header at all").unwrap();
+
+        let error = validate_no_backing_references(&disk)
+            .expect_err("an unparsable disk must not be treated as safe");
+        assert!(
+            error.to_string().contains("qcow2"),
+            "the error must say the disk is not a usable qcow2, got: {error}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Treat `.boxlite` archives as untrusted input: extract only `Regular`, `Continuous`, and `GNUSparse` members, rejecting symlinks and hard links before they reach the filesystem.
- Fail closed when a qcow2 backing-file check cannot parse the disk, and re-check that the disk resolves inside the extraction directory before installation.
- Preserve compatibility with legacy three-member archives and sparse qcow2 exports.

## Call graph

Before

    import_box                              (runtime/import.rs:25)
     ├─ extract_and_validate                (runtime/import.rs:144)
     │   └─ extract_archive                 (litebox/archive.rs:145)
     │       └─ tar::Archive::unpack        ← BUG: writes link members as-is
     └─ install_disks                       (runtime/import.rs:194)
         ├─ validate_no_backing_references  ← BUG: parse errors were treated as safe
         └─ move_file                       (litebox/archive.rs:250)

After

    import_box                              (runtime/import.rs:25)
     ├─ extract_and_validate                (runtime/import.rs:144)
     │   └─ extract_archive                 (litebox/archive.rs:145)
     │       └─ unpack_file_members         (litebox/archive.rs:216)
     │           ├─ allow content-bearing member types only
     │           └─ Entry::unpack_in
     └─ install_disks                       (runtime/import.rs:194)
         ├─ ensure_within_extraction_dir    (runtime/import.rs:226)
         ├─ validate_no_backing_references  (runtime/import.rs:251) — parse errors reject
         └─ move_file                       (litebox/archive.rs:250)

## Verification

Two-sided regression proof:

- Tests only, production fix removed: `extract_archive` ran 4 tests; the 2 compatibility cases passed and both link-rejection cases failed at `expect_err`.
- Tests only, production fix removed: `validate_no_backing_references` ran 4 tests; 3 existing cases passed and the unparsable-disk case failed at `expect_err`.
- Fix restored on latest `main`: `make test:unit:rust FILTER=extract_archive` — 4/4 pass in both Rust configurations.
- Fix restored on latest `main`: `make test:unit:rust FILTER=validate_no_backing_references` — 4/4 pass in both Rust configurations.
- `make fmt:check:rust` — pass.

The broader smart `make fmt:check` did not reach formatting because Yarn reported existing `YN0018` checksum mismatches for `fs-extra@8.1.0` and `jsdoc-type-pratt-parser@4.8.0` while installing apps dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archive extraction safety by rejecting symbolic and hard links.
  * Added validation to ensure extracted disks remain within the expected extraction directory.
  * Invalid or unparsable backing disks are now rejected instead of being accepted.
  * Preserved compatibility with legacy guest root filesystems and sparse disk images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->