### PR TITLE
fix(api): deadline status-sync reads and retire orphaned alerts safely

### DIFF
--- a/apps/api/src/status-sync/services/status-sync.service.spec.ts
+++ b/apps/api/src/status-sync/services/status-sync.service.spec.ts
@@ -457,16 +457,86 @@ describe('StatusSyncService', () => {
     expect(harness.knownIds.has('box-ingress-eu')).toBe(false)
   })
 
-  it('drops a vanished component that was already resolved without sending', async () => {
+  // Resolved-state orphans get the resolve too: stored state can lag reality
+  // by one failed write, and a redundant resolved event is an idempotent
+  // no-op under the dedup key.
+  it('retires a vanished component even when its stored state says resolved', async () => {
     const harness = makeService()
     seedAllResolved(harness)
     seed(harness, 'boxes-eu', 'resolved')
 
     await harness.service.syncStatus()
 
-    expect(harness.incidentIoClient.sendAlertEvent).not.toHaveBeenCalled()
+    expect(harness.incidentIoClient.sendAlertEvent).toHaveBeenCalledTimes(1)
+    expect(harness.incidentIoClient.sendAlertEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'resolved', deduplicationKey: 'boxlite-test-boxes-eu' }),
+    )
     expect(harness.store.has('status-sync:component:boxes-eu')).toBe(false)
     expect(harness.knownIds.has('boxes-eu')).toBe(false)
+  })
+
+  // A stalled DB read must reject the evaluator instead of holding the
+  // self-renewing lease forever and blocking every later tick.
+  it('deadlines a hung runner query and keeps the rest of the tick alive', async () => {
+    const harness = makeService({ 'incidentIo.probeTimeoutMs': 20 })
+    seed(harness, 'boxes-eu', 'firing') // must NOT be retired on a partial tick
+    harness.runnerRepository.find.mockReturnValue(new Promise(() => undefined))
+
+    await harness.service.syncStatus()
+
+    const keys = harness.incidentIoClient.sendAlertEvent.mock.calls.map(([event]) => event.deduplicationKey)
+    expect(keys).toEqual(['boxlite-test-api', 'boxlite-test-box-ingress-us'])
+    expect(harness.redis.smembers).not.toHaveBeenCalled()
+    expect(harness.store.has('status-sync:component:boxes-eu')).toBe(true)
+    expect(harness.incidentIoClient.pingHeartbeat).toHaveBeenCalledTimes(1)
+  })
+
+  // The send-lands-but-state-write-fails corner: the id is registered before
+  // the send, so when the component then vanishes, the sweep can still
+  // resolve the orphaned alert even though no state was ever written.
+  it('retires a component whose firing send landed but whose state write failed', async () => {
+    const harness = makeService()
+    seed(harness, 'api', 'resolved')
+    seed(harness, 'boxes-us', 'resolved')
+    seed(harness, 'box-ingress-us', 'resolved')
+    seed(harness, 'box-ingress-eu', 'resolved', 2) // one bad tick from the threshold
+    harness.regionRepository.find.mockResolvedValueOnce([usRegion, euRegion]) // boxes evaluator
+    harness.regionRepository.find.mockResolvedValueOnce([usRegion, euRegion]) // ingress evaluator
+    probeGet.mockImplementation(async (url: string) => {
+      if (url === 'https://proxy.eu.test/health') {
+        throw Object.assign(new Error('timeout'), { isAxiosError: true, code: 'ECONNABORTED' })
+      }
+      return { status: 200 }
+    })
+    // The firing send succeeds, then that component's state write fails.
+    harness.redis.set.mockImplementation(async (key: string, value: string) => {
+      if (key === 'status-sync:component:box-ingress-eu') {
+        throw new Error('redis write failed')
+      }
+      harness.store.set(key, value)
+      return 'OK'
+    })
+
+    await expect(harness.service.syncStatus()).rejects.toThrow('redis write failed')
+    expect(harness.incidentIoClient.sendAlertEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'firing', deduplicationKey: 'boxlite-test-box-ingress-eu' }),
+    )
+    // The failed write leaves the stale pre-send state behind; only the
+    // pre-send set registration reflects reality.
+    expect(harness.store.get('status-sync:component:box-ingress-eu')).toBe(
+      JSON.stringify({ sent: 'resolved', streak: 2 }),
+    )
+    expect(harness.knownIds.has('box-ingress-eu')).toBe(true)
+
+    // Next tick: the eu region is gone — the sweep must resolve the orphan.
+    harness.incidentIoClient.sendAlertEvent.mockClear()
+    harness.regionRepository.find.mockResolvedValue([usRegion])
+    await harness.service.syncStatus()
+
+    expect(harness.incidentIoClient.sendAlertEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'resolved', deduplicationKey: 'boxlite-test-box-ingress-eu' }),
+    )
+    expect(harness.knownIds.has('box-ingress-eu')).toBe(false)
   })
 
   it('keeps a vanished firing component when the retirement send fails', async () => {

--- a/apps/api/src/status-sync/services/status-sync.service.ts
+++ b/apps/api/src/status-sync/services/status-sync.service.ts
@@ -204,15 +204,18 @@ export class StatusSyncService implements TrackableJobExecutions, OnApplicationS
     // INITIALIZING is the birth state (fleet expansion must not page) and
     // DISABLED/DECOMMISSIONED/unschedulable/draining are operator intent —
     // only runners meant to carry traffic count.
-    const runners = await this.runnerRepository.find({
-      select: ['region', 'state'],
-      where: {
-        region: In(sharedRegionIds),
-        state: In([RunnerState.READY, RunnerState.UNRESPONSIVE]),
-        unschedulable: false,
-        draining: false,
-      },
-    })
+    const runners = await this.withDeadline(
+      this.runnerRepository.find({
+        select: ['region', 'state'],
+        where: {
+          region: In(sharedRegionIds),
+          state: In([RunnerState.READY, RunnerState.UNRESPONSIVE]),
+          unschedulable: false,
+          draining: false,
+        },
+      }),
+      'runner query',
+    )
 
     const byRegion = new Map<string, { total: number; unresponsive: number }>()
     for (const runner of runners) {
@@ -253,7 +256,26 @@ export class StatusSyncService implements TrackableJobExecutions, OnApplicationS
 
   /** Dedicated/custom regions are org-scoped — never on the public page. */
   private sharedRegions(): Promise<Region[]> {
-    return this.regionRepository.find({ where: { regionType: RegionType.SHARED } })
+    return this.withDeadline(this.regionRepository.find({ where: { regionType: RegionType.SHARED } }), 'region query')
+  }
+
+  /**
+   * TypeORM sets no statement timeout, and the tick's lease renews itself for
+   * as long as work runs — so a stalled read would block every later tick
+   * forever. A deadline turns the stall into a rejected evaluator (logged,
+   * skipped, sweep withheld) instead.
+   */
+  private async withDeadline<T>(operation: Promise<T>, label: string): Promise<T> {
+    const timeoutMs = this.configService.get('incidentIo.probeTimeoutMs')
+    let timeout: ReturnType<typeof setTimeout> | undefined
+    const deadline = new Promise<never>((_, reject) => {
+      timeout = setTimeout(() => reject(new Error(`${label} exceeded ${timeoutMs}ms`)), timeoutMs)
+    })
+    try {
+      return await Promise.race([operation, deadline])
+    } finally {
+      clearTimeout(timeout)
+    }
   }
 
   /**
@@ -275,6 +297,10 @@ export class StatusSyncService implements TrackableJobExecutions, OnApplicationS
 
   private async reconcile(observation: ComponentObservation): Promise<void> {
     const observed: AlertStatus = observation.healthy ? 'resolved' : 'firing'
+    // Registered before any send: if the send lands but the state write then
+    // fails and the component vanishes, the retirement sweep still knows this
+    // id exists and can resolve the orphaned alert.
+    await this.redis.sadd(STATE_SET_KEY, observation.id)
     const state = await this.readState(observation.id)
 
     // Unknown last-sent state (first tick, or Redis lost it) is asymmetric on
@@ -327,15 +353,17 @@ export class StatusSyncService implements TrackableJobExecutions, OnApplicationS
         continue
       }
       signal.throwIfAborted()
-      const state = await this.readState(id)
-      if (state?.sent === 'firing') {
-        const retired = {
-          ...this.observationShape(id),
-          detail: 'Component no longer observed (region removed or fleet emptied); retiring.',
-        }
-        if (!(await this.send(retired, 'resolved'))) {
-          continue // keep the state; next tick retries the retirement
-        }
+      // Resolved unconditionally: stored state can lag reality by one failed
+      // write (a firing send that landed whose state write did not), so the
+      // stored value cannot prove the alert is not firing. A resolved event
+      // for an alert that never fired is an idempotent no-op under the
+      // dedup key.
+      const retired = {
+        ...this.observationShape(id),
+        detail: 'Component no longer observed (region removed or fleet emptied); retiring.',
+      }
+      if (!(await this.send(retired, 'resolved'))) {
+        continue // keep the state; next tick retries the retirement
       }
       await this.redis.del(`${STATE_KEY_PREFIX}${id}`)
       await this.redis.srem(STATE_SET_KEY, id)
@@ -383,9 +411,9 @@ export class StatusSyncService implements TrackableJobExecutions, OnApplicationS
     return null
   }
 
+  /** Membership in STATE_SET_KEY is written by reconcile before any send. */
   private async writeState(id: string, state: ComponentSendState): Promise<void> {
     await this.redis.set(`${STATE_KEY_PREFIX}${id}`, JSON.stringify(state), 'EX', STATE_TTL_SECONDS)
-    await this.redis.sadd(STATE_SET_KEY, id)
   }
 
   private async pingHeartbeat(): Promise<void> {

--- a/apps/infra/docs/status-page.md
+++ b/apps/infra/docs/status-page.md
@@ -65,7 +65,7 @@ Do these in order; the stage stays dark until the final step.
    ```sh
    read -rs INCIDENT_IO_KEY   # paste the key; no echo
    printf 'header = "Authorization: Bearer %s"\n' "$INCIDENT_IO_KEY" \
-     | curl -X POST https://api.incident.io/v2/heartbeat/<id>/ping -K -
+     | curl --fail --show-error -X POST https://api.incident.io/v2/heartbeat/<id>/ping -K -
    ```
 
    (a wrong path announces itself as an immediate heartbeat alarm).


### PR DESCRIPTION
## Summary
Closes the three review findings that landed on #1376 after it merged: status-sync DB reads get a deadline (a stalled query can no longer hold the self-renewing lease and freeze every later tick), the retirement sweep can no longer strand a firing alert when a state write fails, and the runbook's heartbeat check fails loudly on HTTP errors.

## Call graph

Before
```
syncStatus                (StatusSyncService · apps/api/src/status-sync/services/status-sync.service.ts:105)
  ├─ evaluateBoxes        (status-sync.service.ts:199)  ← BUG: runnerRepository.find has no deadline — a stalled
  │                                                        read holds the self-renewing lease, freezing every tick
  ├─ sharedRegions        (status-sync.service.ts:255)  ← BUG: same unbounded read
  ├─ reconcile            (status-sync.service.ts:276)  — send() first, then
  │    └─ writeState      (status-sync.service.ts:386)  ← BUG: set + SADD only after the send: a landed send whose
  │                                                        write fails leaves the id unregistered / state stale
  └─ retireVanished       (status-sync.service.ts:323)  ← BUG: resolves only ids whose STORED state says firing
                                                           → stale/lost state ⇒ incident.io alert stuck firing
```

After
```
syncStatus                (StatusSyncService · apps/api/src/status-sync/services/status-sync.service.ts:105)
  ├─ evaluateBoxes        (status-sync.service.ts:199)  — runner query wrapped in withDeadline (:268, probeTimeoutMs)
  ├─ sharedRegions        (status-sync.service.ts:258)  — region query deadlined the same way
  ├─ reconcile            (status-sync.service.ts:298)  — SADDs the id BEFORE any send (:303)
  │    └─ writeState      (status-sync.service.ts:415)  — set only; membership owned by reconcile
  └─ retireVanished       (status-sync.service.ts:349)  — resolves EVERY vanished known id, stored state ignored
                                                           (stale state can't prove no alert fires; redundant
                                                            resolved events are idempotent under the dedup key)
…
runbook                   (apps/infra/docs/status-page.md)  — heartbeat curl gains --fail --show-error
```

Fixes #1385

## Changes
- `withDeadline` helper on the two TypeORM reads; a stall rejects that evaluator (logged, skipped, sweep withheld) while the rest of the tick runs
- Pre-send known-set registration + unconditional retirement resolve; `writeState` no longer manages set membership
- Three new reproducers: hung-query deadline, send-landed-write-failed corner (two full ticks), resolved-state orphan retirement

## How to verify
- `cd apps && NX_DAEMON=false corepack yarn nx run api:test -- status-sync incident-io-config`
- Full: `NX_DAEMON=false corepack yarn nx run api:test`

https://claude.ai/code/session_01Ag7qdP7WvModnKM6tuRMCA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved alerts are now sent when a component disappears, including cases where its previous state was already resolved.
  * Status checks now continue safely when a runner query stalls or exceeds its deadline.
  * Alerts are recovered on a later check if delivery succeeds but state saving fails.

* **Documentation**
  * Improved heartbeat verification so failed responses are clearly reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->