### PR TITLE
fix(usage): atomically attribute warm-pool box claims

### DIFF
--- a/apps/api/src/box/box.module.ts
+++ b/apps/api/src/box/box.module.ts
@@ -51,12 +51,14 @@ import { BoxActivityService } from './services/box-activity.service'
 import { BoxStateWaiterService } from './services/box-state-waiter.service'
 import { BoxMigrationService } from './services/box-migration.service'
 import { BoxMigrationJobReceiver } from './services/box-migration-job-receiver.service'
+import { UsageModule } from '../usage/usage.module'
 
 @Module({
   imports: [
     UserModule,
     OrganizationModule,
     RegionModule,
+    UsageModule,
     TypeOrmModule.forFeature([Box, Runner, WarmPool, Volume, Region, Job, BoxLastActivity, BoxMigration]),
   ],
   controllers: [BoxController, RunnerController, PreviewController, VolumeController, JobController],

--- a/apps/api/src/box/managers/box-actions/box-destroy.action.ts
+++ b/apps/api/src/box/managers/box-actions/box-destroy.action.ts
@@ -14,6 +14,7 @@ import { RunnerAdapterFactory } from '../../runner-adapter/runnerAdapter'
 import { BoxRepository } from '../../repositories/box.repository'
 import { LockCode, RedisLockProvider } from '../../common/redis-lock.provider'
 import { WithSpan } from '../../../common/decorators/otel.decorator'
+import { UsageService } from '../../../usage/services/usage.service'
 
 @Injectable()
 export class BoxDestroyAction extends BoxAction {
@@ -22,8 +23,9 @@ export class BoxDestroyAction extends BoxAction {
     protected runnerAdapterFactory: RunnerAdapterFactory,
     protected boxRepository: BoxRepository,
     protected redisLockProvider: RedisLockProvider,
+    usageService: UsageService,
   ) {
-    super(runnerService, runnerAdapterFactory, boxRepository, redisLockProvider)
+    super(runnerService, runnerAdapterFactory, boxRepository, redisLockProvider, usageService)
   }
 
   @WithSpan()

--- a/apps/api/src/box/managers/box-actions/box-start.action.spec.ts
+++ b/apps/api/src/box/managers/box-actions/box-start.action.spec.ts
@@ -19,6 +19,31 @@ import { RunnerState } from '../../enums/runner-state.enum'
 import { LockCode } from '../../common/redis-lock.provider'
 
 describe('BoxStartAction.handleRunnerBoxStoppedStateOnDesiredStateStart', () => {
+  it('uses atomic STARTED persistence for the final runner state', async () => {
+    const box = new Box('region-1', 'started-box')
+    box.state = BoxState.STARTING
+    box.desiredState = BoxDesiredState.STARTED
+    box.pending = true
+    const lockCode = new LockCode('lock-started')
+    const boxRepository = { update: jest.fn() }
+    const transitionBoxToStarted = jest.fn().mockResolvedValue(box)
+    const action = Object.create(BoxStartAction.prototype) as BoxStartAction
+    Object.assign(action as any, {
+      boxRepository,
+      redisLockProvider: { getCode: jest.fn().mockResolvedValue(lockCode) },
+      usageService: { transitionBoxToStarted },
+      logger: { warn: jest.fn(), error: jest.fn() },
+    })
+
+    await (action as any).updateBoxState(box, BoxState.STARTED, lockCode, undefined, undefined, '1.2.3')
+
+    expect(transitionBoxToStarted).toHaveBeenCalledWith(box.id, {
+      updateData: { state: BoxState.STARTED, daemonVersion: '1.2.3' },
+      entity: box,
+    })
+    expect(boxRepository.update).not.toHaveBeenCalled()
+  })
+
   it('restarts a stopped box on its own runner (no cross-runner reassignment)', async () => {
     const ownRunnerId = 'runner-own-1'
 
@@ -74,6 +99,7 @@ describe('BoxStartAction.handleRunnerBoxStoppedStateOnDesiredStateStart', () => 
       {} as any, // configService
       redisLockProvider as any,
       {} as any, // boxActivityService
+      {} as any, // usageService
     )
 
     const result = await (action as BoxAction).run(box, lockCode)
@@ -116,6 +142,7 @@ describe('BoxStartAction.handleRunnerBoxStoppedStateOnDesiredStateStart', () => 
       organizationService as any,
       {} as any,
       redisLockProvider as any,
+      {} as any,
       {} as any,
     )
 
@@ -164,6 +191,7 @@ describe('BoxStartAction.handleRunnerBoxUnknownStateOnDesiredStateStart', () => 
       {} as any,
       redisLockProvider as any,
       {} as any,
+      {} as any,
     )
 
     const result = await (action as BoxAction).run(box, lockCode)
@@ -206,6 +234,7 @@ describe('BoxStartAction.handleRunnerBoxUnknownStateOnDesiredStateStart', () => 
       organizationService as any,
       {} as any,
       redisLockProvider as any,
+      {} as any,
       {} as any,
     )
 

--- a/apps/api/src/box/managers/box-actions/box-start.action.ts
+++ b/apps/api/src/box/managers/box-actions/box-start.action.ts
@@ -17,6 +17,7 @@ import { TypedConfigService } from '../../../config/typed-config.service'
 import { LockCode, RedisLockProvider } from '../../common/redis-lock.provider'
 import { WithSpan } from '../../../common/decorators/otel.decorator'
 import { BoxActivityService } from '../../services/box-activity.service'
+import { UsageService } from '../../../usage/services/usage.service'
 
 @Injectable()
 export class BoxStartAction extends BoxAction {
@@ -29,8 +30,9 @@ export class BoxStartAction extends BoxAction {
     protected readonly configService: TypedConfigService,
     protected readonly redisLockProvider: RedisLockProvider,
     private readonly boxActivityService: BoxActivityService,
+    usageService: UsageService,
   ) {
-    super(runnerService, runnerAdapterFactory, boxRepository, redisLockProvider)
+    super(runnerService, runnerAdapterFactory, boxRepository, redisLockProvider, usageService)
   }
 
   @WithSpan()

--- a/apps/api/src/box/managers/box-actions/box-stop.action.ts
+++ b/apps/api/src/box/managers/box-actions/box-stop.action.ts
@@ -14,6 +14,7 @@ import { RunnerAdapterFactory } from '../../runner-adapter/runnerAdapter'
 import { BoxRepository } from '../../repositories/box.repository'
 import { LockCode, RedisLockProvider } from '../../common/redis-lock.provider'
 import { WithSpan } from '../../../common/decorators/otel.decorator'
+import { UsageService } from '../../../usage/services/usage.service'
 
 @Injectable()
 export class BoxStopAction extends BoxAction {
@@ -22,8 +23,9 @@ export class BoxStopAction extends BoxAction {
     protected runnerAdapterFactory: RunnerAdapterFactory,
     protected boxRepository: BoxRepository,
     protected redisLockProvider: RedisLockProvider,
+    usageService: UsageService,
   ) {
-    super(runnerService, runnerAdapterFactory, boxRepository, redisLockProvider)
+    super(runnerService, runnerAdapterFactory, boxRepository, redisLockProvider, usageService)
   }
 
   @WithSpan()

--- a/apps/api/src/box/managers/box-actions/box.action.ts
+++ b/apps/api/src/box/managers/box-actions/box.action.ts
@@ -12,6 +12,7 @@ import { BoxRepository } from '../../repositories/box.repository'
 import { BoxState } from '../../enums/box-state.enum'
 import { getStateChangeLockKey } from '../../utils/lock-key.util'
 import { LockCode, RedisLockProvider } from '../../common/redis-lock.provider'
+import { UsageService } from '../../../usage/services/usage.service'
 
 export const SYNC_AGAIN = 'sync-again'
 export const DONT_SYNC_AGAIN = 'dont-sync-again'
@@ -26,6 +27,7 @@ export abstract class BoxAction {
     protected runnerAdapterFactory: RunnerAdapterFactory,
     protected readonly boxRepository: BoxRepository,
     protected readonly redisLockProvider: RedisLockProvider,
+    protected readonly usageService: UsageService,
   ) {}
 
   abstract run(box: Box, lockCode: LockCode): Promise<SyncState>
@@ -89,6 +91,11 @@ export abstract class BoxAction {
 
     if (recoverable !== undefined) {
       updateData.recoverable = recoverable
+    }
+
+    if (state === BoxState.STARTED) {
+      await this.usageService.transitionBoxToStarted(box.id, { updateData, entity: box })
+      return
     }
 
     await this.boxRepository.update(box.id, { updateData, entity: box })

--- a/apps/api/src/box/repositories/box.repository.spec.ts
+++ b/apps/api/src/box/repositories/box.repository.spec.ts
@@ -147,4 +147,45 @@ describe('BoxRepository.update transaction callback', () => {
     expect(eventEmitter.emit).not.toHaveBeenCalled()
     expect(cacheInvalidation.invalidate).not.toHaveBeenCalled()
   })
+
+  it('keeps conditional-update events post-commit when usage attribution fails', async () => {
+    const box = {
+      id: 'stopped-box',
+      organizationId: 'org-1',
+      name: 'stopped-box',
+      authToken: 'redacted',
+      state: BoxState.STOPPED,
+      desiredState: BoxDesiredState.STARTED,
+      pending: false,
+      public: false,
+      assertValid: jest.fn(),
+      enforceInvariants: jest.fn().mockReturnValue({}),
+    } as unknown as Box
+    const findOne = jest.fn().mockResolvedValue(box)
+    const update = jest.fn().mockResolvedValue({ affected: 1 })
+    const upsert = jest.fn().mockResolvedValue(undefined)
+    const entityManager = { findOne, update, upsert }
+    const transaction = jest.fn(async (callback: (manager: typeof entityManager) => Promise<unknown>) =>
+      callback(entityManager),
+    )
+    const eventEmitter = { emit: jest.fn() }
+    const dataSource = { getRepository: jest.fn(() => ({ manager: { transaction } })) }
+    const repository = new BoxRepository(dataSource as any, eventEmitter as any, {} as any)
+    const invalidate = jest.spyOn(repository as any, 'invalidateLookupCacheOnUpdate')
+    const periodError = new Error('injected full-resource period creation failure')
+    const afterUpdateInTransaction = jest.fn().mockRejectedValue(periodError)
+
+    await expect(
+      repository.updateWhere(box.id, {
+        updateData: { state: BoxState.STARTED },
+        whereCondition: { state: BoxState.STOPPED },
+        afterUpdateInTransaction,
+      }),
+    ).rejects.toBe(periodError)
+
+    expect(update.mock.invocationCallOrder[0]).toBeLessThan(upsert.mock.invocationCallOrder[0])
+    expect(upsert.mock.invocationCallOrder[0]).toBeLessThan(afterUpdateInTransaction.mock.invocationCallOrder[0])
+    expect(eventEmitter.emit).not.toHaveBeenCalled()
+    expect(invalidate).not.toHaveBeenCalled()
+  })
 })

--- a/apps/api/src/box/repositories/box.repository.spec.ts
+++ b/apps/api/src/box/repositories/box.repository.spec.ts
@@ -7,6 +7,7 @@ import { BoxRepository } from './box.repository'
 import { Box } from '../entities/box.entity'
 import { BoxState } from '../enums/box-state.enum'
 import { BoxDesiredState } from '../enums/box-desired-state.enum'
+import { BOX_WARM_POOL_UNASSIGNED_ORGANIZATION } from '../constants/box.constants'
 
 // A chainable UPDATE query-builder stub whose terminal execute() is supplied
 // per-test. update/set/where/andWhere/returning all return the same builder.
@@ -100,5 +101,50 @@ describe('BoxRepository.conditionalStartForProxy', () => {
     const { repo } = makeRepository(execute)
 
     await expect(repo.conditionalStartForProxy('box-1', 'org-1')).resolves.toBeNull()
+  })
+})
+
+describe('BoxRepository.update transaction callback', () => {
+  it('runs warm-pool usage attribution after the box writes and before post-commit work', async () => {
+    const update = jest.fn().mockResolvedValue({ affected: 1 })
+    const upsert = jest.fn().mockResolvedValue(undefined)
+    const entityManager = { update, upsert }
+    const transaction = jest.fn(async (callback: (manager: typeof entityManager) => Promise<unknown>) =>
+      callback(entityManager),
+    )
+    const eventEmitter = { emit: jest.fn() }
+    const cacheInvalidation = { invalidate: jest.fn() }
+    const dataSource = {
+      getRepository: jest.fn(() => ({})),
+      transaction,
+    }
+    const repository = new BoxRepository(dataSource as any, eventEmitter as any, cacheInvalidation as any)
+    const box = {
+      id: 'warm-box',
+      organizationId: BOX_WARM_POOL_UNASSIGNED_ORGANIZATION,
+      name: 'warm-box',
+      authToken: 'redacted',
+      state: BoxState.STARTED,
+      desiredState: BoxDesiredState.STARTED,
+      pending: false,
+      public: false,
+      assertValid: jest.fn(),
+      enforceInvariants: jest.fn().mockReturnValue({}),
+    } as unknown as Box
+    const attributionError = new Error('injected usage-period creation failure')
+    const afterUpdateInTransaction = jest.fn().mockRejectedValue(attributionError)
+
+    await expect(
+      repository.update(box.id, {
+        updateData: { organizationId: 'org-target' },
+        entity: box,
+        afterUpdateInTransaction,
+      }),
+    ).rejects.toBe(attributionError)
+
+    expect(update.mock.invocationCallOrder[0]).toBeLessThan(upsert.mock.invocationCallOrder[0])
+    expect(upsert.mock.invocationCallOrder[0]).toBeLessThan(afterUpdateInTransaction.mock.invocationCallOrder[0])
+    expect(eventEmitter.emit).not.toHaveBeenCalled()
+    expect(cacheInvalidation.invalidate).not.toHaveBeenCalled()
   })
 })

--- a/apps/api/src/box/repositories/box.repository.ts
+++ b/apps/api/src/box/repositories/box.repository.ts
@@ -40,11 +40,20 @@ const PG_LOCK_TIMEOUT_CODE = '55P03'
 // A box the migration marker may claim, with the stamp its claim copies.
 type ParkedBox = { id: string; updatedAt: Date }
 
-type BoxUpdateParams = {
+export type BoxUpdateInTransaction = (entityManager: EntityManager, updatedBox: Box) => Promise<void>
+
+export type BoxUpdateParams = {
   updateData: Partial<Box>
   entity?: Box
   /** Runs after the box and last-activity writes, before their transaction commits. */
-  afterUpdateInTransaction?: (entityManager: EntityManager, updatedBox: Box) => Promise<void>
+  afterUpdateInTransaction?: BoxUpdateInTransaction
+}
+
+export type BoxUpdateWhereParams = {
+  updateData: Partial<Box>
+  whereCondition: FindOptionsWhere<Box>
+  /** Runs after the box and last-activity writes, before their transaction commits. */
+  afterUpdateInTransaction?: BoxUpdateInTransaction
 }
 
 @Injectable()
@@ -159,14 +168,11 @@ export class BoxRepository extends BaseRepository<Box> {
    */
   async updateWhere(
     id: string,
-    params: {
-      updateData: Partial<Box>
-      whereCondition: FindOptionsWhere<Box>
-    },
+    params: BoxUpdateWhereParams,
   ): Promise<Box> {
-    const { updateData, whereCondition } = params
+    const { updateData, whereCondition, afterUpdateInTransaction } = params
 
-    return this.manager.transaction(async (entityManager) => {
+    const { box, previousBox } = await this.manager.transaction(async (entityManager) => {
       const whereClause = {
         ...whereCondition,
         id,
@@ -196,11 +202,15 @@ export class BoxRepository extends BaseRepository<Box> {
         await this.upsertLastActivity(entityManager, id, box.updatedAt)
       }
 
-      this.emitUpdateEvents(box, previousBox)
-      this.invalidateLookupCacheOnUpdate(box, previousBox)
+      await afterUpdateInTransaction?.(entityManager, box)
 
-      return box
+      return { box, previousBox }
     })
+
+    this.emitUpdateEvents(box, previousBox)
+    this.invalidateLookupCacheOnUpdate(box, previousBox)
+
+    return box
   }
 
   /**

--- a/apps/api/src/box/repositories/box.repository.ts
+++ b/apps/api/src/box/repositories/box.repository.ts
@@ -40,6 +40,13 @@ const PG_LOCK_TIMEOUT_CODE = '55P03'
 // A box the migration marker may claim, with the stamp its claim copies.
 type ParkedBox = { id: string; updatedAt: Date }
 
+type BoxUpdateParams = {
+  updateData: Partial<Box>
+  entity?: Box
+  /** Runs after the box and last-activity writes, before their transaction commits. */
+  afterUpdateInTransaction?: (entityManager: EntityManager, updatedBox: Box) => Promise<void>
+}
+
 @Injectable()
 export class BoxRepository extends BaseRepository<Box> {
   private readonly logger = new Logger(BoxRepository.name)
@@ -85,12 +92,13 @@ export class BoxRepository extends BaseRepository<Box> {
    * @param id - The ID of the box to update.
    * @param params.updateData - The partial data to update.
    * @param params.entity - Optional pre-fetched box to use instead of fetching from the database.
+   * @param params.afterUpdateInTransaction - Optional internal work that must commit atomically with the box update.
    *
    * @returns The updated box.
    */
-  async update(id: string, params: { updateData: Partial<Box>; entity?: Box }, raw?: false): Promise<Box>
-  async update(id: string, params: { updateData: Partial<Box>; entity?: Box }, raw = false): Promise<Box | void> {
-    const { updateData, entity } = params
+  async update(id: string, params: BoxUpdateParams, raw?: false): Promise<Box>
+  async update(id: string, params: BoxUpdateParams, raw = false): Promise<Box | void> {
+    const { updateData, entity, afterUpdateInTransaction } = params
 
     if (raw) {
       await this.repository.update(id, updateData)
@@ -128,6 +136,8 @@ export class BoxRepository extends BaseRepository<Box> {
       if (previousBox.state !== box.state || previousBox.organizationId !== box.organizationId) {
         await this.upsertLastActivity(entityManager, id, box.updatedAt)
       }
+
+      await afterUpdateInTransaction?.(entityManager, box)
     })
 
     this.emitUpdateEvents(box, previousBox)

--- a/apps/api/src/box/services/box.service.spec.ts
+++ b/apps/api/src/box/services/box.service.spec.ts
@@ -9,6 +9,9 @@ import { BoxState } from '../enums/box-state.enum'
 import { BoxDesiredState } from '../enums/box-desired-state.enum'
 import { RunnerState } from '../enums/runner-state.enum'
 import { BoxEvents } from '../constants/box-events.constants'
+import { BOX_WARM_POOL_UNASSIGNED_ORGANIZATION } from '../constants/box.constants'
+import { UsageService } from '../../usage/services/usage.service'
+import { BoxUsagePeriod } from '../../usage/entities/box-usage-period.entity'
 
 // ensureStartedForProxy only touches boxRepository + eventEmitter +
 // organizationService; every other injected dependency is irrelevant.
@@ -45,6 +48,7 @@ function makeService() {
     noop, // boxActivityService
     noop, // jobRepository
     noop, // jobService
+    noop, // usageService
   )
   return { service, boxRepository, eventEmitter, organizationService }
 }
@@ -87,6 +91,7 @@ function makePreviewUrlService() {
     noop, // boxActivityService
     noop, // jobRepository
     noop, // jobService
+    noop, // usageService
   )
   jest.spyOn(service, 'findOneByIdOrName').mockResolvedValue({
     id: 'MixedCaseBox',
@@ -237,6 +242,7 @@ function makeNetworkTunnelService() {
     noop,
     noop, // jobRepository
     noop, // jobService
+    noop, // usageService
   )
   jest.spyOn(service, 'findOneByIdOrName').mockResolvedValue({
     id: 'MixedCaseBox',
@@ -377,10 +383,10 @@ describe('BoxService public defaults', () => {
     [false, false],
   ])('defaults an assigned warm-pool box to public=%s', async (requestedPublic, expectedPublic) => {
     const warmPoolBox = { id: 'warm-box', runnerId: 'runner-1', name: 'warm-box' } as any
-    const update = jest.fn().mockResolvedValue(warmPoolBox)
+    const claimWarmPoolBox = jest.fn().mockResolvedValue(warmPoolBox)
     const service = Object.create(BoxService.prototype) as BoxService
     Object.assign(service as any, {
-      boxRepository: { update },
+      usageService: { claimWarmPoolBox },
       boxLookupCacheInvalidationService: { invalidateOrgId: jest.fn() },
       eventEmitter: { emit: jest.fn() },
       toBoxDto: jest.fn((box) => box),
@@ -392,9 +398,115 @@ describe('BoxService public defaults', () => {
       { id: 'org-1' },
     )
 
-    expect(update).toHaveBeenCalledWith(
+    expect(claimWarmPoolBox).toHaveBeenCalledWith(
       'warm-box',
-      expect.objectContaining({ updateData: expect.objectContaining({ public: expectedPublic }) }),
+      expect.objectContaining({
+        updateData: expect.objectContaining({ public: expectedPublic }),
+        entity: warmPoolBox,
+      }),
     )
+  })
+
+  it('preserves generated-name retry behavior while claiming warm-pool usage attribution', async () => {
+    const warmPoolBox = { id: 'warm-box', runnerId: 'runner-1', name: 'warm-box' } as any
+    const duplicateNameError = Object.assign(new Error('duplicate name'), { code: '23505' })
+    const claimWarmPoolBox = jest.fn().mockRejectedValueOnce(duplicateNameError).mockResolvedValueOnce(warmPoolBox)
+    const service = Object.create(BoxService.prototype) as BoxService
+    Object.assign(service as any, {
+      usageService: { claimWarmPoolBox },
+      boxLookupCacheInvalidationService: { invalidateOrgId: jest.fn() },
+      eventEmitter: { emit: jest.fn() },
+      toBoxDto: jest.fn((box) => box),
+    })
+
+    await (service as any).assignWarmPoolBox(warmPoolBox, {}, { id: 'org-1' })
+
+    expect(claimWarmPoolBox).toHaveBeenCalledTimes(2)
+    const firstParams = claimWarmPoolBox.mock.calls[0][1]
+    const retryParams = claimWarmPoolBox.mock.calls[1][1]
+    expect(firstParams.entity).toBeUndefined()
+    expect(retryParams.entity).toBeUndefined()
+    expect(retryParams.updateData.name).toBe(`${firstParams.updateData.name}-${warmPoolBox.id}`)
+  })
+
+  it('keeps warm-pool usage attribution billable when the state event is dropped', async () => {
+    const targetOrganizationId = 'org-1'
+    const warmPoolBox = {
+      id: 'warm-box',
+      runnerId: 'runner-1',
+      name: 'warm-box',
+      organizationId: BOX_WARM_POOL_UNASSIGNED_ORGANIZATION,
+      state: BoxState.STARTED,
+      region: 'us',
+      cpu: 2,
+      gpu: 1,
+      mem: 4,
+      disk: 10,
+    } as any
+    const warmPoolPeriod = Object.assign(new BoxUsagePeriod(), {
+      id: 'warm-period',
+      boxId: warmPoolBox.id,
+      organizationId: BOX_WARM_POOL_UNASSIGNED_ORGANIZATION,
+      region: warmPoolBox.region,
+      cpu: warmPoolBox.cpu,
+      gpu: warmPoolBox.gpu,
+      mem: warmPoolBox.mem,
+      disk: warmPoolBox.disk,
+      startAt: new Date('2026-08-01T00:00:00.000Z'),
+      endAt: null,
+    })
+    const storedPeriods = [warmPoolPeriod]
+    const transactionalEntityManager = {
+      findOne: jest.fn(async () => storedPeriods.find((period) => period.endAt === null)),
+      save: jest.fn(async (period: BoxUsagePeriod) => {
+        if (!storedPeriods.includes(period)) {
+          storedPeriods.push(period)
+        }
+        return period
+      }),
+    }
+    const boxRepository = {
+      update: jest.fn(async (_id: string, params: any) => {
+        Object.assign(warmPoolBox, params.updateData)
+        await params.afterUpdateInTransaction?.(transactionalEntityManager, warmPoolBox)
+        return warmPoolBox
+      }),
+    }
+    const lease = {
+      signal: new AbortController().signal,
+      release: jest.fn().mockResolvedValue(undefined),
+    }
+    const usageService = new UsageService(
+      { manager: { transaction: jest.fn() } } as any,
+      { waitForLease: jest.fn().mockResolvedValue(lease) } as any,
+      boxRepository as any,
+      {} as any,
+      {} as any,
+    )
+    const eventEmitter = { emit: jest.fn() }
+    const service = Object.create(BoxService.prototype) as BoxService
+    Object.assign(service as any, {
+      boxRepository,
+      usageService,
+      boxLookupCacheInvalidationService: { invalidateOrgId: jest.fn() },
+      // A process exit or listener failure has the same billing effect as this
+      // deliberately dropped in-process notification.
+      eventEmitter,
+      toBoxDto: jest.fn((box) => box),
+    })
+
+    await (service as any).assignWarmPoolBox(warmPoolBox, { name: 'assigned-box' }, { id: targetOrganizationId })
+
+    const openPeriods = storedPeriods.filter((period) => period.endAt === null)
+    expect(warmPoolPeriod.endAt).toBeInstanceOf(Date)
+    expect(openPeriods).toEqual([
+      expect.objectContaining({
+        boxId: warmPoolBox.id,
+        organizationId: targetOrganizationId,
+        region: warmPoolBox.region,
+      }),
+    ])
+    expect(openPeriods[0].startAt).toEqual(warmPoolPeriod.endAt)
+    expect(eventEmitter.emit).toHaveBeenCalledWith(BoxEvents.STATE_UPDATED, expect.anything())
   })
 })

--- a/apps/api/src/box/services/box.service.start-reconciliation.spec.ts
+++ b/apps/api/src/box/services/box.service.start-reconciliation.spec.ts
@@ -40,6 +40,7 @@ type Harness = {
   jobFindOne: jest.Mock
   updateJobStatus: jest.Mock
   updateWhere: jest.Mock
+  transitionBoxToStarted: jest.Mock
 }
 
 function createService(box: Box | null, stalledJob: Job | null): Harness {
@@ -47,11 +48,13 @@ function createService(box: Box | null, stalledJob: Job | null): Harness {
   const jobFindOne = jest.fn().mockResolvedValue(stalledJob)
   const updateJobStatus = jest.fn().mockResolvedValue(undefined)
   const updateWhere = jest.fn().mockResolvedValue(box)
+  const transitionBoxToStarted = jest.fn().mockResolvedValue(box)
 
   ;(service as any).logger = { debug: jest.fn(), warn: jest.fn(), error: jest.fn(), log: jest.fn() }
   ;(service as any).boxRepository = { findOne: jest.fn().mockResolvedValue(box), updateWhere }
   ;(service as any).jobRepository = { findOne: jobFindOne }
   ;(service as any).jobService = { updateJobStatus }
+  ;(service as any).usageService = { transitionBoxToStarted }
   ;(service as any).configService = {
     getOrThrow: jest.fn((key: string) => {
       if (key !== 'boxSync.startConfirmationStallSeconds') {
@@ -61,10 +64,32 @@ function createService(box: Box | null, stalledJob: Job | null): Harness {
     }),
   }
 
-  return { service, jobFindOne, updateJobStatus, updateWhere }
+  return { service, jobFindOne, updateJobStatus, updateWhere, transitionBoxToStarted }
 }
 
 describe('BoxService.updateState start reconciliation', () => {
+  it('uses atomic STARTED persistence for a stable stopped box', async () => {
+    const box = makeBox(BoxState.STOPPED, BoxDesiredState.STOPPED)
+    box.pending = false
+    const { service, updateWhere, transitionBoxToStarted } = createService(box, null)
+
+    await service.updateState(box.id, BoxState.STARTED)
+
+    expect(transitionBoxToStarted).toHaveBeenCalledWith(box.id, {
+      updateData: {
+        state: BoxState.STARTED,
+        desiredState: BoxDesiredState.STARTED,
+        recoverable: false,
+      },
+      whereCondition: {
+        pending: false,
+        state: BoxState.STOPPED,
+        desiredState: BoxDesiredState.STOPPED,
+      },
+    })
+    expect(updateWhere).not.toHaveBeenCalled()
+  })
+
   it('completes the stalled startup job instead of writing the box directly', async () => {
     const box = makeBox(BoxState.CREATING)
     const job = makeStalledJob(JobType.CREATE_BOX)

--- a/apps/api/src/box/services/box.service.ts
+++ b/apps/api/src/box/services/box.service.ts
@@ -1374,10 +1374,17 @@ export class BoxService {
       updateData.desiredState = desiredState
     }
 
-    await this.boxRepository.updateWhere(box.id, {
+    const updateParams = {
       updateData,
       whereCondition: { pending: false, state: oldState, desiredState: oldDesiredState },
-    })
+    }
+
+    if (newState === BoxState.STARTED) {
+      await this.usageService.transitionBoxToStarted(box.id, updateParams)
+      return
+    }
+
+    await this.boxRepository.updateWhere(box.id, updateParams)
   }
 
   @OnEvent(WarmPoolEvents.TOPUP_REQUESTED)

--- a/apps/api/src/box/services/box.service.ts
+++ b/apps/api/src/box/services/box.service.ts
@@ -85,6 +85,7 @@ import {
   DEFAULT_AUTO_STOP_SECONDS,
   DEFAULT_AUTO_RESUME,
 } from '../constants/box-lifecycle.constants'
+import { UsageService } from '../../usage/services/usage.service'
 
 // TODO(image-rewrite): resource defaults previously came from the removed image subsystem;
 // these mirror the Box entity column defaults until image resolution is rebuilt.
@@ -117,6 +118,7 @@ export class BoxService {
     @InjectRepository(Job)
     private readonly jobRepository: Repository<Job>,
     private readonly jobService: JobService,
+    private readonly usageService: UsageService,
   ) {}
 
   protected getLockKey(id: string): string {
@@ -385,12 +387,12 @@ export class BoxService {
     // the row — reusing the mutated entity would corrupt the optimistic-update
     // guard.
     const updatedBox = createBoxDto.name
-      ? await this.boxRepository.update(warmPoolBox.id, {
+      ? await this.usageService.claimWarmPoolBox(warmPoolBox.id, {
           updateData: { ...updateData, name: createBoxDto.name },
           entity: warmPoolBox,
         })
       : await persistWithGeneratedBoxName(warmPoolBox.id, (name) =>
-          this.boxRepository.update(warmPoolBox.id, { updateData: { ...updateData, name } }),
+          this.usageService.claimWarmPoolBox(warmPoolBox.id, { updateData: { ...updateData, name } }),
         )
 
     // Defensive invalidation of orgId cache since the box moved from unassigned to a real organization

--- a/apps/api/src/box/services/job-state-handler.service.spec.ts
+++ b/apps/api/src/box/services/job-state-handler.service.spec.ts
@@ -9,6 +9,9 @@ import { JobStatus } from '../enums/job-status.enum'
 import { JobType } from '../enums/job-type.enum'
 import { ResourceType } from '../enums/resource-type.enum'
 import { getStateChangeLockKey } from '../utils/lock-key.util'
+import { Box } from '../entities/box.entity'
+import { BoxState } from '../enums/box-state.enum'
+import { BoxDesiredState } from '../enums/box-desired-state.enum'
 
 describe('JobStateHandlerService migration job routing', () => {
   function makeService() {
@@ -22,10 +25,21 @@ describe('JobStateHandlerService migration job routing', () => {
     const boxMigrationJobReceiver = {
       handleJobCompletion: jest.fn().mockResolvedValue(undefined),
     } as any
-    return {
-      service: new JobStateHandlerService(boxRepository, redisLockProvider, boxMigrationJobReceiver),
+    const usageService = {
+      transitionBoxToStarted: jest.fn().mockResolvedValue(undefined),
+    } as any
+    const service = new JobStateHandlerService(
+      boxRepository,
       redisLockProvider,
       boxMigrationJobReceiver,
+      usageService,
+    )
+    return {
+      service,
+      boxRepository,
+      redisLockProvider,
+      boxMigrationJobReceiver,
+      usageService,
     }
   }
 
@@ -70,5 +84,30 @@ describe('JobStateHandlerService migration job routing', () => {
 
     expect(h.boxMigrationJobReceiver.handleJobCompletion).not.toHaveBeenCalled()
     expect(h.redisLockProvider.unlock).toHaveBeenCalledWith(getStateChangeLockKey('box-1'))
+  })
+
+  it('uses atomic STARTED persistence when a start job completes', async () => {
+    const h = makeService()
+    const box = new Box('us', 'box-1')
+    box.state = BoxState.STARTING
+    box.desiredState = BoxDesiredState.STARTED
+    box.pending = true
+    h.boxRepository.findOne.mockResolvedValue(box)
+    const job = new Job({
+      id: 'job-start',
+      type: JobType.START_BOX,
+      status: JobStatus.COMPLETED,
+      runnerId: 'runner-1',
+      resourceType: ResourceType.BOX,
+      resourceId: box.id,
+    })
+
+    await h.service.handleJobCompletion(job)
+
+    expect(h.usageService.transitionBoxToStarted).toHaveBeenCalledWith(box.id, {
+      updateData: { state: BoxState.STARTED, errorReason: null },
+      entity: box,
+    })
+    expect(h.boxRepository.update).not.toHaveBeenCalled()
   })
 })

--- a/apps/api/src/box/services/job-state-handler.service.ts
+++ b/apps/api/src/box/services/job-state-handler.service.ts
@@ -17,6 +17,7 @@ import { RedisLockProvider } from '../common/redis-lock.provider'
 import { ResourceType } from '../enums/resource-type.enum'
 import { getStateChangeLockKey } from '../utils/lock-key.util'
 import { BoxMigrationJobReceiver, isMigrationJobType } from './box-migration-job-receiver.service'
+import { UsageService } from '../../usage/services/usage.service'
 
 /**
  * Service for handling entity state updates based on job completion (v2 runners only).
@@ -30,6 +31,7 @@ export class JobStateHandlerService {
     private readonly boxRepository: BoxRepository,
     private readonly redisLockProvider: RedisLockProvider,
     private readonly boxMigrationJobReceiver: BoxMigrationJobReceiver,
+    private readonly usageService: UsageService,
   ) {}
 
   /**
@@ -120,7 +122,7 @@ export class JobStateHandlerService {
         updateData.recoverable = recoverable
       }
 
-      await this.boxRepository.update(boxId, { updateData, entity: box })
+      await this.persistBoxUpdate(boxId, box, updateData)
     } catch (error) {
       this.logger.error(`Error handling CREATE_BOX job completion for box ${boxId}:`, error)
     }
@@ -162,7 +164,7 @@ export class JobStateHandlerService {
         updateData.recoverable = recoverable
       }
 
-      await this.boxRepository.update(boxId, { updateData, entity: box })
+      await this.persistBoxUpdate(boxId, box, updateData)
     } catch (error) {
       this.logger.error(`Error handling START_BOX job completion for box ${boxId}:`, error)
     }
@@ -200,7 +202,7 @@ export class JobStateHandlerService {
         updateData.recoverable = recoverable
       }
 
-      await this.boxRepository.update(boxId, { updateData, entity: box })
+      await this.persistBoxUpdate(boxId, box, updateData)
     } catch (error) {
       this.logger.error(`Error handling STOP_BOX job completion for box ${boxId}:`, error)
     }
@@ -234,9 +236,18 @@ export class JobStateHandlerService {
         return
       }
 
-      await this.boxRepository.update(boxId, { updateData, entity: box })
+      await this.persistBoxUpdate(boxId, box, updateData)
     } catch (error) {
       this.logger.error(`Error handling DESTROY_BOX job completion for box ${boxId}:`, error)
     }
+  }
+
+  private async persistBoxUpdate(boxId: string, box: Box, updateData: Partial<Box>): Promise<void> {
+    if (updateData.state === BoxState.STARTED) {
+      await this.usageService.transitionBoxToStarted(boxId, { updateData, entity: box })
+      return
+    }
+
+    await this.boxRepository.update(boxId, { updateData, entity: box })
   }
 }

--- a/apps/api/src/usage/entities/box-usage-period.entity.ts
+++ b/apps/api/src/usage/entities/box-usage-period.entity.ts
@@ -47,18 +47,4 @@ export class BoxUsagePeriod {
 
   @Column()
   region: string
-
-  public static fromUsagePeriod(usagePeriod: BoxUsagePeriod) {
-    const usagePeriodEntity = new BoxUsagePeriod()
-    usagePeriodEntity.boxId = usagePeriod.boxId
-    usagePeriodEntity.organizationId = usagePeriod.organizationId
-    usagePeriodEntity.startAt = usagePeriod.startAt
-    usagePeriodEntity.endAt = usagePeriod.endAt
-    usagePeriodEntity.cpu = usagePeriod.cpu
-    usagePeriodEntity.gpu = usagePeriod.gpu
-    usagePeriodEntity.mem = usagePeriod.mem
-    usagePeriodEntity.disk = usagePeriod.disk
-    usagePeriodEntity.region = usagePeriod.region
-    return usagePeriodEntity
-  }
 }

--- a/apps/api/src/usage/services/usage.service.integration.spec.ts
+++ b/apps/api/src/usage/services/usage.service.integration.spec.ts
@@ -10,6 +10,7 @@ import { DataSource, IsNull, Not, Repository } from 'typeorm'
 import { Box } from '../../box/entities/box.entity'
 import { BoxLastActivity } from '../../box/entities/box-last-activity.entity'
 import { BoxState } from '../../box/enums/box-state.enum'
+import { BoxDesiredState } from '../../box/enums/box-desired-state.enum'
 import { BOX_WARM_POOL_UNASSIGNED_ORGANIZATION } from '../../box/constants/box.constants'
 import { RedisLockProvider } from '../../box/common/redis-lock.provider'
 import { CustomNamingStrategy } from '../../common/utils/naming-strategy.util'
@@ -467,6 +468,73 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
       expect.objectContaining({ organizationId: BOX_WARM_POOL_UNASSIGNED_ORGANIZATION }),
     )
     expect(await periods.find()).toEqual([expect.objectContaining({ id: oldPeriod.id, endAt: null })])
+    expect(eventEmitter.emit).not.toHaveBeenCalled()
+  })
+
+  it('atomically restarts usage when the state event is dropped', async () => {
+    const current = {
+      organizationId: '8746db21-0d5b-4f0d-b26d-5a385ba6ecf2',
+      region: 'eu',
+      cpu: 6,
+      gpu: 2,
+      mem: 12,
+      disk: 80,
+    }
+    await insertBox({ state: BoxState.STOPPED, ...current })
+    const stoppedPeriod = await openPeriod({
+      organizationId: box.organizationId,
+      cpu: 0,
+      gpu: 0,
+      mem: 0,
+      disk: 10,
+    })
+    const { service, eventEmitter } = serviceForWarmPoolClaim()
+
+    await service.transitionBoxToStarted(box.id, {
+      updateData: { state: BoxState.STARTED },
+      whereCondition: {
+        state: BoxState.STOPPED,
+        desiredState: BoxDesiredState.STARTED,
+        pending: false,
+      },
+    })
+
+    expect(await dataSource.getRepository(Box).findOneByOrFail({ id: box.id })).toEqual(
+      expect.objectContaining({ state: BoxState.STARTED, ...current }),
+    )
+    const closed = await periods.findOneByOrFail({ id: stoppedPeriod.id })
+    const open = await periods.findOneByOrFail({ boxId: box.id, endAt: IsNull() })
+    expect(closed.endAt).toBeInstanceOf(Date)
+    expect(open.startAt).toEqual(closed.endAt)
+    expect(open).toEqual(expect.objectContaining(current))
+    // The emitter is deliberately not connected to UsageService. Correctness
+    // therefore comes from the transaction, not the notification.
+    expect(eventEmitter.emit).toHaveBeenCalled()
+  })
+
+  it('rolls back a STARTED box transition when creating its full-resource period fails', async () => {
+    await insertBox({ state: BoxState.STOPPED })
+    const stoppedPeriod = await openPeriod({ cpu: 0, gpu: 0, mem: 0 })
+    const { service, eventEmitter } = serviceForWarmPoolClaim()
+    const creationError = new Error('injected full-resource period creation failure')
+    const createUsagePeriod = jest.spyOn(service as any, 'createUsagePeriod').mockRejectedValue(creationError)
+
+    await expect(
+      service.transitionBoxToStarted(box.id, {
+        updateData: { state: BoxState.STARTED },
+        whereCondition: {
+          state: BoxState.STOPPED,
+          desiredState: BoxDesiredState.STARTED,
+          pending: false,
+        },
+      }),
+    ).rejects.toBe(creationError)
+    createUsagePeriod.mockRestore()
+
+    expect(await dataSource.getRepository(Box).findOneByOrFail({ id: box.id })).toEqual(
+      expect.objectContaining({ state: BoxState.STOPPED }),
+    )
+    expect(await periods.find()).toEqual([expect.objectContaining({ id: stoppedPeriod.id, endAt: null })])
     expect(eventEmitter.emit).not.toHaveBeenCalled()
   })
 

--- a/apps/api/src/usage/services/usage.service.integration.spec.ts
+++ b/apps/api/src/usage/services/usage.service.integration.spec.ts
@@ -29,6 +29,7 @@ import { UsageService } from './usage.service'
 import { expectedOpenPeriod } from './expected-usage-period'
 import { UsageConcurrencyService } from './usage-concurrency.service'
 import { UsageConcurrencyGranularity } from '../dto/usage-concurrency.dto'
+import { BoxRepository } from '../../box/repositories/box.repository'
 
 // The three cron jobs are a destructive archive transaction, a roll-over that
 // rewrites resources, and a reconcile pass built on a left join from box to the
@@ -60,7 +61,7 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
   // organizationId is a uuid on the box table, so it has to be a real one here
   // even though the ledger stores it as text.
   const box = {
-    id: 'box-int-1',
+    id: 'BoxIntTest01',
     organizationId: '5c2f6a48-8f2b-4a1e-9d31-2b7e6f0c1a45',
     region: 'us',
     cpu: 2,
@@ -170,6 +171,24 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
       outboxService(exportEnabled),
       { find: async () => [] } as any,
     )
+
+  const serviceForWarmPoolClaim = () => {
+    const eventEmitter = { emit: jest.fn() }
+    const boxRepository = new BoxRepository(
+      dataSource,
+      eventEmitter as any,
+      {
+        invalidate: jest.fn(),
+      } as any,
+    )
+    return {
+      service: new UsageService(periods, new RedisLockProvider(redis), boxRepository, outboxService(), {
+        find: async () => [],
+      } as any),
+      boxRepository,
+      eventEmitter,
+    }
+  }
 
   const quoted = TABLES.map((table) => `"${table}"`).join(', ')
   // CASCADE because box_last_activity references box.
@@ -381,6 +400,63 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
     await serviceForBoxState(BoxState.STARTED).closeAndReopenUsagePeriods()
 
     expect(await periods.find()).toEqual([expect.objectContaining({ id: warmPool.id, endAt: null })])
+  })
+
+  it('switches warm-pool usage attribution in the same transaction as ownership', async () => {
+    const targetOrganizationId = box.organizationId
+    const assignedShape = { region: 'eu', cpu: 6, gpu: 2, mem: 12, disk: 80 }
+    await insertBox({
+      state: BoxState.STARTED,
+      organizationId: BOX_WARM_POOL_UNASSIGNED_ORGANIZATION,
+      ...assignedShape,
+    })
+    const oldPeriod = await openPeriod({
+      organizationId: BOX_WARM_POOL_UNASSIGNED_ORGANIZATION,
+      ...assignedShape,
+    })
+    const { service, boxRepository } = serviceForWarmPoolClaim()
+    const warmPoolBox = await boxRepository.findOneByOrFail({ id: box.id })
+
+    await service.claimWarmPoolBox(box.id, {
+      updateData: { organizationId: targetOrganizationId },
+      entity: warmPoolBox,
+    })
+
+    const persistedBox = await dataSource.getRepository(Box).findOneByOrFail({ id: box.id })
+    const closed = await periods.findOneByOrFail({ id: oldPeriod.id })
+    const open = await periods.findOneByOrFail({ boxId: box.id, endAt: IsNull() })
+    expect(persistedBox.organizationId).toBe(targetOrganizationId)
+    expect(closed.endAt).toBeInstanceOf(Date)
+    expect(open.startAt).toEqual(closed.endAt)
+    expect(open).toEqual(
+      expect.objectContaining({
+        organizationId: targetOrganizationId,
+        ...assignedShape,
+      }),
+    )
+  })
+
+  it('rolls back box ownership when creating warm-pool usage attribution fails', async () => {
+    await insertBox({ state: BoxState.STARTED, organizationId: BOX_WARM_POOL_UNASSIGNED_ORGANIZATION })
+    const oldPeriod = await openPeriod({ organizationId: BOX_WARM_POOL_UNASSIGNED_ORGANIZATION })
+    const { service, boxRepository, eventEmitter } = serviceForWarmPoolClaim()
+    const warmPoolBox = await boxRepository.findOneByOrFail({ id: box.id })
+    const creationError = new Error('injected usage-period creation failure')
+    const createUsagePeriod = jest.spyOn(service as any, 'createUsagePeriod').mockRejectedValue(creationError)
+
+    await expect(
+      service.claimWarmPoolBox(box.id, {
+        updateData: { organizationId: box.organizationId },
+        entity: warmPoolBox,
+      }),
+    ).rejects.toBe(creationError)
+    createUsagePeriod.mockRestore()
+
+    expect(await dataSource.getRepository(Box).findOneByOrFail({ id: box.id })).toEqual(
+      expect.objectContaining({ organizationId: BOX_WARM_POOL_UNASSIGNED_ORGANIZATION }),
+    )
+    expect(await periods.find()).toEqual([expect.objectContaining({ id: oldPeriod.id, endAt: null })])
+    expect(eventEmitter.emit).not.toHaveBeenCalled()
   })
 
   it('starts the reopened period exactly where the closed one ended, with the same attribution', async () => {

--- a/apps/api/src/usage/services/usage.service.integration.spec.ts
+++ b/apps/api/src/usage/services/usage.service.integration.spec.ts
@@ -106,8 +106,8 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
   const openPeriods = () => periods.find({ where: { endAt: IsNull() } })
 
   /**
-   * Inserts a real box row. The reconcile pass joins the box table, so these
-   * cases cannot use the stub above.
+   * Inserts a real box row. Reconcile joins the box table and rollover rereads
+   * it transactionally, so those cases cannot use a stub repository.
    */
   const insertBox = (
     overrides: Partial<typeof box> & { state: BoxState; runnerId?: string; pending?: boolean; updatedAtMsAgo?: number },
@@ -169,6 +169,15 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
       new RedisLockProvider(redis),
       { findOne: async () => ({ ...box, state, ...boxOverrides }) } as any,
       outboxService(exportEnabled),
+      { find: async () => [] } as any,
+    )
+
+  const serviceForPersistedBox = () =>
+    new UsageService(
+      periods,
+      new RedisLockProvider(redis),
+      dataSource.getRepository(Box) as any,
+      outboxService(),
       { find: async () => [] } as any,
     )
 
@@ -363,9 +372,10 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
   })
 
   it('rolls a day-old period over, carrying the resources of a running box', async () => {
+    await insertBox({ state: BoxState.STARTED })
     await openPeriod({ startAt: new Date(Date.now() - DAY_MS - 60_000) })
 
-    await serviceForBoxState(BoxState.STARTED).closeAndReopenUsagePeriods()
+    await serviceForPersistedBox().closeAndReopenUsagePeriods()
 
     const [closed, reopened] = await periods.find({ order: { startAt: 'ASC' } })
     expect(closed.endAt).toBeInstanceOf(Date)
@@ -375,9 +385,10 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
   it('stops charging compute when it rolls over a period whose box is already stopped', async () => {
     // a box that reached STOPPED without passing through STOPPING keeps a
     // full-resource period open; the roll-over must not re-bill its cpu forever
+    await insertBox({ state: BoxState.STOPPED })
     await openPeriod({ startAt: new Date(Date.now() - DAY_MS - 60_000) })
 
-    await serviceForBoxState(BoxState.STOPPED).closeAndReopenUsagePeriods()
+    await serviceForPersistedBox().closeAndReopenUsagePeriods()
 
     const [, reopened] = await periods.find({ order: { startAt: 'ASC' } })
     expect(reopened).toEqual(expect.objectContaining({ endAt: null, cpu: 0, gpu: 0, mem: 0, disk: 10 }))
@@ -386,7 +397,7 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
   it('leaves a period younger than a day alone', async () => {
     const fresh = await openPeriod({ startAt: new Date(Date.now() - 60 * 60 * 1000) })
 
-    await serviceForBoxState(BoxState.STARTED).closeAndReopenUsagePeriods()
+    await serviceForPersistedBox().closeAndReopenUsagePeriods()
 
     expect(await periods.find()).toEqual([expect.objectContaining({ id: fresh.id, endAt: null })])
   })
@@ -397,7 +408,7 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
       startAt: new Date(Date.now() - DAY_MS - 60_000),
     })
 
-    await serviceForBoxState(BoxState.STARTED).closeAndReopenUsagePeriods()
+    await serviceForPersistedBox().closeAndReopenUsagePeriods()
 
     expect(await periods.find()).toEqual([expect.objectContaining({ id: warmPool.id, endAt: null })])
   })
@@ -460,9 +471,10 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
   })
 
   it('starts the reopened period exactly where the closed one ended, with the same attribution', async () => {
+    await insertBox({ state: BoxState.STOPPING })
     await openPeriod({ startAt: new Date(Date.now() - DAY_MS - 60_000) })
 
-    await serviceForBoxState(BoxState.STOPPING).closeAndReopenUsagePeriods()
+    await serviceForPersistedBox().closeAndReopenUsagePeriods()
 
     const [closed, reopened] = await periods.find({ order: { startAt: 'ASC' } })
     // no gap and no overlap: an inherited startAt would bill the elapsed day twice
@@ -472,17 +484,37 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
     )
   })
 
+  it('creates the reopened period from the box current attribution', async () => {
+    const previousOrganizationId = '7f33c512-a431-4a21-9efc-ff6924f9724c'
+    const currentShape = { region: 'eu', cpu: 6, gpu: 2, mem: 12, disk: 80 }
+    await insertBox({ state: BoxState.STARTED, ...currentShape })
+    const oldPeriod = await openPeriod({
+      organizationId: previousOrganizationId,
+      region: 'us',
+      cpu: 1,
+      gpu: 0,
+      mem: 2,
+      disk: 5,
+      startAt: new Date(Date.now() - DAY_MS - 60_000),
+    })
+
+    await serviceForPersistedBox().closeAndReopenUsagePeriods()
+
+    const closed = await periods.findOneByOrFail({ id: oldPeriod.id })
+    const reopened = await periods.findOneByOrFail({ boxId: box.id, endAt: IsNull() })
+    expect(closed).toEqual(
+      expect.objectContaining({ organizationId: previousOrganizationId, region: 'us', cpu: 1, disk: 5 }),
+    )
+    expect(reopened).toEqual(
+      expect.objectContaining({ organizationId: box.organizationId, ...currentShape, endAt: null }),
+    )
+    expect(reopened.startAt).toEqual(closed.endAt)
+  })
+
   it('closes without reopening when the box row no longer exists', async () => {
     await openPeriod({ startAt: new Date(Date.now() - DAY_MS - 60_000) })
-    const serviceWithoutBox = new UsageService(
-      periods,
-      new RedisLockProvider(redis),
-      { findOne: async () => null } as any,
-      outboxService(),
-      { find: async () => [] } as any,
-    )
 
-    await serviceWithoutBox.closeAndReopenUsagePeriods()
+    await serviceForPersistedBox().closeAndReopenUsagePeriods()
 
     // a missing box must not throw inside the transaction — that would roll the
     // close back and leave the period accruing forever
@@ -492,9 +524,10 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
   })
 
   it('does not reopen a period for a box that is already gone', async () => {
+    await insertBox({ state: BoxState.DESTROYED })
     await openPeriod({ startAt: new Date(Date.now() - DAY_MS - 60_000) })
 
-    await serviceForBoxState(BoxState.DESTROYED).closeAndReopenUsagePeriods()
+    await serviceForPersistedBox().closeAndReopenUsagePeriods()
 
     const remaining = await periods.find()
     expect(remaining).toHaveLength(1)
@@ -650,8 +683,10 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
   // it would paper over a roll-over that carried the wrong figures forward, and
   // the ledger would still churn out a wrong period every single day.
   describe('the daily roll-over on its own', () => {
-    const rollOver = (state: BoxState, boxOverrides: Partial<typeof box> = {}) =>
-      serviceForBoxState(state, false, boxOverrides).closeAndReopenUsagePeriods()
+    const rollOver = async (state: BoxState, boxOverrides: Partial<typeof box> = {}) => {
+      await insertBox({ state, ...boxOverrides })
+      await serviceForPersistedBox().closeAndReopenUsagePeriods()
+    }
 
     it('carries the resources the box has now, not the ones the closing period held', async () => {
       await openPeriod({ cpu: 0, gpu: 0, mem: 0, startAt: new Date(Date.now() - DAY_MS - 60_000) })

--- a/apps/api/src/usage/services/usage.service.spec.ts
+++ b/apps/api/src/usage/services/usage.service.spec.ts
@@ -50,7 +50,17 @@ const makeService = (stored: BoxUsagePeriod[] = []) => {
   }
   const transactionalEntityManager = {
     find: jest.fn().mockResolvedValue([]),
-    findOne: jest.fn(),
+    findOne: jest.fn(async (entity, { where }: any) => {
+      if (entity === Box) {
+        return { ...box, state: BoxState.STARTED }
+      }
+      if (entity === BoxUsagePeriod) {
+        return stored.find((period) =>
+          Object.entries(where).every(([column, condition]) => satisfies((period as any)[column], condition)),
+        )
+      }
+      return undefined
+    }),
     delete: jest.fn().mockResolvedValue(undefined),
     save: jest.fn().mockImplementation(async (value) => value),
   }
@@ -70,7 +80,7 @@ const makeService = (stored: BoxUsagePeriod[] = []) => {
     acquireLease: jest.fn().mockResolvedValue(lease),
     waitForLease: jest.fn().mockResolvedValue(lease),
   }
-  const boxRepository = { findOne: jest.fn(), update: jest.fn() }
+  const boxRepository = { findOne: jest.fn(), update: jest.fn(), updateWhere: jest.fn() }
   const usageExportOutboxService = { enqueue: jest.fn().mockResolvedValue(0) }
   // The reconcile pass builds a left join through the query builder, which this
   // fake cannot stand in for; its behaviour is covered in
@@ -143,12 +153,13 @@ describe('UsageService.handleBoxStateUpdate', () => {
   })
 
   it('opens a full-resource period when the box starts', async () => {
-    const { service, usagePeriodRepository } = makeService()
+    const { service, usagePeriodRepository, transactionalEntityManager } = makeService()
 
     await service.handleBoxStateUpdate(event(BoxState.STARTED))
 
-    expect(usagePeriodRepository.save).toHaveBeenCalledTimes(1)
-    expect(usagePeriodRepository.save).toHaveBeenCalledWith(
+    expect(usagePeriodRepository.save).not.toHaveBeenCalled()
+    expect(transactionalEntityManager.save).toHaveBeenCalledTimes(1)
+    expect(transactionalEntityManager.save).toHaveBeenCalledWith(
       expect.objectContaining({
         boxId: 'box-1',
         organizationId: 'org-1',
@@ -161,31 +172,134 @@ describe('UsageService.handleBoxStateUpdate', () => {
       }),
     )
     // billing starts now, not at some inherited timestamp
-    const [[opened]] = usagePeriodRepository.save.mock.calls
+    const [[opened]] = transactionalEntityManager.save.mock.calls
     expect(opened.startAt).toBeInstanceOf(Date)
     expect(Date.now() - opened.startAt.getTime()).toBeLessThan(5_000)
   })
 
   it('closes the previous period before opening a new one when the box starts', async () => {
     const stale = openPeriod()
-    const { service, usagePeriodRepository } = makeService([stale])
+    stale.organizationId = 'org-stale'
+    const { service, transactionalEntityManager } = makeService([stale])
 
     await service.handleBoxStateUpdate(event(BoxState.STARTED))
 
-    const [closed, opened] = usagePeriodRepository.save.mock.calls.map(([period]) => period)
+    const [closed, opened] = transactionalEntityManager.save.mock.calls.map(([period]) => period)
     expect(closed).toBe(stale)
     expect(stale.endAt).toBeInstanceOf(Date)
     expect(opened).toEqual(expect.objectContaining({ cpu: 2, endAt: null }))
   })
 
+  it('atomically replaces a stopped period from the persisted box when the box starts', async () => {
+    const diskOnly = Object.assign(new BoxUsagePeriod(), {
+      id: 'period-stopped',
+      boxId: box.id,
+      organizationId: 'org-previous',
+      region: 'us',
+      cpu: 0,
+      gpu: 0,
+      mem: 0,
+      disk: 10,
+      startAt: new Date(Date.now() - 60_000),
+      endAt: null,
+    })
+    const eventBox = { ...box, organizationId: 'org-event', state: BoxState.STARTED } as Box
+    const persistedBox = {
+      ...box,
+      organizationId: 'org-current',
+      region: 'eu',
+      state: BoxState.STARTED,
+      cpu: 6,
+      gpu: 2,
+      mem: 12,
+      disk: 80,
+    } as Box
+    const { service, usagePeriodRepository, transactionalEntityManager } = makeService([diskOnly])
+    transactionalEntityManager.findOne.mockImplementation(async (entity) =>
+      entity === Box ? persistedBox : diskOnly,
+    )
+
+    await service.handleBoxStateUpdate(
+      new BoxStateUpdatedEvent(eventBox, BoxState.STOPPED, BoxState.STARTED),
+    )
+
+    expect(usagePeriodRepository.manager.transaction).toHaveBeenCalledTimes(1)
+    expect(usagePeriodRepository.save).not.toHaveBeenCalled()
+    expect(transactionalEntityManager.findOne).toHaveBeenCalledWith(Box, {
+      where: { id: box.id },
+      lock: { mode: 'pessimistic_write' },
+      loadEagerRelations: false,
+    })
+    expect(transactionalEntityManager.findOne).toHaveBeenCalledWith(BoxUsagePeriod, {
+      where: { boxId: box.id, endAt: expect.anything() },
+      lock: { mode: 'pessimistic_write' },
+    })
+
+    const [closed, opened] = transactionalEntityManager.save.mock.calls.map(([period]) => period)
+    expect(closed).toBe(diskOnly)
+    expect(opened.startAt).toEqual(closed.endAt)
+    expect(opened).toEqual(
+      expect.objectContaining({
+        boxId: box.id,
+        organizationId: 'org-current',
+        region: 'eu',
+        cpu: 6,
+        gpu: 2,
+        mem: 12,
+        disk: 80,
+        endAt: null,
+      }),
+    )
+  })
+
+  it('does not split a period that already matches the persisted started box', async () => {
+    const current = Object.assign(new BoxUsagePeriod(), {
+      id: 'period-current',
+      boxId: box.id,
+      organizationId: box.organizationId,
+      region: box.region,
+      cpu: box.cpu,
+      gpu: box.gpu,
+      mem: box.mem,
+      disk: box.disk,
+      startAt: new Date(Date.now() - 60_000),
+      endAt: null,
+    })
+    const { service, transactionalEntityManager } = makeService([current])
+
+    await service.handleBoxStateUpdate(
+      new BoxStateUpdatedEvent({ ...box, state: BoxState.STARTED } as Box, BoxState.STOPPED, BoxState.STARTED),
+    )
+
+    expect(transactionalEntityManager.save).not.toHaveBeenCalled()
+    expect(current.endAt).toBeNull()
+  })
+
+  it('ignores a delayed started event after the persisted box has moved on', async () => {
+    const diskOnly = openPeriod(0)
+    const { service, transactionalEntityManager } = makeService([diskOnly])
+    transactionalEntityManager.findOne.mockImplementation(async (entity) =>
+      entity === Box ? ({ ...box, state: BoxState.STOPPED } as Box) : diskOnly,
+    )
+
+    await service.handleBoxStateUpdate(
+      new BoxStateUpdatedEvent({ ...box, state: BoxState.STARTED } as Box, BoxState.STOPPED, BoxState.STARTED),
+    )
+
+    expect(transactionalEntityManager.findOne).toHaveBeenCalledTimes(1)
+    expect(transactionalEntityManager.save).not.toHaveBeenCalled()
+    expect(diskOnly.endAt).toBeNull()
+  })
+
   it('never closes a period belonging to a different box', async () => {
     const otherBoxPeriod = openPeriod(box.cpu, OTHER_BOX_ID)
-    const { service, usagePeriodRepository } = makeService([otherBoxPeriod])
+    const { service, usagePeriodRepository, transactionalEntityManager } = makeService([otherBoxPeriod])
 
     await service.handleBoxStateUpdate(event(BoxState.STARTED))
 
     // only the newly opened period is written; the other box keeps accruing
-    expect(usagePeriodRepository.save).toHaveBeenCalledTimes(1)
+    expect(usagePeriodRepository.save).not.toHaveBeenCalled()
+    expect(transactionalEntityManager.save).toHaveBeenCalledTimes(1)
     expect(otherBoxPeriod.endAt).toBeNull()
   })
 
@@ -300,19 +414,21 @@ describe('UsageService.handleBoxStateUpdate', () => {
 
   it('does not reopen a period after lease ownership is lost while closing it', async () => {
     const open = openPeriod()
-    const { service, usagePeriodRepository, lease } = makeService([open])
+    open.organizationId = 'org-stale'
+    const { service, usagePeriodRepository, lease, transactionalEntityManager } = makeService([open])
     const ownershipError = new Error('ownership was lost')
     const controller = new AbortController()
     lease.signal = controller.signal
-    usagePeriodRepository.save.mockImplementationOnce(async (period) => {
+    transactionalEntityManager.save.mockImplementationOnce(async (period) => {
       controller.abort(ownershipError)
       return period
     })
 
     await expect(service.handleBoxStateUpdate(event(BoxState.STARTED))).rejects.toBe(ownershipError)
 
-    expect(usagePeriodRepository.save).toHaveBeenCalledTimes(1)
-    expect(usagePeriodRepository.save).toHaveBeenCalledWith(open)
+    expect(usagePeriodRepository.save).not.toHaveBeenCalled()
+    expect(transactionalEntityManager.save).toHaveBeenCalledTimes(1)
+    expect(transactionalEntityManager.save).toHaveBeenCalledWith(open)
     expect(lease.release).toHaveBeenCalledTimes(1)
   })
 })
@@ -349,6 +465,74 @@ describe('UsageService.claimWarmPoolBox', () => {
       expect.stringContaining(`warm-pool claim ${box.id} committed`),
       expect.any(Error),
     )
+  })
+})
+
+describe('UsageService.transitionBoxToStarted', () => {
+  it('atomically replaces a disk-only period through a conditional box update', async () => {
+    const diskOnly = Object.assign(new BoxUsagePeriod(), {
+      id: 'period-stopped',
+      boxId: box.id,
+      organizationId: box.organizationId,
+      region: box.region,
+      cpu: 0,
+      gpu: 0,
+      mem: 0,
+      disk: box.disk,
+      startAt: new Date(Date.now() - 60_000),
+      endAt: null,
+    })
+    const { service, boxRepository, transactionalEntityManager } = makeService([diskOnly])
+    const updatedBox = { ...box, state: BoxState.STARTED } as Box
+    boxRepository.updateWhere.mockImplementation(async (_id, params) => {
+      await params.afterUpdateInTransaction(transactionalEntityManager, updatedBox)
+      return updatedBox
+    })
+    const whereCondition = {
+      state: BoxState.STOPPED,
+      desiredState: BoxDesiredState.STARTED,
+      pending: false,
+    }
+
+    await expect(
+      service.transitionBoxToStarted(box.id, {
+        updateData: { state: BoxState.STARTED },
+        whereCondition,
+      }),
+    ).resolves.toBe(updatedBox)
+
+    expect(boxRepository.updateWhere).toHaveBeenCalledWith(box.id, {
+      updateData: { state: BoxState.STARTED },
+      whereCondition,
+      afterUpdateInTransaction: expect.any(Function),
+    })
+    expect(boxRepository.update).not.toHaveBeenCalled()
+    const [closed, opened] = transactionalEntityManager.save.mock.calls.map(([period]) => period)
+    expect(closed).toBe(diskOnly)
+    expect(opened.startAt).toEqual(closed.endAt)
+    expect(opened).toEqual(
+      expect.objectContaining({
+        boxId: box.id,
+        organizationId: box.organizationId,
+        cpu: box.cpu,
+        gpu: box.gpu,
+        mem: box.mem,
+        disk: box.disk,
+        endAt: null,
+      }),
+    )
+  })
+
+  it('rejects before taking a lock when the update does not target STARTED', async () => {
+    const { service, redisLockProvider, boxRepository } = makeService()
+
+    await expect(
+      service.transitionBoxToStarted(box.id, { updateData: { state: BoxState.STOPPED } }),
+    ).rejects.toThrow(`update state must be ${BoxState.STARTED}`)
+
+    expect(redisLockProvider.waitForLease).not.toHaveBeenCalled()
+    expect(boxRepository.update).not.toHaveBeenCalled()
+    expect(boxRepository.updateWhere).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/api/src/usage/services/usage.service.spec.ts
+++ b/apps/api/src/usage/services/usage.service.spec.ts
@@ -50,6 +50,7 @@ const makeService = (stored: BoxUsagePeriod[] = []) => {
   }
   const transactionalEntityManager = {
     find: jest.fn().mockResolvedValue([]),
+    findOne: jest.fn(),
     delete: jest.fn().mockResolvedValue(undefined),
     save: jest.fn().mockImplementation(async (value) => value),
   }
@@ -382,6 +383,61 @@ describe('UsageService.handleBoxDesiredStateUpdate', () => {
     )
 
     expect(lease.release).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('UsageService.closeAndReopenUsagePeriods', () => {
+  it('creates a rolled period from the Box reread at generation time', async () => {
+    const previousPeriod = Object.assign(new BoxUsagePeriod(), {
+      id: 'period-1',
+      boxId: box.id,
+      organizationId: 'org-previous',
+      region: 'us',
+      startAt: new Date(Date.now() - 25 * 60 * 60 * 1000),
+      endAt: null,
+      cpu: 1,
+      gpu: 0,
+      mem: 2,
+      disk: 5,
+    })
+    const currentBox = {
+      ...box,
+      organizationId: 'org-current',
+      region: 'eu',
+      state: BoxState.STARTED,
+      cpu: 6,
+      gpu: 2,
+      mem: 12,
+      disk: 80,
+    } as Box
+    const { service, usagePeriodRepository, boxRepository, transactionalEntityManager } = makeService()
+    usagePeriodRepository.find.mockResolvedValue([previousPeriod])
+    boxRepository.findOne.mockResolvedValue(currentBox)
+    transactionalEntityManager.findOne.mockResolvedValue(currentBox)
+
+    await service.closeAndReopenUsagePeriods()
+
+    const [closed, opened] = transactionalEntityManager.save.mock.calls.map(([period]) => period)
+    expect(closed).toBe(previousPeriod)
+    expect(closed).toEqual(expect.objectContaining({ organizationId: 'org-previous', region: 'us' }))
+    expect(opened).toEqual(
+      expect.objectContaining({
+        boxId: box.id,
+        organizationId: 'org-current',
+        region: 'eu',
+        cpu: 6,
+        gpu: 2,
+        mem: 12,
+        disk: 80,
+        endAt: null,
+      }),
+    )
+    expect(opened.startAt).toEqual(closed.endAt)
+    expect(transactionalEntityManager.findOne).toHaveBeenCalledWith(Box, {
+      where: { id: box.id },
+      loadEagerRelations: false,
+    })
+    expect(boxRepository.findOne).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/api/src/usage/services/usage.service.spec.ts
+++ b/apps/api/src/usage/services/usage.service.spec.ts
@@ -69,7 +69,7 @@ const makeService = (stored: BoxUsagePeriod[] = []) => {
     acquireLease: jest.fn().mockResolvedValue(lease),
     waitForLease: jest.fn().mockResolvedValue(lease),
   }
-  const boxRepository = { findOne: jest.fn() }
+  const boxRepository = { findOne: jest.fn(), update: jest.fn() }
   const usageExportOutboxService = { enqueue: jest.fn().mockResolvedValue(0) }
   // The reconcile pass builds a left join through the query builder, which this
   // fake cannot stand in for; its behaviour is covered in
@@ -88,6 +88,7 @@ const makeService = (stored: BoxUsagePeriod[] = []) => {
     service,
     usagePeriodRepository,
     redisLockProvider,
+    boxRepository,
     usageExportOutboxService,
     lease,
     transactionalEntityManager,
@@ -113,6 +114,16 @@ describe('UsageService event subscriptions', () => {
 })
 
 describe('UsageService.handleBoxStateUpdate', () => {
+  it('ignores a same-state synthetic event without touching usage periods', async () => {
+    const { service, usagePeriodRepository, redisLockProvider } = makeService([openPeriod()])
+
+    await service.handleBoxStateUpdate(new BoxStateUpdatedEvent(box, BoxState.STARTED, BoxState.STARTED))
+
+    expect(redisLockProvider.waitForLease).not.toHaveBeenCalled()
+    expect(usagePeriodRepository.findOne).not.toHaveBeenCalled()
+    expect(usagePeriodRepository.save).not.toHaveBeenCalled()
+  })
+
   it('cancels a pending lock wait during application shutdown', async () => {
     const { service, redisLockProvider } = makeService()
     redisLockProvider.waitForLease.mockImplementation(
@@ -302,6 +313,41 @@ describe('UsageService.handleBoxStateUpdate', () => {
     expect(usagePeriodRepository.save).toHaveBeenCalledTimes(1)
     expect(usagePeriodRepository.save).toHaveBeenCalledWith(open)
     expect(lease.release).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('UsageService.claimWarmPoolBox', () => {
+  it('creates warm-pool usage attribution without an old period and returns the committed box when lease release fails', async () => {
+    const { service, boxRepository, redisLockProvider, lease } = makeService()
+    const logError = jest.spyOn((service as any).logger, 'error').mockImplementation(() => undefined)
+    const updatedBox = { ...box, state: BoxState.STARTED, organizationId: 'org-target' } as Box
+    const transactionalEntityManager = {
+      findOne: jest.fn().mockResolvedValue(null),
+      save: jest.fn().mockImplementation(async (value) => value),
+    }
+    boxRepository.update.mockImplementation(async (_id, params) => {
+      await params.afterUpdateInTransaction(transactionalEntityManager, updatedBox)
+      return updatedBox
+    })
+    lease.release.mockRejectedValue(new Error('Redis unavailable during release'))
+
+    await expect(
+      service.claimWarmPoolBox(box.id, { updateData: { organizationId: updatedBox.organizationId } }),
+    ).resolves.toBe(updatedBox)
+
+    expect(redisLockProvider.waitForLease).toHaveBeenCalledWith(`usage-period-${box.id}`, 60, expect.any(AbortSignal))
+    expect(transactionalEntityManager.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        boxId: box.id,
+        organizationId: updatedBox.organizationId,
+        startAt: expect.any(Date),
+        endAt: null,
+      }),
+    )
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining(`warm-pool claim ${box.id} committed`),
+      expect.any(Error),
+    )
   })
 })
 

--- a/apps/api/src/usage/services/usage.service.ts
+++ b/apps/api/src/usage/services/usage.service.ts
@@ -328,36 +328,27 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
           await this.withLease(
             boxLease,
             async (boxSignal) => {
-              const box = await this.boxRepository.findOne({
-                where: {
-                  id: usagePeriod.boxId,
-                },
-              })
-
               await this.boxUsagePeriodRepository.manager.transaction(async (transactionalEntityManager) => {
                 boxSignal.throwIfAborted()
+                const box = await transactionalEntityManager.findOne(Box, {
+                  where: {
+                    id: usagePeriod.boxId,
+                  },
+                  loadEagerRelations: false,
+                })
+                boxSignal.throwIfAborted()
+
                 // Close usage period
                 const closeTime = new Date()
                 usagePeriod.endAt = closeTime
                 await transactionalEntityManager.save(usagePeriod)
 
-                // Roll over with the resources the box calls for *now*, not the ones
-                // the closing period happened to carry. Copying the old figures kept
-                // any drift alive forever: a period left charging no cpu for a running
-                // box was re-copied every day, and a disk resize that landed while the
-                // box was stopped never reached the ledger at all. A box that is gone
-                // or terminal yields no shape and so is not reopened, which is what
-                // stops a deleted box from accruing.
+                // Derive the entire new period from the box as it exists when the
+                // period is generated. The closing period is historical attribution
+                // and may no longer match the box's owner, region, or resources.
                 const expected = expectedOpenPeriod(box)
                 if (expected !== null) {
-                  const newUsagePeriod = BoxUsagePeriod.fromUsagePeriod(usagePeriod)
-                  newUsagePeriod.startAt = closeTime
-                  newUsagePeriod.endAt = null
-                  newUsagePeriod.cpu = expected.cpu
-                  newUsagePeriod.gpu = expected.gpu
-                  newUsagePeriod.mem = expected.mem
-                  newUsagePeriod.disk = expected.disk
-                  await transactionalEntityManager.save(newUsagePeriod)
+                  await this.createUsagePeriod(box, expected, transactionalEntityManager, closeTime)
                 }
                 boxSignal.throwIfAborted()
               })

--- a/apps/api/src/usage/services/usage.service.ts
+++ b/apps/api/src/usage/services/usage.service.ts
@@ -24,7 +24,11 @@ import { TrackJobExecution } from '../../common/decorators/track-job-execution.d
 import { setTimeout as sleep } from 'timers/promises'
 import { LogExecution } from '../../common/decorators/log-execution.decorator'
 import { WithInstrumentation } from '../../common/decorators/otel.decorator'
-import { BoxRepository } from '../../box/repositories/box.repository'
+import {
+  BoxRepository,
+  type BoxUpdateParams,
+  type BoxUpdateWhereParams,
+} from '../../box/repositories/box.repository'
 import { UsageExportOutboxService } from './usage-export-outbox.service'
 import { Box } from '../../box/entities/box.entity'
 import { Runner } from '../../box/entities/runner.entity'
@@ -71,6 +75,10 @@ interface DriftCandidate {
   box_region: string
   period_id: string | null
 }
+
+export type StartedBoxUpdateParams =
+  | Pick<BoxUpdateParams, 'updateData' | 'entity'>
+  | Pick<BoxUpdateWhereParams, 'updateData' | 'whereCondition'>
 
 @Injectable()
 export class UsageService implements TrackableJobExecutions, OnApplicationShutdown {
@@ -134,9 +142,7 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
         signal.throwIfAborted()
         switch (event.newState) {
           case BoxState.STARTED: {
-            await this.closeUsagePeriod(event.box.id)
-            signal.throwIfAborted()
-            await this.openUsagePeriodFor(event.box, event.newState)
+            await this.syncStartedUsagePeriodFromCurrentBox(event.box.id, signal)
             break
           }
           // Billing stops charging compute the moment a stop is requested.
@@ -180,6 +186,26 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
    * the same database transaction as the box update.
    */
   async claimWarmPoolBox(id: string, params: { updateData: Partial<Box>; entity?: Box }): Promise<Box> {
+    return this.updateBoxAndUsagePeriod(id, params, `warm-pool claim ${id}`)
+  }
+
+  /**
+   * Persists a transition to STARTED and replaces its disk-only period in the
+   * same database transaction.
+   */
+  async transitionBoxToStarted(id: string, params: StartedBoxUpdateParams): Promise<Box> {
+    if (params.updateData.state !== BoxState.STARTED) {
+      throw new Error(`Cannot atomically start box ${id}: update state must be ${BoxState.STARTED}`)
+    }
+
+    return this.updateBoxAndUsagePeriod(id, params, `box start ${id}`)
+  }
+
+  private async updateBoxAndUsagePeriod(
+    id: string,
+    params: StartedBoxUpdateParams,
+    context: string,
+  ): Promise<Box> {
     const lease = await this.waitForLock(id)
     let committedBox: Box | null = null
 
@@ -188,47 +214,66 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
         lease,
         async (signal) => {
           signal.throwIfAborted()
-          const updatedBox = await this.boxRepository.update(id, {
-            ...params,
-            afterUpdateInTransaction: async (entityManager, transactionalBox) => {
-              signal.throwIfAborted()
-              await this.switchWarmPoolUsagePeriod(entityManager, transactionalBox, signal)
-              signal.throwIfAborted()
-            },
-          })
+          const afterUpdateInTransaction = async (entityManager: EntityManager, transactionalBox: Box) => {
+            signal.throwIfAborted()
+            await this.syncUsagePeriodInTransaction(entityManager, transactionalBox, signal)
+            signal.throwIfAborted()
+          }
+          const updatedBox =
+            'whereCondition' in params
+              ? await this.boxRepository.updateWhere(id, {
+                  updateData: params.updateData,
+                  whereCondition: params.whereCondition,
+                  afterUpdateInTransaction,
+                })
+              : await this.boxRepository.update(id, {
+                  updateData: params.updateData,
+                  entity: params.entity,
+                  afterUpdateInTransaction,
+                })
           committedBox = updatedBox
           return updatedBox
         },
-        `warm-pool claim ${id}`,
+        context,
       )
     } catch (error) {
       // The database is already authoritative at this point. Returning success
-      // prevents a client retry from claiming another warm-pool box merely
-      // because lease renewal or release failed after commit.
+      // prevents a caller retry merely because lease renewal or release failed
+      // after commit.
       if (committedBox) {
-        this.logger.error(
-          `Usage lease failed after warm-pool claim ${id} committed; returning the committed box`,
-          error,
-        )
+        this.logger.error(`Usage lease failed after ${context} committed; returning the committed box`, error)
         return committedBox
       }
       throw error
     }
   }
 
-  private async switchWarmPoolUsagePeriod(entityManager: EntityManager, box: Box, signal: AbortSignal): Promise<void> {
+  private async syncUsagePeriodInTransaction(
+    entityManager: EntityManager,
+    box: Box,
+    signal: AbortSignal,
+  ): Promise<void> {
     const expected = expectedOpenPeriod(box)
     if (expected === null) {
-      throw new Error(`Cannot claim warm-pool box ${box.id}: state ${box.state} has no billable usage period`)
+      throw new Error(`Cannot synchronize usage for box ${box.id}: state ${box.state} has no billable period`)
     }
 
-    // The box UPDATE has already locked its row. Lock the ledger second so all
-    // claim writers use the same Box -> BoxUsagePeriod ordering.
+    // The box row is already locked. Lock the ledger second so every atomic
+    // state and attribution writer uses the same Box -> BoxUsagePeriod order.
     const openPeriod = await entityManager.findOne(BoxUsagePeriod, {
       where: { boxId: box.id, endAt: IsNull() },
       lock: { mode: 'pessimistic_write' },
     })
     signal.throwIfAborted()
+
+    if (
+      openPeriod &&
+      sameShape(openPeriod, expected) &&
+      openPeriod.organizationId === box.organizationId &&
+      openPeriod.region === box.region
+    ) {
+      return
+    }
 
     const transitionAt = new Date()
     if (openPeriod) {
@@ -238,6 +283,37 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
     }
 
     await this.createUsagePeriod(box, expected, entityManager, transitionAt)
+    signal.throwIfAborted()
+  }
+
+  /**
+   * Synchronizes the open period for a STARTED Box from the persisted row. The
+   * state event is only a notification and may carry an attribution snapshot
+   * that is stale by the time it is handled.
+   */
+  private async syncStartedUsagePeriodFromCurrentBox(boxId: string, signal: AbortSignal): Promise<void> {
+    await this.boxUsagePeriodRepository.manager.transaction(async (entityManager) => {
+      signal.throwIfAborted()
+      const box = await entityManager.findOne(Box, {
+        where: { id: boxId },
+        lock: { mode: 'pessimistic_write' },
+        loadEagerRelations: false,
+      })
+      signal.throwIfAborted()
+
+      // A delayed STARTED event must not overwrite the period for a newer Box
+      // state. The event that produced that state owns its own billing change.
+      if (!box || box.state !== BoxState.STARTED) {
+        return
+      }
+
+      const expected = expectedOpenPeriod(box)
+      if (expected === null) {
+        return
+      }
+
+      await this.syncUsagePeriodInTransaction(entityManager, box, signal)
+    })
   }
 
   /**

--- a/apps/api/src/usage/services/usage.service.ts
+++ b/apps/api/src/usage/services/usage.service.ts
@@ -120,6 +120,12 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
   @OnEvent(BoxEvents.STATE_UPDATED)
   @TrackJobExecution()
   async handleBoxStateUpdate(event: BoxStateUpdatedEvent) {
+    // Warm-pool claims deliberately publish a synthetic STARTED event for
+    // downstream observers. Its billing cutover already committed with the box.
+    if (event.oldState === event.newState) {
+      return
+    }
+
     const lease = await this.waitForLock(event.box.id)
 
     await this.withLease(
@@ -170,6 +176,71 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
   }
 
   /**
+   * Claims a warm-pool box and moves its open usage period to the new owner in
+   * the same database transaction as the box update.
+   */
+  async claimWarmPoolBox(id: string, params: { updateData: Partial<Box>; entity?: Box }): Promise<Box> {
+    const lease = await this.waitForLock(id)
+    let committedBox: Box | null = null
+
+    try {
+      return await this.withLease(
+        lease,
+        async (signal) => {
+          signal.throwIfAborted()
+          const updatedBox = await this.boxRepository.update(id, {
+            ...params,
+            afterUpdateInTransaction: async (entityManager, transactionalBox) => {
+              signal.throwIfAborted()
+              await this.switchWarmPoolUsagePeriod(entityManager, transactionalBox, signal)
+              signal.throwIfAborted()
+            },
+          })
+          committedBox = updatedBox
+          return updatedBox
+        },
+        `warm-pool claim ${id}`,
+      )
+    } catch (error) {
+      // The database is already authoritative at this point. Returning success
+      // prevents a client retry from claiming another warm-pool box merely
+      // because lease renewal or release failed after commit.
+      if (committedBox) {
+        this.logger.error(
+          `Usage lease failed after warm-pool claim ${id} committed; returning the committed box`,
+          error,
+        )
+        return committedBox
+      }
+      throw error
+    }
+  }
+
+  private async switchWarmPoolUsagePeriod(entityManager: EntityManager, box: Box, signal: AbortSignal): Promise<void> {
+    const expected = expectedOpenPeriod(box)
+    if (expected === null) {
+      throw new Error(`Cannot claim warm-pool box ${box.id}: state ${box.state} has no billable usage period`)
+    }
+
+    // The box UPDATE has already locked its row. Lock the ledger second so all
+    // claim writers use the same Box -> BoxUsagePeriod ordering.
+    const openPeriod = await entityManager.findOne(BoxUsagePeriod, {
+      where: { boxId: box.id, endAt: IsNull() },
+      lock: { mode: 'pessimistic_write' },
+    })
+    signal.throwIfAborted()
+
+    const transitionAt = new Date()
+    if (openPeriod) {
+      openPeriod.endAt = transitionAt
+      await entityManager.save(openPeriod)
+      signal.throwIfAborted()
+    }
+
+    await this.createUsagePeriod(box, expected, entityManager, transitionAt)
+  }
+
+  /**
    * Opens the period the box's current state calls for. A box that bills nothing
    * (terminal) or whose state is still in flight gets none — the caller has
    * already closed whatever was open.
@@ -189,10 +260,11 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
     box: Pick<Box, 'id' | 'organizationId' | 'region'>,
     shape: UsagePeriodShape,
     entityManager?: EntityManager,
+    startAt = new Date(),
   ) {
     const usagePeriod = new BoxUsagePeriod()
     usagePeriod.boxId = box.id
-    usagePeriod.startAt = new Date()
+    usagePeriod.startAt = startAt
     usagePeriod.endAt = null
     usagePeriod.cpu = shape.cpu
     usagePeriod.gpu = shape.gpu


### PR DESCRIPTION
## Summary

`assignWarmPoolBox` committed `Box.organizationId` before publishing the in-process synthetic state event that moved usage attribution. A process exit, dropped event, or failed listener therefore left the open period on the warm-pool sentinel until reconcile, creating an unbillable interval that reconcile cannot backfill. A claim now holds the existing per-box lease and commits ownership and the ledger cutover in one PostgreSQL transaction; notifications remain post-commit.

## Call graph

Before

```
assignWarmPoolBox      (BoxService · apps/api/src/box/services/box.service.ts:347) — warm-pool claim
  update               (BoxRepository · apps/api/src/box/repositories/box.repository.ts:92)  ← BUG: commits the target organization before the usage ledger changes
  emit STATE_UPDATED   (BoxService · apps/api/src/box/services/box.service.ts:404)             ← BUG: a non-durable post-commit event is the only billing handoff
    handleBoxStateUpdate (UsageService · apps/api/src/usage/services/usage.service.ts:122)
      closeUsagePeriod   (UsageService · apps/api/src/usage/services/usage.service.ts:207) — closes the sentinel period later
      openUsagePeriodFor (UsageService · apps/api/src/usage/services/usage.service.ts:177) — opens the tenant period with a second timestamp
```

After

```
assignWarmPoolBox        (BoxService · apps/api/src/box/services/box.service.ts:349)
  claimWarmPoolBox       (UsageService · apps/api/src/usage/services/usage.service.ts:182) — holds usage-period-{boxId}
    update               (BoxRepository · apps/api/src/box/repositories/box.repository.ts:100) — conditional UPDATE locks Box first
      afterUpdateInTransaction (BoxRepository · apps/api/src/box/repositories/box.repository.ts:140) — still inside the Box transaction
        switchWarmPoolUsagePeriod (UsageService · apps/api/src/usage/services/usage.service.ts:219)
          findOne        (EntityManager · apps/api/src/usage/services/usage.service.ts:227) — locks the open period second
          save           (EntityManager · apps/api/src/usage/services/usage.service.ts:236) — closes sentinel at T
          createUsagePeriod (UsageService · apps/api/src/usage/services/usage.service.ts:259) — opens the current owner at the same T
    emitUpdateEvents     (BoxRepository · apps/api/src/box/repositories/box.repository.ts:143) — ownership observers run after commit
  emit STATE_UPDATED     (BoxService · apps/api/src/box/services/box.service.ts:406) — notification, analytics, and webhook signal remains
    handleBoxStateUpdate (UsageService · apps/api/src/usage/services/usage.service.ts:122) — same-state events no longer rewrite the ledger
```

Refs POL-175

## Changes

- Adds a private non-raw `BoxRepository.update` transaction callback, run after the conditional Box and `BoxLastActivity` writes but before commit. A callback error rolls the whole transaction back; cache invalidation and events keep their existing post-commit boundary.
- Adds `UsageService.claimWarmPoolBox`, reusing the renewable `usage-period-{boxId}` lease and the Box -> BoxUsagePeriod lock order. The old period ends exactly where the target period starts, and a box with no old period opens the target period directly from its current organization, region, and resources.
- Returns the committed Box if only Redis renewal or release fails after the transaction, preventing a client retry from claiming a second box.
- Routes both explicit-name and generated-name retry paths through the atomic claim and ignores same-state synthetic events only in the usage listener. Every other listener still receives the event.
- Covers dropped events, exact period boundaries, current attribution, rollback before post-commit events, absent old periods, lease-release failure, same-state handling, and both naming paths.

## How to verify

```bash
DB_HOST='' REDIS_HOST='' make test:apps FILTER='warm-pool usage attribution|same-state'
DB_HOST='' REDIS_HOST='' make test:apps
make lint:apps
GOFLAGS='-tags=boxlite_dev' VERSION=0.10.0 make build:apps
```

The focused run passed 5 tests. The full API run passed 621 tests with 74 integration tests skipped, lint completed with 0 errors and 41 pre-existing warnings, and all 9 apps projects built. The changed files also pass Prettier and `git diff --check`.

Two-side verified: with every production file reverted and the dropped event reproducer left in place, the Box belonged to the target tenant while the sentinel period remained open (`Expected constructor: Date`, `Received value: null`). Restored, the focused suite passes and both periods share the same boundary.

## Risks / rollout

- A warm-pool claim now keeps its database transaction open while it locks and writes one usage period. The existing per-box renewable lease serializes normal writers; a ledger failure now rejects and rolls back the claim instead of exposing partially committed ownership.
- Same-state Box events no longer touch usage periods. Notification, analytics, webhook, and warm-pool observers still receive the original event.
- A post-commit Redis failure returns success and may leave the lease key until its TTL expires. This delays another writer but avoids the more dangerous duplicate client claim.
- The real PostgreSQL + Redis rollback cases are checked in but skipped locally because those services were not running. Repository-boundary and event-drop tests exercised the same failure path without them.

Not included: daily rollover attribution from POL-175, ordinary organization-to-organization transfers, historical billing backfill, or changes to EventEmitter, reconcile, export, HTTP APIs, and schemas.

## Summary
<!-- 1-2 sentences: what this changes and why. -->

## Call graph
<!-- Required. The end-to-end path this PR touches, before and after; one line
     per hop, only the hops that change. Worked example and the bug-fix markers:
     CONTRIBUTING.md#commit--pr-messages. -->

Before
<!-- replace with the hops: fn_name (Type · path/file.rs:LOC) — role -->

After
<!-- replace with the same hops, post-change -->

Fixes #<!-- issue number — bug fixes only; delete this line otherwise -->

## Changes
- <!-- notable change — what changed, not a restatement of the diff -->

## How to verify
- <!-- a command or step a reviewer can run -->

## Risks / rollout
- <!-- only if any; delete this section otherwise -->

<!-- Describe the change, not the process: no pasted logs, no AI/conversation
     narrative, no secrets. Keep it tight and delete sections that don't apply. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Warm-pool box assignments now transfer usage and billing attribution to the new organization.
  * Box ownership and usage-period updates are coordinated transactionally for consistent results.
  * Usage periods now roll over using the box’s current billing attribution.
  * Box start operations now atomically update state and usage periods.

* **Bug Fixes**
  * Failed usage attribution now rolls back box ownership changes.
  * Stale or redundant state events no longer trigger unnecessary processing.
  * Post-assignment events and cache updates are skipped when a transaction fails.
  * Assignment results remain available even if post-assignment lease cleanup fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->