### PR TITLE
fix(rest): send legacy flat network shape when inbound is at default

### DIFF
--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -266,7 +266,11 @@ impl serde::Serialize for CreateBoxNetworkSpec {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         use serde::ser::SerializeMap;
         if self.legacy {
-            let len = if self.outbound.allow_net.is_empty() { 1 } else { 2 };
+            let len = if self.outbound.allow_net.is_empty() {
+                1
+            } else {
+                2
+            };
             let mut map = serializer.serialize_map(Some(len))?;
             map.serialize_entry("mode", &self.outbound.mode)?;
             if !self.outbound.allow_net.is_empty() {

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -250,40 +250,30 @@ impl From<&crate::runtime::options::VolumeSpec> for CreateBoxVolumeSpec {
 
 /// Wire shape sent to the server when creating a box.
 ///
-/// Serializes as the legacy flat shape `{"mode","allow_net"}` when inbound is
-/// at its default (enabled, no allowlist), so servers that predate the
-/// inbound/outbound split (#1199) keep working. Serializes as the nested shape
-/// `{"outbound","inbound"}` when inbound is explicitly configured — that
-/// requires a server with #1199+ support.
-#[derive(Debug)]
-pub(crate) struct CreateBoxNetworkSpec {
-    pub outbound: CreateBoxOutboundNetworkSpec,
-    pub inbound: CreateBoxInboundNetworkSpec,
-    legacy: bool,
+/// `Legacy` is the pre-split flat shape `{"mode","allow_net"}`, accepted by
+/// all server versions. `Nested` carries explicit inbound/outbound directions
+/// and requires a server with #1199+ support.
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub(crate) enum CreateBoxNetworkSpec {
+    /// Pre-split shape — sent when inbound is at its default so servers that
+    /// predate the inbound/outbound split (#1199) keep working.
+    Legacy(CreateBoxLegacyNetworkSpec),
+    /// Inbound/outbound shape — sent when inbound is explicitly configured.
+    Nested(CreateBoxNestedNetworkSpec),
 }
 
-impl serde::Serialize for CreateBoxNetworkSpec {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        use serde::ser::SerializeMap;
-        if self.legacy {
-            let len = if self.outbound.allow_net.is_empty() {
-                1
-            } else {
-                2
-            };
-            let mut map = serializer.serialize_map(Some(len))?;
-            map.serialize_entry("mode", &self.outbound.mode)?;
-            if !self.outbound.allow_net.is_empty() {
-                map.serialize_entry("allow_net", &self.outbound.allow_net)?;
-            }
-            map.end()
-        } else {
-            let mut map = serializer.serialize_map(Some(2))?;
-            map.serialize_entry("outbound", &self.outbound)?;
-            map.serialize_entry("inbound", &self.inbound)?;
-            map.end()
-        }
-    }
+#[derive(Debug, Serialize)]
+pub(crate) struct CreateBoxLegacyNetworkSpec {
+    pub mode: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub allow_net: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct CreateBoxNestedNetworkSpec {
+    pub outbound: CreateBoxOutboundNetworkSpec,
+    pub inbound: CreateBoxInboundNetworkSpec,
 }
 
 #[derive(Debug, Serialize)]
@@ -316,20 +306,23 @@ impl CreateBoxNetworkSpec {
         // Use the legacy flat shape when inbound is at its default (Enabled,
         // empty allowlist). Any explicit inbound configuration requires the
         // nested shape and a server that understands it (#1199+).
-        let legacy = match inbound {
-            crate::runtime::options::NetworkSpec::Enabled { allow_net } => allow_net.is_empty(),
-            _ => false,
-        };
-        Self {
-            outbound: CreateBoxOutboundNetworkSpec {
-                mode: mode_str(config.outbound.mode),
-                allow_net: config.outbound.allow_net,
-            },
-            inbound: CreateBoxInboundNetworkSpec {
-                mode: mode_str(config.inbound.mode),
-                allow_net: config.inbound.allow_net,
-            },
-            legacy,
+        match inbound {
+            crate::runtime::options::NetworkSpec::Enabled { allow_net } if allow_net.is_empty() => {
+                Self::Legacy(CreateBoxLegacyNetworkSpec {
+                    mode: mode_str(config.outbound.mode),
+                    allow_net: config.outbound.allow_net,
+                })
+            }
+            _ => Self::Nested(CreateBoxNestedNetworkSpec {
+                outbound: CreateBoxOutboundNetworkSpec {
+                    mode: mode_str(config.outbound.mode),
+                    allow_net: config.outbound.allow_net,
+                },
+                inbound: CreateBoxInboundNetworkSpec {
+                    mode: mode_str(config.inbound.mode),
+                    allow_net: config.inbound.allow_net,
+                },
+            }),
         }
     }
 }
@@ -776,21 +769,13 @@ mod tests {
         assert!(req.rootfs_path.is_none());
         assert_eq!(req.cpus, Some(4));
         assert_eq!(req.memory_mib, Some(1024));
-        assert_eq!(
-            req.network.as_ref().map(|n| n.outbound.mode.as_str()),
-            Some("enabled")
-        );
-        assert_eq!(
-            req.network.as_ref().map(|n| n.outbound.allow_net.clone()),
-            Some(vec!["api.openai.com".into()])
-        );
-        assert_eq!(
-            req.network.as_ref().map(|n| n.inbound.mode.as_str()),
-            Some("disabled")
-        );
         // inbound is Disabled (non-default) → nested shape required.
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["network"]["outbound"]["mode"], "enabled");
+        assert_eq!(
+            json["network"]["outbound"]["allow_net"][0],
+            "api.openai.com"
+        );
         assert_eq!(json["network"]["inbound"]["mode"], "disabled");
         assert!(json["network"]["mode"].is_null());
         assert_eq!(req.secrets.as_ref().map(Vec::len), Some(1));
@@ -965,15 +950,12 @@ mod tests {
         };
 
         let req = CreateBoxRequest::from_options(&opts, None);
-        assert_eq!(
-            req.network.as_ref().map(|n| n.outbound.mode.as_str()),
-            Some("disabled")
-        );
-        assert!(req.network.as_ref().unwrap().outbound.allow_net.is_empty());
-        // NetworkSpec::outbound_disabled() only overrides outbound; inbound keeps its
-        // default (Enabled/public), matching the control plane's existing
-        // preview-URL default.
-        assert_eq!(req.network.as_ref().unwrap().inbound.mode, "enabled");
+        // inbound at default → legacy flat shape.
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["network"]["mode"], "disabled");
+        // NetworkSpec::Disabled only overrides outbound; inbound keeps its
+        // default (Enabled/public) — not present in the legacy flat shape.
+        assert!(json["network"]["outbound"].is_null());
     }
 
     /// REST is intentionally a "the server picks the security policy"

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -248,10 +248,38 @@ impl From<&crate::runtime::options::VolumeSpec> for CreateBoxVolumeSpec {
     }
 }
 
-#[derive(Debug, Serialize)]
+/// Wire shape sent to the server when creating a box.
+///
+/// Serializes as the legacy flat shape `{"mode","allow_net"}` when inbound is
+/// at its default (enabled, no allowlist), so servers that predate the
+/// inbound/outbound split (#1199) keep working. Serializes as the nested shape
+/// `{"outbound","inbound"}` when inbound is explicitly configured — that
+/// requires a server with #1199+ support.
+#[derive(Debug)]
 pub(crate) struct CreateBoxNetworkSpec {
     pub outbound: CreateBoxOutboundNetworkSpec,
     pub inbound: CreateBoxInboundNetworkSpec,
+    legacy: bool,
+}
+
+impl serde::Serialize for CreateBoxNetworkSpec {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+        if self.legacy {
+            let len = if self.outbound.allow_net.is_empty() { 1 } else { 2 };
+            let mut map = serializer.serialize_map(Some(len))?;
+            map.serialize_entry("mode", &self.outbound.mode)?;
+            if !self.outbound.allow_net.is_empty() {
+                map.serialize_entry("allow_net", &self.outbound.allow_net)?;
+            }
+            map.end()
+        } else {
+            let mut map = serializer.serialize_map(Some(2))?;
+            map.serialize_entry("outbound", &self.outbound)?;
+            map.serialize_entry("inbound", &self.inbound)?;
+            map.end()
+        }
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -281,6 +309,13 @@ impl CreateBoxNetworkSpec {
         inbound: &crate::runtime::options::NetworkSpec,
     ) -> Self {
         let config = crate::runtime::options::NetworkConfig::from_specs(outbound, inbound);
+        // Use the legacy flat shape when inbound is at its default (Enabled,
+        // empty allowlist). Any explicit inbound configuration requires the
+        // nested shape and a server that understands it (#1199+).
+        let legacy = match inbound {
+            crate::runtime::options::NetworkSpec::Enabled { allow_net } => allow_net.is_empty(),
+            _ => false,
+        };
         Self {
             outbound: CreateBoxOutboundNetworkSpec {
                 mode: mode_str(config.outbound.mode),
@@ -290,6 +325,7 @@ impl CreateBoxNetworkSpec {
                 mode: mode_str(config.inbound.mode),
                 allow_net: config.inbound.allow_net,
             },
+            legacy,
         }
     }
 }
@@ -669,53 +705,38 @@ mod tests {
 
     #[test]
     fn test_create_box_request_serialization() {
-        let req = CreateBoxRequest {
-            name: Some("mybox".into()),
-            image: Some("python:3.11".into()),
-            rootfs_path: None,
+        use crate::runtime::options::{BoxOptions, NetworkSpec, RootfsSpec};
+
+        // inbound at default → legacy flat shape, accepted by all server versions.
+        let opts = BoxOptions {
+            rootfs: RootfsSpec::Image("python:3.11".into()),
             cpus: Some(2),
             memory_mib: Some(512),
-            disk_size_gb: None,
-            working_dir: None,
-            env: None,
-            network: Some(CreateBoxNetworkSpec {
-                outbound: CreateBoxOutboundNetworkSpec {
-                    mode: "enabled".into(),
-                    allow_net: vec!["api.openai.com".into()],
-                },
-                inbound: CreateBoxInboundNetworkSpec {
-                    mode: "enabled".into(),
-                    allow_net: vec![],
-                },
-            }),
-            entrypoint: None,
-            cmd: None,
-            user: None,
-            tty: None,
-            secrets: Some(vec![CreateBoxSecret {
-                name: "openai".into(),
-                value: "sk-test".into(),
-                hosts: vec!["api.openai.com".into()],
-                placeholder: "<BOXLITE_SECRET:openai>".into(),
-            }]),
-            volumes: None,
-            detach: None,
-            advanced: None,
-            auto_stop: Some(900),
-            auto_delete: Some(604800),
-            auto_resume: None,
+            network: NetworkSpec::Enabled {
+                allow_net: vec!["api.openai.com".into()],
+            },
+            // inbound_network left at default: Enabled { allow_net: [] }
+            ..Default::default()
         };
+        let mut req = CreateBoxRequest::from_options(&opts, Some("mybox".into()));
+        req.secrets = Some(vec![CreateBoxSecret {
+            name: "openai".into(),
+            value: "sk-test".into(),
+            hosts: vec!["api.openai.com".into()],
+            placeholder: "<BOXLITE_SECRET:openai>".into(),
+        }]);
+        req.auto_stop = Some(900);
+        req.auto_delete = Some(604800);
+
         let json = serde_json::to_string(&req).unwrap();
         assert!(json.contains("\"name\":\"mybox\""));
         assert!(json.contains("\"image\":\"python:3.11\""));
         assert!(json.contains("\"cpus\":2"));
         let value: serde_json::Value = serde_json::from_str(&json).unwrap();
-        assert_eq!(value["network"]["outbound"]["mode"], "enabled");
-        assert_eq!(
-            value["network"]["outbound"]["allow_net"][0],
-            "api.openai.com"
-        );
-        assert_eq!(value["network"]["inbound"]["mode"], "enabled");
+        // Legacy flat shape: top-level mode/allow_net, no outbound/inbound nesting.
+        assert_eq!(value["network"]["mode"], "enabled");
+        assert_eq!(value["network"]["allow_net"][0], "api.openai.com");
+        assert!(value["network"]["outbound"].is_null());
         assert!(json.contains("\"secrets\""));
         // None fields should be skipped
         assert!(!json.contains("rootfs_path"));
@@ -763,6 +784,11 @@ mod tests {
             req.network.as_ref().map(|n| n.inbound.mode.as_str()),
             Some("disabled")
         );
+        // inbound is Disabled (non-default) → nested shape required.
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["network"]["outbound"]["mode"], "enabled");
+        assert_eq!(json["network"]["inbound"]["mode"], "disabled");
+        assert!(json["network"]["mode"].is_null());
         assert_eq!(req.secrets.as_ref().map(Vec::len), Some(1));
         let volume = &req.volumes.as_ref().unwrap()[0];
         assert_eq!(volume.managed_volume, "volume-123");


### PR DESCRIPTION
## Summary

Fixes backward compatibility for self-hosted users who upgrade their SDK/CLI before upgrading their server.

Old servers (pre-#1199) set `forbidNonWhitelisted: true` in NestJS, so the new nested `{outbound, inbound}` wire shape produces a 400 even when the user never configures inbound — the unknown `inbound` key is enough to reject the request.

Serialize as the legacy flat shape `{mode, allow_net}` when inbound is at its default (`Enabled`, empty allowlist). Emit the nested shape only when inbound is explicitly configured, which requires a server with #1199+ support anyway.

## Before/after

```
(before)
BoxOptions { network: Enabled, inbound_network: Enabled }   ← default
  -> POST /boxes { network: { outbound: {mode,allow_net}, inbound: {mode} } }
     ← 400 on old server (forbidNonWhitelisted rejects outbound/inbound keys)

(after)
BoxOptions { network: Enabled, inbound_network: Enabled }   ← default
  -> POST /boxes { network: { mode, allow_net } }           ← legacy flat shape
     ← 200 on any server

BoxOptions { ..., inbound_network: Disabled }               ← explicit inbound
  -> POST /boxes { network: { outbound: {...}, inbound: {...} } }
     ← requires #1199+ server
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network configuration compatibility by preserving the legacy format when default inbound networking settings are used.
  * Added support for the newer nested outbound and inbound network configuration format when inbound settings are explicitly customized.
  * Improved reliability by ensuring network settings are serialized in the correct format for each configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->