### PR TITLE
fix(python): stop passing sccache wrapper into wheel containers

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -138,9 +138,9 @@ repair-wheel-command = ""  # Skip auditwheel repair
 # SKIP_GUEST_BUILD=1: Use the restored boxlite-guest from the Ubuntu host
 environment = { SKIP_GUEST_BUILD = "1", PATH = "/usr/local/go/bin:$HOME/.cargo/bin:/usr/local/bin:$PATH", PKG_CONFIG_PATH = "/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig", LD_LIBRARY_PATH = "/usr/local/lib64:/usr/local/lib" }
 
-# Pass sccache env vars from host into cibuildwheel's manylinux container
-# These enable sccache to use the GHA cache API for compilation caching
-environment-pass = ["ACTIONS_RESULTS_URL", "ACTIONS_RUNTIME_TOKEN", "ACTIONS_CACHE_SERVICE_V2", "SCCACHE_GHA_ENABLED", "RUSTC_WRAPPER"]
+# Keep the GHA cache credentials available for the planned stable-wrapper fix.
+# Do not pass the host's relative RUSTC_WRAPPER: cibuildwheel rebuilds PATH for each Python.
+environment-pass = ["ACTIONS_RESULTS_URL", "ACTIONS_RUNTIME_TOKEN", "ACTIONS_CACHE_SERVICE_V2", "SCCACHE_GHA_ENABLED"]
 
 # Retag wheel for PyPI compliance without bundling libs (we handle runtime deps ourselves)
 # Uses 'wheel tags' to change linux_x86_64 -> manylinux_2_28_x86_64


### PR DESCRIPTION
## Summary

Stop forwarding the runner-local `RUSTC_WRAPPER=sccache` value into cibuildwheel's Linux containers. cibuildwheel rebuilds `PATH` for each Python interpreter, so later wheel builds could no longer resolve the wrapper and Cargo failed before compiling.

This is a temporary correctness-first mitigation: Linux wheel builds use `rustc` directly, while the GHA cache credentials remain available for a future stable-wrapper configuration. Earlier builds passed because the wrapper was not forwarded into these containers, so Cargo invoked `rustc` directly even though Rust compilation caching was effectively inactive there.

## Call graph

Before

```text
Build wheels          (GitHub Actions · .github/workflows/build-wheels.yml:41) — invokes cibuildwheel
  └─ environment-pass (cibuildwheel · sdks/python/pyproject.toml:143)           — forwards RUSTC_WRAPPER=sccache
       └─ cargo/rustc  (manylinux container · per-Python PATH)                 ← BUG: later interpreters cannot resolve sccache
```

After

```text
Build wheels          (GitHub Actions · .github/workflows/build-wheels.yml:41) — invokes cibuildwheel
  └─ environment-pass (cibuildwheel · sdks/python/pyproject.toml:143)           — keeps GHA cache credentials, omits RUSTC_WRAPPER
       └─ cargo/rustc  (manylinux container · per-Python PATH)                 — invokes rustc directly
```

## Changes

- Remove `RUSTC_WRAPPER` from the Linux cibuildwheel `environment-pass` list.
- Preserve the GHA cache environment variables for a later stable wrapper-path fix.

## How to verify

- `make lint:python`
- `make fmt:check:python`
- [Build Wheels workflow_dispatch run #33151231876](https://github.com/boxlite-ai/boxlite/actions/runs/33151231876) — succeeded across all build and install/import jobs; publish/release jobs were skipped, and temporary Actions artifacts were deleted after validation.

## Risks / rollout

- Linux wheel compilation temporarily loses sccache acceleration and may take longer; wheel behavior is unchanged.
