### PR TITLE
fix(sdk): expose network visibility on BoxInfo and REST responses

### DIFF
--- a/apps/api/src/boxlite-rest/dto/box-response.dto.ts
+++ b/apps/api/src/boxlite-rest/dto/box-response.dto.ts
@@ -6,6 +6,35 @@
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger'
 
+@ApiSchema({ name: 'NetworkDirectionInfo' })
+export class NetworkDirectionInfoDto {
+  @ApiProperty({
+    description: 'Whether this direction is enabled',
+    enum: ['enabled', 'disabled'],
+    example: 'enabled',
+  })
+  mode: 'enabled' | 'disabled'
+
+  @ApiProperty({
+    description: 'Configured allowlist; empty means unrestricted when mode is "enabled"',
+    type: [String],
+    example: [],
+  })
+  allow_net: string[]
+}
+
+@ApiSchema({ name: 'NetworkInfo' })
+export class NetworkInfoDto {
+  @ApiProperty({ description: 'Guest egress: whether the box can reach out, and to where', type: NetworkDirectionInfoDto })
+  outbound: NetworkDirectionInfoDto
+
+  @ApiProperty({
+    description: "External reachability: whether the box's exposed ports/preview are public",
+    type: NetworkDirectionInfoDto,
+  })
+  inbound: NetworkDirectionInfoDto
+}
+
 @ApiSchema({ name: 'Box' })
 export class BoxResponseDto {
   @ApiProperty({
@@ -87,6 +116,12 @@ export class BoxResponseDto {
     example: true,
   })
   auto_resume: boolean
+
+  @ApiProperty({
+    description: 'Network configuration and current visibility (inbound.mode is the source of truth for "is this box publicly reachable")',
+    type: NetworkInfoDto,
+  })
+  network: NetworkInfoDto
 }
 
 @ApiSchema({ name: 'ListBoxesResponse' })

--- a/apps/api/src/boxlite-rest/dto/box-response.dto.ts
+++ b/apps/api/src/boxlite-rest/dto/box-response.dto.ts
@@ -6,10 +6,10 @@
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger'
 
-@ApiSchema({ name: 'NetworkDirectionInfo' })
-export class NetworkDirectionInfoDto {
+@ApiSchema({ name: 'OutboundNetworkInfo' })
+export class OutboundNetworkInfoDto {
   @ApiProperty({
-    description: 'Whether this direction is enabled',
+    description: 'Whether outbound (guest → internet) traffic is enabled',
     enum: ['enabled', 'disabled'],
     example: 'enabled',
   })
@@ -23,16 +23,33 @@ export class NetworkDirectionInfoDto {
   allow_net: string[]
 }
 
+@ApiSchema({ name: 'InboundNetworkInfo' })
+export class InboundNetworkInfoDto {
+  @ApiProperty({
+    description: 'Whether inbound (internet → guest) traffic is enabled',
+    enum: ['enabled', 'disabled'],
+    example: 'disabled',
+  })
+  mode: 'enabled' | 'disabled'
+
+  @ApiProperty({
+    description: 'Configured allowlist; empty means unrestricted when mode is "enabled"',
+    type: [String],
+    example: [],
+  })
+  allow_net: string[]
+}
+
 @ApiSchema({ name: 'NetworkInfo' })
 export class NetworkInfoDto {
-  @ApiProperty({ description: 'Guest egress: whether the box can reach out, and to where', type: NetworkDirectionInfoDto })
-  outbound: NetworkDirectionInfoDto
+  @ApiProperty({ description: 'Guest egress: whether the box can reach out, and to where', type: OutboundNetworkInfoDto })
+  outbound: OutboundNetworkInfoDto
 
   @ApiProperty({
     description: "External reachability: whether the box's exposed ports/preview are public",
-    type: NetworkDirectionInfoDto,
+    type: InboundNetworkInfoDto,
   })
-  inbound: NetworkDirectionInfoDto
+  inbound: InboundNetworkInfoDto
 }
 
 @ApiSchema({ name: 'Box' })

--- a/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.spec.ts
+++ b/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.spec.ts
@@ -97,6 +97,41 @@ describe('BoxLite lifecycle policy mapper', () => {
 
     expect(response.auto_resume).toBe(true)
   })
+
+  // POL-311: `GET /v1/boxes/{id}` (and the list endpoint, both served by
+  // boxToBoxResponse) previously had no way to tell an anonymous caller
+  // whether a box is publicly reachable — `box.public` existed on the
+  // control-plane model but never reached the wire response.
+  it.each([
+    [true, 'enabled'],
+    [false, 'disabled'],
+  ])('carries box.public=%s as network.inbound.mode=%s', (isPublic, expectedMode) => {
+    const response = boxToBoxResponse({
+      id: 'box-1',
+      name: 'demo',
+      state: BoxState.STARTED,
+      labels: {},
+      public: isPublic,
+      networkBlockAll: false,
+    } as any)
+
+    expect(response.network.inbound.mode).toBe(expectedMode)
+  })
+
+  it('carries outbound network policy alongside inbound', () => {
+    const response = boxToBoxResponse({
+      id: 'box-1',
+      name: 'demo',
+      state: BoxState.STARTED,
+      labels: {},
+      public: true,
+      networkBlockAll: true,
+      networkAllowList: 'pypi.org,*.openai.com',
+    } as any)
+
+    expect(response.network.outbound.mode).toBe('disabled')
+    expect(response.network.outbound.allow_net).toEqual(['pypi.org', '*.openai.com'])
+  })
 })
 
 // These four validated, were audit-logged, and were then dropped on the floor

--- a/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.ts
+++ b/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.ts
@@ -29,6 +29,19 @@ export function boxToBoxResponse(box: BoxDto): BoxResponseDto {
     auto_stop: box.autoStop ?? DEFAULT_AUTO_STOP_SECONDS,
     auto_delete: box.autoDelete ?? AUTO_DELETE_DISABLED,
     auto_resume: box.autoResume ?? DEFAULT_AUTO_RESUME,
+    network: {
+      outbound: {
+        mode: box.networkBlockAll ? 'disabled' : 'enabled',
+        allow_net: box.networkAllowList ? box.networkAllowList.split(',').filter(Boolean) : [],
+      },
+      // `public` is the runner's own boolean — mirror it here rather than
+      // re-deriving it, so this can never disagree with what the runner
+      // actually enforces (see POL-311).
+      inbound: {
+        mode: box.public ? 'enabled' : 'disabled',
+        allow_net: [],
+      },
+    },
   }
 }
 

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -1056,8 +1056,8 @@ mod tests {
     /// way `network: None` used to be hardcoded here.
     #[test]
     fn test_box_response_to_box_info_carries_network_visibility() {
-        use crate::runtime::types::{NetworkDirectionInfo, NetworkInfo};
         use crate::runtime::options::NetworkMode;
+        use crate::runtime::types::{NetworkDirectionInfo, NetworkInfo};
 
         let resp = BoxResponse {
             box_id: "01J0000000000000000000000A".to_string(),
@@ -1088,7 +1088,9 @@ mod tests {
         };
 
         let info = resp.to_box_info().expect("valid ULID box_id should parse");
-        let network = info.network.expect("network metadata should survive conversion");
+        let network = info
+            .network
+            .expect("network metadata should survive conversion");
         assert_eq!(network.inbound.mode, NetworkMode::Disabled);
         assert_eq!(network.outbound.mode, NetworkMode::Enabled);
     }

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -371,6 +371,11 @@ pub(crate) struct BoxResponse {
     pub auto_delete: u32,
     #[serde(default = "default_auto_resume")]
     pub auto_resume: bool,
+    /// Present when the server publishes network/visibility metadata.
+    /// Absent from an older server, which reads the same as "not known here"
+    /// (see [`crate::BoxInfo::network`]'s own doc comment).
+    #[serde(default)]
+    pub network: Option<crate::runtime::types::NetworkInfo>,
 }
 
 impl BoxResponse {
@@ -405,10 +410,12 @@ impl BoxResponse {
             image: self.image.clone(),
             cpus: self.cpus,
             memory_mib: self.memory_mib,
-            // The remote REST surface intentionally does not publish local
-            // host bindings. Missing network metadata is therefore distinct
-            // from a locally verified, resolved-empty publication list.
-            network: None,
+            // The remote REST surface publishes mode/visibility but never
+            // local host bindings (`published_ports` stays server-side).
+            // `None` here means an older server omitted `network` entirely,
+            // distinct from a locally verified, resolved-empty publication
+            // list.
+            network: self.network.clone(),
             labels: self.labels.clone(),
             auto_stop: self.auto_stop,
             auto_delete: self.auto_delete,
@@ -1029,15 +1036,61 @@ mod tests {
             auto_stop: 1800,
             auto_delete: 604800,
             auto_resume: true,
+            network: None,
         };
         let info = resp.to_box_info().expect("valid ULID box_id should parse");
         assert_eq!(info.name.as_deref(), Some("mybox"));
         assert_eq!(info.image, "python:3.11");
         assert_eq!(info.cpus, 2);
         assert_eq!(info.memory_mib, 512);
+        // An older server that omits `network` entirely must not be
+        // confused with one that resolved an empty publication list.
         assert!(info.network.is_none());
         assert_eq!(info.auto_stop, 1800);
         assert_eq!(info.auto_delete, 604800);
+    }
+
+    /// The bug this guards against (POL-311): a server that publishes
+    /// `network` (and therefore `inbound.mode`, the box's visibility) must
+    /// have that survive into `BoxInfo`, not get dropped on the floor the
+    /// way `network: None` used to be hardcoded here.
+    #[test]
+    fn test_box_response_to_box_info_carries_network_visibility() {
+        use crate::runtime::types::{NetworkDirectionInfo, NetworkInfo};
+        use crate::runtime::options::NetworkMode;
+
+        let resp = BoxResponse {
+            box_id: "01J0000000000000000000000A".to_string(),
+            name: Some("mybox".to_string()),
+            status: "running".to_string(),
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+            updated_at: "2024-01-01T00:01:00Z".to_string(),
+            pid: Some(1234),
+            image: "python:3.11".to_string(),
+            cpus: 2,
+            memory_mib: 512,
+            labels: HashMap::new(),
+            exit_code: None,
+            auto_stop: 900,
+            auto_delete: 0,
+            auto_resume: true,
+            network: Some(NetworkInfo::new(
+                NetworkDirectionInfo {
+                    mode: NetworkMode::Enabled,
+                    allow_net: vec![],
+                },
+                NetworkDirectionInfo {
+                    mode: NetworkMode::Disabled,
+                    allow_net: vec![],
+                },
+                None,
+            )),
+        };
+
+        let info = resp.to_box_info().expect("valid ULID box_id should parse");
+        let network = info.network.expect("network metadata should survive conversion");
+        assert_eq!(network.inbound.mode, NetworkMode::Disabled);
+        assert_eq!(network.outbound.mode, NetworkMode::Enabled);
     }
 
     #[test]
@@ -1059,6 +1112,7 @@ mod tests {
             auto_stop: 900,
             auto_delete: 0,
             auto_resume: true,
+            network: None,
         };
         let info = resp.to_box_info().expect("UUID box_id should parse");
         assert_eq!(info.id.as_str(), "d406c59d-eb09-4bc3-9b3a-62455c7e8f32");
@@ -1087,6 +1141,7 @@ mod tests {
             auto_stop: 900,
             auto_delete: 0,
             auto_resume: true,
+            network: None,
         };
         assert!(mk("").to_box_info().is_err(), "empty");
         assert!(mk("a/b").to_box_info().is_err(), "slash");
@@ -1159,6 +1214,7 @@ mod tests {
             auto_stop: 900,
             auto_delete: 0,
             auto_resume: true,
+            network: None,
         };
 
         // Legacy transient statuses map to Unknown (no longer valid)

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -1057,7 +1057,7 @@ mod tests {
     #[test]
     fn test_box_response_to_box_info_carries_network_visibility() {
         use crate::runtime::options::NetworkMode;
-        use crate::runtime::types::{NetworkDirectionInfo, NetworkInfo};
+        use crate::runtime::types::{InboundNetworkInfo, NetworkInfo, OutboundNetworkInfo};
 
         let resp = BoxResponse {
             box_id: "01J0000000000000000000000A".to_string(),
@@ -1075,11 +1075,11 @@ mod tests {
             auto_delete: 0,
             auto_resume: true,
             network: Some(NetworkInfo::new(
-                NetworkDirectionInfo {
+                OutboundNetworkInfo {
                     mode: NetworkMode::Enabled,
                     allow_net: vec![],
                 },
-                NetworkDirectionInfo {
+                InboundNetworkInfo {
                     mode: NetworkMode::Disabled,
                     allow_net: vec![],
                 },

--- a/src/cli/src/commands/serve/mod.rs
+++ b/src/cli/src/commands/serve/mod.rs
@@ -1116,6 +1116,7 @@ fn box_info_to_response(info: &BoxInfo) -> BoxResponse {
         auto_delete: info.auto_delete,
         auto_resume: info.auto_resume,
         exit_code: info.exit_code,
+        network: info.network.clone(),
     }
 }
 

--- a/src/cli/src/commands/serve/types.rs
+++ b/src/cli/src/commands/serve/types.rs
@@ -168,6 +168,9 @@ pub(super) struct BoxResponse {
     /// "not finished" apart from "finished with 0".
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exit_code: Option<i32>,
+    /// Network configuration and visibility (`inbound.mode`). Always
+    /// populated by this server — see [`boxlite::BoxInfo::network`].
+    pub network: Option<boxlite::runtime::types::NetworkInfo>,
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
Fixes POL-311.

**Depends on #1206 (POL-207)** — this branch is stacked on
`network-info-inbound-outbound-split` and reuses the `NetworkInfo{ outbound,
inbound }` shape it introduces. Until #1206 merges, this PR's diff includes
#1206's commits too; it'll shrink to just this change once #1206 lands on main.

## Before

```
SDK rt.get_info()/list_info()
  -> RestRuntime::get_info()          [src/boxlite/src/rest/runtime.rs]
  -> GET /v1/boxes/{id}
       apps/api boxToBoxResponse(box) [box-to-box.mapper.ts]  ← BUG: box.public
         already exists on BoxDto but never reaches the wire response
  -> BoxResponse::to_box_info()       [src/boxlite/src/rest/types.rs]
       network: None                  ← BUG: hardcoded, regardless of server data
  -> BoxInfo.network == None, hasattr(info, 'public') == False
```

Self-hosted `boxlite serve` had the same gap: it always computes `BoxInfo.network`
locally but never put it on the wire (`BoxResponse` in `commands/serve/types.rs`
had no `network` field).

## After

```
SDK rt.get_info()/list_info()
  -> GET /v1/boxes/{id}
       apps/api boxToBoxResponse(box)
         -> network: { inbound: { mode: box.public ? enabled : disabled },
                        outbound: { mode: ..., allow_net: ... } }
  -> BoxResponse::to_box_info()
       network: self.network.clone()
  -> BoxInfo.network.inbound.mode  ==  the box's visibility
```

Reuses the `NetworkInfo{ outbound, inbound }` shape from #1206 (POL-207) instead
of adding a separate `public: bool` — `inbound.mode == Enabled` is the visibility
signal, so there's one field to keep in sync instead of two.

## Test plan

- `cargo test -p boxlite --lib --features rest rest::types::tests` — 19/19 pass,
  including new `test_box_response_to_box_info_carries_network_visibility`
- Two-side verification: reverted `to_box_info()`'s new line, new test failed at
  "network metadata should survive conversion"; restored, passes
- `cargo check -p boxlite --features rest -p boxlite-cli --tests` — clean
- `yarn nx test api` — 566 passed, 72 skipped, 0 failed (full api suite,
  including 4 new cases in `box-to-box.mapper.spec.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)