### PR TITLE
feat(api): stop a migration on a called-off drain or a failed export

### DIFF
--- a/apps/api/src/box/enums/box-migration-state.enum.ts
+++ b/apps/api/src/box/enums/box-migration-state.enum.ts
@@ -13,6 +13,10 @@
  *     (no row) ─▶ PENDING_EXPORT ─▶ PENDING_IMPORT ─▶ PENDING_DISCARD_EXPORTED ─▶ COMPLETED
  *                       └──────────────┴──▶ PENDING_ROLLBACK ─▶ (row deleted)
  *
+ * PENDING_EXPORT has a second way out: an EXPORT_BOX that failed deletes the row
+ * outright, since a migration that has not exported yet owns no artifact. The
+ * box becomes unclaimed again and the marker decides afresh whether to move it.
+ *
  * The state records what the migration is waiting for, never what it has
  * produced: `box_migration.arcPath` says an archive is on the object store and
  * `box_migration.runnerId` says a box exists on another runner. Nor does the

--- a/apps/api/src/box/managers/box-migration.manager.ts
+++ b/apps/api/src/box/managers/box-migration.manager.ts
@@ -209,9 +209,10 @@ export class BoxMigrationManager implements TrackableJobExecutions, OnApplicatio
    * the migration keeps until the export's receiver records an archive. Every 10s
    * tick in between calls this again, and what happens then is the job lock's
    * doing — a held lock means the runner is still working on the job this already
-   * submitted, while a submission that threw is retried by the tick after it. A
-   * failed ValidCheck is the one outcome not retried: it turns the migration
-   * around instead of exporting.
+   * submitted, while a submission that threw is retried by the tick after it.
+   * Two outcomes end the migration instead of retrying it: a failed ValidCheck
+   * turns it around, and an EXPORT_BOX the runner reports as failed drops the
+   * row, leaving the box for the Marker to claim again.
    *
    * The job goes to the runner still holding the box, which is the draining one:
    * the archive can only be made where the box is.

--- a/apps/api/src/box/services/box-migration-job-receiver.service.spec.ts
+++ b/apps/api/src/box/services/box-migration-job-receiver.service.spec.ts
@@ -69,14 +69,25 @@ function makeJob(type: JobType, overrides: Partial<ConstructorParameters<typeof 
 }
 
 type RecordedWrite = { table: 'box' | 'migrate'; values: any; params: any }
+type RecordedDelete = { table: 'box' | 'migrate'; params: any }
 
-/** Collects the SET/WHERE of the receiver's conditional writes, per table. */
+/** Collects the SET/WHERE of the receiver's conditional writes and deletes. */
 function makeWriteRecorder() {
   const writes: RecordedWrite[] = []
+  const deletes: RecordedDelete[] = []
   const createQueryBuilder = () => {
     const recorded: RecordedWrite = { table: 'migrate', values: undefined, params: {} }
+    let removing = false
     const builder: any = {
       update: (target: any) => {
+        recorded.table = target === Box ? 'box' : 'migrate'
+        return builder
+      },
+      delete: () => {
+        removing = true
+        return builder
+      },
+      from: (target: any) => {
         recorded.table = target === Box ? 'box' : 'migrate'
         return builder
       },
@@ -93,17 +104,21 @@ function makeWriteRecorder() {
         return builder
       },
       execute: async () => {
-        writes.push(recorded)
+        if (removing) {
+          deletes.push({ table: recorded.table, params: recorded.params })
+        } else {
+          writes.push(recorded)
+        }
         return { affected: 1 }
       },
     }
     return builder
   }
-  return { writes, createQueryBuilder }
+  return { writes, deletes, createQueryBuilder }
 }
 
 function makeHarness(row?: { box?: Box | null; migration?: BoxMigration | null; sourceDraining?: boolean }) {
-  const { writes, createQueryBuilder } = makeWriteRecorder()
+  const { writes, deletes, createQueryBuilder } = makeWriteRecorder()
   const box = row?.box === undefined ? makeBox() : row.box
   const migration = row?.migration === undefined ? makeMigration(BoxMigrationState.PENDING_EXPORT) : row.migration
   // The marker only claims boxes off draining runners, so a migration that
@@ -133,6 +148,7 @@ function makeHarness(row?: { box?: Box | null; migration?: BoxMigration | null; 
   return {
     receiver: new BoxMigrationJobReceiver(dataSource, redisLockProvider, boxLookupCacheInvalidationService),
     writes,
+    deletes,
     redisLockProvider,
     boxLookupCacheInvalidationService,
   }
@@ -227,13 +243,20 @@ describe('BoxMigrationJobReceiver EXPORT_BOX', () => {
     expect(h.writes[0].values).toEqual({ state: BoxMigrationState.PENDING_IMPORT, arcPath: '' })
   })
 
-  it('leaves the state alone when the job failed, so the submitter retries', async () => {
+  // A migration still in PENDING_EXPORT owns no artifact, so there is nothing to
+  // reclaim and nothing to keep the row for. Dropping it hands the box back to
+  // the marker, which re-opens a migration only if the box is still parked on a
+  // runner still draining — a retry in place would keep exporting regardless.
+  it('drops the migration when the export failed, so the marker decides afresh', async () => {
     const h = makeHarness()
     const job = makeExportJob({ status: JobStatus.FAILED, errorMessage: 'upload timed out' })
 
     await h.receiver.handleJobCompletion(job)
 
     expect(h.writes).toHaveLength(0)
+    expect(h.deletes).toEqual([
+      { table: 'migrate', params: { boxId: BOX_ID, expected: BoxMigrationState.PENDING_EXPORT } },
+    ])
     expect(h.redisLockProvider.unlock).toHaveBeenCalledWith(getMigrateJobLockKey(BOX_ID, JobType.EXPORT_BOX))
   })
 
@@ -282,6 +305,20 @@ describe('BoxMigrationJobReceiver IMPORT_BOX', () => {
     })
   })
 
+  // Only the export drops its migration on failure; every other leg still has
+  // the state its submitting loop reads to decide what to retry.
+  it('leaves the state alone when the import failed, so the submitter retries', async () => {
+    const h = makeHarness({ migration: makeMigration(BoxMigrationState.PENDING_IMPORT, { arcPath: ARC_PATH }) })
+
+    await h.receiver.handleJobCompletion(
+      makeJob(JobType.IMPORT_BOX, { status: JobStatus.FAILED, errorMessage: 'restore timed out' }),
+    )
+
+    expect(h.writes).toHaveLength(0)
+    expect(h.deletes).toHaveLength(0)
+    expect(h.redisLockProvider.unlock).toHaveBeenCalledWith(getMigrateJobLockKey(BOX_ID, JobType.IMPORT_BOX))
+  })
+
   it('records the copy on the target runner and rolls back when the box was touched', async () => {
     const h = makeHarness({
       box: makeBox({ desiredState: BoxDesiredState.STARTED, updatedAt: new Date('2026-01-01T00:05:00.000Z') }),
@@ -301,10 +338,10 @@ describe('BoxMigrationJobReceiver IMPORT_BOX', () => {
     expect(h.boxLookupCacheInvalidationService.invalidate).not.toHaveBeenCalled()
   })
 
-  // Past this point ownership would move for good, so a drain called off while
-  // the import ran has to be caught here — the copy on the target runner is
-  // recorded and reclaimed rather than becoming the box's new home.
-  it('records the copy on the target runner and rolls back when the runner stopped draining', async () => {
+  // The copy the drain asked for is already made, so a drain called off while
+  // the import ran does not undo it: rolling back here would destroy a good copy
+  // to put the box back where it started.
+  it('commits the move even though the runner stopped draining while the import ran', async () => {
     const h = makeHarness({
       migration: makeMigration(BoxMigrationState.PENDING_IMPORT, { arcPath: ARC_PATH }),
       sourceDraining: false,
@@ -314,12 +351,17 @@ describe('BoxMigrationJobReceiver IMPORT_BOX', () => {
 
     expect(h.writes).toEqual([
       {
+        table: 'box',
+        values: { runnerId: TARGET_RUNNER },
+        params: { id: BOX_ID },
+      },
+      {
         table: 'migrate',
-        values: { state: BoxMigrationState.PENDING_ROLLBACK, runnerId: TARGET_RUNNER },
+        values: { state: BoxMigrationState.PENDING_DISCARD_EXPORTED, runnerId: SOURCE_RUNNER },
         params: { boxId: BOX_ID, expected: BoxMigrationState.PENDING_IMPORT },
       },
     ])
-    expect(h.boxLookupCacheInvalidationService.invalidate).not.toHaveBeenCalled()
+    expect(h.boxLookupCacheInvalidationService.invalidate).toHaveBeenCalled()
   })
 })
 

--- a/apps/api/src/box/services/box-migration-job-receiver.service.spec.ts
+++ b/apps/api/src/box/services/box-migration-job-receiver.service.spec.ts
@@ -7,6 +7,7 @@ import { BoxMigrationJobReceiver } from './box-migration-job-receiver.service'
 import { Box } from '../entities/box.entity'
 import { BoxMigration } from '../entities/box-migration.entity'
 import { Job } from '../entities/job.entity'
+import { Runner } from '../entities/runner.entity'
 import { BoxMigrationState } from '../enums/box-migration-state.enum'
 import { BoxDesiredState } from '../enums/box-desired-state.enum'
 import { BoxState } from '../enums/box-state.enum'
@@ -46,6 +47,13 @@ function makeMigration(state: BoxMigrationState, overrides: Partial<BoxMigration
   migration.updatedAt = STAMPED
   Object.assign(migration, overrides)
   return migration
+}
+
+function makeRunner(draining: boolean): Runner {
+  const runner = new Runner({ region: 'us-east', name: 'runner-a', apiKey: 'k', apiVersion: '1' })
+  runner.id = SOURCE_RUNNER
+  runner.draining = draining
+  return runner
 }
 
 function makeJob(type: JobType, overrides: Partial<ConstructorParameters<typeof Job>[0]> = {}): Job {
@@ -94,13 +102,21 @@ function makeWriteRecorder() {
   return { writes, createQueryBuilder }
 }
 
-function makeHarness(row?: { box?: Box | null; migration?: BoxMigration | null }) {
+function makeHarness(row?: { box?: Box | null; migration?: BoxMigration | null; sourceDraining?: boolean }) {
   const { writes, createQueryBuilder } = makeWriteRecorder()
   const box = row?.box === undefined ? makeBox() : row.box
   const migration = row?.migration === undefined ? makeMigration(BoxMigrationState.PENDING_EXPORT) : row.migration
+  // The marker only claims boxes off draining runners, so a migration that
+  // reaches its receiver started out on one.
+  const sourceRunner = makeRunner(row?.sourceDraining ?? true)
 
   const entityManager = {
-    findOne: jest.fn().mockImplementation(async (entity: any) => (entity === Box ? box : migration)),
+    findOne: jest.fn().mockImplementation(async (entity: any) => {
+      if (entity === Box) {
+        return box
+      }
+      return entity === Runner ? sourceRunner : migration
+    }),
     createQueryBuilder,
   }
   const dataSource = {
@@ -156,6 +172,25 @@ describe('BoxMigrationJobReceiver EXPORT_BOX', () => {
     const h = makeHarness({
       box: makeBox({ desiredState: BoxDesiredState.STARTED, updatedAt: new Date('2026-01-01T00:05:00.000Z') }),
     })
+    const job = makeExportJob()
+    job.resultMetadata = JSON.stringify({ arcPath: ARC_PATH })
+
+    await h.receiver.handleJobCompletion(job)
+
+    expect(h.writes).toEqual([
+      {
+        table: 'migrate',
+        values: { state: BoxMigrationState.PENDING_ROLLBACK, arcPath: ARC_PATH },
+        params: { boxId: BOX_ID, expected: BoxMigrationState.PENDING_EXPORT },
+      },
+    ])
+  })
+
+  // The drain is the migration's only reason to exist; an operator calling it
+  // off mid-export takes that reason away, so the archive is recorded and the
+  // migration turned around instead of the box being moved anyway.
+  it('records the archive and turns the migration around when the runner stopped draining', async () => {
+    const h = makeHarness({ sourceDraining: false })
     const job = makeExportJob()
     job.resultMetadata = JSON.stringify({ arcPath: ARC_PATH })
 
@@ -256,6 +291,27 @@ describe('BoxMigrationJobReceiver IMPORT_BOX', () => {
     await h.receiver.handleJobCompletion(makeJob(JobType.IMPORT_BOX))
 
     // The box keeps its runner: ownership only moves on the validated branch.
+    expect(h.writes).toEqual([
+      {
+        table: 'migrate',
+        values: { state: BoxMigrationState.PENDING_ROLLBACK, runnerId: TARGET_RUNNER },
+        params: { boxId: BOX_ID, expected: BoxMigrationState.PENDING_IMPORT },
+      },
+    ])
+    expect(h.boxLookupCacheInvalidationService.invalidate).not.toHaveBeenCalled()
+  })
+
+  // Past this point ownership would move for good, so a drain called off while
+  // the import ran has to be caught here — the copy on the target runner is
+  // recorded and reclaimed rather than becoming the box's new home.
+  it('records the copy on the target runner and rolls back when the runner stopped draining', async () => {
+    const h = makeHarness({
+      migration: makeMigration(BoxMigrationState.PENDING_IMPORT, { arcPath: ARC_PATH }),
+      sourceDraining: false,
+    })
+
+    await h.receiver.handleJobCompletion(makeJob(JobType.IMPORT_BOX))
+
     expect(h.writes).toEqual([
       {
         table: 'migrate',

--- a/apps/api/src/box/services/box-migration-job-receiver.service.ts
+++ b/apps/api/src/box/services/box-migration-job-receiver.service.ts
@@ -11,6 +11,7 @@ import { RedisLockProvider } from '../common/redis-lock.provider'
 import { Box } from '../entities/box.entity'
 import { BoxMigration } from '../entities/box-migration.entity'
 import { Job } from '../entities/job.entity'
+import { Runner } from '../entities/runner.entity'
 import { BoxMigrationState } from '../enums/box-migration-state.enum'
 import { JobStatus } from '../enums/job-status.enum'
 import { JobType } from '../enums/job-type.enum'
@@ -50,6 +51,11 @@ interface ValidatedMigration {
   //  ValidCheck: nothing outside the migration has touched the box since it was
   //  claimed, so the migration may still move it.
   undisturbed: boolean
+  //  DrainCheck: the runner still holding the box is still being emptied, which
+  //  is the migration's only reason to exist. An operator who calls the drain
+  //  off takes that reason away, so the result is turned around rather than
+  //  applied.
+  sourceDraining: boolean
 }
 
 /**
@@ -61,11 +67,12 @@ interface ValidatedMigration {
  * submitted from, so a status redelivered after a restart matches nothing and
  * applies once.
  *
- * The two legs that move real data — export and import — re-run ValidCheck in
- * the transaction that records their result, because the box may have been
- * started while the runner was working. That turns the migration around rather
- * than failing it: the artifact is recorded either way, since it exists either
- * way and the rollback path needs the field to reclaim it.
+ * The two legs that move real data — export and import — re-run ValidCheck and
+ * DrainCheck in the transaction that records their result, because the box may
+ * have been started, or its runner taken out of drain, while the runner was
+ * working. Either turns the migration around rather than failing it: the
+ * artifact is recorded either way, since it exists either way and the rollback
+ * path needs the field to reclaim it.
  *
  * Job failure is not this receiver's to repair. The state stays where it is,
  * the job's lock is released, and the loop that submitted it retries.
@@ -133,16 +140,24 @@ export class BoxMigrationJobReceiver {
       this.logger.error(`EXPORT_BOX for box ${job.resourceId} was submitted with no archive key`)
     }
 
-    await this.withMigration(job, BoxMigrationState.PENDING_EXPORT, async ({ entityManager, box, undisturbed }) => {
-      if (!undisturbed) {
-        this.logger.log(`Box ${box.id} was touched while it was exported; rolling back instead of importing`)
-      }
+    await this.withMigration(
+      job,
+      BoxMigrationState.PENDING_EXPORT,
+      async ({ entityManager, box, undisturbed, sourceDraining }) => {
+        if (!undisturbed) {
+          this.logger.log(`Box ${box.id} was touched while it was exported; rolling back instead of importing`)
+        } else if (!sourceDraining) {
+          this.logger.log(
+            `Runner ${box.runnerId} stopped draining while box ${box.id} was exported; rolling back instead of importing`,
+          )
+        }
 
-      await this.updateMigration(entityManager, box.id, BoxMigrationState.PENDING_EXPORT, {
-        state: undisturbed ? BoxMigrationState.PENDING_IMPORT : BoxMigrationState.PENDING_ROLLBACK,
-        arcPath,
-      })
-    })
+        await this.updateMigration(entityManager, box.id, BoxMigrationState.PENDING_EXPORT, {
+          state: undisturbed && sourceDraining ? BoxMigrationState.PENDING_IMPORT : BoxMigrationState.PENDING_ROLLBACK,
+          arcPath,
+        })
+      },
+    )
   }
 
   /**
@@ -158,7 +173,7 @@ export class BoxMigrationJobReceiver {
     const moved = await this.withMigration(
       job,
       BoxMigrationState.PENDING_IMPORT,
-      async ({ entityManager, box, undisturbed }) => {
+      async ({ entityManager, box, undisturbed, sourceDraining }) => {
         //  A box with no runner has nothing to migrate away from, and moving
         //  ownership anyway would leave a discard that nothing can run. The
         //  marker only claims a box on a runner, so ValidCheck already rules
@@ -168,9 +183,13 @@ export class BoxMigrationJobReceiver {
           this.logger.error(`Box ${box.id} was imported onto runner ${targetRunnerId} but has no runner of its own`)
         } else if (!undisturbed) {
           this.logger.log(`Box ${box.id} was touched while it was imported; rolling back the copy on ${targetRunnerId}`)
+        } else if (!sourceDraining) {
+          this.logger.log(
+            `Runner ${sourceRunnerId} stopped draining while box ${box.id} was imported; rolling back the copy on ${targetRunnerId}`,
+          )
         }
 
-        if (!sourceRunnerId || !undisturbed) {
+        if (!sourceRunnerId || !undisturbed || !sourceDraining) {
           //  The copy on the target runner is what rollback reclaims.
           await this.updateMigration(entityManager, box.id, BoxMigrationState.PENDING_IMPORT, {
             state: BoxMigrationState.PENDING_ROLLBACK,
@@ -286,8 +305,43 @@ export class BoxMigrationJobReceiver {
         return null
       }
 
-      return apply({ entityManager, box, undisturbed: migration.isUndisturbedBy(box) })
+      return apply({
+        entityManager,
+        box,
+        undisturbed: migration.isUndisturbedBy(box),
+        sourceDraining: await this.isDraining(entityManager, box.runnerId),
+      })
     })
+  }
+
+  /**
+   * DrainCheck — whether the runner still holding the box is still being emptied.
+   *
+   * A migration exists only because the marker found the box on a draining
+   * runner, and an operator may call that drain off at any point, including
+   * while the job reporting here was running. Re-reading the flag where the
+   * result lands is what stops a called-off drain from moving boxes anyway, and
+   * it is the only place that can do so without stranding an artifact: the
+   * archive or the imported copy already exists by now, so the same transaction
+   * records it and turns the migration around.
+   *
+   * Read rather than locked. The flag is the operator's to move, and the check
+   * bounds how long a called-off drain keeps moving boxes rather than pinning an
+   * exact instant — a migration that reads the flag just before it flips is no
+   * worse off than one that read it just after.
+   */
+  private async isDraining(entityManager: EntityManager, runnerId: string | undefined): Promise<boolean> {
+    if (!runnerId) {
+      return false
+    }
+
+    const runner = await entityManager.findOne(Runner, {
+      where: { id: runnerId },
+      select: ['id', 'draining'],
+      loadEagerRelations: false,
+    })
+
+    return runner?.draining === true
   }
 
   /**

--- a/apps/api/src/box/services/box-migration-job-receiver.service.ts
+++ b/apps/api/src/box/services/box-migration-job-receiver.service.ts
@@ -51,11 +51,6 @@ interface ValidatedMigration {
   //  ValidCheck: nothing outside the migration has touched the box since it was
   //  claimed, so the migration may still move it.
   undisturbed: boolean
-  //  DrainCheck: the runner still holding the box is still being emptied, which
-  //  is the migration's only reason to exist. An operator who calls the drain
-  //  off takes that reason away, so the result is turned around rather than
-  //  applied.
-  sourceDraining: boolean
 }
 
 /**
@@ -67,15 +62,19 @@ interface ValidatedMigration {
  * submitted from, so a status redelivered after a restart matches nothing and
  * applies once.
  *
- * The two legs that move real data — export and import — re-run ValidCheck and
- * DrainCheck in the transaction that records their result, because the box may
- * have been started, or its runner taken out of drain, while the runner was
- * working. Either turns the migration around rather than failing it: the
- * artifact is recorded either way, since it exists either way and the rollback
- * path needs the field to reclaim it.
+ * The two legs that move real data — export and import — re-run ValidCheck in
+ * the transaction that records their result, because the box may have been
+ * started while the runner was working. The export also re-runs DrainCheck,
+ * since the import it is about to ask for is only worth starting while the
+ * drain that asked for it is still on. Either check turns the migration around
+ * rather than failing it: the artifact is recorded either way, since it exists
+ * either way and the rollback path needs the field to reclaim it.
  *
- * Job failure is not this receiver's to repair. The state stays where it is,
- * the job's lock is released, and the loop that submitted it retries.
+ * Job failure is not this receiver's to repair either. Every leg but the export
+ * keeps its state, so the loop that submitted the job retries it; a failed
+ * export instead drops the migration, because a migration that has not exported
+ * yet owns nothing, and the marker is a better judge than a retry of whether the
+ * box should still be moved at all.
  */
 @Injectable()
 export class BoxMigrationJobReceiver {
@@ -100,14 +99,34 @@ export class BoxMigrationJobReceiver {
       if (job.status === JobStatus.COMPLETED) {
         await this.applySuccess(job)
       } else {
-        // Left where it is on purpose: the submitting loop reads the state to
-        // decide what to retry, and the job's own artifacts are unchanged.
-        this.logger.error(`${job.type} failed for box ${job.resourceId}: ${job.errorMessage ?? 'no error reported'}`)
+        await this.applyFailure(job)
       }
     } catch (error) {
       this.logger.error(`Error applying ${job.type} for box ${job.resourceId}:`, error)
     } finally {
       await this.releaseJobLock(job)
+    }
+  }
+
+  /**
+   * A failed job leaves the migration where it is, because the submitting loop
+   * reads the state to decide what to retry and the job's own artifacts are
+   * unchanged — with one exception.
+   *
+   * A failed EXPORT_BOX drops the migration instead. A row still in
+   * PENDING_EXPORT names no artifact — the archive key is recorded by the same
+   * write that leaves PENDING_EXPORT — so there is nothing to reclaim and
+   * nothing to keep the row for. Deleting it puts the box back among the
+   * unclaimed, and the marker re-opens a migration on its next tick only if the
+   * box is still parked on a runner still draining. Retrying in place would keep
+   * re-exporting a box whose drain may since have been called off, and would do
+   * so with the stamp of the claim that failed.
+   */
+  private async applyFailure(job: Job): Promise<void> {
+    this.logger.error(`${job.type} failed for box ${job.resourceId}: ${job.errorMessage ?? 'no error reported'}`)
+
+    if (job.type === JobType.EXPORT_BOX) {
+      await this.dropFailedExport(job.resourceId)
     }
   }
 
@@ -140,30 +159,33 @@ export class BoxMigrationJobReceiver {
       this.logger.error(`EXPORT_BOX for box ${job.resourceId} was submitted with no archive key`)
     }
 
-    await this.withMigration(
-      job,
-      BoxMigrationState.PENDING_EXPORT,
-      async ({ entityManager, box, undisturbed, sourceDraining }) => {
-        if (!undisturbed) {
-          this.logger.log(`Box ${box.id} was touched while it was exported; rolling back instead of importing`)
-        } else if (!sourceDraining) {
-          this.logger.log(
-            `Runner ${box.runnerId} stopped draining while box ${box.id} was exported; rolling back instead of importing`,
-          )
-        }
+    await this.withMigration(job, BoxMigrationState.PENDING_EXPORT, async ({ entityManager, box, undisturbed }) => {
+      const sourceDraining = await this.isDraining(entityManager, box.runnerId)
+      if (!undisturbed) {
+        this.logger.log(`Box ${box.id} was touched while it was exported; rolling back instead of importing`)
+      } else if (!sourceDraining) {
+        this.logger.log(
+          `Runner ${box.runnerId} stopped draining while box ${box.id} was exported; rolling back instead of importing`,
+        )
+      }
 
-        await this.updateMigration(entityManager, box.id, BoxMigrationState.PENDING_EXPORT, {
-          state: undisturbed && sourceDraining ? BoxMigrationState.PENDING_IMPORT : BoxMigrationState.PENDING_ROLLBACK,
-          arcPath,
-        })
-      },
-    )
+      await this.updateMigration(entityManager, box.id, BoxMigrationState.PENDING_EXPORT, {
+        state: undisturbed && sourceDraining ? BoxMigrationState.PENDING_IMPORT : BoxMigrationState.PENDING_ROLLBACK,
+        arcPath,
+      })
+    })
   }
 
   /**
    * The box now exists on the target runner. If it is still the migration's to
    * move, this is the commit point: ownership moves in the same transaction that
    * checks it, and what was the box's runner becomes the copy left to discard.
+   *
+   * DrainCheck is not re-run here, unlike on the export. The copy the drain
+   * asked for is already made, so a drain called off now would buy nothing but a
+   * rollback that destroys a good copy to put the box back where it started;
+   * committing costs a discard the migration owed anyway. The box is served off
+   * a runner that is up either way, so the finished move is the cheaper end.
    */
   private async receiveImport(job: Job): Promise<void> {
     //  The target runner is the runner this job was submitted to, so the runner
@@ -173,7 +195,7 @@ export class BoxMigrationJobReceiver {
     const moved = await this.withMigration(
       job,
       BoxMigrationState.PENDING_IMPORT,
-      async ({ entityManager, box, undisturbed, sourceDraining }) => {
+      async ({ entityManager, box, undisturbed }) => {
         //  A box with no runner has nothing to migrate away from, and moving
         //  ownership anyway would leave a discard that nothing can run. The
         //  marker only claims a box on a runner, so ValidCheck already rules
@@ -183,13 +205,9 @@ export class BoxMigrationJobReceiver {
           this.logger.error(`Box ${box.id} was imported onto runner ${targetRunnerId} but has no runner of its own`)
         } else if (!undisturbed) {
           this.logger.log(`Box ${box.id} was touched while it was imported; rolling back the copy on ${targetRunnerId}`)
-        } else if (!sourceDraining) {
-          this.logger.log(
-            `Runner ${sourceRunnerId} stopped draining while box ${box.id} was imported; rolling back the copy on ${targetRunnerId}`,
-          )
         }
 
-        if (!sourceRunnerId || !undisturbed || !sourceDraining) {
+        if (!sourceRunnerId || !undisturbed) {
           //  The copy on the target runner is what rollback reclaims.
           await this.updateMigration(entityManager, box.id, BoxMigrationState.PENDING_IMPORT, {
             state: BoxMigrationState.PENDING_ROLLBACK,
@@ -305,12 +323,7 @@ export class BoxMigrationJobReceiver {
         return null
       }
 
-      return apply({
-        entityManager,
-        box,
-        undisturbed: migration.isUndisturbedBy(box),
-        sourceDraining: await this.isDraining(entityManager, box.runnerId),
-      })
+      return apply({ entityManager, box, undisturbed: migration.isUndisturbedBy(box) })
     })
   }
 
@@ -319,10 +332,10 @@ export class BoxMigrationJobReceiver {
    *
    * A migration exists only because the marker found the box on a draining
    * runner, and an operator may call that drain off at any point, including
-   * while the job reporting here was running. Re-reading the flag where the
-   * result lands is what stops a called-off drain from moving boxes anyway, and
-   * it is the only place that can do so without stranding an artifact: the
-   * archive or the imported copy already exists by now, so the same transaction
+   * while the export reporting here was running. Re-reading the flag where the
+   * export lands is what stops a called-off drain from starting an import
+   * nothing asked for, and it is the only place that can do so without
+   * stranding the archive: it already exists by now, so the same transaction
    * records it and turns the migration around.
    *
    * Read rather than locked. The flag is the operator's to move, and the check
@@ -342,6 +355,29 @@ export class BoxMigrationJobReceiver {
     })
 
     return runner?.draining === true
+  }
+
+  /**
+   * Delete a migration whose export failed, conditional on PENDING_EXPORT the
+   * same way every other write here is conditional: a status redelivered after
+   * the migration moved on matches nothing and takes no row with it.
+   *
+   * The archive key a later migration derives is the same one this attempt used
+   * — both come from the box id — so whatever a half-finished export left on the
+   * object store is overwritten rather than stranded behind the deleted row.
+   */
+  private async dropFailedExport(boxId: string): Promise<void> {
+    const result = await this.dataSource.manager
+      .createQueryBuilder()
+      .delete()
+      .from(BoxMigration)
+      .where('"boxId" = :boxId', { boxId })
+      .andWhere('"state" = :expected', { expected: BoxMigrationState.PENDING_EXPORT })
+      .execute()
+
+    if (result.affected > 0) {
+      this.logger.log(`Dropped the migration of box ${boxId} after its export failed; the marker may claim it again`)
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

A box migration exists only because the marker found the box on a draining runner, and an export is worth running only while that is still true. The export receiver now re-reads the source runner's `draining` flag in the transaction that records the job's result, and an `EXPORT_BOX` the runner reports as failed drops the migration row instead of retrying it in place. Both end a migration that has produced nothing worth keeping.

## Call graph

Before

```
handleJobCompletion   (BoxMigrationJobReceiver · apps/api/src/box/services/box-migration-job-receiver.service.ts:91)
  ├─ applySuccess     (… :107)
  │    └─ receiveExport      (… :128)
  │         └─ withMigration      (… :258)   — ValidCheck only: was the box touched?
  │              └─ updateMigration (… :297) — PENDING_IMPORT whenever undisturbed
  └─ failure handled inline                  — logs and returns; every leg keeps its state for the submit loop to retry
```

After

```
handleJobCompletion   (BoxMigrationJobReceiver · apps/api/src/box/services/box-migration-job-receiver.service.ts:97)
  ├─ applySuccess     (… :133)
  │    └─ receiveExport      (… :154)
  │         └─ withMigration      (… :295)   — ValidCheck, box + migrate rows locked
  │              ├─ isDraining      (… :346) — DrainCheck: re-reads Runner.draining in the same tx
  │              └─ updateMigration (… :387) — PENDING_IMPORT only if undisturbed AND still draining,
  │                                            else PENDING_ROLLBACK with the archive key recorded
  └─ applyFailure     (… :125)               — logs, then splits by job type
       └─ dropFailedExport (… :369)          — EXPORT_BOX only: deletes the row, conditional on PENDING_EXPORT
```

`receiveImport` (`BoxMigrationJobReceiver · apps/api/src/box/services/box-migration-job-receiver.service.ts:190`) is unchanged by this PR: ValidCheck alone decides it.

## Changes

- `isDraining` reads `Runner.draining` for `box.runnerId` inside the receiver's transaction. Read, not locked: the flag is the operator's to move, and the check bounds how long a called-off drain keeps exporting rather than pinning an exact instant.
- A drain called off while the export ran turns the migration around — `PENDING_ROLLBACK` with the archive key recorded, because the archive already exists by the time the job reports and the rollback path needs the field to reclaim it.
- The import leg deliberately does **not** get the same check. Once the copy is on the target runner, the move the drain asked for has happened and only the ownership flip plus a discard remain; rolling back there would destroy a good copy to put the box back where it started.
- A failed `EXPORT_BOX` deletes the migration row rather than leaving it for the submit loop. A row still in `PENDING_EXPORT` names no artifact, so there is nothing to reclaim and nothing to keep the row for; the box becomes unclaimed and the marker re-opens a migration on its next tick only if it is still parked on a runner still draining. Every other leg keeps its state.
- The `BoxMigrationState` state-machine comment records the second way out of `PENDING_EXPORT`.

## How to verify

```bash
cd apps && yarn nx test api --testPathPatterns=box-migration-job-receiver
```

Three cases carry the behaviour:

- `records the archive and turns the migration around when the runner stopped draining` — export DrainCheck
- `drops the migration when the export failed, so the marker decides afresh` — failed export
- `commits the move even though the runner stopped draining while the import ran` — the import leg stays unguarded on purpose

## Risks / rollout

- One extra indexed primary-key read per export completion; migration jobs are low-volume.
- Inert until a runner is flagged `draining`.
- A repeatedly failing export no longer pins a row in `PENDING_EXPORT` — the box returns to the marker each time and is re-claimed rather than stuck.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Migration exports and imports now detect when source draining is disabled during processing.
  * Affected migrations are safely rolled back instead of proceeding with an invalid state.
  * Failed exports can now clear the migration record, allowing the box to be reconsidered.
  * Failed imports preserve existing writes and deletes for safe retry.
  * Added coverage for export, import, rollback, and retry scenarios to improve migration reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
