### PR TITLE
refactor(dashboard): place balance warnings by severity

### DIFF
--- a/apps/dashboard/src/components/billing/BalanceLowBanner.test.ts
+++ b/apps/dashboard/src/components/billing/BalanceLowBanner.test.ts
@@ -1,5 +1,18 @@
-import { describe, expect, it } from 'vitest'
-import { balanceWarning } from './BalanceLowBanner'
+import type { OrganizationPlan, OrganizationWallet } from '@/billing-api'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { balanceWarning, BalanceLowBanner } from './BalanceLowBanner'
+
+const queryMocks = vi.hoisted(() => ({
+  plan: undefined as OrganizationPlan | undefined,
+  wallet: undefined as OrganizationWallet | undefined,
+}))
+
+vi.mock('@/hooks/queries/billingQueries', () => ({
+  useOwnerPlanQuery: () => ({ data: queryMocks.plan }),
+  useOwnerWalletQuery: () => ({ data: queryMocks.wallet }),
+}))
 
 const autoTopUp = { thresholdAmount: 20, targetAmount: 100 }
 const spentQuota = { quotaRemainingCents: 0 }
@@ -52,5 +65,32 @@ describe('balanceWarning', () => {
 
   it('stays silent without a wallet', () => {
     expect(balanceWarning(undefined)).toBeNull()
+  })
+})
+
+describe('BalanceLowBanner placement', () => {
+  beforeEach(() => {
+    queryMocks.plan = undefined
+    queryMocks.wallet = undefined
+  })
+
+  it('keeps below-threshold warnings out of the page-level banner', () => {
+    queryMocks.wallet = {
+      ongoingBalanceCents: 1_999,
+      automaticTopUp: autoTopUp,
+    } as OrganizationWallet
+
+    expect(renderToStaticMarkup(createElement(BalanceLowBanner, { onGoToWallet: vi.fn() }))).toBe('')
+  })
+
+  it('keeps overdrawn and empty warnings in the page-level banner', () => {
+    queryMocks.wallet = { ongoingBalanceCents: -1 } as OrganizationWallet
+    expect(renderToStaticMarkup(createElement(BalanceLowBanner, { onGoToWallet: vi.fn() }))).toContain(
+      'Wallet overdrawn',
+    )
+
+    queryMocks.wallet = { ongoingBalanceCents: 0 } as OrganizationWallet
+    queryMocks.plan = { quotaRemainingCents: 0 } as OrganizationPlan
+    expect(renderToStaticMarkup(createElement(BalanceLowBanner, { onGoToWallet: vi.fn() }))).toContain('Wallet empty')
   })
 })

--- a/apps/dashboard/src/components/billing/BalanceLowBanner.tsx
+++ b/apps/dashboard/src/components/billing/BalanceLowBanner.tsx
@@ -72,6 +72,64 @@ function detail(warning: BalanceWarning): string {
   }
 }
 
+function BalanceWarningBanner({
+  balanceCents,
+  contained = false,
+  onAction,
+  warning,
+}: {
+  balanceCents: number
+  contained?: boolean
+  onAction?: () => void
+  warning: BalanceWarning
+}) {
+  const { title, destructive } = COPY[warning.level]
+  const tone = destructive ? 'destructive' : 'warning'
+
+  return (
+    <div
+      data-balance-warning-level={warning.level}
+      className={cn(
+        'flex flex-wrap items-center justify-between gap-4 border px-[22px] py-4',
+        contained && 'mt-4 w-full min-w-0 px-4 py-3 sm:px-[18px]',
+        destructive ? 'border-destructive/60 bg-destructive/10' : 'border-warning/60 bg-warning/10',
+      )}
+    >
+      <div className={cn('flex flex-col gap-1', contained && 'min-w-0')}>
+        <span
+          className={cn(
+            'flex items-center gap-2 font-mono text-[12px] font-semibold',
+            contained && 'items-start',
+            destructive ? 'text-destructive' : 'text-warning',
+          )}
+        >
+          <span
+            className={cn('size-[9px]', contained && 'mt-0.5 shrink-0')}
+            style={{ background: `hsl(var(--${tone}))` }}
+          />
+          {title(formatAmount(balanceCents))}
+        </span>
+        <span className={cn('font-mono text-[11px] text-muted-foreground', contained && 'break-words')}>
+          {detail(warning)}
+        </span>
+      </div>
+      {onAction && (
+        <button
+          className={cn(
+            'border px-4 py-2 font-mono text-[12px] transition-colors',
+            destructive
+              ? 'border-destructive/60 text-destructive hover:bg-destructive/10'
+              : 'border-warning/60 text-warning hover:bg-warning/10',
+          )}
+          onClick={onAction}
+        >
+          Top up →
+        </button>
+      )}
+    </div>
+  )
+}
+
 /**
  * Warns on a wallet that cannot fund what comes next. Suspension states are the
  * global banner's job (useSuspensionBanner), not repeated here.
@@ -80,41 +138,15 @@ export function BalanceLowBanner({ onGoToWallet }: { onGoToWallet: () => void })
   const { data: wallet } = useOwnerWalletQuery()
   const { data: plan } = useOwnerPlanQuery()
   const warning = balanceWarning(wallet, plan)
-  if (!wallet || !warning) return null
+  if (!wallet || !warning || warning.level === 'below-threshold') return null
 
-  const { title, destructive } = COPY[warning.level]
-  const tone = destructive ? 'destructive' : 'warning'
+  return <BalanceWarningBanner balanceCents={wallet.ongoingBalanceCents} onAction={onGoToWallet} warning={warning} />
+}
 
-  return (
-    <div
-      className={cn(
-        'flex flex-wrap items-center justify-between gap-4 border px-[22px] py-4',
-        destructive ? 'border-destructive/60 bg-destructive/10' : 'border-warning/60 bg-warning/10',
-      )}
-    >
-      <div className="flex flex-col gap-1">
-        <span
-          className={cn(
-            'flex items-center gap-2 font-mono text-[12px] font-semibold',
-            destructive ? 'text-destructive' : 'text-warning',
-          )}
-        >
-          <span className="size-[9px]" style={{ background: `hsl(var(--${tone}))` }} />
-          {title(formatAmount(wallet.ongoingBalanceCents))}
-        </span>
-        <span className="font-mono text-[11px] text-muted-foreground">{detail(warning)}</span>
-      </div>
-      <button
-        className={cn(
-          'border px-4 py-2 font-mono text-[12px] transition-colors',
-          destructive
-            ? 'border-destructive/60 text-destructive hover:bg-destructive/10'
-            : 'border-warning/60 text-warning hover:bg-warning/10',
-        )}
-        onClick={onGoToWallet}
-      >
-        Top up →
-      </button>
-    </div>
-  )
+/** Contextual threshold warning for the Wallet Balance panel. */
+export function BalanceThresholdBanner({ wallet, plan }: { wallet: WalletFacts; plan?: PlanFacts | null }) {
+  const warning = balanceWarning(wallet, plan)
+  if (!warning || warning.level !== 'below-threshold') return null
+
+  return <BalanceWarningBanner balanceCents={wallet.ongoingBalanceCents} contained warning={warning} />
 }

--- a/apps/dashboard/src/components/billing/UsageSection.tsx
+++ b/apps/dashboard/src/components/billing/UsageSection.tsx
@@ -5,7 +5,6 @@
  */
 
 import { Panel, SectionTitle } from '@/components/ascii'
-import { BalanceLowBanner } from '@/components/billing/BalanceLowBanner'
 import { CostOverTime } from '@/components/billing/CostOverTime'
 import { ThisCycleCard } from '@/components/billing/ThisCycleCard'
 import { ConcurrencyTimeline } from '@/components/billing/ConcurrencyTimeline'
@@ -32,12 +31,12 @@ const analyticsQuickRanges: QuickRangesConfig = {
 
 /**
  * The Usage tab, on the billing service's own numbers (Subscription.md v2):
- * a low-balance warning, the current cycle's quota meter, and cost split by
- * who funded it — then the analytics-backed resource sections when an
- * analytics deployment exists. Everything shown is served state; sections
- * whose data has no API stay absent rather than invented.
+ * the current cycle's quota meter and cost split by who funded it — then the
+ * analytics-backed resource sections when an analytics deployment exists.
+ * Everything shown is served state; sections whose data has no API stay absent
+ * rather than invented.
  */
-export function UsageSection({ onGoToWallet }: { onGoToWallet: () => void }) {
+export function UsageSection() {
   const { selectedOrganization } = useSelectedOrganization()
   const config = useConfig()
   const spendingEnabled = useFeatureFlagEnabled(FeatureFlags.BOX_SPENDING)
@@ -80,7 +79,6 @@ export function UsageSection({ onGoToWallet }: { onGoToWallet: () => void }) {
 
   return (
     <div className="flex flex-col gap-8">
-      <BalanceLowBanner onGoToWallet={onGoToWallet} />
       <ThisCycleCard />
       <CostOverTime />
       <ConcurrencyTimeline />

--- a/apps/dashboard/src/components/billing/WalletSection.integration.test.tsx
+++ b/apps/dashboard/src/components/billing/WalletSection.integration.test.tsx
@@ -7,6 +7,7 @@
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AutomaticTopUp } from '@/billing-api/types/OrganizationWallet'
 import { WalletSection } from './WalletSection'
 
 const mocks = vi.hoisted(() => ({
@@ -22,6 +23,7 @@ const mocks = vi.hoisted(() => ({
   setAutomaticTopUp: vi.fn(),
   topUpWallet: vi.fn(),
   wallet: {
+    automaticTopUp: undefined as AutomaticTopUp | undefined,
     balanceCents: 0,
     ongoingBalanceCents: 0,
     name: 'Wallet',
@@ -43,6 +45,7 @@ vi.mock('@/hooks/queries/billingQueries', () => ({
   useOwnerBillingPortalUrlQuery: () => ({ data: undefined, isLoading: false }),
   useOwnerInvoicesQuery: () => ({ data: { items: [], totalItems: 0, totalPages: 0 }, isLoading: false }),
   useOwnerPaymentMethodsQuery: () => ({ data: mocks.paymentMethods, isLoading: false, isError: false }),
+  useOwnerPlanQuery: () => ({ data: { quotaRemainingCents: 0 } }),
   useOwnerWalletQuery: () => ({ data: mocks.wallet, isLoading: false }),
 }))
 
@@ -80,6 +83,8 @@ describe('WalletSection top-up checkout', () => {
   beforeEach(() => {
     globalThis.IS_REACT_ACT_ENVIRONMENT = true
     mocks.paymentMethods = []
+    mocks.wallet.automaticTopUp = undefined
+    mocks.wallet.ongoingBalanceCents = 0
     mocks.wallet.creditCardConnected = false
     mocks.topUpWallet.mockClear()
     mocks.topUpWallet.mockResolvedValue({ url: 'https://checkout.stripe.com/pay/cs_top_up' })
@@ -209,5 +214,30 @@ describe('WalletSection top-up checkout', () => {
     // divider reach the panel's right edge instead of stopping at an action rail.
     expect(rows[0].contains(updateButtons[0])).toBe(true)
     expect(document.body.textContent).not.toContain('pm_default')
+  })
+
+  it('fits the threshold warning below Auto-reload inside Wallet Balance', async () => {
+    mocks.wallet.ongoingBalanceCents = 1_999
+    mocks.wallet.automaticTopUp = { thresholdAmount: 20, targetAmount: 100 }
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+
+    await act(async () => {
+      root = createRoot(host)
+      root.render(<WalletSection />)
+    })
+    await flush()
+
+    const autoReload = [...document.querySelectorAll<HTMLButtonElement>('button')].find((button) =>
+      button.textContent?.includes('Auto-reload'),
+    )
+    const banner = document.querySelector<HTMLElement>('[data-balance-warning-level="below-threshold"]')
+
+    expect(autoReload).toBeDefined()
+    expect(banner).not.toBeNull()
+    expect(banner?.parentElement).toBe(autoReload?.parentElement)
+    expect(autoReload?.compareDocumentPosition(banner as Node) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(banner?.classList.contains('w-full')).toBe(true)
+    expect(banner?.classList.contains('min-w-0')).toBe(true)
   })
 })

--- a/apps/dashboard/src/components/billing/WalletSection.tsx
+++ b/apps/dashboard/src/components/billing/WalletSection.tsx
@@ -6,6 +6,7 @@
 
 import { AutomaticTopUp } from '@/billing-api/types/OrganizationWallet'
 import { AsciiButton, AsciiChip, BRAND, Panel, PanelNote, SectionTitle, SegmentedBar } from '@/components/ascii'
+import { BalanceThresholdBanner } from '@/components/billing/BalanceLowBanner'
 import { InvoicesTable } from '@/components/Invoices'
 import { Input } from '@/components/ui/input'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -19,6 +20,7 @@ import {
   useOwnerBillingPortalUrlQuery,
   useOwnerInvoicesQuery,
   useOwnerPaymentMethodsQuery,
+  useOwnerPlanQuery,
   useOwnerWalletQuery,
 } from '@/hooks/queries/billingQueries'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
@@ -73,6 +75,7 @@ export function WalletSection() {
   const billingPortalUrlQuery = useOwnerBillingPortalUrlQuery()
   const invoicesQuery = useOwnerInvoicesQuery(invoicesPagination.pageIndex + 1, invoicesPagination.pageSize)
   const paymentMethodsQuery = useOwnerPaymentMethodsQuery()
+  const planQuery = useOwnerPlanQuery()
 
   const isCheckoutUrlLoading = useIsOwnerCheckoutUrlFetching()
   const fetchCheckoutUrl = useFetchOwnerCheckoutUrlQuery()
@@ -458,6 +461,8 @@ export function WalletSection() {
                     </p>
                   ))}
               </>
+
+              <BalanceThresholdBanner wallet={wallet} plan={planQuery.data} />
 
               {user?.profile.email_verified && (
                 <>

--- a/apps/dashboard/src/pages/Billing.test.tsx
+++ b/apps/dashboard/src/pages/Billing.test.tsx
@@ -14,11 +14,20 @@ vi.mock('@/hooks/useConfig', () => ({
 }))
 
 vi.mock('@/components/billing/BillingAlerts', () => ({ BillingAlerts: () => null }))
+vi.mock('@/components/billing/BalanceLowBanner', () => ({
+  BalanceLowBanner: ({ onGoToWallet }: { onGoToWallet: () => void }) => (
+    <button data-testid="critical-balance-banner" onClick={onGoToWallet}>
+      Critical balance warning
+    </button>
+  ),
+}))
 vi.mock('@/components/billing/PlanSection', () => ({
   PlanSection: () => <div data-testid="plan-section">Plan section</div>,
 }))
 vi.mock('@/components/billing/UsageSection', () => ({ UsageSection: () => <div>Usage section</div> }))
-vi.mock('@/components/billing/WalletSection', () => ({ WalletSection: () => <div>Wallet section</div> }))
+vi.mock('@/components/billing/WalletSection', () => ({
+  WalletSection: () => <div data-testid="wallet-section">Wallet section</div>,
+}))
 
 function closestMaxWidthContainer(element: Element | null): Element | null {
   let current = element
@@ -63,5 +72,33 @@ describe('Billing layout', () => {
     expect(headingContainer).not.toBeNull()
     expect(closestMaxWidthContainer(tabs)).toBe(headingContainer)
     expect(closestMaxWidthContainer(activePanel)).toBe(headingContainer)
+  })
+
+  it('keeps critical balance warnings between the title and tabs in the wide-page container', () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+
+    act(() => {
+      root = createRoot(host)
+      root.render(<Billing />)
+    })
+
+    const heading = Array.from(document.querySelectorAll('h1')).find((element) => element.textContent === 'Billing')
+    const banner = document.querySelector('[data-testid="critical-balance-banner"]')
+    const tabs = document.querySelector('[data-slot="tabs-list"]')
+    const headingContainer = closestMaxWidthContainer(heading ?? null)
+
+    expect(banner).not.toBeNull()
+    expect(closestMaxWidthContainer(banner)).toBe(headingContainer)
+    expect(heading?.compareDocumentPosition(banner as Node) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(banner?.compareDocumentPosition(tabs as Node) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(banner?.parentElement?.classList.contains('mt-4')).toBe(true)
+    expect(banner?.parentElement?.classList.contains('w-full')).toBe(true)
+    expect(tabs?.classList.contains('mt-5')).toBe(true)
+
+    act(() => {
+      ;(banner as HTMLElement).click()
+    })
+    expect(document.querySelector('[data-testid="wallet-section"]')).not.toBeNull()
   })
 })

--- a/apps/dashboard/src/pages/Billing.tsx
+++ b/apps/dashboard/src/pages/Billing.tsx
@@ -5,6 +5,7 @@
  */
 
 import { BILLING_PAGE_CONTAINER } from '@/components/billing/billingLayout'
+import { BalanceLowBanner } from '@/components/billing/BalanceLowBanner'
 import { BillingAlerts } from '@/components/billing/BillingAlerts'
 import { PlanSection } from '@/components/billing/PlanSection'
 import { UsageSection } from '@/components/billing/UsageSection'
@@ -82,13 +83,12 @@ function BillingComingSoon() {
 
 /**
  * One page, three tabs — the arrangement in the design. Each tab is a section
- * that keeps its own hooks; this only composes and switches them. Alerts sit
- * inside Overview, where identity and payment-setup guidance belongs.
+ * that keeps its own hooks; this only composes and switches them. Critical wallet
+ * warnings stay above the tabs; identity and payment guidance stays in Overview.
  */
 function Billing() {
   const config = useConfig()
-  // Controlled, so a section can send the user to a sibling tab — the usage
-  // tab's low-balance banner tops up in the wallet tab.
+  // Controlled, so the page-level balance warning can send the user to Wallet.
   const [tab, setTab] = useState('overview')
 
   if (!config.billingApiUrl) {
@@ -100,6 +100,9 @@ function Billing() {
       <div className={BILLING_PAGE_CONTAINER}>
         <div className="pt-6">
           <h1 className="font-display text-2xl font-semibold leading-none tracking-tight">Billing</h1>
+          <div className="mt-4 w-full empty:hidden">
+            <BalanceLowBanner onGoToWallet={() => setTab('wallet')} />
+          </div>
           <TabsList className="mt-5 h-9 gap-0 rounded-none border border-border bg-transparent p-0">
             <TabsTrigger value="overview" className={TAB_TRIGGER}>
               Overview
@@ -122,7 +125,7 @@ function Billing() {
         </TabsContent>
         <TabsContent value="usage">
           <div className={TAB_PANE}>
-            <UsageSection onGoToWallet={() => setTab('wallet')} />
+            <UsageSection />
           </div>
         </TabsContent>
         <TabsContent value="wallet">


### PR DESCRIPTION
## Summary

Wallet balance warnings were confined to the Usage tab and treated every
severity as page-global. Keep overdrawn and empty warnings visible across
Billing while placing the below-threshold warning beside its Auto-reload
setting in Wallet Balance.

## Call graph

Before

```text
Billing (page · apps/dashboard/src/pages/Billing.tsx:89) — composes the billing tabs
└─ UsageSection (component · apps/dashboard/src/components/billing/UsageSection.tsx:39) — mounts the only balance warning
   └─ BalanceLowBanner (component · apps/dashboard/src/components/billing/BalanceLowBanner.tsx:80) — every severity is visible only in Usage and outside Wallet context
```

After

```text
Billing (page · apps/dashboard/src/pages/Billing.tsx:89) — composes the billing tabs
├─ BalanceLowBanner (component · apps/dashboard/src/components/billing/BalanceLowBanner.tsx:137) — renders overdrawn and empty above the tabs
│  └─ setTab (Billing · apps/dashboard/src/pages/Billing.tsx:104) — Top up selects Wallet
└─ WalletSection (component · apps/dashboard/src/components/billing/WalletSection.tsx:56) — renders Wallet Balance
   └─ BalanceThresholdBanner (component · apps/dashboard/src/components/billing/BalanceLowBanner.tsx:147) — renders below-threshold beneath Auto-reload
```

## Changes

- Move overdrawn and empty wallet warnings from Usage to the Billing header.
- Render below-threshold warnings beneath Auto-reload in Wallet Balance.
- Fit the contextual warning to the panel width and narrow screens.
- Cover severity routing, page placement, panel placement, and responsive width.

## How to verify

- `cd apps/dashboard && corepack yarn vitest run src/components/billing/BalanceLowBanner.test.ts src/components/billing/WalletSection.test.ts src/components/billing/WalletSection.integration.test.tsx src/pages/Billing.test.tsx` — 21/21 passed.
- `cd apps && corepack yarn prettier --check dashboard/src/components/billing/BalanceLowBanner.tsx dashboard/src/components/billing/BalanceLowBanner.test.ts dashboard/src/components/billing/WalletSection.tsx dashboard/src/components/billing/WalletSection.integration.test.tsx dashboard/src/pages/Billing.tsx dashboard/src/pages/Billing.test.tsx` — passed.
- `make lint:apps` — 0 errors; 41 existing warnings in untouched files.
- `cd apps && corepack yarn nx run dashboard:build` — production build passed.
- `git diff-tree --check HEAD^ HEAD` — passed.

## Risks / rollout

- Billing APIs, wallet data, and warning classification rules are unchanged.
- The full apps build remains blocked in Runner when `sdks/go/libboxlite.a`
  is absent; the focused Dashboard production build passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a page-level low-balance banner that guides users to the Wallet section.
  * Added a dedicated threshold warning within the Wallet balance panel.
  * Improved warning presentation for overdrawn, empty, and below-threshold balances.

* **Bug Fixes**
  * Low-balance warnings now appear in the appropriate location without duplicating alerts in the Usage section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->