### PR TITLE
build(node): pin napi-rs CLI to 3.7.2

### DIFF
--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -37,7 +37,7 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
-    "@napi-rs/cli": "^3.0.0-alpha.62",
+    "@napi-rs/cli": "3.7.2",
     "@types/node": "^22.0.0",
     "playwright-core": "1.58.0",
     "prettier": "^3.6.2",


### PR DESCRIPTION
## Summary

Pin `@napi-rs/cli` to the last known-good release so each single-target Node build job can package its artifact again. This is a temporary unblock for the v0.10.0 release failure while the workflow is redesigned to aggregate all native targets before running `napi artifacts`.

Failed run: [Build Node.js #33147385680](https://github.com/boxlite-ai/boxlite/actions/runs/33147385680)

## Call graph

Before
```text
  Build Node.js package  (workflow · .github/workflows/build-node.yml:72)  — builds one matrix target
    └─ npm install       (manifest · sdks/node/package.json:40)            — resolves the floating CLI range to 3.8.x
         └─ artifacts    (script · sdks/node/package.json:31)              ← BUG: requires the other two target artifacts and exits 1
```

After
```text
  Build Node.js package  (workflow · .github/workflows/build-node.yml:72)  — builds one matrix target
    └─ npm install       (manifest · sdks/node/package.json:40)            — installs exact CLI 3.7.2
         └─ artifacts    (script · sdks/node/package.json:31)              — packages the current target successfully
```

## Changes

- Pin `@napi-rs/cli` from `^3.0.0-alpha.62` to exact version `3.7.2`.
- Keep the existing per-target packaging workflow unchanged as a temporary release unblock.

## How to verify

- `make fmt:check:node`
- [Build Node.js #33155334475](https://github.com/boxlite-ai/boxlite/actions/runs/33155334475): all 3 platform builds and all 9 platform/Node test jobs succeeded.

## Risks / rollout

- The pin intentionally excludes later CLI fixes. Follow up by aggregating all native artifacts before one `napi artifacts` invocation, then remove the pin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development tooling to a stable CLI release for improved reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->