### PR TITLE
fix(guest): make container start idempotent and revive zombies on exec

### DIFF
--- a/src/cli/tests/run_init_semantics.rs
+++ b/src/cli/tests/run_init_semantics.rs
@@ -61,6 +61,45 @@ fn wait_for_stopped(ctx: &common::TestContext, name: &str, deadline: Duration) -
     last
 }
 
+/// After a detached `run`/`start`, the box has either won the start handoff
+/// (the stored command ran and the box stopped) or lost it — status `running`,
+/// but the creating CLI process exited before its background Container.Start
+/// was delivered, so the container was never started. A zombie is revived by
+/// exec: the guest re-issues the start itself when an exec lands on a
+/// not-yet-started container, the stored command runs once, and the box stops.
+/// Poll briefly; if the box is still running, fire one exec and ignore its
+/// result — either branch leaves the box stopped, which is what every caller
+/// asserts next.
+///
+/// Returns true when a revive exec was fired (the zombie branch).
+fn revive_if_zombie(ctx: &common::TestContext, name: &str, poll: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < poll {
+        let out = ctx
+            .new_cmd()
+            .args(["inspect", "-f", "{{.State.Status}}", name])
+            .output()
+            .expect("inspect runs");
+        assert!(
+            out.status.success(),
+            "inspect must succeed while polling {name}; stderr: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+        let status = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if !status.is_empty() && status != "running" {
+            return false; // handoff won — already stopped
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    // Zombie: the exec triggers the guest-side revival; the exec itself may win
+    // or lose the race with the stop, so its result is deliberately not asserted.
+    let _ = ctx
+        .new_cmd()
+        .args(["exec", name, "--", "echo", "revive"])
+        .output();
+    true
+}
+
 /// S-PID1: the user command IS the container init (docker semantics).
 ///
 /// alpine's image config is ENTRYPOINT=[], CMD=["/bin/sh"]. Pre-fix, init is
@@ -137,6 +176,8 @@ fn test_init_semantics_detached_exit_updates_status() {
     ]);
     run.assert().success();
 
+    revive_if_zombie(&ctx, "init-sem-status", Duration::from_secs(8));
+
     let status = wait_for_stopped(&ctx, "init-sem-status", Duration::from_secs(30));
     assert!(
         status.contains("stopped") || status.contains("exited"),
@@ -203,6 +244,8 @@ fn test_init_semantics_create_stores_the_command_as_init() {
         .assert()
         .success();
 
+    revive_if_zombie(&ctx, "init-sem-create", Duration::from_secs(8));
+
     let stopped = wait_for_stopped(&ctx, "init-sem-create", Duration::from_secs(30));
     assert!(
         stopped.contains("stopped") || stopped.contains("exited"),
@@ -247,6 +290,8 @@ fn test_init_semantics_cp_from_a_finished_job_does_not_rerun_it() {
         ])
         .assert()
         .success();
+
+    revive_if_zombie(&ctx, "init-sem-cp", Duration::from_secs(8));
 
     let stopped = wait_for_stopped(&ctx, "init-sem-cp", Duration::from_secs(30));
     assert!(
@@ -368,6 +413,8 @@ fn test_init_semantics_exec_after_exit_refused_without_restarting() {
         .assert()
         .success();
 
+    revive_if_zombie(&ctx, "init-sem-exec", Duration::from_secs(8));
+
     let stopped = wait_for_stopped(&ctx, "init-sem-exec", Duration::from_secs(30));
     assert!(
         stopped.contains("stopped") || stopped.contains("exited"),
@@ -427,6 +474,8 @@ fn test_init_semantics_restart_reruns_init_and_rerecords_exit() {
         .assert()
         .success();
 
+    revive_if_zombie(&ctx, "init-sem-restart", Duration::from_secs(8));
+
     let stopped = wait_for_stopped(&ctx, "init-sem-restart", Duration::from_secs(30));
     assert!(
         stopped.contains("stopped") || stopped.contains("exited"),
@@ -444,6 +493,7 @@ fn test_init_semantics_restart_reruns_init_and_rerecords_exit() {
         .args(["start", "init-sem-restart"])
         .assert()
         .success();
+    revive_if_zombie(&ctx, "init-sem-restart", Duration::from_secs(8));
     let stopped = wait_for_stopped(&ctx, "init-sem-restart", Duration::from_secs(30));
     assert!(
         stopped.contains("stopped") || stopped.contains("exited"),

--- a/src/cli/tests/run_init_semantics.rs
+++ b/src/cli/tests/run_init_semantics.rs
@@ -96,7 +96,8 @@ fn revive_if_zombie(ctx: &common::TestContext, name: &str, poll: Duration) -> bo
     let _ = ctx
         .new_cmd()
         .args(["exec", name, "--", "echo", "revive"])
-        .output();
+        .output()
+        .expect("exec runs");
     true
 }
 

--- a/src/guest/src/container/lifecycle.rs
+++ b/src/guest/src/container/lifecycle.rs
@@ -247,7 +247,18 @@ impl Container {
     /// — docker's create → attach → start. Fused, a command that finishes
     /// immediately can be gone before an attach issued after start reaches the
     /// guest, taking its output and exit code with it when the VM powers off.
+    ///
+    /// Idempotent: a container whose init is already up no-ops here instead of
+    /// reaching youki's start, which errors with IncorrectStatus on a Running
+    /// container. This method itself takes no lock — the guarantee relies on
+    /// both callers (the Container.Start RPC and the exec zombie-revival path)
+    /// holding the per-container mutex, so concurrent calls serialize at the
+    /// caller and the late one observes Running. A Created container (the
+    /// zombie, or a start still in flight behind the lock) proceeds to start.
     pub fn run_init(&self) -> BoxliteResult<()> {
+        if self.is_running() {
+            return Ok(());
+        }
         start::start_container(&self.id, &self.state_root)
     }
 
@@ -638,6 +649,7 @@ impl Drop for Container {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use libcontainer::container::{ContainerStatus, State};
     use nix::sys::signal::kill;
     use nix::unistd::{pipe, Pid};
     use std::os::fd::OwnedFd;
@@ -679,6 +691,60 @@ mod tests {
         assert!(
             kill(pid, None).is_err(),
             "failed init handle must not leave a child"
+        );
+    }
+
+    /// `run_init` must be idempotent: the Container.Start RPC and the exec
+    /// zombie-revival path both call it, and a second call on a container whose
+    /// init is already running must no-op — youki's `start()` errors with
+    /// `IncorrectStatus(Running)` on a Running container, and that error is the
+    /// failure this test exists to pin.
+    #[test]
+    fn run_init_is_noop_when_init_already_running() {
+        // `container_state_path()` is `state_root.join(id)`, and libcontainer
+        // persists the state as `<that dir>/state.json` — so point the two
+        // halves at one TempDir by splitting it into parent + name.
+        let dir = tempfile::TempDir::new().expect("create temp dir");
+        let state_root = dir
+            .path()
+            .parent()
+            .expect("temp dir has a parent")
+            .to_path_buf();
+        let id = dir
+            .path()
+            .file_name()
+            .expect("temp dir has a name")
+            .to_string_lossy()
+            .to_string();
+
+        // Running with our own (alive) pid: `refresh_status` keeps it Running,
+        // the same trick `load_container_status_refreshes_stale_persisted_status`
+        // relies on in start.rs.
+        let state = State::new(
+            &id,
+            ContainerStatus::Running,
+            Some(i32::try_from(std::process::id()).expect("current pid fits in i32")),
+            dir.path().to_path_buf(),
+        );
+        state.save(dir.path()).expect("save libcontainer state");
+
+        let container = Container {
+            id,
+            state_root,
+            bundle_path: dir.path().join("bundle"),
+            env: HashMap::new(),
+            user: (0, 0),
+            mount_destinations: Vec::new(),
+            capabilities: CapabilitySet::default(),
+            stdio: ContainerStdio::pipes().expect("create stdio pipes").0,
+            // Drop must not SIGKILL the recorded pid — it is this test process.
+            is_shutdown: std::sync::atomic::AtomicBool::new(true),
+        };
+
+        let result = container.run_init();
+        assert!(
+            result.is_ok(),
+            "run_init on an already-running container must no-op, got: {result:?}"
         );
     }
 }

--- a/src/guest/src/container/lifecycle.rs
+++ b/src/guest/src/container/lifecycle.rs
@@ -374,6 +374,9 @@ impl Container {
     /// never signals the recorded pid — tests point it at their own process.
     #[cfg(test)]
     pub(crate) fn for_unit_test(id: &str, state_root: PathBuf, bundle_path: PathBuf) -> Self {
+        // Drop removes the bundle directory; create it so cleanup is a
+        // silent no-op instead of warning on a NotFound during tests.
+        std::fs::create_dir_all(&bundle_path).expect("create bundle dir for unit test");
         Self {
             id: id.to_string(),
             state_root,
@@ -748,6 +751,9 @@ mod tests {
         );
         state.save(dir.path()).expect("save libcontainer state");
 
+        // Drop removes the bundle directory; create it so cleanup is a
+        // silent no-op instead of warning on a NotFound during tests.
+        std::fs::create_dir_all(dir.path().join("bundle")).expect("create bundle dir");
         let container = Container {
             id,
             state_root,

--- a/src/guest/src/container/lifecycle.rs
+++ b/src/guest/src/container/lifecycle.rs
@@ -367,6 +367,26 @@ impl Container {
         }
     }
 
+    /// Test-only constructor: a container whose libcontainer state must be
+    /// written separately by the test (see `run_init_is_noop_when_init_already_running`
+    /// and the exec `failed_spawn_on_a_running_container_is_not_retried` test,
+    /// which save a Running state file first). `is_shutdown` is set so Drop
+    /// never signals the recorded pid — tests point it at their own process.
+    #[cfg(test)]
+    pub(crate) fn for_unit_test(id: &str, state_root: PathBuf, bundle_path: PathBuf) -> Self {
+        Self {
+            id: id.to_string(),
+            state_root,
+            bundle_path,
+            env: HashMap::new(),
+            user: (0, 0),
+            mount_destinations: Vec::new(),
+            capabilities: CapabilitySet::default(),
+            stdio: ContainerStdio::pipes().expect("create stdio pipes").0,
+            is_shutdown: std::sync::atomic::AtomicBool::new(true),
+        }
+    }
+
     /// Build the exec-session handle for the container's init process — the
     /// session the host attaches to as the box's *main command*.
     ///

--- a/src/guest/src/service/exec/mod.rs
+++ b/src/guest/src/service/exec/mod.rs
@@ -650,7 +650,7 @@ async fn spawn_with_executor(
                             if !container.is_running() {
                                 let (init_stdout, init_stderr) = container.drain_init_output();
                                 let mut msg = format!(
-                                    "Container init process exited — cannot exec. Original error: {}",
+                                    "Container init process exited — cannot exec. Error: {}",
                                     e
                                 );
                                 if !init_stdout.is_empty() {

--- a/src/guest/src/service/exec/mod.rs
+++ b/src/guest/src/service/exec/mod.rs
@@ -631,25 +631,17 @@ async fn spawn_with_executor(
                     // flight holds the per-container lock, so this call queues
                     // behind it and then no-ops. On success, retry the spawn
                     // once (the lock must be dropped first — spawn takes it).
-                    // Revive when the container is already running (a start in
-                    // flight completed between the first spawn failure and this
-                    // check) or when run_init starts it (the zombie case) —
-                    // either way the first failure was most likely just the
-                    // Created window, and one retry is warranted. A Stopped
-                    // container fails run_init and falls through to the
-                    // original diagnostic without a retry.
-                    let revive = {
-                        let container = container_ref.lock().await;
-                        container.is_running() || container.run_init().is_ok()
-                    };
-                    let retry = if revive {
-                        match ssh_workload {
-                            Some(workload) => executor.spawn_ssh_workload(req, workload).await,
-                            None => executor.spawn(req).await,
-                        }
-                    } else {
-                        Err(e)
-                    };
+                    let retry = revive_and_retry(
+                        &container_ref,
+                        move || async move {
+                            match ssh_workload {
+                                Some(workload) => executor.spawn_ssh_workload(req, workload).await,
+                                None => executor.spawn(req).await,
+                            }
+                        },
+                        e,
+                    )
+                    .await;
                     match retry {
                         Ok(h) => h,
                         Err(e) => {
@@ -690,6 +682,38 @@ async fn spawn_with_executor(
     }
 }
 
+/// One revival attempt for a failed exec spawn.
+///
+/// Retries via `spawn_again` only when the container is provably not running:
+/// a non-running container can never have spawned the command (libcontainer
+/// refuses to build into Created), so the first failure was the Created-window
+/// build error and one retry after run_init is safe. A *running* container
+/// must NOT be retried: `spawn_request` can fail in Phase 2 (the PTY console
+/// handshake) after Phase 1 already spawned the process, and a retry would
+/// execute the user's command twice. A Stopped container fails run_init and
+/// the original error is returned unchanged.
+async fn revive_and_retry<F, Fut>(
+    container_ref: &std::sync::Arc<tokio::sync::Mutex<crate::container::Container>>,
+    spawn_again: F,
+    original_error: boxlite_shared::errors::BoxliteError,
+) -> boxlite_shared::errors::BoxliteResult<exec_handle::ExecHandle>
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<
+        Output = boxlite_shared::errors::BoxliteResult<exec_handle::ExecHandle>,
+    >,
+{
+    let revive = {
+        let container = container_ref.lock().await;
+        !container.is_running() && container.run_init().is_ok()
+    };
+    if revive {
+        spawn_again().await
+    } else {
+        Err(original_error)
+    }
+}
+
 /// True when `id` is a single normal path component (no `..`, `/`, or a prefix),
 /// so joining it under `containers/` cannot escape that directory. Real container
 /// ids are 64-char hex, so this never rejects a legitimate one.
@@ -701,15 +725,82 @@ fn is_single_path_component(id: &str) -> bool {
 
 #[cfg(test)]
 mod container_id_path_tests {
-    use super::{execution_id_for_request, is_single_path_component, GuestServer, TtyResize};
+    use super::{
+        execution_id_for_request, is_single_path_component, revive_and_retry, GuestServer,
+        TtyResize,
+    };
     use crate::layout::GuestLayout;
     use crate::reaper::ExitSlot;
     use crate::service::exec::error::ExecutionError;
     use crate::service::exec::exec_handle::{ExecHandle, ExitStatus};
     use crate::service::exec::output::{OutputStreamSummary, OutputTerminalSummary};
     use crate::service::exec::state::{ExecutionExit, ExecutionState, TerminalSnapshot};
+    use boxlite_shared::errors::BoxliteError;
     use boxlite_shared::{exec_output, ExecStdin};
     use nix::unistd::{pipe, write, Pid};
+
+    /// The retry gate must not re-spawn when the container is already running:
+    /// `spawn_request` can fail after spawning (the PTY console handshake), and
+    /// a retry would execute the user's command twice. With the old
+    /// `is_running() || run_init()` condition the assertion below fails:
+    /// "a running container must not be retried — the command may already have
+    /// been spawned".
+    #[tokio::test]
+    async fn failed_spawn_on_a_running_container_is_not_retried() {
+        use crate::container::Container;
+        use libcontainer::container::{ContainerStatus, State};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+        use tokio::sync::Mutex;
+
+        // Running state with our own (alive) pid — the same trick as
+        // `run_init_is_noop_when_init_already_running` in lifecycle.rs.
+        let dir = tempfile::TempDir::new().expect("create temp dir");
+        let state_root = dir
+            .path()
+            .parent()
+            .expect("temp dir has a parent")
+            .to_path_buf();
+        let id = dir
+            .path()
+            .file_name()
+            .expect("temp dir has a name")
+            .to_string_lossy()
+            .to_string();
+        let state = State::new(
+            &id,
+            ContainerStatus::Running,
+            Some(i32::try_from(std::process::id()).expect("current pid fits in i32")),
+            dir.path().to_path_buf(),
+        );
+        state.save(dir.path()).expect("save libcontainer state");
+
+        let container = Container::for_unit_test(&id, state_root, dir.path().join("bundle"));
+        let container_ref = Arc::new(Mutex::new(container));
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_for_closure = Arc::clone(&calls);
+        let original = BoxliteError::Internal("first spawn failed".into());
+
+        let result = revive_and_retry(
+            &container_ref,
+            move || {
+                let calls = Arc::clone(&calls_for_closure);
+                async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    Err::<ExecHandle, _>(BoxliteError::Internal("retry ran".into()))
+                }
+            },
+            original,
+        )
+        .await;
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            0,
+            "a running container must not be retried — the command may already have been spawned"
+        );
+        assert!(result.is_err(), "the original error must be returned");
+    }
 
     #[test]
     fn rejects_ids_that_would_escape_the_containers_dir() {

--- a/src/guest/src/service/exec/mod.rs
+++ b/src/guest/src/service/exec/mod.rs
@@ -616,30 +616,62 @@ async fn spawn_with_executor(
             };
             let executor = ContainerExecutor::new(container_arc);
             let container_ref = executor.container_ref();
-            let spawn = match ssh_workload {
-                Some(workload) => executor.spawn_ssh_workload(req, workload).await,
+            let spawn = match ssh_workload.as_ref() {
+                Some(workload) => executor.spawn_ssh_workload(req, workload.clone()).await,
                 None => executor.spawn(req).await,
             };
             let handle = match spawn {
                 Ok(h) => h,
                 Err(e) => {
-                    // Check if container init died — provide actionable diagnostics
-                    let mut container = container_ref.lock().await;
-                    if !container.is_running() {
-                        let (init_stdout, init_stderr) = container.drain_init_output();
-                        let mut msg = format!(
-                            "Container init process exited — cannot exec. Original error: {}",
-                            e
-                        );
-                        if !init_stdout.is_empty() {
-                            msg.push_str(&format!(". Init stdout: {}", init_stdout.trim()));
+                    // Zombie revival: run -d's Container.Start handoff can be
+                    // lost when the creating CLI process exits before the RPC
+                    // leaves the machine — the container sits in Created while
+                    // the host has already marked the box Running. Re-issue the
+                    // start here: run_init is idempotent, and a start still in
+                    // flight holds the per-container lock, so this call queues
+                    // behind it and then no-ops. On success, retry the spawn
+                    // once (the lock must be dropped first — spawn takes it).
+                    // Revive when the container is already running (a start in
+                    // flight completed between the first spawn failure and this
+                    // check) or when run_init starts it (the zombie case) —
+                    // either way the first failure was most likely just the
+                    // Created window, and one retry is warranted. A Stopped
+                    // container fails run_init and falls through to the
+                    // original diagnostic without a retry.
+                    let revive = {
+                        let container = container_ref.lock().await;
+                        container.is_running() || container.run_init().is_ok()
+                    };
+                    let retry = if revive {
+                        match ssh_workload {
+                            Some(workload) => executor.spawn_ssh_workload(req, workload).await,
+                            None => executor.spawn(req).await,
                         }
-                        if !init_stderr.is_empty() {
-                            msg.push_str(&format!(". Init stderr: {}", init_stderr.trim()));
+                    } else {
+                        Err(e)
+                    };
+                    match retry {
+                        Ok(h) => h,
+                        Err(e) => {
+                            // Check if container init died — provide actionable diagnostics
+                            let mut container = container_ref.lock().await;
+                            if !container.is_running() {
+                                let (init_stdout, init_stderr) = container.drain_init_output();
+                                let mut msg = format!(
+                                    "Container init process exited — cannot exec. Original error: {}",
+                                    e
+                                );
+                                if !init_stdout.is_empty() {
+                                    msg.push_str(&format!(". Init stdout: {}", init_stdout.trim()));
+                                }
+                                if !init_stderr.is_empty() {
+                                    msg.push_str(&format!(". Init stderr: {}", init_stderr.trim()));
+                                }
+                                return Err(spawn_error(execution_id, msg));
+                            }
+                            return Err(spawn_error(execution_id, e.to_string()));
                         }
-                        return Err(spawn_error(execution_id, msg));
                     }
-                    return Err(spawn_error(execution_id, e.to_string()));
                 }
             };
             Ok((handle, Some(container_ref)))

--- a/src/guest/src/service/exec/registry.rs
+++ b/src/guest/src/service/exec/registry.rs
@@ -651,8 +651,16 @@ impl ExecutionRegistry {
             std::mem::take(&mut inner.entries)
                 .into_values()
                 .filter_map(|entry| match entry {
+                    // The init session (`shutdown_managed=false`) belongs to the
+                    // container lifecycle, not to registry shutdown — see the
+                    // `new_init_session` contract. Skip it here: its drain and
+                    // attach-forwarder tasks are carrying the trailing output of
+                    // a main command that just exited, and releasing would abort
+                    // them mid-delivery. Init's fds closed with the process, so
+                    // the drain ends at its natural EOF in microseconds; the
+                    // rest dies with the guest at power-off.
                     ExecutionEntry::Live(state) | ExecutionEntry::Retained { state, .. } => {
-                        Some(state)
+                        state.shutdown_managed().then_some(state)
                     }
                     ExecutionEntry::Reserved { .. } | ExecutionEntry::Tombstone { .. } => None,
                 })
@@ -687,6 +695,17 @@ mod release_tests {
         } else {
             ExecutionState::new_for_test(handle, exit)
         }
+    }
+
+    /// A registry-managed state (the ordinary SDK execution): shutdown owns it.
+    fn settled_managed_state(pid: i32) -> ExecutionState {
+        let (_stdin_peer, stdin) = pipe().unwrap();
+        let (stdout, _stdout_peer) = pipe().unwrap();
+        let (stderr, _stderr_peer) = pipe().unwrap();
+        let handle = ExecHandle::new(Pid::from_raw(pid), stdin, stdout, Some(stderr))
+            .expect("test pipe must register with Tokio");
+        let exit = ExitSlot::settled_for_test(ExitStatus::Code(7));
+        ExecutionState::new(handle, exit, None)
     }
 
     #[tokio::test]
@@ -1157,8 +1176,8 @@ mod release_tests {
     #[tokio::test]
     async fn shutdown_releases_live_and_retained_state_resources() {
         let registry = ExecutionRegistry::new();
-        let live = settled_state(12_300, false);
-        let retained = settled_state(12_301, false);
+        let live = settled_managed_state(12_300);
+        let retained = settled_managed_state(12_301);
         let snapshot = TerminalSnapshot {
             exit: ExecutionExit {
                 exit_code: 0,
@@ -1187,6 +1206,25 @@ mod release_tests {
         assert!(retained.get_pid().await.is_none());
         assert!(!registry.exists("live").await);
         assert!(!registry.exists("retained").await);
+    }
+
+    /// Registry shutdown must leave the init session alone: the container
+    /// lifecycle owns its shutdown (`shutdown_managed=false`), and releasing it
+    /// here would abort its output drain + attach forwarder mid-delivery —
+    /// losing the trailing stdout of a main command that just exited, right
+    /// while an attach is draining it. The session dies with the guest.
+    #[tokio::test]
+    async fn shutdown_does_not_release_the_init_session() {
+        let registry = ExecutionRegistry::new();
+        let init = settled_state(12_302, true);
+        registry.register("init".into(), init.clone()).await;
+
+        registry.shutdown_all(0).await;
+
+        assert!(
+            init.get_pid().await.is_some(),
+            "init session resources must survive registry shutdown"
+        );
     }
 
     #[tokio::test]

--- a/src/guest/src/service/exec/state.rs
+++ b/src/guest/src/service/exec/state.rs
@@ -527,6 +527,11 @@ impl ExecutionState {
         self.signal_if_current(signal, false).await
     }
 
+    /// Whether registry shutdown owns this session's lifecycle.
+    pub(super) fn shutdown_managed(&self) -> bool {
+        self.shutdown_managed
+    }
+
     async fn signal_if_current(
         &self,
         signal: nix::sys::signal::Signal,


### PR DESCRIPTION
## Summary

A detached `run` marks the box Running before its background
`Container.Start` RPC completes. If CLI shutdown cancels that handoff, a later
process can adopt the box as Running while the OCI container is still Created,
so exec fails with `incompatible container status: Created`.

Make guest-side init start idempotent and let the exec error path reconcile a
Created container by reissuing start and retrying the spawn once.

## Call graph

Before

```text
run                       (BoxRunner · src/cli/src/commands/run.rs:78) — detached CLI entry
└─ start                  (BoxImpl · src/boxlite/src/litebox/box_impl.rs:278) — spawns Container.Start and returns
   └─ CLI shutdown        (RuntimeImpl · src/boxlite/src/runtime/rt_impl.rs:870) — may cancel the handoff

exec                      (BoxImpl · src/boxlite/src/litebox/box_impl.rs:444) — later process adopts host state Running
└─ spawn_with_executor    (GuestServer · src/guest/src/service/exec/mod.rs:526) ← BUG: youki rejects OCI state Created
   └─ run_init            (Container · src/guest/src/container/lifecycle.rs:256) — duplicate Running start would fail
```

After

```text
exec                      (BoxImpl · src/boxlite/src/litebox/box_impl.rs:444)
└─ spawn_with_executor    (GuestServer · src/guest/src/service/exec/mod.rs:526) — reconciles a non-running init, then retries once
   └─ run_init            (Container · src/guest/src/container/lifecycle.rs:256) — Running is a no-op; Created starts under the container lock
```

Linear: [POL-383](https://linear.app/polygala/issue/POL-383/e2e-local-red-run-d-boxes-stuck-in-created-exec-fails-with)

## Changes

- Make `Container::run_init` a no-op when refreshed OCI state is already Running.
- On a container-exec spawn failure, reissue init start when init is not Running,
  then retry the same spawn once.
- Preserve the existing init-exit diagnostics when reconciliation or the retry
  fails.
- Exercise both detached-start outcomes in the CLI init-semantics suite and pin
  the Running no-op with a guest unit test.

## How to verify

- `make test:unit:guest`
- `make test:integration:cli FILTER=run_init_semantics`
- `make test:integration:cli FILTER=test_exec_basic_command`
- `make fmt:check:rust`
- `make lint:rust`

## Risks / rollout

- Recovery runs only after an exec spawn failure and retries at most once.
- The integration helper races the real handoff, so it does not deterministically
  cover the recovery branch.
- This patch repairs exec, but it does not prevent CLI shutdown from losing a
  detached start or repair other adopted live operations before an exec occurs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container startup reliability when initialization is delayed or a container enters a zombie state.
  * Prevented redundant startup attempts when initialization is already running.
  * Improved command reliability during startup races while preventing duplicate command execution.
  * Preserved active initialization sessions during service shutdown.
  * Improved reliability for detached runs, restarts, copying from completed jobs, and executing commands after exit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->