### PR TITLE
fix(dashboard): round top-up amounts to integer cents

### DIFF
--- a/apps/dashboard/src/components/billing/WalletSection.integration.test.tsx
+++ b/apps/dashboard/src/components/billing/WalletSection.integration.test.tsx
@@ -61,6 +61,12 @@ vi.mock('@/hooks/mutations/useTopUpWalletMutation', () => ({
 vi.mock('@/components/Invoices', () => ({ InvoicesTable: () => null }))
 vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
 
+function typeInto(element: HTMLInputElement, value: string) {
+  const descriptor = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')
+  descriptor?.set?.call(element, value)
+  element.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
 async function flush() {
   await act(async () => {
     await Promise.resolve()
@@ -75,6 +81,7 @@ describe('WalletSection top-up checkout', () => {
     globalThis.IS_REACT_ACT_ENVIRONMENT = true
     mocks.paymentMethods = []
     mocks.wallet.creditCardConnected = false
+    mocks.topUpWallet.mockClear()
     mocks.topUpWallet.mockResolvedValue({ url: 'https://checkout.stripe.com/pay/cs_top_up' })
   })
 
@@ -113,6 +120,38 @@ describe('WalletSection top-up checkout', () => {
     expect(open).toHaveBeenCalledWith('', '_blank')
     expect(mocks.topUpWallet).toHaveBeenCalledWith({ organizationId: 'org-without-card', amountCents: 10_000 })
     expect(checkoutWindow.location.href).toBe('https://checkout.stripe.com/pay/cs_top_up')
+  })
+
+  it('rounds a custom two-decimal dollar amount to integer cents', async () => {
+    const checkoutWindow = { location: { href: '' }, close: vi.fn() }
+    vi.spyOn(window, 'open').mockReturnValue(checkoutWindow as unknown as Window)
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+
+    await act(async () => {
+      root = createRoot(host)
+      root.render(<WalletSection />)
+    })
+    await flush()
+
+    const customAmount = document.querySelector<HTMLInputElement>('#customTopUpAmount')
+    expect(customAmount).not.toBeNull()
+
+    await act(async () => {
+      customAmount?.focus()
+      if (customAmount) typeInto(customAmount, '10.13')
+    })
+    await flush()
+
+    const topUpButton = [...document.querySelectorAll<HTMLButtonElement>('button')].find(
+      (button) => button.textContent?.trim() === 'Top up →',
+    )
+    expect(topUpButton?.disabled).toBe(false)
+
+    await act(async () => topUpButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+    await flush()
+
+    expect(mocks.topUpWallet).toHaveBeenCalledWith({ organizationId: 'org-without-card', amountCents: 1013 })
   })
 
   it('renders every stored method and marks only the API default as chargeable', async () => {

--- a/apps/dashboard/src/components/billing/WalletSection.tsx
+++ b/apps/dashboard/src/components/billing/WalletSection.tsx
@@ -187,7 +187,7 @@ export function WalletSection() {
     try {
       const result = await topUpWalletMutation.mutateAsync({
         organizationId: selectedOrganization.id,
-        amountCents: amount * 100,
+        amountCents: Math.round(amount * 100),
       })
       if (newWindow) {
         newWindow.location.href = result.url


### PR DESCRIPTION
## Summary

A custom USD top-up such as `$10.13` became
`1013.0000000000001` after JavaScript converted dollars to cents. The Commerce API requires integer `amountCents`, so the request failed before Stripe Checkout could open.

Round at the Dashboard's dollar-to-cent boundary so every valid two-decimal top-up reaches the existing API as integer cents. Keep the minimum amount, preset amounts, automatic top-up rules, and API contract unchanged.

## Call graph

Before

```text
onValueChange          (NumericFormat · components/billing/WalletSection.tsx:321) — stores decimal USD
  └─ handleTopUpWallet (WalletSection · components/billing/WalletSection.tsx:177) ← BUG: amount * 100 retains floating-point residue
       └─ mutationFn    (useTopUpWalletMutation.ts:22) — forwards non-integer cents
            └─ topUpWallet (BillingApiClient · billingApiClient.ts:189) — POST { amountCents }
```

After

```text
onValueChange          (NumericFormat · components/billing/WalletSection.tsx:321) — stores decimal USD
  └─ handleTopUpWallet (WalletSection · components/billing/WalletSection.tsx:177) — Math.round produces integer cents
       └─ mutationFn    (useTopUpWalletMutation.ts:22) — forwards integer cents
            └─ topUpWallet (BillingApiClient · billingApiClient.ts:189) — POST { amountCents }
```

Linear: POL-380

## Changes

- Round the one-time top-up amount while constructing the mutation payload, before it is sent to the billing client.
- Add a UI-to-mutation regression test proving `$10.13` is sent as exactly `1013` cents.
- Leave automatic top-up, minimum-amount validation, and the billing client contract unchanged.

## Verification

- Failing-first: with the production fix absent, the new regression expected `1013` and received `1013.0000000000001`.
- `cd apps && yarn vitest run --config dashboard/vite.config.mts src/components/billing/WalletSection.test.ts src/components/billing/WalletSection.integration.test.tsx` — 7/7 passed.
- `make lint:apps` — 0 errors; 41 existing warnings in untouched files.
- `git diff-tree --check HEAD^ HEAD` — passed.

## Risks / rollout

- No API, schema, or payment-flow sequencing changes; only the Dashboard payload value is normalized before the existing request.
- Dashboard has no Nx `test` target, so `make test:apps` does not execute these Vitest files. The focused Dashboard command above is the regression gate for this change.

## Summary
<!-- 1-2 sentences: what this changes and why. -->

## Call graph
<!-- Required. The end-to-end path this PR touches, before and after; one line
     per hop, only the hops that change. Worked example and the bug-fix markers:
     CONTRIBUTING.md#commit--pr-messages. -->

Before
<!-- replace with the hops: fn_name (Type · path/file.rs:LOC) — role -->

After
<!-- replace with the same hops, post-change -->

Fixes #<!-- issue number — bug fixes only; delete this line otherwise -->

## Changes
- <!-- notable change — what changed, not a restatement of the diff -->

## How to verify
- <!-- a command or step a reviewer can run -->

## Risks / rollout
- <!-- only if any; delete this section otherwise -->

<!-- Describe the change, not the process: no pasted logs, no AI/conversation
     narrative, no secrets. Keep it tight and delete sections that don't apply. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed one-time wallet top-ups to correctly convert dollar amounts with decimal values into cents.
  * Custom amounts such as $10.13 are now processed as 1,013 cents, preventing inaccurate charges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->