### PR TITLE
refactor(dashboard): show remaining quota in usage summary

### DIFF
--- a/apps/dashboard/src/components/billing/ThisCycleCard.render.test.tsx
+++ b/apps/dashboard/src/components/billing/ThisCycleCard.render.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { ThisCycleCard } from './ThisCycleCard'
+
+const plan = {
+  planId: 'pro',
+  planName: 'Pro',
+  status: 'active' as const,
+  cycleFrom: new Date('2026-08-05T12:00:00.000Z'),
+  cycleTo: new Date('2026-09-05T12:00:00.000Z'),
+  includedQuotaCents: 25_000,
+  quotaConsumedCents: 6_250,
+  quotaRemainingCents: 18_750,
+}
+
+vi.mock('@/hooks/queries/billingQueries', () => ({
+  useOwnerPlanQuery: () => ({ data: plan, isLoading: false }),
+  useOwnerWalletQuery: () => ({ data: undefined }),
+}))
+
+vi.mock('@/hooks/queries/usePlansQuery', () => ({
+  usePlansQuery: () => ({ data: undefined }),
+}))
+
+vi.mock('@/hooks/queries/useRunningBoxCountQuery', () => ({
+  useRunningBoxCountQuery: () => ({ data: undefined }),
+}))
+
+vi.mock('@/hooks/useSelectedOrganization', () => ({
+  useSelectedOrganization: () => ({ selectedOrganization: { id: 'org-1' } }),
+}))
+
+describe('ThisCycleCard quota summary', () => {
+  let root: Root | null = null
+
+  beforeAll(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  })
+
+  afterEach(() => {
+    act(() => root?.unmount())
+    root = null
+    document.body.innerHTML = ''
+  })
+
+  it('renders quota remaining from the plan response', () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+
+    act(() => {
+      root = createRoot(host)
+      root.render(<ThisCycleCard />)
+    })
+
+    const label = [...document.querySelectorAll('span')].find((element) =>
+      element.textContent?.includes('Quota Remaining'),
+    )
+
+    expect(label).toBeDefined()
+    expect(label?.parentElement?.textContent).toContain('$187.50')
+    expect(label?.parentElement?.textContent).not.toContain('$62.50')
+    expect(document.body.textContent).not.toContain('Quota consumed')
+  })
+})

--- a/apps/dashboard/src/components/billing/ThisCycleCard.tsx
+++ b/apps/dashboard/src/components/billing/ThisCycleCard.tsx
@@ -47,7 +47,7 @@ export function cycleFacts(plan: OrganizationPlan, now: Date, catalog: Plan[] = 
 }
 
 /**
- * The current billing cycle at a glance: quota consumed against the plan's
+ * The current billing cycle at a glance: quota remaining from the plan's
  * grant, the wallet that funds the overage, and when the cycle rolls. Every
  * number is the billing service's own — the plan block and the wallet — so
  * the meter here is the meter settlement charges by. Renders nothing when
@@ -89,8 +89,8 @@ export function ThisCycleCard() {
       <Panel>
         <div className="flex flex-col gap-6 px-[22px] py-6 sm:flex-row sm:gap-14">
           <Metric
-            label="Quota consumed"
-            value={formatAmount(plan.quotaConsumedCents)}
+            label="Quota Remaining"
+            value={formatAmount(plan.quotaRemainingCents ?? 0)}
             sub={unlimited ? 'unlimited quota' : `of ${formatAmount(plan.includedQuotaCents ?? 0)} included`}
           />
           {wallet && (


### PR DESCRIPTION
## Summary

The Usage tab reports its primary current-cycle metric as quota consumed even
though the plan response provides the remaining allowance. Show the remaining
quota in the headline while leaving the consumption meter below unchanged.

## Call graph

Before

```text
UsageSection (component · apps/dashboard/src/components/billing/UsageSection.tsx:43) — renders the Usage tab
└─ ThisCycleCard (component · apps/dashboard/src/components/billing/ThisCycleCard.tsx:57) — renders the current cycle
   └─ Metric (component · apps/dashboard/src/components/billing/ThisCycleCard.tsx:91) — labels quota consumed and formats plan.quotaConsumedCents
```

After

```text
UsageSection (component · apps/dashboard/src/components/billing/UsageSection.tsx:43) — renders the Usage tab
└─ ThisCycleCard (component · apps/dashboard/src/components/billing/ThisCycleCard.tsx:57) — renders the current cycle
   └─ Metric (component · apps/dashboard/src/components/billing/ThisCycleCard.tsx:91) — labels quota remaining and formats plan.quotaRemainingCents
```

## Changes

- Rename the current-cycle headline metric to Quota Remaining.
- Render the remaining cents returned by the organization plan response.
- Cover the label and response-field selection with a component test.

## How to verify

- `cd apps && yarn vitest --config dashboard/vite.config.mts run dashboard/src/components/billing/ThisCycleCard.test.ts dashboard/src/components/billing/ThisCycleCard.render.test.tsx` — 9/9 passed.
- `cd apps && yarn prettier --check dashboard/src/components/billing/ThisCycleCard.tsx dashboard/src/components/billing/ThisCycleCard.render.test.tsx --config ../.prettierrc` — passed.
- `cd apps && yarn nx run dashboard:build` — production build passed.
- `git diff-tree --check HEAD^ HEAD` — passed.

## Risks / rollout

- Billing API contracts and the lower quota-used meter are unchanged.
- The full apps build requires VERSION for Runner; the focused Dashboard production build passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the billing card to prominently display the remaining quota for the current plan.

* **Bug Fixes**
  * Corrected the primary quota metric to show the remaining amount rather than the consumed amount.
  * Preserved the separate quota-used breakdown and reset information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->