### PR TITLE
chore(infra): move Auth0 email bodies to HTML and set signup flag

### DIFF
--- a/apps/infra/bootstrap/auth0-email-provider.test.ts
+++ b/apps/infra/bootstrap/auth0-email-provider.test.ts
@@ -6,20 +6,20 @@ import { mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
+import { fileURLToPath } from 'node:url'
 
 import {
   Auth0EmailProviderConfigurator,
   buildAuth0CodeEmailTemplates,
   parseAuth0EmailProviderOptions,
+  readAuth0CodeEmailTemplates,
 } from './auth0-email-provider.js'
 import type { Auth0ManagementClient } from './auth0-login-policy.js'
 
 type JsonObject = Record<string, any>
 
 function sourceTemplates(): JsonObject[] {
-  return ['verify-email-by-code.json', 'reset-email-by-code.json'].map((name) =>
-    JSON.parse(readFileSync(new URL(`./auth0/email-templates/${name}`, import.meta.url), 'utf8')),
-  )
+  return readAuth0CodeEmailTemplates(fileURLToPath(new URL('./auth0/email-templates.json', import.meta.url)))
 }
 
 function options(apply = false) {
@@ -81,8 +81,18 @@ test('checked-in Auth0 code templates render a code and receive the selected sen
     true,
   )
   assert.equal(
-    templates.every((template) => template.body.includes('{{ code }}')),
+    templates.every((template) => !('render_html' in template)),
     true,
+  )
+  // The build above is the positive check: it throws unless every checked-in
+  // body renders the code variable, whichever Liquid filters it uses.
+  assert.throws(
+    () =>
+      buildAuth0CodeEmailTemplates(
+        'no-reply@boxlite.example',
+        sourceTemplates().map((template) => ({ ...template, body: '<p>Sign in to BoxLite.</p>' })),
+      ),
+    /must render the code variable/,
   )
 })
 

--- a/apps/infra/bootstrap/auth0-email-provider.ts
+++ b/apps/infra/bootstrap/auth0-email-provider.ts
@@ -3,7 +3,7 @@
 
 import { randomUUID } from 'node:crypto'
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { parseArgs } from 'node:util'
 
 import { assertJournalSnapshotSafe } from './auth0-login-policy.js'
@@ -94,6 +94,33 @@ export function buildSesEmailProvider(options: Pick<Auth0EmailProviderOptions, '
   }
 }
 
+export function readAuth0CodeEmailTemplates(manifestPath: string): JsonObject[] {
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
+  if (!Array.isArray(manifest)) throw new Error(`Auth0 email-template manifest '${manifestPath}' must be a JSON array`)
+  const manifestRoot = dirname(manifestPath)
+
+  return manifest.map(({ render_html: renderHtml, ...template }) => {
+    const name = template.template ?? 'unknown'
+    if (typeof renderHtml !== 'string' || renderHtml.trim() === '') {
+      throw new Error(`Auth0 email template '${name}' must point render_html at an HTML body file`)
+    }
+    const bodyPath = join(manifestRoot, renderHtml)
+    try {
+      // Auth0 stores the body verbatim and never echoes render_html back, so the manifest
+      // reference is resolved away here to keep desired state comparable to tenant state.
+      return { ...template, body: readFileSync(bodyPath, 'utf8').trim() }
+    } catch (cause) {
+      throw new Error(`Auth0 email template '${name}' cannot read render_html '${bodyPath}'`, { cause })
+    }
+  })
+}
+
+// Liquid permits filters and whitespace control on an interpolation, so the
+// stock Auth0 bodies write `{{ code | escape }}`. Match the variable itself
+// rather than one spelling of it, while still rejecting a body that never
+// renders the code at all.
+const CODE_VARIABLE = /\{\{-?\s*code\s*(?:\||-?\}\})/
+
 export function buildAuth0CodeEmailTemplates(fromAddress: string, templates: JsonObject[]): JsonObject[] {
   const expectedNames = new Set(['verify_email_by_code', 'reset_email_by_code'])
   if (templates.length !== expectedNames.size) throw new Error('exactly two Auth0 code-email templates are required')
@@ -102,7 +129,7 @@ export function buildAuth0CodeEmailTemplates(fromAddress: string, templates: Jso
     if (!expectedNames.delete(template.template)) {
       throw new Error(`unexpected or duplicate Auth0 email template '${template.template ?? 'unknown'}'`)
     }
-    if (!template.body?.includes('{{ code }}')) {
+    if (!CODE_VARIABLE.test(template.body ?? '')) {
       throw new Error(`Auth0 email template '${template.template}' must render the code variable`)
     }
     return { ...structuredClone(template), from: fromAddress }

--- a/apps/infra/bootstrap/auth0.test.ts
+++ b/apps/infra/bootstrap/auth0.test.ts
@@ -4,7 +4,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { customApiArgs, enableRpLogoutDiscoveryArgs, spaApplicationArgs } from './auth0.js'
+import { customApiArgs, spaApplicationArgs, tenantSettingsArgs } from './auth0.js'
 
 function valueAfter(args: any, flag: any) {
   const index = args.indexOf(flag)
@@ -31,10 +31,11 @@ test('customApiArgs derives the identifier that becomes OIDC_AUDIENCE', () => {
   )
 })
 
-test('enableRpLogoutDiscoveryArgs flips the tenant logout-discovery setting', () => {
-  const args = enableRpLogoutDiscoveryArgs()
+test('tenantSettingsArgs sets logout discovery and keeps public signup non-enumerable', () => {
+  const args = tenantSettingsArgs()
   assert.deepEqual(args.slice(0, 3), ['api', 'patch', 'tenants/settings'])
   assert.deepEqual(JSON.parse(valueAfter(args, '--data')), {
     oidc_logout: { rp_logout_end_session_endpoint_discovery: true },
+    flags: { enable_public_signup_user_exists_error: false },
   })
 })

--- a/apps/infra/bootstrap/auth0.ts
+++ b/apps/infra/bootstrap/auth0.ts
@@ -8,8 +8,8 @@
  * have separate previewable reconcilers in auth0-email-provider.ts and
  * auth0-login-policy.ts.
  *
- * RP-initiated-logout discovery has no first-class CLI verb and goes through
- * `auth0 api`, the raw Management API passthrough.
+ * Tenant settings have no first-class CLI verb and go through `auth0 api`,
+ * the raw Management API passthrough.
  *
  * Creating the tenant itself has no Management API and stays manual.
  */
@@ -54,15 +54,24 @@ export function customApiArgs({ stackDomain, name = 'boxlite-api' }: any) {
   return ['apis', 'create', '--name', name, '--identifier', `https://${stackDomain}/api`, '--json']
 }
 
-// Without this the dashboard's "Sign out" only clears BoxLite's own session:
-// the still-live Auth0 cookie silently re-authenticates and logout looks like
-// a page refresh.
-export function enableRpLogoutDiscoveryArgs() {
+/*
+ * Without rp_logout_end_session_endpoint_discovery the dashboard's "Sign out"
+ * only clears BoxLite's own session: the still-live Auth0 cookie silently
+ * re-authenticates and logout looks like a page refresh.
+ *
+ * enable_public_signup_user_exists_error stays off so /dbconnections/signup
+ * answers a duplicate address with the generic invalid_signup rather than
+ * user_exists, which would let anyone enumerate registered emails.
+ */
+export function tenantSettingsArgs() {
   return [
     'api',
     'patch',
     'tenants/settings',
     '--data',
-    JSON.stringify({ oidc_logout: { rp_logout_end_session_endpoint_discovery: true } }),
+    JSON.stringify({
+      oidc_logout: { rp_logout_end_session_endpoint_discovery: true },
+      flags: { enable_public_signup_user_exists_error: false },
+    }),
   ]
 }

--- a/apps/infra/bootstrap/auth0/email-templates.json
+++ b/apps/infra/bootstrap/auth0/email-templates.json
@@ -1,0 +1,16 @@
+[
+  {
+    "template": "verify_email_by_code",
+    "subject": "Verify your BoxLite email",
+    "syntax": "liquid",
+    "enabled": true,
+    "render_html": "./email-templates/verify-email-by-code.html"
+  },
+  {
+    "template": "reset_email_by_code",
+    "subject": "Reset your BoxLite password",
+    "syntax": "liquid",
+    "enabled": true,
+    "render_html": "./email-templates/reset-email-by-code.html"
+  }
+]

--- a/apps/infra/bootstrap/auth0/email-templates/reset-email-by-code.html
+++ b/apps/infra/bootstrap/auth0/email-templates/reset-email-by-code.html
@@ -1,0 +1,268 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html dir="ltr" lang="en">
+  <head>
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+    <meta name="x-apple-disable-message-reformatting" />
+  </head>
+  <div style="display:none;overflow:hidden;line-height:1px;opacity:0;max-height:0;max-width:0">
+    You have submitted a password change request!
+  </div>
+
+  <body
+    style="margin-left:auto;margin-right:auto;margin-top:auto;margin-bottom:auto;height:100vh;background-color:rgb(245,245,245);padding-left:1rem;padding-right:1rem;padding-bottom:2.5rem;padding-top:1rem;font-family:ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial, Noto Sans, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale"
+  >
+    <table
+      align="center"
+      width="100%"
+      border="0"
+      cellpadding="0"
+      cellspacing="0"
+      role="presentation"
+      style="margin-left:auto;margin-right:auto;border-radius:1rem;background-color:rgb(255,255,255);padding:2rem;border-width:1px;border-style:solid;border-color:rgb(229,229,229);max-width:37.5em"
+    >
+      <tbody>
+        <tr style="width:100%">
+          <td>
+            <table
+              align="center"
+              width="100%"
+              id="header"
+              class=""
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+            >
+              <tbody>
+                <tr>
+                  <td>
+                    <a
+                      href="{{ home_url | escape }}"
+                      style="margin-bottom:1rem;display:block;color:#067df7;text-decoration:none"
+                      target="_blank"
+                      ><img
+                        alt="Auth0 Logo"
+                        height="32"
+                        src="{{ logo_url | escape }}"
+                        style="margin-left:auto;margin-right:auto;display:block;outline:none;border:none;text-decoration:none"
+                        width="auto"
+                    /></a>
+                    <hr
+                      style="margin-top:1.25rem;margin-bottom:1.25rem;border-width:1px;border-color:rgb(212,212,212);width:100%;border:none;border-top:1px solid #eaeaea"
+                    />
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <table
+              align="center"
+              width="100%"
+              id="subject"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+            >
+              <tbody>
+                <tr>
+                  <td>
+                    <table
+                      align="center"
+                      width="100%"
+                      border="0"
+                      cellpadding="0"
+                      cellspacing="0"
+                      role="presentation"
+                      style="height:4rem;width:4rem;border-radius:0.75rem;background-color:rgb(245,245,245);max-width:37.5em"
+                    >
+                      <tbody>
+                        <tr style="width:100%">
+                          <td>
+                            <img
+                              alt="Icon"
+                              height="24"
+                              src="https://cdn.auth0.com/website/emails/product/icon-password.png"
+                              style="margin-left:auto;margin-right:auto;display:block;outline:none;border:none;text-decoration:none"
+                              width="24"
+                            />
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                    <h1
+                      style="padding:0px;text-align:center;font-size:1.5rem;line-height:2rem;font-weight:600;color:rgb(23,23,23)"
+                    >
+                      You have submitted a password change request!
+                    </h1>
+                    <hr
+                      style="margin-top:1.25rem;margin-bottom:1.25rem;border-width:1px;border-color:rgb(212,212,212);width:100%;border:none;border-top:1px solid #eaeaea"
+                    />
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <table
+              align="center"
+              width="100%"
+              id="body"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+            >
+              <tbody>
+                <tr>
+                  <td>
+                    <p
+                      style="margin-top:1.5rem;text-align:center;font-size:1rem;line-height:1.5rem;color:rgb(23,23,23);margin:16px 0"
+                    >
+                      If it was you, confirm the password change using this code
+                    </p>
+                    <p
+                      style="margin-top:1.5rem;text-align:center;font-size:1rem;line-height:1.5rem;font-weight:600;color:rgb(23,23,23);margin:16px 0"
+                    >
+                      Your code is:
+                    </p>
+                    <code
+                      style='margin-bottom:0.5rem;display:block;border-radius:0.5rem;border-width:1px;border-style:solid;border-color:rgb(212,212,212);background-color:rgb(245,245,245);padding-left:0.625rem;padding-right:0.625rem;padding-top:0.75rem;padding-bottom:0.75rem;text-align:center;font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;font-size:1.25rem;line-height:1.75rem;font-weight:600;color:rgb(23,23,23)'
+                      >{{ code | escape }}</code
+                    >
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <table
+              align="center"
+              width="100%"
+              id="issue-note"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+              style="text-align:center;margin-top:1.5rem"
+            >
+              <tbody>
+                <tr>
+                  <td>
+                    <table
+                      align="center"
+                      width="100%"
+                      border="0"
+                      cellpadding="0"
+                      cellspacing="0"
+                      role="presentation"
+                      style="width:100%;text-align:center;max-width:37.5em"
+                    >
+                      <tbody>
+                        <tr style="width:100%">
+                          <td>
+                            <p
+                              style="margin:0px;margin-left:2rem;margin-right:2rem;font-size:0.875rem;line-height:1.25rem;color:rgb(163,163,163)"
+                            >
+                              If you are having any issues with your account, please don&#x27;t hesitate to contact us
+                              by replying to this mail.
+                            </p>
+                            <p
+                              style="margin:0px;margin-left:2rem;margin-right:2rem;font-size:0.875rem;line-height:1.25rem;color:rgb(163,163,163)"
+                            >
+                              Thanks!
+                            </p>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <table
+              align="center"
+              width="100%"
+              id="footer"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+              style="margin-top:1.5rem"
+            >
+              <tbody>
+                <tr>
+                  <td>
+                    <hr
+                      style="margin-top:0.75rem;margin-bottom:1.5rem;border-width:1px;border-color:rgb(212,212,212);width:100%;border:none;border-top:1px solid #eaeaea"
+                    />
+                    <p
+                      style="text-align:center;font-size:0.75rem;line-height:1rem;color:rgb(163,163,163);margin:16px 0"
+                    >
+                      You&#x27;re receiving this email because you have an account in<!-- -->
+                      <!-- -->{{ friendly_name | escape }}<!-- -->. If you are not sure why you’re receiving this,
+                      please contact us<!-- -->{% if support_url != blank %}
+                      <!-- -->
+                      through our<!-- -->
+                      <a
+                        href="{{ support_url | escape }}"
+                        style="color:rgb(0,0,0);text-underline-offset:4px;text-decoration:underline"
+                        target="_blank"
+                        >Support Center</a
+                      >{% endif %}<!-- -->.
+                    </p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <table
+      align="center"
+      width="100%"
+      border="0"
+      cellpadding="0"
+      cellspacing="0"
+      role="presentation"
+      style="margin-top:1rem;max-width:37.5em"
+    >
+      <tbody>
+        <tr style="width:100%">
+          <td>
+            <table
+              align="center"
+              width="100%"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+              style="width:fit-content;opacity:0.5"
+            >
+              <tbody style="width:100%">
+                <tr style="width:100%">
+                  <td align="right" data-id="__react-email-column" style="height:40px;width:fit-content">
+                    <p
+                      style="margin-top:-0.5rem;font-size:0.75rem;line-height:1rem;color:rgb(23,23,23);margin:16px 0"
+                    >
+                      Powered by
+                    </p>
+                  </td>
+                  <td align="left" data-id="__react-email-column" style="height:40px;width:fit-content">
+                    <a
+                      href="https://auth0.com"
+                      style="display:block;color:#067df7;text-decoration:none"
+                      target="_blank"
+                      ><img
+                        alt="Auth0 Logo"
+                        height="24"
+                        src="https://cdn.auth0.com/website/auth0-logos/2025-branding/png/auth0-lockup-en-onlight.png"
+                        style="margin-left:0.5rem;margin-top:2px;display:inline-block;width:auto;outline:none;border:none;text-decoration:none"
+                        width="auto"
+                    /></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/apps/infra/bootstrap/auth0/email-templates/reset-email-by-code.json
+++ b/apps/infra/bootstrap/auth0/email-templates/reset-email-by-code.json
@@ -1,7 +1,0 @@
-{
-  "template": "reset_email_by_code",
-  "subject": "Reset your BoxLite password",
-  "syntax": "liquid",
-  "enabled": true,
-  "body": "<h2>Reset your password</h2><p>Your BoxLite password-reset code is:</p><p style=\"font-size: 28px; font-weight: 700; letter-spacing: 0.16em;\">{{ code }}</p><p>Enter this code in the BoxLite password-reset window. If you did not request a reset, you can ignore this email.</p>"
-}

--- a/apps/infra/bootstrap/auth0/email-templates/verify-email-by-code.html
+++ b/apps/infra/bootstrap/auth0/email-templates/verify-email-by-code.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html dir="ltr" lang="en">
+  <head>
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+    <meta name="x-apple-disable-message-reformatting" />
+  </head>
+  <div style="display:none;overflow:hidden;line-height:1px;opacity:0;max-height:0;max-width:0">
+    Verify your identity
+  </div>
+
+  <body
+    style="margin-left:auto;margin-right:auto;margin-top:auto;margin-bottom:auto;height:100vh;background-color:rgb(245,245,245);padding-left:1rem;padding-right:1rem;padding-bottom:2.5rem;padding-top:1rem;font-family:ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial, Noto Sans, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale"
+  >
+    <table
+      align="center"
+      width="100%"
+      border="0"
+      cellpadding="0"
+      cellspacing="0"
+      role="presentation"
+      style="margin-left:auto;margin-right:auto;border-radius:1rem;background-color:rgb(255,255,255);padding:2rem;border-width:1px;border-style:solid;border-color:rgb(229,229,229);max-width:37.5em"
+    >
+      <tbody>
+        <tr style="width:100%">
+          <td>
+            <table
+              align="center"
+              width="100%"
+              id="header"
+              class=""
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+            >
+              <tbody>
+                <tr>
+                  <td>
+                    <a
+                      href="{{ home_url | escape }}"
+                      style="margin-bottom:1rem;display:block;color:#067df7;text-decoration:none"
+                      target="_blank"
+                      ><img
+                        alt="Auth0 Logo"
+                        height="32"
+                        src="{{ logo_url | escape }}"
+                        style="margin-left:auto;margin-right:auto;display:block;outline:none;border:none;text-decoration:none"
+                        width="auto"
+                    /></a>
+                    <hr
+                      style="margin-top:1.25rem;margin-bottom:1.25rem;border-width:1px;border-color:rgb(212,212,212);width:100%;border:none;border-top:1px solid #eaeaea"
+                    />
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <table
+              align="center"
+              width="100%"
+              id="subject"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+            >
+              <tbody>
+                <tr>
+                  <td>
+                    <table
+                      align="center"
+                      width="100%"
+                      border="0"
+                      cellpadding="0"
+                      cellspacing="0"
+                      role="presentation"
+                      style="height:4rem;width:4rem;border-radius:0.75rem;background-color:rgb(245,245,245);max-width:37.5em"
+                    >
+                      <tbody>
+                        <tr style="width:100%">
+                          <td>
+                            <img
+                              alt="Icon"
+                              height="24"
+                              src="https://cdn.auth0.com/website/emails/product/icon-password.png"
+                              style="margin-left:auto;margin-right:auto;display:block;outline:none;border:none;text-decoration:none"
+                              width="24"
+                            />
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                    <h1
+                      style="padding:0px;text-align:center;font-size:1.5rem;line-height:2rem;font-weight:600;color:rgb(23,23,23)"
+                    >
+                      Verify your identity
+                    </h1>
+                    <hr
+                      style="margin-top:1.25rem;margin-bottom:1.25rem;border-width:1px;border-color:rgb(212,212,212);width:100%;border:none;border-top:1px solid #eaeaea"
+                    />
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <table
+              align="center"
+              width="100%"
+              id="body"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+            >
+              <tbody>
+                <tr>
+                  <td>
+                    <p
+                      style="margin-top:1.5rem;margin-bottom:1.5rem;text-align:center;font-size:1rem;line-height:1.5rem;color:rgb(23,23,23);margin:16px 0"
+                    >
+                      Please use the following code to help verify your identity:
+                    </p>
+                    <p
+                      style="margin-top:1.5rem;margin-bottom:1.5rem;text-align:center;font-size:1rem;line-height:1.5rem;color:rgb(23,23,23);margin:16px 0"
+                    >
+                      Your code is:
+                    </p>
+                    <code
+                      style='margin-bottom:0.5rem;display:block;border-radius:0.5rem;border-width:1px;border-style:solid;border-color:rgb(212,212,212);background-color:rgb(245,245,245);padding-left:0.625rem;padding-right:0.625rem;padding-top:0.75rem;padding-bottom:0.75rem;text-align:center;font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;font-size:1.25rem;line-height:1.75rem;font-weight:600;color:rgb(23,23,23)'
+                      >{{ code | escape }}</code
+                    >
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <table
+              align="center"
+              width="100%"
+              id="footer"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+              style="margin-top:1.5rem"
+            >
+              <tbody>
+                <tr>
+                  <td>
+                    <hr
+                      style="margin-top:0.75rem;margin-bottom:1.5rem;border-width:1px;border-color:rgb(212,212,212);width:100%;border:none;border-top:1px solid #eaeaea"
+                    />
+                    <p
+                      style="text-align:center;font-size:0.75rem;line-height:1rem;color:rgb(163,163,163);margin:16px 0"
+                    >
+                      You&#x27;re receiving this email because you have an account in<!-- -->
+                      <!-- -->{{ friendly_name | escape }}<!-- -->. If you are not sure why you’re receiving this,
+                      please contact us<!-- -->{% if support_url != blank %}
+                      <!-- -->
+                      through our<!-- -->
+                      <a
+                        href="{{ support_url | escape }}"
+                        style="color:rgb(0,0,0);text-underline-offset:4px;text-decoration:underline"
+                        target="_blank"
+                        >Support Center</a
+                      >{% endif %}<!-- -->.
+                    </p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <table
+      align="center"
+      width="100%"
+      border="0"
+      cellpadding="0"
+      cellspacing="0"
+      role="presentation"
+      style="margin-top:1rem;max-width:37.5em"
+    >
+      <tbody>
+        <tr style="width:100%">
+          <td>
+            <table
+              align="center"
+              width="100%"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+              style="width:fit-content;opacity:0.5"
+            >
+              <tbody style="width:100%">
+                <tr style="width:100%">
+                  <td align="right" data-id="__react-email-column" style="height:40px;width:fit-content">
+                    <p
+                      style="margin-top:-0.5rem;font-size:0.75rem;line-height:1rem;color:rgb(23,23,23);margin:16px 0"
+                    >
+                      Powered by
+                    </p>
+                  </td>
+                  <td align="left" data-id="__react-email-column" style="height:40px;width:fit-content">
+                    <a
+                      href="https://auth0.com"
+                      style="display:block;color:#067df7;text-decoration:none"
+                      target="_blank"
+                      ><img
+                        alt="Auth0 Logo"
+                        height="24"
+                        src="https://cdn.auth0.com/website/auth0-logos/2025-branding/png/auth0-lockup-en-onlight.png"
+                        style="margin-left:0.5rem;margin-top:2px;display:inline-block;width:auto;outline:none;border:none;text-decoration:none"
+                        width="auto"
+                    /></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/apps/infra/bootstrap/auth0/email-templates/verify-email-by-code.json
+++ b/apps/infra/bootstrap/auth0/email-templates/verify-email-by-code.json
@@ -1,7 +1,0 @@
-{
-  "template": "verify_email_by_code",
-  "subject": "Verify your BoxLite email",
-  "syntax": "liquid",
-  "enabled": true,
-  "body": "<h2>Verify your email</h2><p>Your BoxLite verification code is:</p><p style=\"font-size: 28px; font-weight: 700; letter-spacing: 0.16em;\">{{ code }}</p><p>Enter this code in the BoxLite sign-up window. If you did not request this code, you can ignore this email.</p>"
-}

--- a/apps/infra/bootstrap/bootstrap.ts
+++ b/apps/infra/bootstrap/bootstrap.ts
@@ -93,11 +93,7 @@ import {
 } from './environment.js'
 import { validateDotenvSyntax } from '../deployment/key-policy.js'
 import { promptSecret, requireNonEmptySecret } from './secret-prompt.js'
-import {
-  customApiArgs,
-  enableRpLogoutDiscoveryArgs,
-  spaApplicationArgs,
-} from './auth0.js'
+import { customApiArgs, spaApplicationArgs, tenantSettingsArgs } from './auth0.js'
 import {
   environmentApiPath,
   githubEnvironmentPayload,
@@ -648,8 +644,8 @@ function provisionAuth0({ stackDomain }: any) {
   const api = auth0Json(customApiArgs({ stackDomain }))
   console.log(`[${SCRIPT_NAME}] Auth0 custom API ... created (audience ${api.identifier})`)
 
-  auth0Run(enableRpLogoutDiscoveryArgs())
-  console.log(`[${SCRIPT_NAME}] Auth0 RP-initiated logout discovery ... enabled`)
+  auth0Run(tenantSettingsArgs())
+  console.log(`[${SCRIPT_NAME}] Auth0 tenant settings ... applied (logout discovery, public-signup error)`)
 
   const tenants = auth0Json(['tenants', 'list', '--json'])
   const activeTenants = tenants.filter((tenant: any) => tenant.active)

--- a/apps/infra/bootstrap/configure-auth0-email.ts
+++ b/apps/infra/bootstrap/configure-auth0-email.ts
@@ -5,7 +5,11 @@ import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { Auth0EmailProviderConfigurator, parseAuth0EmailProviderOptions } from './auth0-email-provider.js'
+import {
+  Auth0EmailProviderConfigurator,
+  parseAuth0EmailProviderOptions,
+  readAuth0CodeEmailTemplates,
+} from './auth0-email-provider.js'
 import { Auth0CliManagementClient } from './auth0-login-policy.js'
 import { promptSecret, requireNonEmptySecret } from './secret-prompt.js'
 
@@ -13,9 +17,7 @@ const bootstrapRoot = dirname(fileURLToPath(import.meta.url))
 
 function sources() {
   return {
-    templates: ['verify-email-by-code.json', 'reset-email-by-code.json'].map((name) =>
-      JSON.parse(readFileSync(join(bootstrapRoot, 'auth0', 'email-templates', name), 'utf8')),
-    ),
+    templates: readAuth0CodeEmailTemplates(join(bootstrapRoot, 'auth0', 'email-templates.json')),
     receiptDirectory: join(bootstrapRoot, '..', '.sst', 'auth0-backups'),
   }
 }


### PR DESCRIPTION
## Summary

The two Auth0 code-email bodies were single-line strings inside their own JSON files, so the markup was neither reviewable nor editable as HTML. They now live as HTML files behind a manifest, carry Auth0's stock code templates, and the tenant bootstrap additionally turns off `enable_public_signup_user_exists_error` so public signup cannot be used to enumerate registered emails.

## Call graph

Before

```text
auth0:configure-email      (npm script · apps/infra/package.json:19)
  └─ sources               (function · apps/infra/bootstrap/configure-auth0-email.ts:14) — hardcodes two JSON filenames, JSON.parse each
       └─ Auth0EmailProviderConfigurator.apply  (class · apps/infra/bootstrap/auth0-email-provider.ts:145)
            └─ buildAuth0CodeEmailTemplates     (function · apps/infra/bootstrap/auth0-email-provider.ts:97)
                 └─ body?.includes('{{ code }}')  (apps/infra/bootstrap/auth0-email-provider.ts:105) — one literal spelling only

bootstrap --provision-auth0  (apps/infra/bootstrap/bootstrap.ts:640)
  └─ enableRpLogoutDiscoveryArgs  (function · apps/infra/bootstrap/auth0.ts:60) — PATCH tenants/settings with oidc_logout only
```

After

```text
auth0:configure-email          (npm script · apps/infra/package.json:19)
  └─ sources                   (function · apps/infra/bootstrap/configure-auth0-email.ts:18) — names one manifest
       └─ readAuth0CodeEmailTemplates  (function · apps/infra/bootstrap/auth0-email-provider.ts:97) — resolves render_html to body, strips the reference
            └─ Auth0EmailProviderConfigurator.apply  (class · apps/infra/bootstrap/auth0-email-provider.ts:172)
                 └─ buildAuth0CodeEmailTemplates     (function · apps/infra/bootstrap/auth0-email-provider.ts:124)
                      └─ CODE_VARIABLE                (apps/infra/bootstrap/auth0-email-provider.ts:122) — matches the Liquid variable with optional filters

bootstrap --provision-auth0  (apps/infra/bootstrap/bootstrap.ts:636)
  └─ tenantSettingsArgs      (function · apps/infra/bootstrap/auth0.ts:66) — one PATCH: oidc_logout plus flags.enable_public_signup_user_exists_error: false
```

## Changes

- `auth0/email-templates.json` holds each template's `template`, `subject`, `syntax`, and `enabled`, and points `render_html` at a sibling HTML file. `readAuth0CodeEmailTemplates` resolves the path relative to the manifest and inlines the file as `body`. The reference is stripped from the result — Auth0 never echoes `render_html` back, so leaving it in would break the adopt and read-back comparisons against tenant state.
- Both bodies are now Auth0's stock code templates rather than the previous four-tag strings, so subject styling, the code block, and the footer come from Auth0's own markup.
- The code-variable guard matched only the bare `{{ code }}`. Liquid permits filters and whitespace control, and the stock bodies write `{{ code | escape }}`, so the guard now matches the variable itself while still rejecting a body that never renders the code.
- `enableRpLogoutDiscoveryArgs` becomes `tenantSettingsArgs` and carries both tenant settings in one `tenants/settings` PATCH. With `enable_public_signup_user_exists_error` off, `/dbconnections/signup` answers a duplicate address with the generic `invalid_signup` instead of `user_exists`.
- The template test no longer asserts one spelling of the interpolation. `buildAuth0CodeEmailTemplates` throwing on the checked-in bodies is the positive check; a body with no code variable is asserted to be rejected.

## How to verify

```bash
make test:apps:infra
make lint:apps
cd apps/infra && npm run auth0:configure-email -- \
  --tenant <tenant> --from <verified-sender> --region <ses-region>
```

The preview is read-only and reports `create` or `reuse` per template without writing to the tenant.

## Risks / rollout

- The template bodies changed, and the configurator only ever creates templates — it has no update path. Applying against a tenant that already holds the previous bodies refuses rather than overwrites, reporting that the checked-in template differs. Roll the old templates back first, then reapply.
- `enable_public_signup_user_exists_error` is tenant-wide. Any client that distinguished "already registered" from other signup failures now receives `invalid_signup` for both; that is the point of the flag, but it is a visible change to signup error handling.
- The manifest `subject` values keep BoxLite wording while the stock HTML headings read "Verify your identity" and "You have submitted a password change request!", and the footer still renders Auth0's "Powered by" lockup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added branded HTML email templates for verification and password-reset codes.
  - Email templates now support escaped code values and optional support links.

- **Bug Fixes**
  - Improved template validation to recognize supported Liquid formatting.
  - Added clearer errors when templates cannot render verification codes.
  - Auth configuration now applies public-signup error handling alongside logout discovery settings.

- **Documentation**
  - Updated tenant-settings documentation to reference the raw management API path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->