### PR TITLE
fix(auth0): report a duplicate signup instead of a generic failure

### DIFF
--- a/apps/infra/bootstrap/auth0-login-policy.test.ts
+++ b/apps/infra/bootstrap/auth0-login-policy.test.ts
@@ -16,6 +16,7 @@ import {
   buildDatabaseConnectionUpdate,
   buildLoginPolicyBindings,
   buildPromptUpdate,
+  buildTenantSettingsUpdate,
   hydrateEmailVerificationTemplate,
   hydrateLoginPolicyAction,
   parseAuth0LoginPolicyOptions,
@@ -122,13 +123,15 @@ test('assertDatabaseConnectionCompatible rejects configurations that cannot safe
   )
 })
 
-test('Auth0 login policy login requests connection-options scopes', () => {
+test('Auth0 login policy login requests connection-options and tenant-settings scopes', () => {
   const packageJson = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'))
   const loginCommand = packageJson.scripts['auth0:login-policy-login']
 
   assert.match(loginCommand, /read:connections_options/)
   assert.match(loginCommand, /update:connections_options/)
   assert.match(loginCommand, /read:client_credentials/)
+  assert.match(loginCommand, /read:tenant_settings/)
+  assert.match(loginCommand, /update:tenant_settings/)
 })
 
 test('rollback snapshots reject credential fields and credential-like string values before writing', () => {
@@ -163,6 +166,19 @@ test('buildPromptUpdate enables New Universal Login Identifier First without rep
     universal_login_experience: 'new',
     identifier_first: true,
   })
+})
+
+test('buildTenantSettingsUpdate reveals the duplicate-signup error without replacing other flags', () => {
+  const settings = {
+    friendly_name: 'BoxLite',
+    flags: { enable_client_connections: true, enable_public_signup_user_exists_error: false },
+  }
+
+  assert.deepEqual(buildTenantSettingsUpdate(settings), {
+    flags: { enable_client_connections: true, enable_public_signup_user_exists_error: true },
+  })
+  assert.equal(settings.flags.enable_public_signup_user_exists_error, false)
+  assert.deepEqual(buildTenantSettingsUpdate({}), { flags: { enable_public_signup_user_exists_error: true } })
 })
 
 test('buildLoginPolicyBindings replaces the legacy claims Action and preserves unrelated Actions', () => {
@@ -296,6 +312,7 @@ test('Auth0LoginPolicyConfigurator preview is read-only and reports prerequisite
         'email-templates/verify_email_by_code': { template: 'verify_email_by_code', enabled: true },
         'email-templates/reset_email_by_code': { template: 'reset_email_by_code', enabled: true },
         prompts: { universal_login_experience: 'classic', identifier_first: false },
+        'tenants/settings': { flags: { enable_public_signup_user_exists_error: false } },
         clients: [{ client_id: 'spa_123', name: 'boxlite-dashboard', app_type: 'spa' }],
         'client-grants': [],
         'flows/vault/connections': [],
@@ -353,6 +370,7 @@ test('Auth0LoginPolicyConfigurator applies, binds last, reads back, and journals
     },
     clientConnectionEnabled: false,
     prompt: { universal_login_experience: 'classic', identifier_first: false },
+    tenantSettings: { friendly_name: 'BoxLite', flags: { enable_public_signup_user_exists_error: false } },
     managementClient: {
       client_id: 'm2m_123',
       name: 'boxlite-forms-email-verification',
@@ -432,6 +450,7 @@ test('Auth0LoginPolicyConfigurator applies, binds last, reads back, and journals
           'email-templates/verify_email_by_code': { enabled: true },
           'email-templates/reset_email_by_code': { enabled: true },
           prompts: state.prompt,
+          'tenants/settings': state.tenantSettings,
           clients: [state.client, state.managementClient],
           'client-grants': [state.grant],
           'flows/vault/connections': [state.vault],
@@ -453,6 +472,10 @@ test('Auth0LoginPolicyConfigurator applies, binds last, reads back, and journals
         state.clientConnectionEnabled = update?.status === true
       }
       if (method === 'patch' && path === 'prompts') state.prompt = { ...state.prompt, ...options.data }
+      if (method === 'patch' && path === 'tenants/settings') {
+        const flags = Array.isArray(options.data) ? {} : (options.data?.flags ?? {})
+        state.tenantSettings = { ...state.tenantSettings, flags: { ...state.tenantSettings.flags, ...flags } }
+      }
       if (method === 'patch' && path === 'client-grants/cgr_123') Object.assign(state.grant, options.data)
       if (method === 'patch' && path.startsWith('flows/')) {
         const flow = state.flows.find((candidate: any) => candidate.id === path.split('/')[1])
@@ -533,6 +556,8 @@ test('Auth0LoginPolicyConfigurator applies, binds last, reads back, and journals
     assert.deepEqual(connectionBindingCall?.data, [{ client_id: 'spa_123', status: true }])
     assert.equal(state.clientConnectionEnabled, true)
     assert.equal(state.prompt.identifier_first, true)
+    assert.equal(state.tenantSettings.flags.enable_public_signup_user_exists_error, true)
+    assert.equal(state.tenantSettings.friendly_name, 'BoxLite')
     assert.equal(
       state.bindings.some((binding: any) => binding.action.id === 'act_policy'),
       true,
@@ -548,6 +573,7 @@ test('Auth0LoginPolicyConfigurator applies, binds last, reads back, and journals
     assert.equal(rollback.mode, 'rolled-back')
     assert.equal(state.clientConnectionEnabled, false)
     assert.equal(state.prompt.identifier_first, false)
+    assert.equal(state.tenantSettings.flags.enable_public_signup_user_exists_error, false)
     assert.deepEqual(state.grant.scope, ['update:users', 'delete:users'])
     assert.equal(state.grant.allow_all_scopes, true)
   } finally {

--- a/apps/infra/bootstrap/auth0-login-policy.ts
+++ b/apps/infra/bootstrap/auth0-login-policy.ts
@@ -43,6 +43,8 @@ const LOGIN_POLICY_MANAGEMENT_SCOPES = [
   'read:email_templates',
   'read:prompts',
   'update:prompts',
+  'read:tenant_settings',
+  'update:tenant_settings',
   'read:actions',
   'create:actions',
   'update:actions',
@@ -173,6 +175,20 @@ export function buildPromptUpdate(prompt: JsonObject): JsonObject {
     ...structuredClone(prompt),
     universal_login_experience: 'new',
     identifier_first: true,
+  }
+}
+
+/*
+ * A tenant that answers a duplicate signup generically leaves Universal Login
+ * nothing to say but its `auth0-users-validation` text ("Something went wrong,
+ * please try again later"); with the flag on, Auth0 names the real cause on the
+ * screen that caught the duplicate. The cost is that the public signup API
+ * confirms which emails have an account; brute_force_protection and the signup
+ * rate limit remain the defense.
+ */
+export function buildTenantSettingsUpdate(settings: JsonObject): JsonObject {
+  return {
+    flags: { ...(settings.flags ?? {}), enable_public_signup_user_exists_error: true },
   }
 }
 
@@ -308,6 +324,7 @@ interface PolicyState {
   verifyTemplate: JsonObject | null
   resetTemplate: JsonObject | null
   prompt: JsonObject
+  tenantSettings: JsonObject
   managementClient: JsonObject | null
   clientGrant: JsonObject | null
   vaultConnection: JsonObject | null
@@ -423,6 +440,7 @@ export class Auth0LoginPolicyConfigurator {
       this.updateDatabaseConnection(connection)
       this.enableConnectionForClient(connection, state.clientConnections)
       this.updatePrompt(state.prompt)
+      this.updateTenantSettings(state.tenantSettings)
       const action = this.ensureAction(requireResourceId('verification form', form), state.action)
       if (!state.action) this.deployAction(action)
       this.bindAction(action, state.bindings)
@@ -503,6 +521,7 @@ export class Auth0LoginPolicyConfigurator {
       this.client.request('get', 'email-templates/reset_email_by_code', { allowNotFound: true }),
     )
     const prompt = requireObject('prompt settings', this.client.request('get', 'prompts'))
+    const tenantSettings = requireObject('tenant settings', this.client.request('get', 'tenants/settings'))
     const clients = this.readAllResources('clients', 'clients')
     const managementClientSummary = uniqueNamed(clients, RESOURCE_NAMES.managementClient, 'management client')
     const managementClient = managementClientSummary
@@ -537,6 +556,7 @@ export class Auth0LoginPolicyConfigurator {
       verifyTemplate,
       resetTemplate,
       prompt,
+      tenantSettings,
       managementClient,
       clientGrant,
       vaultConnection: this.readResourceDetail(
@@ -893,6 +913,19 @@ export class Auth0LoginPolicyConfigurator {
     this.client.request('patch', 'prompts', { data: buildPromptUpdate(existing) })
   }
 
+  /*
+   * Only the one flag is journalled: tenant settings carry read-only fields
+   * that a rollback PATCH would be rejected for, and an absent flag means Auth0
+   * is answering generically, which is what restoring `false` reproduces.
+   */
+  private updateTenantSettings(existing: JsonObject): void {
+    const wasRevealed = existing.flags?.enable_public_signup_user_exists_error === true
+    this.recordAdopted('tenant settings', 'tenants/settings', undefined, {
+      flags: { enable_public_signup_user_exists_error: wasRevealed },
+    })
+    this.client.request('patch', 'tenants/settings', { data: buildTenantSettingsUpdate(existing) })
+  }
+
   private ensureAction(formId: string, existing: JsonObject | null): JsonObject {
     const payload = this.actionPayload(formId)
     if (!existing) {
@@ -959,6 +992,9 @@ export class Auth0LoginPolicyConfigurator {
     }
     if (state.prompt.identifier_first !== true || state.prompt.universal_login_experience !== 'new') {
       throw new Error('Auth0 prompt read-back is not Identifier First New Universal Login')
+    }
+    if (state.tenantSettings.flags?.enable_public_signup_user_exists_error !== true) {
+      throw new Error('Auth0 tenant read-back still answers a duplicate signup with a generic error')
     }
     this.assertManagementClientCompatible(state.managementClient)
     if (

--- a/apps/infra/docs/deployment.md
+++ b/apps/infra/docs/deployment.md
@@ -135,6 +135,12 @@ Existing unverified database users receive a hosted Auth0 verification Form on
 their next browser login. Social and enterprise connections, other Auth0
 applications, and non-`auth0` subjects are outside this policy.
 
+It also turns the tenant flag `enable_public_signup_user_exists_error` on, so a
+signup with an address that already has an account is told the account exists
+instead of Auth0's generic "Something went wrong, please try again later". The
+trade-off is that the public signup API then confirms which addresses have an
+account.
+
 First configure an external Auth0 email provider and enable the
 `verify_email_by_code` and `reset_email_by_code` templates. Auth0's built-in
 provider is testing-only. The stack's own SES identity serves this: run

--- a/apps/infra/package.json
+++ b/apps/infra/package.json
@@ -14,7 +14,7 @@
     "runner:update": "tsx runner/update.ts",
     "auth0:universal-login": "tsx auth0/universal-login-command.ts",
     "login": "tsx bootstrap/login.ts",
-    "auth0:login-policy-login": "auth0 login --scopes read:clients,read:client_credentials,create:clients,delete:clients,read:client_grants,create:client_grants,update:client_grants,delete:client_grants,read:connections,create:connections,update:connections,delete:connections,read:connections_options,update:connections_options,read:users,read:email_provider,read:email_templates,read:prompts,update:prompts,read:actions,create:actions,update:actions,delete:actions,read:forms,create:forms,update:forms,delete:forms,read:flows,create:flows,update:flows,delete:flows,read:flows_vault_connections,create:flows_vault_connections,update:flows_vault_connections,delete:flows_vault_connections",
+    "auth0:login-policy-login": "auth0 login --scopes read:clients,read:client_credentials,create:clients,delete:clients,read:client_grants,create:client_grants,update:client_grants,delete:client_grants,read:connections,create:connections,update:connections,delete:connections,read:connections_options,update:connections_options,read:users,read:email_provider,read:email_templates,read:prompts,update:prompts,read:tenant_settings,update:tenant_settings,read:actions,create:actions,update:actions,delete:actions,read:forms,create:forms,update:forms,delete:forms,read:flows,create:flows,update:flows,delete:flows,read:flows_vault_connections,create:flows_vault_connections,update:flows_vault_connections,delete:flows_vault_connections",
     "bootstrap": "tsx bootstrap/bootstrap.ts",
     "auth0:configure-login": "tsx bootstrap/configure-auth0-login.ts",
     "verify-deploy-role": "tsx deployment/verify-role.ts",


### PR DESCRIPTION
## Summary

Signing up with an email that already has an account showed "Something went wrong, please try again later", because the tenant answers the public signup API generically and Universal Login has nothing left to show but its `auth0-users-validation` text. The login policy reconciler now sets the tenant flag `enable_public_signup_user_exists_error`, so Auth0 names the real cause on the screen that caught the duplicate.

## Call graph

Before

```text
visitor submits an email that already has an account
  POST /dbconnections/signup   (Auth0 Authentication API)   ← BUG: tenant answers generically, no user_exists reaches the UI
    └─ Universal Login signup screen                        — renders `auth0-users-validation`:
                                                              "Something went wrong, please try again later"

apply                      (Auth0LoginPolicyConfigurator · apps/infra/bootstrap/auth0-login-policy.ts:406)
  ├─ readState             (Auth0LoginPolicyConfigurator · apps/infra/bootstrap/auth0-login-policy.ts:496)
  │                                   — no hop reads tenants/settings
  ├─ updatePrompt          (Auth0LoginPolicyConfigurator · apps/infra/bootstrap/auth0-login-policy.ts:911)  ← BUG: last tenant-level write; nothing sets enable_public_signup_user_exists_error, so the tenant keeps answering a duplicate signup generically
  └─ assertApplied         (Auth0LoginPolicyConfigurator · apps/infra/bootstrap/auth0-login-policy.ts:972)
                                      — read-back never checks how a duplicate signup is answered
```

After

```text
apply                      (Auth0LoginPolicyConfigurator · apps/infra/bootstrap/auth0-login-policy.ts:406)
  ├─ readState             (… :496)   — GET tenants/settings into PolicyState.tenantSettings (… :524)
  ├─ updatePrompt          (… :911)   — PATCH prompts: Identifier First, New Universal Login
  ├─ updateTenantSettings  (… :921)   — journals the one flag, then PATCH tenants/settings
  │    └─ buildTenantSettingsUpdate (… :189)  — sets enable_public_signup_user_exists_error, keeps other flags
  └─ assertApplied         (… :996)   — refuses an apply that leaves the tenant answering generically

visitor submits an email that already has an account
  POST /dbconnections/signup   (Auth0 Authentication API)   — returns user_exists
    └─ Universal Login signup screen                        — renders Auth0's "The user already exists."
```

Fixes #1373

## Changes

- `buildTenantSettingsUpdate` merges the flag into whatever flags the tenant already carries, so unrelated tenant behavior is untouched.
- The rollback journal records only that one flag: tenant settings carry read-only fields a restore PATCH would be rejected for, and an absent flag means Auth0 is answering generically, which restoring `false` reproduces.
- The apply read-back fails when the flag is not live, so a silently ignored PATCH cannot pass as applied.
- `read:tenant_settings` / `update:tenant_settings` added to the reconciler's scope list and to `npm run auth0:login-policy-login`; operators must re-run that login once before the next apply.

## How to verify

```bash
make test:apps:infra
```

Against a tenant, after `npm run auth0:login-policy-login`:

```bash
cd apps/infra
npm run auth0:configure-login -- --tenant <tenant.auth0.com> \
  --client-id <boxlite-spa-client-id> --connection boxlite-users --apply
```

Then sign up with an address that already has an account: the signup screen names the duplicate instead of the generic failure. Apply prints a rollback journal path if the tenant flag needs reverting.

## Risks / rollout

- The public signup API now confirms which addresses have an account — user enumeration is the documented trade-off of the specific error. `brute_force_protection` on the connection and Auth0's signup rate limit remain the defense.
- Tenant-wide setting: it changes every signup surface on the tenant, not only the dashboard's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Auth0 email-first sign-up messaging by informing users when an email address is already registered.
  * Tenant settings are updated and verified during policy application, with safe restoration during rollback.
* **Documentation**
  * Added deployment guidance describing the improved messaging and its public sign-up API behavior.
* **Bug Fixes**
  * Preserved unrelated tenant settings while managing duplicate-signup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->