### PR TITLE
chore(seccomp): wrap over-width line to satisfy rustfmt

### DIFF
--- a/src/boxlite/src/jailer/seccomp.rs
+++ b/src/boxlite/src/jailer/seccomp.rs
@@ -483,7 +483,8 @@ mod tests {
             if apply_filter(vmm_filter).is_err() {
                 unsafe { libc::_exit(2) };
             }
-            let ret = unsafe { libc::syscall(libc::SYS_time, std::ptr::null_mut::<libc::time_t>()) };
+            let ret =
+                unsafe { libc::syscall(libc::SYS_time, std::ptr::null_mut::<libc::time_t>()) };
             // `time` is allowlisted: the raw syscall returns the current time
             // (>= 0), not -1. `trap` would SIGSYS-kill the child before this
             // point; guard the errno-returning case so a future default-action


### PR DESCRIPTION
## Summary

Wrap the `SYS_time` test invocation to satisfy the repository's 100-column rustfmt limit and restore the Rust formatting gate on `main` and dependent PR merge refs.

## Call graph

Before
  fmt:check:rust  (make target · make/quality.mk:49)  — checks workspace formatting
    └─ test_vmm_filter_allows_time_syscall  (test · src/boxlite/src/jailer/seccomp.rs:468)  ← BUG: 101-column invocation fails rustfmt

After
  fmt:check:rust  (make target · make/quality.mk:49)  — checks workspace formatting
    └─ test_vmm_filter_allows_time_syscall  (test · src/boxlite/src/jailer/seccomp.rs:468)  — invocation follows rustfmt wrapping

## Changes

- Apply rustfmt's line wrap to the `SYS_time` invocation without changing behavior.

## How to verify

- `make fmt:check:rust`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted a test statement for improved readability.
  * No user-facing behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->