### PR TITLE
fix(proxy): gate box preview access on an active network-tunnel lease

### DIFF
--- a/apps/api/src/box/services/box.service.spec.ts
+++ b/apps/api/src/box/services/box.service.spec.ts
@@ -218,6 +218,7 @@ function makeNetworkTunnelService() {
     }),
   } as any
   const regionService = { findOne: jest.fn().mockResolvedValue(null) } as any
+  const redis = { setex: jest.fn().mockResolvedValue('OK'), del: jest.fn().mockResolvedValue(1) } as any
   const noop = {} as any
   const service = new BoxService(
     noop,
@@ -236,6 +237,7 @@ function makeNetworkTunnelService() {
     noop, // jobRepository
     noop, // jobService
   )
+  ;(service as any).redis = redis
   jest.spyOn(service, 'findOneByIdOrName').mockResolvedValue({
     id: 'MixedCaseBox',
     region: 'region-1',
@@ -243,13 +245,24 @@ function makeNetworkTunnelService() {
   return service
 }
 
-describe('BoxService network tunnel URLs', () => {
-  it('creates a case-safe endpoint for an SDK tunnel', async () => {
+describe('BoxService network tunnel', () => {
+  it('openNetworkTunnel sets liveness lease and returns a case-safe endpoint', async () => {
     const service = makeNetworkTunnelService()
+    const redis = (service as any).redis
 
-    const result = await service.getNetworkTunnelUrl('MixedCaseBox', 'org-1', 3000)
+    const result = await service.openNetworkTunnel('MixedCaseBox', 'org-1', 3000)
 
     expect(result).toBe('https://3000-d-4d6978656443617365426f78.proxy.example.test')
+    expect(redis.setex).toHaveBeenCalledWith('box:network-tunnel-live:MixedCaseBox', 15, '1')
+  })
+
+  it('closeNetworkTunnel deletes the liveness lease', async () => {
+    const service = makeNetworkTunnelService()
+    const redis = (service as any).redis
+
+    await service.closeNetworkTunnel('MixedCaseBox', 'org-1')
+
+    expect(redis.del).toHaveBeenCalledWith('box:network-tunnel-live:MixedCaseBox')
   })
 })
 

--- a/apps/api/src/box/services/box.service.ts
+++ b/apps/api/src/box/services/box.service.ts
@@ -807,7 +807,20 @@ export class BoxService {
     }
   }
 
-  async getNetworkTunnelUrl(boxIdOrName: string, organizationId: string, port: number): Promise<string> {
+  // TTL must be longer than the CLI/SDK renewal interval (5s) with ample
+  // headroom for slow renewals.  The proxy's boxPublicCache TTL (3s) adds
+  // to the worst-case reachability window after a tunnel closes.
+  private static readonly NETWORK_TUNNEL_LIVE_TTL_SECONDS = 15
+
+  private networkTunnelLiveKey(boxId: string): string {
+    return `box:network-tunnel-live:${boxId}`
+  }
+
+  // openNetworkTunnel sets a short-lived Redis liveness lease so the Go proxy
+  // will forward browser traffic, then returns the public URL.  The caller
+  // (CLI/SDK) must renew the lease regularly; expiry makes the box private
+  // again automatically.
+  async openNetworkTunnel(boxIdOrName: string, organizationId: string, port: number): Promise<string> {
     if (port < 1 || port > 65535) {
       throw new BadRequestError('Invalid port')
     }
@@ -815,14 +828,25 @@ export class BoxService {
     const proxyDomain = this.configService.getOrThrow('proxy.domain')
     const proxyProtocol = this.configService.getOrThrow('proxy.protocol')
     const box = await this.findOneByIdOrName(boxIdOrName, organizationId)
+    await this.redis.setex(
+      this.networkTunnelLiveKey(box.id),
+      BoxService.NETWORK_TUNNEL_LIVE_TTL_SECONDS,
+      '1',
+    )
     const endpointId = encodeDirectPreviewBoxId(box.id)
-
     let url = `${proxyProtocol}://${port}-${endpointId}.${proxyDomain}`
     const region = await this.regionService.findOne(box.region, true)
     if (region?.proxyUrl) {
       url = region.proxyUrl.replace(/(https?:\/)(\/)/, `$1/${port}-${endpointId}.`)
     }
     return url
+  }
+
+  // closeNetworkTunnel deletes the liveness lease immediately so the proxy
+  // stops forwarding without waiting for the TTL to expire.
+  async closeNetworkTunnel(boxIdOrName: string, organizationId: string): Promise<void> {
+    const box = await this.findOneByIdOrName(boxIdOrName, organizationId)
+    await this.redis.del(this.networkTunnelLiveKey(box.id))
   }
 
   async getSignedPortPreviewUrl(

--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.spec.ts
@@ -26,7 +26,8 @@ function makeHarness() {
       .fn()
       .mockResolvedValue({ id: 'box-uuid', runnerId: 'runner-1', autoResume: true, state: 'started', public: true }),
     updateLastActivityAt: jest.fn().mockResolvedValue(undefined),
-    getNetworkTunnelUrl: jest.fn().mockResolvedValue('https://3000-box.proxy.test'),
+    openNetworkTunnel: jest.fn().mockResolvedValue('https://3000-box.proxy.test'),
+    closeNetworkTunnel: jest.fn().mockResolvedValue(undefined),
   }
   const runnerService = {
     findOne: jest.fn().mockResolvedValue({ apiUrl: 'http://runner.local', apiKey: 'runner-key' }),
@@ -112,7 +113,7 @@ describe('BoxliteProxyController', () => {
 
     const result = await controller.proxyNetworkTunnel(activeAuth as never, 'public-box', 3000)
 
-    expect(boxService.getNetworkTunnelUrl).toHaveBeenCalledWith('public-box', 'org-1', 3000)
+    expect(boxService.openNetworkTunnel).toHaveBeenCalledWith('public-box', 'org-1', 3000)
     expect(result).toEqual({ uri: 'https://3000-box.proxy.test' })
   })
 
@@ -129,7 +130,15 @@ describe('BoxliteProxyController', () => {
     await expect(controller.proxyNetworkTunnel(activeAuth as never, 'public-box', 3000)).rejects.toMatchObject({
       status: 409,
     })
-    expect(boxService.getNetworkTunnelUrl).not.toHaveBeenCalled()
+    expect(boxService.openNetworkTunnel).not.toHaveBeenCalled()
+  })
+
+  it('closes the tunnel on DELETE', async () => {
+    const { controller, boxService } = makeHarness()
+
+    await controller.proxyNetworkTunnelClose(activeAuth as never, 'public-box')
+
+    expect(boxService.closeNetworkTunnel).toHaveBeenCalledWith('public-box', 'org-1')
   })
 
   it('rejects a tunnel request for a stopped box with 409, without auto-resuming it', async () => {
@@ -148,7 +157,7 @@ describe('BoxliteProxyController', () => {
       status: 409,
     })
     expect(autoResume.ensureReady).not.toHaveBeenCalled()
-    expect(boxService.getNetworkTunnelUrl).not.toHaveBeenCalled()
+    expect(boxService.openNetworkTunnel).not.toHaveBeenCalled()
   })
 
   it.each(['creating', 'starting', 'error', 'archived', 'unknown'])(
@@ -165,7 +174,7 @@ describe('BoxliteProxyController', () => {
       await expect(controller.proxyNetworkTunnel(activeAuth as never, 'public-box', 3000)).rejects.toMatchObject({
         status: 409,
       })
-      expect(boxService.getNetworkTunnelUrl).not.toHaveBeenCalled()
+      expect(boxService.openNetworkTunnel).not.toHaveBeenCalled()
     },
   )
 

--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
@@ -230,8 +230,17 @@ export class BoxliteProxyController {
       throw new ConflictException(`Box ${boxId} is not public; set public: true before opening a tunnel`)
     }
 
-    const uri = await this.boxService.getNetworkTunnelUrl(boxId, authContext.organizationId, port)
+    const uri = await this.boxService.openNetworkTunnel(boxId, authContext.organizationId, port)
     return { uri }
+  }
+
+  @Delete(':boxId/network/tunnel')
+  @HttpCode(HttpStatus.OK)
+  async proxyNetworkTunnelClose(
+    @AuthContext() authContext: OrganizationAuthContext,
+    @Param('boxId') boxId: string,
+  ) {
+    await this.boxService.closeNetworkTunnel(boxId, authContext.organizationId)
   }
 
   private async proxyToRunner(

--- a/apps/libs/common-go/pkg/cache/redis_cache.go
+++ b/apps/libs/common-go/pkg/cache/redis_cache.go
@@ -72,35 +72,73 @@ func (c *RedisCache[T]) Delete(ctx context.Context, key string) error {
 	return c.redis.Del(ctx, c.keyPrefix+key).Err()
 }
 
-func NewRedisCache[T any](config *RedisConfig, keyPrefix string) (*RedisCache[T], error) {
+// NetworkTunnelChecker checks whether a box has an active network-tunnel live
+// lease in Redis. The lease key is set by the API's openNetworkTunnel endpoint
+// and renewed by the CLI/SDK tunnel foreground loop; it expires automatically
+// when the holder stops renewing (TTL set server-side).
+type NetworkTunnelChecker struct {
+	redis *redis.Client
+}
+
+// NewNetworkTunnelChecker returns a checker backed by the given Redis config.
+// Returns nil, nil when config is nil (no Redis available), so callers can
+// handle the no-Redis case without branching on error.
+func NewNetworkTunnelChecker(config *RedisConfig) (*NetworkTunnelChecker, error) {
+	if config == nil {
+		return nil, nil
+	}
+	c, err := redisClient(config)
+	if err != nil {
+		return nil, err
+	}
+	return &NetworkTunnelChecker{redis: c}, nil
+}
+
+// IsLive reports whether boxId currently has an active tunnel lease.
+// A Redis error is treated as "not live" (fail-closed).
+func (c *NetworkTunnelChecker) IsLive(ctx context.Context, boxId string) bool {
+	if c == nil {
+		return false
+	}
+	n, err := c.redis.Exists(ctx, "box:network-tunnel-live:"+boxId).Result()
+	return err == nil && n > 0
+}
+
+func redisClient(config *RedisConfig) (*redis.Client, error) {
 	if config.Host == nil || config.Port == nil {
 		return nil, errors.New("host and port are required")
 	}
-
+	// Reuse the module-level singleton when one is already initialised.
+	if client != nil {
+		return client, nil
+	}
 	username := ""
 	if config.Username != nil {
 		username = *config.Username
 	}
-
 	password := ""
 	if config.Password != nil {
 		password = *config.Password
 	}
-
-	if client == nil {
-		options := &redis.Options{
-			Addr:     fmt.Sprintf("%s:%d", *config.Host, *config.Port),
-			Username: username,
-			Password: password,
-		}
-		if config.TLS != nil && *config.TLS {
-			options.TLSConfig = &tls.Config{}
-		}
-		client = redis.NewClient(options)
+	options := &redis.Options{
+		Addr:     fmt.Sprintf("%s:%d", *config.Host, *config.Port),
+		Username: username,
+		Password: password,
 	}
+	if config.TLS != nil && *config.TLS {
+		options.TLSConfig = &tls.Config{}
+	}
+	client = redis.NewClient(options)
+	return client, nil
+}
 
+func NewRedisCache[T any](config *RedisConfig, keyPrefix string) (*RedisCache[T], error) {
+	c, err := redisClient(config)
+	if err != nil {
+		return nil, err
+	}
 	return &RedisCache[T]{
-		redis:     client,
+		redis:     c,
 		keyPrefix: keyPrefix,
 	}, nil
 }

--- a/apps/proxy/pkg/proxy/get_box_target.go
+++ b/apps/proxy/pkg/proxy/get_box_target.go
@@ -280,6 +280,15 @@ func (p *Proxy) getBoxPublic(ctx context.Context, boxId string) (*bool, error) {
 		return nil, err
 	}
 
+	// A public box still requires an active network-tunnel lease (set by the
+	// CLI/SDK `network tunnel` command and renewed every 5s). Without a live
+	// lease the proxy treats the box as private, so browser access lapses
+	// automatically when the CLI exits — even though box.public stays true.
+	// We check Redis here so isBoxPublic on the API side stays a pure DB read.
+	if isPublic && !p.tunnelChecker.IsLive(ctx, boxId) {
+		isPublic = false
+	}
+
 	if cacheErr := p.boxPublicCache.Set(ctx, boxId, isPublic, 3*time.Second); cacheErr != nil {
 		slog.ErrorContext(ctx, "Failed to set box public in cache", "error", cacheErr)
 	}

--- a/apps/proxy/pkg/proxy/proxy.go
+++ b/apps/proxy/pkg/proxy/proxy.go
@@ -73,6 +73,9 @@ type Proxy struct {
 	boxAuthKeyValidCache       common_cache.ICache[bool]
 	boxLastActivityUpdateCache common_cache.ICache[bool]
 	guestPortTransport         *http.Transport
+	// tunnelChecker checks the Redis liveness lease set by network-tunnel.
+	// Nil when Redis is not configured (local/dev deployment without Redis).
+	tunnelChecker *common_cache.NetworkTunnelChecker
 }
 
 func StartProxy(ctx context.Context, config *config.Config) error {
@@ -88,6 +91,15 @@ func StartProxy(ctx context.Context, config *config.Config) error {
 
 	proxy.apiclient = config.ApiClient
 	proxy.guestPortTransport = proxy.newGuestPortTransport()
+
+	// tunnelChecker is intentionally initialised outside the Redis block so
+	// it can reuse the same client; NewNetworkTunnelChecker returns nil,nil
+	// when config.Redis is nil (no Redis configured).
+	var tunnelErr error
+	proxy.tunnelChecker, tunnelErr = common_cache.NewNetworkTunnelChecker(config.Redis)
+	if tunnelErr != nil {
+		return tunnelErr
+	}
 
 	if config.Redis != nil {
 		var err error

--- a/src/cli/src/commands/network/tunnel.rs
+++ b/src/cli/src/commands/network/tunnel.rs
@@ -1,8 +1,17 @@
-//! Print a remote URL or run a local tunnel listener.
+//! Open a network tunnel to a box service.
+//!
+//! Without --listen: prints the public URL and stays running, renewing the
+//! server-side liveness lease every few seconds.  Browser traffic reaches the
+//! box only while this command keeps running; Ctrl-C makes the box private
+//! again within the lease TTL.
+//!
+//! With --listen: forwards connections from a local socket to the box port AND
+//! holds the liveness lease so browser access works in parallel.
 
 use std::io::Write;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
+use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow};
 use boxlite::SocketAddress;
@@ -50,6 +59,10 @@ fn parse_socket_address(value: &str) -> std::result::Result<SocketAddress, Strin
         })
 }
 
+// Comfortably under the server's lease TTL so a slow renewal round-trip
+// never lets the lease lapse.
+const RENEW_INTERVAL: Duration = Duration::from_secs(5);
+
 pub async fn execute(args: TunnelArgs, global: &GlobalFlags) -> Result<()> {
     let runtime = global.create_runtime()?;
     let box_handle = runtime
@@ -57,35 +70,71 @@ pub async fn execute(args: TunnelArgs, global: &GlobalFlags) -> Result<()> {
         .await?
         .ok_or_else(|| anyhow!("No such box: {}", args.target))?;
 
-    let guest_ip = boxlite::net::constants::GUEST_IP
+    let guest_ip: std::net::IpAddr = boxlite::net::constants::GUEST_IP
         .parse()
         .context("BoxLite guest IP constant is invalid")?;
-    let network = box_handle.network();
     let target = SocketAddr::new(guest_ip, args.port);
-    let tunnel = network.tunnel(target).await?;
-    let Some(listen) = args.listen else {
-        let url = tunnel.uri().ok_or_else(|| {
-            anyhow!("local boxes have no public URL; point boxlite at a remote service with --url or --profile")
-        })?;
-        println!("{url}");
-        return Ok(());
-    };
 
-    let forwarder = tunnel
-        .forward_with_bound(listen, |address| {
-            println!("{address}");
-            std::io::stdout().flush().map_err(|error| {
-                boxlite::BoxliteError::Internal(format!("flush tunnel listener address: {error}"))
-            })
-        })
-        .await?;
+    let tunnel = box_handle.network().tunnel(target).await?;
 
-    tokio::select! {
-        result = forwarder.wait() => result?,
-        signal = tokio::signal::ctrl_c() => {
-            signal.context("wait for Ctrl-C")?;
-            forwarder.close().await?;
+    match args.listen {
+        None => {
+            // URL-only mode: print the URL and hold the liveness lease until
+            // the user presses Ctrl-C.  Each renewal re-calls tunnel() for its
+            // Redis-setex side effect and immediately drops the result.
+            let url = tunnel.uri().ok_or_else(|| {
+                anyhow!("local boxes have no public URL; point boxlite at a remote service with --url or --profile")
+            })?;
+            println!("{url}");
+            println!(
+                "Tunnel open — reachable while this command keeps running. Press Ctrl-C to close."
+            );
+
+            loop {
+                tokio::select! {
+                    _ = tokio::signal::ctrl_c() => break,
+                    _ = tokio::time::sleep(RENEW_INTERVAL) => {
+                        if let Err(error) = box_handle.network().tunnel(target).await {
+                            eprintln!("warning: failed to renew tunnel, it may go unreachable soon: {error}");
+                        }
+                    }
+                }
+            }
+        }
+        Some(listen) => {
+            // Local-forward mode: forward connections from a local socket AND
+            // renew the liveness lease so browser access works in parallel.
+            let forwarder = tunnel
+                .forward_with_bound(listen, |address| {
+                    println!("{address}");
+                    std::io::stdout().flush().map_err(|error| {
+                        boxlite::BoxliteError::Internal(format!(
+                            "flush tunnel listener address: {error}"
+                        ))
+                    })
+                })
+                .await?;
+
+            loop {
+                tokio::select! {
+                    result = forwarder.wait() => {
+                        result?;
+                        break;
+                    }
+                    signal = tokio::signal::ctrl_c() => {
+                        signal.context("wait for Ctrl-C")?;
+                        forwarder.close().await?;
+                        break;
+                    }
+                    _ = tokio::time::sleep(RENEW_INTERVAL) => {
+                        if let Err(error) = box_handle.network().tunnel(target).await {
+                            eprintln!("warning: failed to renew tunnel, it may go unreachable soon: {error}");
+                        }
+                    }
+                }
+            }
         }
     }
+
     Ok(())
 }


### PR DESCRIPTION
Box services must not be reachable from a guessed URL unless the owner explicitly opts in (`public: true`) or holds a `network tunnel` open.

Test plan:
- [x] `npx jest --testPathPatterns 'box.service.spec|boxlite-proxy.controller.spec'` — 48 tests pass
- [x] `go test ./proxy/...` — all proxy Go tests pass
- [x] `cargo check -p boxlite-cli` — CLI compiles cleanly
- [ ] e2e against dev not run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Network tunnels remain active while the CLI tunnel command runs, with automatic lease renewal.
  - Added support for explicitly closing network tunnels.
  - Local forwarding and URL-only tunnel modes continue until interrupted.
- **Bug Fixes**
  - Browser access automatically stops when the tunnel process exits or its lease expires.
  - Tunnel URLs use consistent casing and remain available during active forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->