### PR TITLE
fix(seccomp): allow time syscall in x86_64 vmm filter

### DIFF
--- a/src/boxlite/resources/seccomp/x86_64-unknown-linux-gnu.json
+++ b/src/boxlite/resources/seccomp/x86_64-unknown-linux-gnu.json
@@ -643,6 +643,10 @@
         "comment": "libkrun: precise sleep (glibc maps nanosleep to clock_nanosleep). Required at steady-state."
       },
       {
+        "syscall": "time",
+        "comment": "glibc: get_nprocs() ages its CPU-count cache with time(NULL), reached during vCPU thread init. A blocked time SIGSYS-kills the VMM."
+      },
+      {
         "syscall": "getpid",
         "comment": "libkrun: get process ID. Required at steady-state."
       },

--- a/src/boxlite/src/jailer/seccomp.rs
+++ b/src/boxlite/src/jailer/seccomp.rs
@@ -464,4 +464,38 @@ mod tests {
             "vcpu filter is empty"
         );
     }
+
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    #[test]
+    fn test_vmm_filter_allows_time_syscall() {
+        // glibc's get_nprocs() calls time(NULL) during vCPU thread init; a
+        // missing `time` entry makes the vmm filter's `trap` default action
+        // SIGSYS-kill every thread. The raw syscall (not libc::time, which may
+        // resolve through the vDSO and bypass seccomp) must be allowed.
+        let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/seccomp_filter.bpf"));
+        let filters = deserialize_binary(&bytes[..]).expect("deserialize embedded filter");
+        let vmm_filter = get_filter(&filters, SeccompRole::Vmm).expect("vmm filter present");
+
+        // fork() so a SIGSYS from the `trap` default action kills only the child.
+        let pid = unsafe { libc::fork() };
+        assert!(pid >= 0, "fork failed");
+        if pid == 0 {
+            if apply_filter(vmm_filter).is_err() {
+                unsafe { libc::_exit(2) };
+            }
+            unsafe {
+                libc::syscall(libc::SYS_time, std::ptr::null_mut::<libc::time_t>());
+                libc::_exit(0);
+            }
+        }
+
+        let mut status = 0;
+        assert_eq!(unsafe { libc::waitpid(pid, &mut status, 0) }, pid);
+        assert!(
+            libc::WIFEXITED(status),
+            "child killed by signal {} (SIGSYS=31)",
+            libc::WTERMSIG(status)
+        );
+        assert_eq!(libc::WEXITSTATUS(status), 0);
+    }
 }

--- a/src/boxlite/src/jailer/seccomp.rs
+++ b/src/boxlite/src/jailer/seccomp.rs
@@ -483,14 +483,28 @@ mod tests {
             if apply_filter(vmm_filter).is_err() {
                 unsafe { libc::_exit(2) };
             }
-            unsafe {
-                libc::syscall(libc::SYS_time, std::ptr::null_mut::<libc::time_t>());
-                libc::_exit(0);
-            }
+            let ret = unsafe { libc::syscall(libc::SYS_time, std::ptr::null_mut::<libc::time_t>()) };
+            // `time` is allowlisted: the raw syscall returns the current time
+            // (>= 0), not -1. `trap` would SIGSYS-kill the child before this
+            // point; guard the errno-returning case so a future default-action
+            // change can't let a blocked call exit 0 and pass.
+            unsafe { libc::_exit(i32::from(ret == -1)) };
         }
 
         let mut status = 0;
-        assert_eq!(unsafe { libc::waitpid(pid, &mut status, 0) }, pid);
+        loop {
+            let waited = unsafe { libc::waitpid(pid, &mut status, 0) };
+            if waited == pid {
+                break;
+            }
+            // waitpid returns -1/EINTR if a signal lands in the parent test
+            // thread; retry, but surface any other failure.
+            assert!(
+                waited == -1 && unsafe { *libc::__errno_location() } == libc::EINTR,
+                "waitpid failed: {}",
+                std::io::Error::last_os_error()
+            );
+        }
         assert!(
             libc::WIFEXITED(status),
             "child killed by signal {} (SIGSYS=31)",


### PR DESCRIPTION
## Summary

`network.mode=disabled` boxes built against manylinux_2_28 fail during `krun_start_enter` on x86_64 because glibc's `get_nprocs()` calls `time(NULL)` and the VMM seccomp allowlist traps `SYS_time`. Allow that syscall and pin the compiled filter behavior with a regression test.

## Call graph

Before
  run_shim              (shim · src/shim/src/main.rs:127)  — network disabled ⇒ apply VMM seccomp
    └─ apply_vmm_filter (seccomp · src/boxlite/src/jailer/seccomp.rs:243)  — installs the embedded x86_64 VMM filter
         └─ start_enter (KrunContext · src/boxlite/src/vmm/krun/context.rs:605)  ← BUG: glibc `get_nprocs()` calls blocked `time(NULL)`; SIGSYS kills the VMM

After
  run_shim              (shim · src/shim/src/main.rs:127)
    └─ apply_vmm_filter (seccomp · src/boxlite/src/jailer/seccomp.rs:243)  — embedded filter allows `SYS_time`
         └─ start_enter (KrunContext · src/boxlite/src/vmm/krun/context.rs:605)  — vCPU initialization proceeds

Fixes #1366
Linear: POL-203

## Changes

- Add `time` to the x86_64 GNU VMM seccomp allowlist used by CI-built manylinux artifacts.
- Add `test_vmm_filter_allows_time_syscall`, which applies the compiled filter in a child process and verifies a raw `SYS_time` call is not killed by SIGSYS.

## How to verify

- `make test:unit:rust`
- Build the x86_64 manylinux artifact and boot a box with `network.mode=disabled`; the box should start and retain no guest network interface.

## Risks / rollout

- Scoped to `x86_64-unknown-linux-gnu`. aarch64 is unchanged because it has no `time` syscall and already allows `clock_gettime`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved x86_64 Linux compatibility by allowing the required `time` system call during virtual machine initialization.
  * Prevented initialization failures when virtual machine CPU threads query system information.
  * Improved reliability when monitoring initialization processes interrupted by system signals.

* **Tests**
  * Added coverage confirming the system call is permitted and returns successfully.
  * Added validation for retrying interrupted process-wait operations and reporting other failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->