### PR TITLE
feat(api): report last activity in box metadata

### DIFF
--- a/apps/api/src/box/dto/box.dto.ts
+++ b/apps/api/src/box/dto/box.dto.ts
@@ -249,6 +249,15 @@ export class BoxDto {
   updatedAt?: string
 
   @ApiPropertyOptional({
+    description:
+      'The timestamp of the last recorded activity on the box, absent when no activity has been recorded yet',
+    example: '2024-10-01T12:00:00Z',
+    required: false,
+  })
+  @IsOptional()
+  lastActivityAt?: string
+
+  @ApiPropertyOptional({
     description: 'The class of the box',
     enum: BoxClass,
     example: Object.values(BoxClass)[0],
@@ -281,7 +290,12 @@ export class BoxDto {
   })
   toolboxProxyUrl: string
 
-  static fromBox(box: Box, toolboxProxyUrl: string): BoxDto {
+  // `lastActivityAt` is passed in rather than read off the entity: the freshest
+  // value lives in the activity service's Redis buffer, and the entity's
+  // same-named relation is a `BoxLastActivity` row that read paths do not join.
+  // It is reported raw, without the auto-stop sweeper's fallback to
+  // `updatedAt` — that fallback is a stop policy, not recorded activity.
+  static fromBox(box: Box, toolboxProxyUrl: string, lastActivityAt?: Date | null): BoxDto {
     return {
       id: box.id,
       organizationId: box.organizationId,
@@ -309,6 +323,7 @@ export class BoxDto {
       class: box.class,
       createdAt: box.createdAt ? new Date(box.createdAt).toISOString() : undefined,
       updatedAt: box.updatedAt ? new Date(box.updatedAt).toISOString() : undefined,
+      lastActivityAt: lastActivityAt ? new Date(lastActivityAt).toISOString() : undefined,
       daemonVersion: box.daemonVersion,
       runnerId: box.runnerId,
       toolboxProxyUrl,

--- a/apps/api/src/box/services/box-activity.service.read.spec.ts
+++ b/apps/api/src/box/services/box-activity.service.read.spec.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { In } from 'typeorm'
+import { BoxActivityService } from './box-activity.service'
+
+// The buffer is drained to the database every few seconds, so a read has to
+// answer from whichever side holds the box: these cases pin the precedence and
+// keep the database out of a read the buffer already answered.
+describe('BoxActivityService activity reads', () => {
+  const bufferedAt = new Date('2026-08-27T10:00:00.000Z')
+  const storedAt = new Date('2026-08-27T09:00:00.000Z')
+
+  let buffer: Map<string, Date>
+  let stored: Map<string, Date>
+  let findByCalls: unknown[]
+  let service: BoxActivityService
+
+  beforeEach(() => {
+    buffer = new Map()
+    stored = new Map()
+    findByCalls = []
+
+    const redis = {
+      pipeline: () => {
+        const requestedBoxIds: string[] = []
+        return {
+          zscore: (_key: string, boxId: string) => {
+            requestedBoxIds.push(boxId)
+          },
+          exec: () =>
+            Promise.resolve(
+              requestedBoxIds.map((boxId) => {
+                const at = buffer.get(boxId)
+                return [null, at ? String(at.getTime()) : null]
+              }),
+            ),
+        }
+      },
+    }
+
+    const dataSource = {
+      getRepository: () => ({
+        findBy: (where: { boxId: unknown }) => {
+          findByCalls.push(where.boxId)
+          return Promise.resolve([...stored].map(([boxId, lastActivityAt]) => ({ boxId, lastActivityAt })))
+        },
+      }),
+    }
+
+    service = new BoxActivityService(redis as any, dataSource as any, {} as any, {} as any)
+  })
+
+  it('prefers the buffered timestamp over the stored one', async () => {
+    buffer.set('box-buffered', bufferedAt)
+    stored.set('box-buffered', storedAt)
+
+    await expect(service.getLastActivityAt('box-buffered')).resolves.toEqual(bufferedAt)
+    expect(findByCalls).toEqual([])
+  })
+
+  it('falls back to the stored timestamp when the buffer has no entry', async () => {
+    stored.set('box-stored', storedAt)
+
+    await expect(service.getLastActivityAt('box-stored')).resolves.toEqual(storedAt)
+    expect(findByCalls).toEqual([In(['box-stored'])])
+  })
+
+  it('reports null for a box with no recorded activity', async () => {
+    await expect(service.getLastActivityAt('box-idle')).resolves.toBeNull()
+  })
+
+  it('merges both sides for many boxes and queries only the unbuffered ones', async () => {
+    buffer.set('box-buffered', bufferedAt)
+    stored.set('box-stored', storedAt)
+
+    const timestamps = await service.getLastActivityAtMany(['box-buffered', 'box-stored', 'box-idle', 'box-buffered'])
+
+    expect(timestamps.get('box-buffered')).toEqual(bufferedAt)
+    expect(timestamps.get('box-stored')).toEqual(storedAt)
+    expect(timestamps.has('box-idle')).toBe(false)
+    expect(findByCalls).toEqual([In(['box-stored', 'box-idle'])])
+  })
+
+  it('touches neither store when asked for no boxes', async () => {
+    await expect(service.getLastActivityAtMany([])).resolves.toEqual(new Map())
+    expect(findByCalls).toEqual([])
+  })
+})

--- a/apps/api/src/box/services/box-activity.service.ts
+++ b/apps/api/src/box/services/box-activity.service.ts
@@ -7,7 +7,7 @@ import { Injectable, Logger } from '@nestjs/common'
 import { InjectRedis } from '@nestjs-modules/ioredis'
 import Redis from 'ioredis'
 import { InjectDataSource } from '@nestjs/typeorm'
-import { DataSource } from 'typeorm'
+import { DataSource, In } from 'typeorm'
 import { Cron, CronExpression } from '@nestjs/schedule'
 import { RedisLockProvider } from '../common/redis-lock.provider'
 import { BoxLastActivity } from '../entities/box-last-activity.entity'
@@ -56,14 +56,60 @@ export class BoxActivityService {
    * Checks Redis buffer first, falls back to the database.
    */
   async getLastActivityAt(boxId: string): Promise<Date | null> {
-    const score = await this.redis.zscore(REDIS_ACTIVITY_KEY, boxId)
-    if (score !== null) {
-      return new Date(Number(score))
+    const timestamps = await this.getLastActivityAtMany([boxId])
+    return timestamps.get(boxId) ?? null
+  }
+
+  /**
+   * Read the last activity timestamps for many boxes.
+   *
+   * Same buffer-before-database precedence as {@link getLastActivityAt}, in two
+   * round trips regardless of how many boxes are asked for: one pipelined Redis
+   * read, then a single query for the boxes the buffer did not answer. Boxes
+   * with no recorded activity are absent from the map.
+   */
+  async getLastActivityAtMany(boxIds: string[]): Promise<Map<string, Date>> {
+    const timestamps = new Map<string, Date>()
+    const uniqueBoxIds = [...new Set(boxIds)]
+    if (uniqueBoxIds.length === 0) {
+      return timestamps
     }
 
-    const row = await this.dataSource.getRepository(BoxLastActivity).findOne({ where: { boxId } })
+    const pipeline = this.redis.pipeline()
+    for (const boxId of uniqueBoxIds) {
+      pipeline.zscore(REDIS_ACTIVITY_KEY, boxId)
+    }
+    // ZMSCORE would be one command, but it needs Redis 6.2; a pipeline reads
+    // the same buffer in one round trip against any server version.
+    const bufferedScores = await pipeline.exec()
 
-    return row?.lastActivityAt ?? null
+    const unbufferedBoxIds: string[] = []
+    uniqueBoxIds.forEach((boxId, index) => {
+      const [error, score] = bufferedScores?.[index] ?? [null, null]
+      // A per-command failure is raised rather than answered from the database:
+      // a single-box ZSCORE failure has always surfaced to the caller.
+      if (error) {
+        throw error
+      }
+      if (score === null || score === undefined) {
+        unbufferedBoxIds.push(boxId)
+        return
+      }
+      timestamps.set(boxId, new Date(Number(score)))
+    })
+
+    if (unbufferedBoxIds.length === 0) {
+      return timestamps
+    }
+
+    const rows = await this.dataSource.getRepository(BoxLastActivity).findBy({ boxId: In(unbufferedBoxIds) })
+    for (const row of rows) {
+      if (row.lastActivityAt) {
+        timestamps.set(row.boxId, row.lastActivityAt)
+      }
+    }
+
+    return timestamps
   }
 
   /**

--- a/apps/api/src/box/services/box.service.dto.spec.ts
+++ b/apps/api/src/box/services/box.service.dto.spec.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Box } from '../entities/box.entity'
+import { BoxService } from './box.service'
+
+// create() persists the box before it converts, so a rejection from the
+// activity read reads to the client as a failed creation and invites a
+// duplicate on retry. Last activity is metadata: it degrades, the box does not.
+describe('BoxService DTO conversion', () => {
+  const activityFailure = new Error('READONLY You cannot write against a read only replica')
+
+  function createService(boxActivityService: unknown): BoxService {
+    const service = Object.create(BoxService.prototype) as BoxService
+    Object.assign(service as any, {
+      logger: { warn: jest.fn(), error: jest.fn() },
+      boxActivityService,
+      resolveToolboxProxyUrl: jest.fn().mockResolvedValue('https://proxy.test/toolbox'),
+      resolveToolboxProxyUrls: jest.fn(
+        async (regionIds: string[]) => new Map(regionIds.map((id) => [id, `https://${id}.test/toolbox`])),
+      ),
+    })
+    return service
+  }
+
+  it('serves a box without its last activity when the activity read fails', async () => {
+    const box = new Box('us', 'data-loader')
+    const service = createService({ getLastActivityAt: jest.fn().mockRejectedValue(activityFailure) })
+
+    const dto = await service.toBoxDto(box)
+
+    expect(dto.id).toBe(box.id)
+    expect(dto.toolboxProxyUrl).toBe('https://proxy.test/toolbox')
+    expect(dto.lastActivityAt).toBeUndefined()
+  })
+
+  it('serves a box list without last activity when the bulk activity read fails', async () => {
+    const boxes = [new Box('us', 'data-loader'), new Box('eu', 'log-shipper')]
+    const service = createService({ getLastActivityAtMany: jest.fn().mockRejectedValue(activityFailure) })
+
+    const dtos = await service.toBoxDtos(boxes)
+
+    expect(dtos.map((dto) => dto.id)).toEqual(boxes.map((box) => box.id))
+    expect(dtos.map((dto) => dto.toolboxProxyUrl)).toEqual(['https://us.test/toolbox', 'https://eu.test/toolbox'])
+    expect(dtos.map((dto) => dto.lastActivityAt)).toEqual([undefined, undefined])
+  })
+
+  it('still fails the conversion when the toolbox proxy URL cannot be resolved', async () => {
+    const box = new Box('us', 'data-loader')
+    const service = createService({ getLastActivityAt: jest.fn().mockResolvedValue(null) })
+    ;(service as any).resolveToolboxProxyUrl = jest.fn().mockRejectedValue(new Error('region lookup failed'))
+
+    await expect(service.toBoxDto(box)).rejects.toThrow('region lookup failed')
+  })
+})

--- a/apps/api/src/box/services/box.service.ts
+++ b/apps/api/src/box/services/box.service.ts
@@ -1087,19 +1087,40 @@ export class BoxService {
     return this.resolveToolboxProxyUrl(box.region)
   }
 
+  /**
+   * Last activity is metadata about the box rather than part of it, so the read
+   * degrades to absent instead of failing the conversion: create() has already
+   * persisted the box by the time it converts, and a rejection there would read
+   * to the client as a failed creation and invite a duplicate on retry. The
+   * auto-lifecycle paths keep reading it directly, where the distinction
+   * between "unknown" and "idle" decides whether a box is stopped.
+   */
   async toBoxDto(box: Box): Promise<BoxDto> {
-    const toolboxProxyUrl = await this.resolveToolboxProxyUrl(box.region)
-    return BoxDto.fromBox(box, toolboxProxyUrl)
+    const [toolboxProxyUrl, lastActivityAt] = await Promise.all([
+      this.resolveToolboxProxyUrl(box.region),
+      this.boxActivityService.getLastActivityAt(box.id).catch((err) => {
+        this.logger.warn(`Failed to read last activity for box ${box.id}: ${err}`)
+        return null
+      }),
+    ])
+    return BoxDto.fromBox(box, toolboxProxyUrl, lastActivityAt)
   }
 
+  /** Degrades a failed activity read to absent, as {@link toBoxDto} does. */
   async toBoxDtos(boxes: Box[]): Promise<BoxDto[]> {
-    const urlMap = await this.resolveToolboxProxyUrls(boxes.map((s) => s.region))
+    const [urlMap, activityMap] = await Promise.all([
+      this.resolveToolboxProxyUrls(boxes.map((s) => s.region)),
+      this.boxActivityService.getLastActivityAtMany(boxes.map((s) => s.id)).catch((err) => {
+        this.logger.warn(`Failed to read last activity for ${boxes.length} boxes: ${err}`)
+        return new Map<string, Date>()
+      }),
+    ])
     return boxes.map((s) => {
       const url = urlMap.get(s.region)
       if (!url) {
         throw new NotFoundException(`Toolbox proxy URL not resolved for region ${s.region}`)
       }
-      return BoxDto.fromBox(s, url)
+      return BoxDto.fromBox(s, url, activityMap.get(s.id))
     })
   }
 

--- a/apps/api/src/boxlite-rest/dto/box-response.dto.ts
+++ b/apps/api/src/boxlite-rest/dto/box-response.dto.ts
@@ -39,6 +39,12 @@ export class BoxResponseDto {
   updated_at: string
 
   @ApiPropertyOptional({
+    description: 'Timestamp of the last recorded activity on the box; absent when none was recorded',
+    example: '2026-06-04T12:04:30.000Z',
+  })
+  last_activity_at?: string
+
+  @ApiPropertyOptional({
     description: 'Runtime process ID when available',
     example: 12345,
   })

--- a/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.ts
+++ b/apps/api/src/boxlite-rest/mappers/box-to-box.mapper.ts
@@ -22,6 +22,7 @@ export function boxToBoxResponse(box: BoxDto): BoxResponseDto {
     status: mapState(box.state),
     created_at: box.createdAt || new Date().toISOString(),
     updated_at: box.updatedAt || new Date().toISOString(),
+    last_activity_at: box.lastActivityAt,
     image: box.image || '',
     cpus: box.cpu || 1,
     memory_mib: (box.memory || 1) * 1024,

--- a/apps/libs/api-client-go/api/openapi.yaml
+++ b/apps/libs/api-client-go/api/openapi.yaml
@@ -5335,6 +5335,7 @@ components:
           subpath: users/alice
         createdAt: 2024-10-01T12:00:00Z
         updatedAt: 2024-10-01T12:00:00Z
+        lastActivityAt: 2024-10-01T12:00:00Z
         class: small
         daemonVersion: 1.0.0
         runnerId: runner123
@@ -5450,6 +5451,11 @@ components:
           description: The last update timestamp of the box
           example: 2024-10-01T12:00:00Z
           type: string
+        lastActivityAt:
+          description: "The timestamp of the last recorded activity on the box, absent\
+            \ when no activity has been recorded yet"
+          example: 2024-10-01T12:00:00Z
+          type: string
         class:
           deprecated: true
           description: The class of the box
@@ -5523,6 +5529,7 @@ components:
             subpath: users/alice
           createdAt: 2024-10-01T12:00:00Z
           updatedAt: 2024-10-01T12:00:00Z
+          lastActivityAt: 2024-10-01T12:00:00Z
           class: small
           daemonVersion: 1.0.0
           runnerId: runner123
@@ -5560,6 +5567,7 @@ components:
             subpath: users/alice
           createdAt: 2024-10-01T12:00:00Z
           updatedAt: 2024-10-01T12:00:00Z
+          lastActivityAt: 2024-10-01T12:00:00Z
           class: small
           daemonVersion: 1.0.0
           runnerId: runner123

--- a/apps/libs/api-client-go/model_box.go
+++ b/apps/libs/api-client-go/model_box.go
@@ -71,6 +71,8 @@ type Box struct {
 	CreatedAt *string `json:"createdAt,omitempty"`
 	// The last update timestamp of the box
 	UpdatedAt *string `json:"updatedAt,omitempty"`
+	// The timestamp of the last recorded activity on the box, absent when no activity has been recorded yet
+	LastActivityAt *string `json:"lastActivityAt,omitempty"`
 	// The class of the box
 	// Deprecated
 	Class *string `json:"class,omitempty"`
@@ -812,6 +814,38 @@ func (o *Box) SetUpdatedAt(v string) {
 	o.UpdatedAt = &v
 }
 
+// GetLastActivityAt returns the LastActivityAt field value if set, zero value otherwise.
+func (o *Box) GetLastActivityAt() string {
+	if o == nil || IsNil(o.LastActivityAt) {
+		var ret string
+		return ret
+	}
+	return *o.LastActivityAt
+}
+
+// GetLastActivityAtOk returns a tuple with the LastActivityAt field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Box) GetLastActivityAtOk() (*string, bool) {
+	if o == nil || IsNil(o.LastActivityAt) {
+		return nil, false
+	}
+	return o.LastActivityAt, true
+}
+
+// HasLastActivityAt returns a boolean if a field has been set.
+func (o *Box) HasLastActivityAt() bool {
+	if o != nil && !IsNil(o.LastActivityAt) {
+		return true
+	}
+
+	return false
+}
+
+// SetLastActivityAt gets a reference to the given string and assigns it to the LastActivityAt field.
+func (o *Box) SetLastActivityAt(v string) {
+	o.LastActivityAt = &v
+}
+
 // GetClass returns the Class field value if set, zero value otherwise.
 // Deprecated
 func (o *Box) GetClass() string {
@@ -994,6 +1028,9 @@ func (o Box) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.UpdatedAt) {
 		toSerialize["updatedAt"] = o.UpdatedAt
 	}
+	if !IsNil(o.LastActivityAt) {
+		toSerialize["lastActivityAt"] = o.LastActivityAt
+	}
 	if !IsNil(o.Class) {
 		toSerialize["class"] = o.Class
 	}
@@ -1085,6 +1122,7 @@ func (o *Box) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "volumes")
 		delete(additionalProperties, "createdAt")
 		delete(additionalProperties, "updatedAt")
+		delete(additionalProperties, "lastActivityAt")
 		delete(additionalProperties, "class")
 		delete(additionalProperties, "daemonVersion")
 		delete(additionalProperties, "runnerId")

--- a/apps/libs/api-client/src/docs/Box.md
+++ b/apps/libs/api-client/src/docs/Box.md
@@ -30,6 +30,7 @@ Name | Type | Description | Notes
 **volumes** | [**Array&lt;BoxVolume&gt;**](BoxVolume.md) | Array of volumes attached to the box | [optional] [default to undefined]
 **createdAt** | **string** | The creation timestamp of the box | [optional] [default to undefined]
 **updatedAt** | **string** | The last update timestamp of the box | [optional] [default to undefined]
+**lastActivityAt** | **string** | The timestamp of the last recorded activity on the box, absent when no activity has been recorded yet | [optional] [default to undefined]
 **_class** | **string** | The class of the box | [optional] [default to undefined]
 **daemonVersion** | **string** | The version of the daemon running in the box | [optional] [default to undefined]
 **runnerId** | **string** | The runner ID of the box | [optional] [default to undefined]
@@ -66,6 +67,7 @@ const instance: Box = {
     volumes,
     createdAt,
     updatedAt,
+    lastActivityAt,
     _class,
     daemonVersion,
     runnerId,

--- a/apps/libs/api-client/src/models/box.ts
+++ b/apps/libs/api-client/src/models/box.ts
@@ -125,6 +125,10 @@ export interface Box {
      */
     'updatedAt'?: string;
     /**
+     * The timestamp of the last recorded activity on the box, absent when no activity has been recorded yet
+     */
+    'lastActivityAt'?: string;
+    /**
      * The class of the box
      * @deprecated
      */

--- a/docs/reference/cli/README.md
+++ b/docs/reference/cli/README.md
@@ -466,7 +466,9 @@ Show detailed information for one or more boxes.
 The Go-template engine exposes a `json` function for serializing nested values.
 `State.StartedAt` is when the box most recently entered `Running`, in RFC 3339
 format, or `null` if the start time has not been recorded or is unavailable
-over REST.
+over REST. `State.LastActivityAt` is when the box was last active in RFC 3339
+format — the clock AutoStop measures idleness against — or `null` for a local
+box, which records no activity.
 
 **Examples:**
 
@@ -474,6 +476,7 @@ over REST.
 boxlite inspect mybox
 boxlite inspect --format '{{.State.Status}}' mybox
 boxlite inspect --format '{{.State.StartedAt}}' mybox
+boxlite inspect --format '{{.State.LastActivityAt}}' mybox
 boxlite inspect -l --format yaml
 ```
 

--- a/docs/reference/nodejs/README.md
+++ b/docs/reference/nodejs/README.md
@@ -240,6 +240,7 @@ Metadata about a box.
 | `state` | `JsBoxStateInfo` | Runtime state with `status`, `running`, and optional `pid` fields |
 | `createdAt` | `string` | Creation timestamp (ISO 8601) |
 | `startedAt` | `string \| undefined` | Time when the box most recently entered `Running` (RFC 3339); absent if not recorded or unavailable over REST |
+| `lastActivityAt` | `string \| undefined` | Time the box was last active (RFC 3339), the clock AutoStop measures idleness against; absent for a local box, which records no activity |
 | `image` | `string` | OCI image reference or rootfs path |
 | `cpus` | `number` | Allocated CPU count |
 | `memoryMib` | `number` | Allocated memory in MiB |

--- a/docs/reference/python/README.md
+++ b/docs/reference/python/README.md
@@ -263,6 +263,7 @@ Metadata about a box.
 | `state` | `BoxStateInfo` | Runtime state with `status`, `running`, and nullable `pid` fields |
 | `created_at` | `str` | ISO 8601 creation timestamp |
 | `started_at` | `str \| None` | Time when the box most recently entered `Running` (RFC 3339); `None` if not recorded or unavailable over REST |
+| `last_activity_at` | `str \| None` | Time the box was last active (RFC 3339), the clock AutoStop measures idleness against; `None` for a local box, which records no activity |
 | `image` | `str` | OCI image used |
 | `cpus` | `int` | Allocated CPU cores |
 | `memory_mib` | `int` | Allocated memory in MiB |

--- a/openapi/box.openapi.yaml
+++ b/openapi/box.openapi.yaml
@@ -1638,6 +1638,14 @@ components:
           type: string
           format: date-time
           description: Last state change timestamp (UTC)
+        last_activity_at:
+          type: string
+          format: date-time
+          description: |
+            Last recorded activity on the box (UTC) — the clock AutoStop
+            measures idleness against. Absent when the server recorded no
+            activity, which is always the case for a server without an
+            AutoStop sweeper.
         pid:
           type: integer
           nullable: true

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -327,6 +327,10 @@ typedef struct CBoxInfo {
   // Milliseconds — not `created_at`'s seconds — preserve sub-second ordering
   // against a job's timeline.
   int64_t started_at;
+  // Unix milliseconds of the box's last recorded activity — the clock
+  // AutoStop measures idleness against; `0` when nothing was recorded, which
+  // is always the case for local runtimes.
+  int64_t last_activity_at;
 } CBoxInfo;
 
 // Box info completion. On success the callback owns the non-null metadata and

--- a/sdks/c/src/event_queue.rs
+++ b/sdks/c/src/event_queue.rs
@@ -1293,6 +1293,7 @@ mod owned_ffi_ptr_nested_leak_tests {
                 }]),
             })),
             started_at: 0,
+            last_activity_at: 0,
         });
 
         let owned = OwnedFfiPtr::new_with(payload, crate::info::free_box_info_ptr);
@@ -1365,6 +1366,7 @@ mod owned_ffi_ptr_nested_leak_tests {
             created_at: 0,
             network: std::ptr::null_mut(),
             started_at: 0,
+            last_activity_at: 0,
         }];
         let items_ptr = items_vec.as_mut_ptr();
         let items_len = items_vec.len();

--- a/sdks/c/src/info.rs
+++ b/sdks/c/src/info.rs
@@ -84,6 +84,10 @@ pub struct CBoxInfo {
     /// Milliseconds — not `created_at`'s seconds — preserve sub-second ordering
     /// against a job's timeline.
     pub started_at: i64,
+    /// Unix milliseconds of the box's last recorded activity — the clock
+    /// AutoStop measures idleness against; `0` when nothing was recorded, which
+    /// is always the case for local runtimes.
+    pub last_activity_at: i64,
 }
 
 #[repr(C)]
@@ -250,6 +254,10 @@ impl CBoxInfo {
             created_at: info.created_at.timestamp(),
             network: network_to_c_ptr(&info.network),
             started_at: info.started_at.map(|at| at.timestamp_millis()).unwrap_or(0),
+            last_activity_at: info
+                .last_activity_at
+                .map(|at| at.timestamp_millis())
+                .unwrap_or(0),
         }
     }
 }

--- a/sdks/go/info.go
+++ b/sdks/go/info.go
@@ -67,6 +67,11 @@ type BoxInfo struct {
 	// the configured user task becomes ready, exits, or completes; those are
 	// workload lifecycle outcomes.
 	StartedAt time.Time
+	// LastActivityAt is when the box was last active, as recorded by the
+	// control plane from toolbox and proxy traffic — the clock AutoStop
+	// measures idleness against. The zero time means no activity was
+	// recorded, which is always the case for local runtimes.
+	LastActivityAt time.Time
 }
 
 // Info returns information about the box.
@@ -159,6 +164,10 @@ func cBoxInfoToGo(info *C.CBoxInfo) BoxInfo {
 	if ms := int64(info.started_at); ms > 0 {
 		boxStartedAt = time.UnixMilli(ms)
 	}
+	var boxLastActivityAt time.Time
+	if ms := int64(info.last_activity_at); ms > 0 {
+		boxLastActivityAt = time.UnixMilli(ms)
+	}
 	return BoxInfo{
 		ID:         cString(info.id),
 		Name:       cString(info.name),
@@ -174,7 +183,8 @@ func cBoxInfoToGo(info *C.CBoxInfo) BoxInfo {
 		AutoResume: info.auto_resume != 0,
 		CreatedAt:  time.Unix(int64(info.created_at), 0),
 
-		StartedAt: boxStartedAt,
+		StartedAt:      boxStartedAt,
+		LastActivityAt: boxLastActivityAt,
 	}
 }
 

--- a/sdks/node/lib/native-contracts.ts
+++ b/sdks/node/lib/native-contracts.ts
@@ -266,6 +266,7 @@ export interface JsBoxInfo {
   state: JsBoxStateInfo;
   createdAt: string;
   startedAt?: string;
+  lastActivityAt?: string;
   image: string;
   cpus: number;
   memoryMib: number;

--- a/sdks/node/src/info.rs
+++ b/sdks/node/src/info.rs
@@ -187,6 +187,10 @@ pub struct JsBoxInfo {
     /// When the box most recently entered `Running` (RFC 3339), when recorded
     pub started_at: Option<String>,
 
+    /// When the box was last active (RFC 3339), as recorded by the control
+    /// plane; absent for local runtimes and before any activity
+    pub last_activity_at: Option<String>,
+
     /// Image reference or rootfs path
     pub image: String,
 
@@ -230,6 +234,7 @@ impl From<BoxInfo> for JsBoxInfo {
             state,
             created_at: info.created_at.to_rfc3339(),
             started_at: info.started_at.map(|at| at.to_rfc3339()),
+            last_activity_at: info.last_activity_at.map(|at| at.to_rfc3339()),
             image: info.image,
             cpus: info.cpus,
             memory_mib: info.memory_mib,
@@ -278,6 +283,7 @@ mod tests {
             health_status: HealthStatus::default(),
             exit_code: None,
             started_at: None,
+            last_activity_at: None,
         }
     }
 
@@ -351,5 +357,18 @@ mod tests {
             Some("1970-01-01T00:00:01+00:00")
         );
         assert!(JsBoxInfo::from(core_info(None)).started_at.is_none());
+    }
+
+    #[test]
+    fn box_info_conversion_exposes_last_activity_at() {
+        let mut info = core_info(None);
+        info.last_activity_at = Some((SystemTime::UNIX_EPOCH + Duration::from_secs(2)).into());
+
+        let active = JsBoxInfo::from(info);
+        assert_eq!(
+            active.last_activity_at.as_deref(),
+            Some("1970-01-01T00:00:02+00:00")
+        );
+        assert!(JsBoxInfo::from(core_info(None)).last_activity_at.is_none());
     }
 }

--- a/sdks/python/src/info.rs
+++ b/sdks/python/src/info.rs
@@ -287,6 +287,8 @@ pub(crate) struct PyBoxInfo {
     #[pyo3(get)]
     pub(crate) started_at: Option<String>,
     #[pyo3(get)]
+    pub(crate) last_activity_at: Option<String>,
+    #[pyo3(get)]
     pub(crate) image: String,
     #[pyo3(get)]
     pub(crate) cpus: u8,
@@ -325,6 +327,7 @@ impl PyBoxInfo {
             "auto_resume": self.auto_resume,
             "created_at": self.created_at,
             "started_at": self.started_at,
+            "last_activity_at": self.last_activity_at,
             "health_status": {
                 "state": self.health_status.state.value,
                 "failures": self.health_status.failures,
@@ -350,6 +353,7 @@ impl From<BoxInfo> for PyBoxInfo {
             state,
             created_at: info.created_at.to_rfc3339(),
             started_at: info.started_at.map(|at| at.to_rfc3339()),
+            last_activity_at: info.last_activity_at.map(|at| at.to_rfc3339()),
             image: info.image,
             cpus: info.cpus,
             memory_mib: info.memory_mib,
@@ -393,6 +397,7 @@ mod tests {
             health_status: HealthStatus::default(),
             exit_code: None,
             started_at: None,
+            last_activity_at: None,
         }
     }
 
@@ -460,5 +465,18 @@ mod tests {
             Some("1970-01-01T00:00:01+00:00")
         );
         assert!(PyBoxInfo::from(core_info(None)).started_at.is_none());
+    }
+
+    #[test]
+    fn box_info_conversion_exposes_last_activity_at() {
+        let mut info = core_info(None);
+        info.last_activity_at = Some((SystemTime::UNIX_EPOCH + Duration::from_secs(2)).into());
+
+        let active = PyBoxInfo::from(info);
+        assert_eq!(
+            active.last_activity_at.as_deref(),
+            Some("1970-01-01T00:00:02+00:00")
+        );
+        assert!(PyBoxInfo::from(core_info(None)).last_activity_at.is_none());
     }
 }

--- a/sdks/python/tests/test_box_management_mock.py
+++ b/sdks/python/tests/test_box_management_mock.py
@@ -104,6 +104,9 @@ class TestBoxInfoStructure:
     def test_has_started_at(self, box_info_cls):
         assert "started_at" in dir(box_info_cls)
 
+    def test_has_last_activity_at(self, box_info_cls):
+        assert "last_activity_at" in dir(box_info_cls)
+
     def test_has_image(self, box_info_cls):
         assert "image" in dir(box_info_cls)
 

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -293,6 +293,10 @@ pub(crate) struct BoxResponse {
     pub status: String,
     pub created_at: String,
     pub updated_at: String,
+    /// Absent when the server recorded no activity for the box, and from any
+    /// server too old to publish it.
+    #[serde(default)]
+    pub last_activity_at: Option<String>,
     pub pid: Option<u32>,
     pub image: String,
     pub cpus: u8,
@@ -334,6 +338,16 @@ impl BoxResponse {
             .map(|dt| dt.with_timezone(&chrono::Utc))
             .unwrap_or_else(|_| chrono::Utc::now());
 
+        // Unlike the two timestamps above, an unparseable value becomes `None`
+        // rather than `now()`: activity dated to this instant would read as a
+        // box that was just used, which is exactly the wrong answer for the
+        // idleness this field describes.
+        let last_activity_at = self
+            .last_activity_at
+            .as_deref()
+            .and_then(|at| chrono::DateTime::parse_from_rfc3339(at).ok())
+            .map(|dt| dt.with_timezone(&chrono::Utc));
+
         Ok(crate::BoxInfo {
             id,
             name: self.name.clone(),
@@ -358,6 +372,7 @@ impl BoxResponse {
             // local start timestamp; `None` means "not known here", not
             // "the box never entered Running".
             started_at: None,
+            last_activity_at,
         })
     }
 }
@@ -961,6 +976,7 @@ mod tests {
             status: "running".to_string(),
             created_at: "2024-01-01T00:00:00Z".to_string(),
             updated_at: "2024-01-01T00:01:00Z".to_string(),
+            last_activity_at: None,
             pid: Some(1234),
             image: "python:3.11".to_string(),
             cpus: 2,
@@ -982,6 +998,40 @@ mod tests {
     }
 
     #[test]
+    fn box_response_to_box_info_reports_last_activity() {
+        let mut resp = BoxResponse {
+            box_id: "01J0000000000000000000000A".to_string(),
+            name: None,
+            status: "running".to_string(),
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+            updated_at: "2024-01-01T00:01:00Z".to_string(),
+            last_activity_at: Some("2024-01-01T00:02:30Z".to_string()),
+            pid: None,
+            image: "python:3.11".to_string(),
+            cpus: 2,
+            memory_mib: 512,
+            labels: HashMap::new(),
+            exit_code: None,
+            auto_stop: 1800,
+            auto_delete: 0,
+            auto_resume: true,
+        };
+
+        let info = resp.to_box_info().expect("valid box_id should parse");
+        assert_eq!(
+            info.last_activity_at.map(|at| at.to_rfc3339()),
+            Some("2024-01-01T00:02:30+00:00".to_string())
+        );
+
+        // An absent value means "no activity recorded", and an unparseable one
+        // must not be rounded up to "active now".
+        resp.last_activity_at = None;
+        assert!(resp.to_box_info().unwrap().last_activity_at.is_none());
+        resp.last_activity_at = Some("yesterday".to_string());
+        assert!(resp.to_box_info().unwrap().last_activity_at.is_none());
+    }
+
+    #[test]
     fn test_box_response_to_box_info_uuid() {
         // Some servers may return UUIDs as box_id (not just 12-char Base62 / 26-char ULID).
         // Verify the SDK accepts them and round-trips the id verbatim.
@@ -991,6 +1041,7 @@ mod tests {
             status: "running".to_string(),
             created_at: "2024-01-01T00:00:00Z".to_string(),
             updated_at: "2024-01-01T00:01:00Z".to_string(),
+            last_activity_at: None,
             pid: Some(5678),
             image: "alpine:latest".to_string(),
             cpus: 1,
@@ -1019,6 +1070,7 @@ mod tests {
             status: "running".to_string(),
             created_at: "2024-01-01T00:00:00Z".to_string(),
             updated_at: "2024-01-01T00:01:00Z".to_string(),
+            last_activity_at: None,
             pid: None,
             image: "alpine:latest".to_string(),
             cpus: 1,
@@ -1091,6 +1143,7 @@ mod tests {
             status: "snapshotting".to_string(),
             created_at: "2024-01-01T00:00:00Z".to_string(),
             updated_at: "2024-01-01T00:01:00Z".to_string(),
+            last_activity_at: None,
             pid: Some(1234),
             image: "python:3.11".to_string(),
             cpus: 2,

--- a/src/boxlite/src/runtime/types.rs
+++ b/src/boxlite/src/runtime/types.rs
@@ -414,6 +414,16 @@ pub struct BoxInfo {
     /// readable.
     #[serde(default)]
     pub started_at: Option<DateTime<Utc>>,
+
+    /// When the box was last active, as recorded by the control plane from
+    /// toolbox and proxy traffic — the clock AutoStop measures idleness
+    /// against. `None` when no activity has been recorded yet.
+    ///
+    /// Local runtimes never report this: AutoStop needs an idle sweeper they
+    /// do not have, so they record no activity. Serde default keeps metadata
+    /// from an older producer readable.
+    #[serde(default)]
+    pub last_activity_at: Option<DateTime<Utc>>,
 }
 
 impl BoxInfo {
@@ -452,6 +462,8 @@ impl BoxInfo {
             health_status: state.health_status,
             exit_code: state.exit_code,
             started_at: state.started_at,
+            // Activity is recorded by the control plane, not by a local box.
+            last_activity_at: None,
         }
     }
 }

--- a/src/cli/src/commands/inspect.rs
+++ b/src/cli/src/commands/inspect.rs
@@ -56,6 +56,10 @@ struct InspectStatePresenter {
     exit_code: i32,
     #[serde(rename = "StartedAt")]
     started_at: Option<String>,
+    /// Control-plane activity clock, not a local state transition; `null` for
+    /// local boxes, which record no activity.
+    #[serde(rename = "LastActivityAt")]
+    last_activity_at: Option<String>,
 }
 
 impl From<&BoxInfo> for InspectPresenter {
@@ -73,6 +77,7 @@ impl From<&BoxInfo> for InspectPresenter {
                 pid: state.pid.unwrap_or(0),
                 exit_code: state.exit_code.unwrap_or(0),
                 started_at: info.started_at.as_ref().map(|at| at.to_rfc3339()),
+                last_activity_at: info.last_activity_at.as_ref().map(|at| at.to_rfc3339()),
             },
             cpus: info.cpus,
             memory: info.memory_mib as u64 * 1024 * 1024,
@@ -254,6 +259,7 @@ mod tests {
             health_status: HealthStatus::new(),
             exit_code: None,
             started_at,
+            last_activity_at: None,
         }
     }
 
@@ -274,5 +280,21 @@ mod tests {
 
         let value = serde_json::to_value(InspectPresenter::from(&inspect_info(None))).unwrap();
         assert!(value["State"]["StartedAt"].is_null());
+    }
+
+    #[test]
+    fn inspect_exposes_last_activity_at() {
+        let last_activity_at = chrono::DateTime::from_timestamp(2, 0).unwrap();
+        let mut info = inspect_info(None);
+        info.last_activity_at = Some(last_activity_at);
+
+        let value = serde_json::to_value(InspectPresenter::from(&info)).unwrap();
+        assert_eq!(
+            value["State"]["LastActivityAt"],
+            last_activity_at.to_rfc3339()
+        );
+
+        let value = serde_json::to_value(InspectPresenter::from(&inspect_info(None))).unwrap();
+        assert!(value["State"]["LastActivityAt"].is_null());
     }
 }


### PR DESCRIPTION
## Summary

Box metadata reported `createdAt` and `updatedAt` but never when a box was last
*used* — the clock AutoStop measures idleness against. This adds
`lastActivityAt` (`last_activity_at` on the REST surface) to box metadata, read
from the same source the idle sweeper acts on, and surfaces it through the
generated clients, the SDKs, and `boxlite inspect`.

## Call graph

```text
Before
  toBoxDto              (BoxService · apps/api/src/box/services/box.service.ts:1090)
    └─ fromBox          (BoxDto · apps/api/src/box/dto/box.dto.ts:298)              — createdAt/updatedAt only
  toBoxDtos             (BoxService · apps/api/src/box/services/box.service.ts:1098)
    └─ fromBox          (BoxDto · apps/api/src/box/dto/box.dto.ts:298)              — per box, same fields
  …
  boxToBoxResponse      (mapper · apps/api/src/boxlite-rest/mappers/box-to-box.mapper.ts:18)
  …
  to_box_info           (BoxResponse · src/boxlite/src/rest/types.rs:320)           — no activity field to carry
    └─ InspectPresenter::from  (src/cli/src/commands/inspect.rs:65)

After
  toBoxDto              (BoxService · apps/api/src/box/services/box.service.ts:1090)
    ├─ getLastActivityAt      (BoxActivityService · apps/api/src/box/services/box-activity.service.ts:58)
    │                                                                              — delegates to the batch read
    └─ fromBox          (BoxDto · apps/api/src/box/dto/box.dto.ts:298)              — takes lastActivityAt as an argument
  toBoxDtos             (BoxService · apps/api/src/box/services/box.service.ts:1098)
    ├─ getLastActivityAtMany  (BoxActivityService · apps/api/src/box/services/box-activity.service.ts:71)
    │                                                                              — one pipelined ZSCORE + one query
    └─ fromBox          (BoxDto · apps/api/src/box/dto/box.dto.ts:298)              — per box, from the merged map
  …
  boxToBoxResponse      (mapper · apps/api/src/boxlite-rest/mappers/box-to-box.mapper.ts:18)  — emits last_activity_at
  …
  to_box_info           (BoxResponse · src/boxlite/src/rest/types.rs:320)           — parses it; unparseable ⇒ None
    └─ InspectPresenter::from  (src/cli/src/commands/inspect.rs:65)                 — renders State.LastActivityAt
```

## Changes

- `BoxActivityService.getLastActivityAtMany` reads many boxes in two round trips
  regardless of count: one pipelined `ZSCORE` over the Redis buffer, then a
  single `findBy(In(...))` for only the boxes the buffer did not answer. The
  single-box `getLastActivityAt` is now a thin wrapper over it, so both paths
  share one buffer-before-database precedence. A per-command pipeline error is
  raised rather than quietly answered from the database, matching what a
  single-box `ZSCORE` failure has always done.
- List responses take the batch path, so the new field does not put a read on
  the per-box N+1 path.
- The value is reported raw. The sweeper's fallback to `updatedAt` is a stop
  policy, not recorded activity, so a box that has never been used reports
  nothing rather than its creation time.
- Local runtimes have no idle sweeper and record no activity, so `BoxInfo`
  from a local box carries `None`.
- `BoxResponse::to_box_info` maps an absent *or unparseable* timestamp to `None`
  rather than `now()` (as `created_at`/`updated_at` do): dating activity to this
  instant would read as "just used", the exact opposite of the idleness this
  field describes. `#[serde(default)]` keeps responses from older servers
  readable.
- Regenerated clients (`api-client`, `api-client-go`), OpenAPI specs, and the
  Python/Node/Go/C SDK info surfaces; docs updated for CLI, Node, and Python.

## How to verify

```bash
make test:apps FILTER='BoxActivityService activity reads'
make test:unit:rust
```

- `boxlite inspect <box>` against a cloud box shows `State.LastActivityAt`; the
  same command against a local box shows `null`.

## Risks / rollout

- Additive and optional on every surface: a client that does not know the field
  ignores it, and a server that does not send it deserializes to `None`.
- List endpoints gain one pipelined Redis read plus at most one extra query per
  request — bounded by page size, not by box count.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Box information now includes the timestamp of its most recent recorded activity.
  * Activity timestamps are available through the REST API, OpenAPI schema, and C, Go, Node.js, and Python SDKs.
  * CLI inspection output displays the last activity time when available.
  * Local boxes report no recorded activity.
* **Documentation**
  * Updated API and SDK references with field formats and availability.
* **Tests**
  * Added coverage for buffered, stored, missing, and invalid timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->