### PR TITLE
chore(release): bump version to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite"
-version = "0.9.7"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-c"
-version = "0.9.7"
+version = "0.10.0"
 dependencies = [
  "boxlite",
  "cbindgen",
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-cli"
-version = "0.9.7"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-guest"
-version = "0.9.7"
+version = "0.10.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-node"
-version = "0.9.7"
+version = "0.10.0"
 dependencies = [
  "boxlite",
  "boxlite-shared",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-python"
-version = "0.9.7"
+version = "0.10.0"
 dependencies = [
  "boxlite",
  "futures",
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-shared"
-version = "0.9.7"
+version = "0.10.0"
 dependencies = [
  "proptest",
  "prost",
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "boxlite-shim"
-version = "0.9.7"
+version = "0.10.0"
 dependencies = [
  "boxlite",
  "boxlite-shared",
@@ -783,7 +783,7 @@ dependencies = [
 
 [[package]]
 name = "bubblewrap-sys"
-version = "0.9.7"
+version = "0.10.0"
 dependencies = [
  "num_cpus",
 ]
@@ -1593,7 +1593,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2fsprogs-sys"
-version = "0.9.7"
+version = "0.10.0"
 dependencies = [
  "num_cpus",
 ]
@@ -2999,14 +2999,14 @@ dependencies = [
 
 [[package]]
 name = "libgvproxy-sys"
-version = "0.9.7"
+version = "0.10.0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "libkrun-sys"
-version = "0.9.7"
+version = "0.10.0"
 dependencies = [
  "libc",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,12 @@ exclude = ["build/tmp", "target", ".venv", "examples/*/.venv"]
 resolver = "2"
 
 [workspace.dependencies]
-boxlite = { path = "src/boxlite", version = "0.9.7" }
-boxlite-shared = { path = "src/shared", version = "0.9.7" }
-bubblewrap-sys = { path = "src/deps/bubblewrap-sys", version = "0.9.7" }
-e2fsprogs-sys = { path = "src/deps/e2fsprogs-sys", version = "0.9.7" }
-libgvproxy-sys = { path = "src/deps/libgvproxy-sys", version = "0.9.7" }
-libkrun-sys = { path = "src/deps/libkrun-sys", version = "0.9.7" }
+boxlite = { path = "src/boxlite", version = "0.10.0" }
+boxlite-shared = { path = "src/shared", version = "0.10.0" }
+bubblewrap-sys = { path = "src/deps/bubblewrap-sys", version = "0.10.0" }
+e2fsprogs-sys = { path = "src/deps/e2fsprogs-sys", version = "0.10.0" }
+libgvproxy-sys = { path = "src/deps/libgvproxy-sys", version = "0.10.0" }
+libkrun-sys = { path = "src/deps/libkrun-sys", version = "0.10.0" }
 
 [patch.crates-io]
 # Pull in youki PR #3504 (split intermediate/init readiness channels) which
@@ -33,7 +33,7 @@ libkrun-sys = { path = "src/deps/libkrun-sys", version = "0.9.7" }
 libcontainer = { git = "https://github.com/youki-dev/youki", rev = "4b2f0e00a4a11107f3a338c21c17407d2f664ec9" }
 
 [workspace.package]
-version = "0.9.7"
+version = "0.10.0"
 edition = "2024"
 authors = ["Dorian Zheng <https://github.com/dorianzheng>"]
 license = "Apache-2.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/boxlite-ai/boxlite#readme",
   "dependencies": {
-    "@boxlite-ai/boxlite": "^0.9.7"
+    "@boxlite-ai/boxlite": "^0.10.0"
   },
   "optionalDependencies": {
     "@boxlite-ai/boxlite-darwin-arm64": "^0.2.8",

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boxlite-ai/boxlite",
-  "version": "0.9.7",
+  "version": "0.10.0",
   "description": "BoxLite - Embeddable micro-VM runtime for secure, isolated code execution",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boxlite"
-version = "0.9.7"
+version = "0.10.0"
 description = "Python bindings for Boxlite runtime"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Bump all canonical BoxLite package versions from `0.9.7` to `0.10.0` so the Rust workspace, Node SDK, Python SDK, and root Node dependency stay aligned for the release.

## Call graph

Before

```text
workspace.package.version        (Cargo workspace · Cargo.toml:36)               — 0.9.7
├─ workspace dependency pins     (Cargo workspace · Cargo.toml:22)               — require 0.9.7
│  └─ resolved workspace crates  (Cargo lockfile · Cargo.lock:522)               — locked at 0.9.7
├─ package.version               (Node package · sdks/node/package.json:3)        — publishes 0.9.7
│  └─ @boxlite-ai/boxlite        (Root dependency · package.json:26)              — consumes ^0.9.7
└─ project.version               (Python package · sdks/python/pyproject.toml:3)  — publishes 0.9.7
```

After

```text
workspace.package.version        (Cargo workspace · Cargo.toml:36)               — 0.10.0
├─ workspace dependency pins     (Cargo workspace · Cargo.toml:22)               — require 0.10.0
│  └─ resolved workspace crates  (Cargo lockfile · Cargo.lock:522)               — locked at 0.10.0
├─ package.version               (Node package · sdks/node/package.json:3)        — publishes 0.10.0
│  └─ @boxlite-ai/boxlite        (Root dependency · package.json:26)              — consumes ^0.10.0
└─ project.version               (Python package · sdks/python/pyproject.toml:3)  — publishes 0.10.0
```

## Changes

- Update the Cargo workspace version and all internal workspace dependency pins.
- Re-lock the 12 workspace crates without changing third-party dependencies.
- Align the Node and Python package metadata with version `0.10.0`.
- Update the root package dependency range to `^0.10.0`.

## How to verify

- `cargo metadata --locked --offline`
- Confirm the canonical Rust, Node, and Python package metadata reports `0.10.0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the BoxLite platform and SDKs to version 0.10.0.
  * Updated the Node.js and Python package versions.
  * Updated the application dependency to use the 0.10.0 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->