### PR TITLE
fix(core): map BoxOptions caller-input validation errors to 400

### DIFF
--- a/src/boxlite/src/runtime/core.rs
+++ b/src/boxlite/src/runtime/core.rs
@@ -574,9 +574,12 @@ mod tests {
             .await
             .err()
             .expect("detached remove-on-stop must be rejected at create");
+        // POL-356: caller-input validation errors map to InvalidArgument
+        // (→ HTTP 400 over boxlite serve), not Config (→ 500) — this is the
+        // caller's mistake, not a server/environment fault.
         assert!(
-            matches!(err, BoxliteError::Config(_)),
-            "expected a Config error, got: {err:?}"
+            matches!(err, BoxliteError::InvalidArgument(_)),
+            "expected an InvalidArgument error, got: {err:?}"
         );
         assert!(
             err.to_string().contains("remove-on-stop is incompatible"),

--- a/src/boxlite/src/runtime/options.rs
+++ b/src/boxlite/src/runtime/options.rs
@@ -762,25 +762,25 @@ impl VolumeSpec {
     pub fn validate(&self) -> BoxliteResult<()> {
         let guest_path = &self.guest_path;
         match &self.managed_volume {
-            Some(volume) if !self.host_path.is_empty() => {
-                Err(boxlite_shared::errors::BoxliteError::InvalidArgument(format!(
+            Some(volume) if !self.host_path.is_empty() => Err(
+                boxlite_shared::errors::BoxliteError::InvalidArgument(format!(
                     "volume mount {guest_path:?} sets both managed_volume ({volume:?}) and \
                      host_path; use exactly one"
-                )))
-            }
-            Some(volume) if volume.trim().is_empty() => {
-                Err(boxlite_shared::errors::BoxliteError::InvalidArgument(format!(
+                )),
+            ),
+            Some(volume) if volume.trim().is_empty() => Err(
+                boxlite_shared::errors::BoxliteError::InvalidArgument(format!(
                     "volume mount {guest_path:?} has an empty managed_volume; pass a volume id \
                      or name"
-                )))
-            }
+                )),
+            ),
             Some(_) => Ok(()),
-            None if self.host_path.is_empty() => {
-                Err(boxlite_shared::errors::BoxliteError::InvalidArgument(format!(
+            None if self.host_path.is_empty() => Err(
+                boxlite_shared::errors::BoxliteError::InvalidArgument(format!(
                     "volume mount {guest_path:?} needs a managed_volume (volume id or name) or \
                      a host_path"
-                )))
-            }
+                )),
+            ),
             None => Ok(()),
         }
     }
@@ -802,10 +802,12 @@ impl std::str::FromStr for NetworkMode {
         match value.to_ascii_lowercase().as_str() {
             "enabled" => Ok(Self::Enabled),
             "disabled" => Ok(Self::Disabled),
-            _ => Err(boxlite_shared::errors::BoxliteError::InvalidArgument(format!(
-                "invalid network mode {:?}. Expected \"enabled\" or \"disabled\".",
-                value
-            ))),
+            _ => Err(boxlite_shared::errors::BoxliteError::InvalidArgument(
+                format!(
+                    "invalid network mode {:?}. Expected \"enabled\" or \"disabled\".",
+                    value
+                ),
+            )),
         }
     }
 }
@@ -1702,7 +1704,10 @@ mod tests {
         // variant is what BoxliteError::http() dispatches on, so pin it here
         // rather than only the message.
         assert!(
-            matches!(err, boxlite_shared::errors::BoxliteError::InvalidArgument(_)),
+            matches!(
+                err,
+                boxlite_shared::errors::BoxliteError::InvalidArgument(_)
+            ),
             "expected InvalidArgument (→ HTTP 400), got {err:?}"
         );
     }
@@ -1722,7 +1727,10 @@ mod tests {
         // POL-356: same HTTP-mapping requirement as the try_from path above —
         // this backstop must not silently regress to a 500.
         assert!(
-            matches!(err, boxlite_shared::errors::BoxliteError::InvalidArgument(_)),
+            matches!(
+                err,
+                boxlite_shared::errors::BoxliteError::InvalidArgument(_)
+            ),
             "expected InvalidArgument (→ HTTP 400), got {err:?}"
         );
     }

--- a/src/boxlite/src/runtime/options.rs
+++ b/src/boxlite/src/runtime/options.rs
@@ -577,7 +577,7 @@ impl BoxOptions {
     ///   guest-networking switch (it gates host jailer grants only)
     pub(crate) fn sanitize_common(&self) -> BoxliteResult<()> {
         if self.removes_on_stop() && self.detach {
-            return Err(boxlite_shared::errors::BoxliteError::Config(
+            return Err(boxlite_shared::errors::BoxliteError::InvalidArgument(
                 "remove-on-stop is incompatible with detach=true. Detached boxes should use \
                  auto_delete=0 (or deprecated auto_remove=false) for manual lifecycle control."
                     .to_string(),
@@ -597,7 +597,7 @@ impl BoxOptions {
         }
 
         if matches!(self.network, NetworkSpec::Disabled) && !self.ports.is_empty() {
-            return Err(boxlite_shared::errors::BoxliteError::Config(
+            return Err(boxlite_shared::errors::BoxliteError::InvalidArgument(
                 "ports require network.outbound.mode=\"enabled\"".to_string(),
             ));
         }
@@ -607,7 +607,7 @@ impl BoxOptions {
         // them at create. See try_from for the rationale.
         if matches!(&self.inbound_network, NetworkSpec::Enabled { allow_net } if !allow_net.is_empty())
         {
-            return Err(boxlite_shared::errors::BoxliteError::Config(
+            return Err(boxlite_shared::errors::BoxliteError::InvalidArgument(
                 "inbound.allow_net is not supported yet; remove it \
                  (inbound access is controlled by mode only)"
                     .to_string(),
@@ -625,7 +625,7 @@ impl BoxOptions {
         if !self.advanced.security.network_enabled
             && matches!(self.network, NetworkSpec::Enabled { .. })
         {
-            return Err(boxlite_shared::errors::BoxliteError::Config(
+            return Err(boxlite_shared::errors::BoxliteError::InvalidArgument(
                 "advanced.security.network_enabled=false does not disable guest networking — \
                  it only drops the host sandbox's network grants. Set network.mode=\"disabled\" \
                  to create a box with no network interface, or leave \
@@ -763,20 +763,20 @@ impl VolumeSpec {
         let guest_path = &self.guest_path;
         match &self.managed_volume {
             Some(volume) if !self.host_path.is_empty() => {
-                Err(boxlite_shared::errors::BoxliteError::Config(format!(
+                Err(boxlite_shared::errors::BoxliteError::InvalidArgument(format!(
                     "volume mount {guest_path:?} sets both managed_volume ({volume:?}) and \
                      host_path; use exactly one"
                 )))
             }
             Some(volume) if volume.trim().is_empty() => {
-                Err(boxlite_shared::errors::BoxliteError::Config(format!(
+                Err(boxlite_shared::errors::BoxliteError::InvalidArgument(format!(
                     "volume mount {guest_path:?} has an empty managed_volume; pass a volume id \
                      or name"
                 )))
             }
             Some(_) => Ok(()),
             None if self.host_path.is_empty() => {
-                Err(boxlite_shared::errors::BoxliteError::Config(format!(
+                Err(boxlite_shared::errors::BoxliteError::InvalidArgument(format!(
                     "volume mount {guest_path:?} needs a managed_volume (volume id or name) or \
                      a host_path"
                 )))
@@ -802,7 +802,7 @@ impl std::str::FromStr for NetworkMode {
         match value.to_ascii_lowercase().as_str() {
             "enabled" => Ok(Self::Enabled),
             "disabled" => Ok(Self::Disabled),
-            _ => Err(boxlite_shared::errors::BoxliteError::Config(format!(
+            _ => Err(boxlite_shared::errors::BoxliteError::InvalidArgument(format!(
                 "invalid network mode {:?}. Expected \"enabled\" or \"disabled\".",
                 value
             ))),
@@ -850,7 +850,7 @@ impl TryFrom<OutboundNetworkConfig> for NetworkSpec {
                 allow_net: config.allow_net,
             }),
             NetworkMode::Disabled if !config.allow_net.is_empty() => {
-                Err(boxlite_shared::errors::BoxliteError::Config(
+                Err(boxlite_shared::errors::BoxliteError::InvalidArgument(
                     "network.outbound.mode=\"disabled\" is incompatible with allow_net. \
                      Remove allow_net or use mode=\"enabled\"."
                         .to_string(),
@@ -870,7 +870,7 @@ impl TryFrom<InboundNetworkConfig> for NetworkSpec {
         // caller a box that is fully open while they believe it is
         // restricted. Reject under either mode; lift once enforcement lands.
         if !config.allow_net.is_empty() {
-            return Err(boxlite_shared::errors::BoxliteError::Config(
+            return Err(boxlite_shared::errors::BoxliteError::InvalidArgument(
                 "inbound.allow_net is not supported yet; remove it \
                  (inbound access is controlled by mode only)"
                     .to_string(),
@@ -1004,7 +1004,7 @@ impl PortSpec {
     /// publication planning both go through it, so they can never disagree.
     pub(crate) fn validate_publishable(&self) -> BoxliteResult<SocketAddr> {
         if self.guest_port == 0 {
-            return Err(boxlite_shared::errors::BoxliteError::Config(
+            return Err(boxlite_shared::errors::BoxliteError::InvalidArgument(
                 "guest port must be in range 1-65535".to_string(),
             ));
         }
@@ -1016,7 +1016,7 @@ impl PortSpec {
         let host_ip = match self.host_ip.as_deref() {
             None => IpAddr::V4(Ipv4Addr::UNSPECIFIED),
             Some(host_ip) => host_ip.parse::<IpAddr>().map_err(|_| {
-                boxlite_shared::errors::BoxliteError::Config(format!(
+                boxlite_shared::errors::BoxliteError::InvalidArgument(format!(
                     "invalid port host_ip {host_ip:?}; expected an IPv4 or IPv6 address"
                 ))
             })?,
@@ -1697,6 +1697,14 @@ mod tests {
         })
         .unwrap_err();
         assert!(err.to_string().contains("not supported yet"));
+        // POL-356: this is the caller's mistake, not the server's — over
+        // boxlite serve it must reach the client as a 400, not a 500. The
+        // variant is what BoxliteError::http() dispatches on, so pin it here
+        // rather than only the message.
+        assert!(
+            matches!(err, boxlite_shared::errors::BoxliteError::InvalidArgument(_)),
+            "expected InvalidArgument (→ HTTP 400), got {err:?}"
+        );
     }
 
     #[test]
@@ -1709,8 +1717,14 @@ mod tests {
             },
             ..Default::default()
         };
-        let err = opts.sanitize().unwrap_err().to_string();
-        assert!(err.contains("not supported yet"));
+        let err = opts.sanitize().unwrap_err();
+        assert!(err.to_string().contains("not supported yet"));
+        // POL-356: same HTTP-mapping requirement as the try_from path above —
+        // this backstop must not silently regress to a 500.
+        assert!(
+            matches!(err, boxlite_shared::errors::BoxliteError::InvalidArgument(_)),
+            "expected InvalidArgument (→ HTTP 400), got {err:?}"
+        );
     }
 
     /// `VolumeSpec::managed_volume` and `VolumeSpec::bind_mount` cannot produce a mount


### PR DESCRIPTION
Fixes POL-356.

**Depends on #1206 (POL-207)** — stacked on `network-info-inbound-outbound-split`
for the inbound/outbound NetworkSpec shape; diff will shrink once #1206 merges.

## Investigation

POL-356 as filed reads as "inbound.allow_net isn't rejected yet" — but it already
is, and has been on main, across every layer: core Rust (`options.rs`), Python/Node/Go
SDKs, the apps/api DTO, self-hosted `boxlite serve`, the CLI (flag not exposed),
and the OpenAPI spec. The actual bug is narrower and more interesting:

## Before

```
POST /v1/boxes {"network":{"inbound":{"mode":"enabled","allow_net":["10.0.0.0/8"]}}}
  -> build_box_options()                    [commands/serve/mod.rs]
  -> NetworkSpec::try_from(InboundNetworkConfig)  [runtime/options.rs]
       Err(BoxliteError::Config("inbound.allow_net is not supported yet..."))
  -> error_from_boxlite() -> err.http()     [shared/src/errors.rs:190]
       BoxliteError::Config(_) => (500, "ConfigError", "config_error")  ← BUG
  -> client sees: 500 Internal Server Error, for their own mistake
```

`Config` is used for two unrelated things: genuine caller-input mistakes (bad
`BoxOptions`) and real system/environment faults (jailer/sandbox setup, image
store). Mixing them meant every caller-input validation error in `options.rs`
— not just inbound.allow_net — surfaced as a 500 over `boxlite serve`.

## After

```
POST /v1/boxes {"network":{"inbound":{"mode":"enabled","allow_net":["10.0.0.0/8"]}}}
  -> NetworkSpec::try_from(InboundNetworkConfig)
       Err(BoxliteError::InvalidArgument("inbound.allow_net is not supported yet..."))
  -> err.http() -> (400, "InvalidArgumentError", "invalid_argument")
  -> client sees: 400 Bad Request with the same message
```

Retargets the ~12 `BoxOptions`/`NetworkSpec`/`PortSpec` validation call sites in
`options.rs` (inbound.allow_net, network mode parsing, ports-without-network,
remove-on-stop+detach, malformed volume mounts, invalid port host_ip) from
`Config` to `InvalidArgument`. Leaves every other `Config` use (jailer, image
store, custom kernel — genuine environment problems) untouched — that variant
still correctly maps to 500 there.

The REST client already reconstructs `InvalidArgument` symmetrically from the
wire (`rest/error.rs`'s `"invalid_argument"` dispatch arm predates this change),
so no client-side change was needed.

## Test plan

- Strengthened `test_network_config_rejects_unsupported_inbound_allow_net` and
  `test_sanitize_rejects_unsupported_inbound_allow_net` to pin the error variant
  (not just the message) — this is what `BoxliteError::http()` dispatches on
- Two-side verification: reverted only the 12 production call sites (kept the
  test assertions on `InvalidArgument`), both tests failed with
  `expected InvalidArgument (→ HTTP 400), got Config(...)`; restored, both pass
- Fixed `create_rejects_detached_remove_on_stop`, the one test that asserted
  the old `Config` variant for a caller-input error
- `cargo test -p boxlite --lib --features rest`: 1169 passed, 2 failed — both
  pre-existing and unrelated (confirmed identical failures on the unmodified
  tree): a missing vendored libkrun submodule in this sandbox, and a flaky
  watchdog-timing test
- `cargo check --workspace --features rest --tests --exclude boxlite-guest`: clean
  (`boxlite-guest` is Linux-only, unbuildable on this host regardless of this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation error handling for box, volume, network, and port configuration.
  * Invalid caller-provided settings are now consistently reported as invalid arguments, corresponding to HTTP 400 responses instead of server errors.
  * Added coverage for invalid network configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->