### PR TITLE
feat(api): enforce Commerce limits on hosted REST box creation

### DIFF
--- a/apps/API.md
+++ b/apps/API.md
@@ -640,9 +640,11 @@ same time.
 ## Externally served APIs
 
 These interfaces are called from this directory but served by systems outside
-it, so no route table above owns them. The analytics and billing clients take
-their base URL from `GET /api/config` and disable the corresponding UI when it
-is unset; the same document carries PostHog's key and host to the browser.
+it, so no route table above owns them. The dashboard analytics and billing
+clients take their base URL from `GET /api/config` and disable the corresponding
+UI when it is unset; the API reads that same billing base from
+`BILLING_API_URL`. The same config document carries PostHog's key and host to
+the browser.
 
 <details>
 <summary><b>External interfaces</b> · 2 APIs, 2 SaaS integrations</summary>
@@ -650,7 +652,7 @@ is unset; the same document carries PostHog's key and host to the browser.
 | Interface     | Client                                                                                 | Base URL source                  | What it covers                                                                                                                                               |
 | ------------- | -------------------------------------------------------------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Analytics API | [`libs/analytics-api-client`](./libs/analytics-api-client/), generated                 | `analyticsApiUrl`                | 8 routes: per-box and organization usage, aggregates, and charts, plus box logs, metrics, and traces.                                                        |
-| Billing API   | [`billingApiClient.ts`](./dashboard/src/billing-api/billingApiClient.ts), hand-written | `billingApiUrl`                  | 20 routes: usage, wallet and top-ups, plans, invoices, coupons, billing emails, portal and checkout URLs.                                                    |
+| Billing API   | [`billingApiClient.ts`](./dashboard/src/billing-api/billingApiClient.ts) and [`CommerceBoxLimitService`](./api/src/boxlite-rest/services/commerce-box-limit.service.ts), hand-written | `billingApiUrl`; `BILLING_API_URL` | Dashboard billing routes plus API-side `GET /plan` and `GET /organization/{id}/plan` reads used to limit hosted REST box creation. |
 | PostHog       | `posthog-js` in the dashboard; `posthog-node` in the API                               | `posthog.apiKey`, `posthog.host` | Browser product analytics; server-side `api_*` operation events from the global metrics interceptor, two `groupIdentify` calls, and feature-flag evaluation. |
 | Pylon         | [`App.tsx`](./dashboard/src/App.tsx) widget, production builds only                    | `pylonAppId`                     | Outbound support-chat widget; it registers no route here.                                                                                                    |
 
@@ -659,7 +661,11 @@ The analytics client is generated from
 routes duplicate the control plane's own [box telemetry](#control-plane-api)
 routes, and the dashboard's box telemetry views call the analytics client only —
 they disable themselves when `analyticsApiUrl` is unset rather than falling back.
-Nothing in this directory registers the analytics or billing paths.
+The API authenticates both server-side plan reads with `USAGE_EXPORT_TOKEN`.
+Successful resolutions are cached for 10 seconds; Commerce errors or malformed
+responses fall back to 20 for the current create request without being cached.
+With no `BILLING_API_URL`, the hosted REST path is unlimited. Nothing in this
+directory registers the analytics or billing paths.
 
 </details>
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -76,6 +76,12 @@ PROXY_TOOLBOX_BASE_URL=http://proxy.localhost:4000
 
 PYLON_APP_ID=
 
+# Public Commerce billing API. When unset, hosted REST box creation has no
+# organization box-count ceiling. When set, the API reads the public plan
+# catalog and organization plan with USAGE_EXPORT_TOKEN, caches successful
+# resolutions for 10 seconds, and enforces the resolved concurrency limit on
+# POST /api/v1/boxes and POST /api/v1/<prefix>/boxes. Failed or malformed
+# Commerce responses use a per-request limit of 20 and are not cached.
 BILLING_API_URL=
 
 # Export of finalized usage periods to the Commerce service. Separate from
@@ -89,7 +95,8 @@ BILLING_API_URL=
 # delivery must behave and are checked only while USAGE_EXPORT_ENABLED is true,
 # so a stage may leave a placeholder destination here without failing to boot:
 #   USAGE_EXPORT_URL   required, and an absolute http(s) URL
-#   USAGE_EXPORT_TOKEN required
+#   USAGE_EXPORT_TOKEN required; it also authenticates plan reads when
+#     BILLING_API_URL enables the hosted REST box-count ceiling
 #   USAGE_EXPORT_TIMEOUT_MS below the window a claimed batch stays hidden for —
 #     at or above it, rows can be re-claimed while their request is in flight
 USAGE_EXPORT_ENABLED=false

--- a/apps/api/src/box/errors/box-inventory-limit-exceeded.error.ts
+++ b/apps/api/src/box/errors/box-inventory-limit-exceeded.error.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+export class BoxInventoryLimitExceededError extends Error {
+  constructor(
+    public readonly current: number,
+    public readonly limit: number,
+  ) {
+    super(`Box inventory count ${current} reaches or exceeds limit ${limit}`)
+    this.name = 'BoxInventoryLimitExceededError'
+  }
+}

--- a/apps/api/src/box/repositories/box.repository.inventory-limit.integration.spec.ts
+++ b/apps/api/src/box/repositories/box.repository.inventory-limit.integration.spec.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { randomUUID } from 'node:crypto'
+import { DataSource, Repository } from 'typeorm'
+import { CustomNamingStrategy } from '../../common/utils/naming-strategy.util'
+import { BOX_WARM_POOL_UNASSIGNED_ORGANIZATION } from '../constants/box.constants'
+import { BoxInventoryLimitExceededError } from '../errors/box-inventory-limit-exceeded.error'
+import { Box } from '../entities/box.entity'
+import { BoxLastActivity } from '../entities/box-last-activity.entity'
+import { BoxRepository } from './box.repository'
+
+const describeIfDatabase = process.env.DB_HOST ? describe : describe.skip
+const schemaName = `box_inventory_limit_${process.pid}_${randomUUID().replaceAll('-', '')}`
+const organizationId = '00000000-0000-4000-8000-000000000140'
+
+function quotaBox(name: string, boxOrganizationId = organizationId): Box {
+  const box = new Box('us', name)
+  box.organizationId = boxOrganizationId
+  box.osUser = 'boxlite'
+  return box
+}
+
+describeIfDatabase('BoxRepository inventory commit fence (integration, real Postgres)', () => {
+  let dataSource: DataSource
+  let boxes: Repository<Box>
+  let repository: BoxRepository
+  let ownsSchema = false
+
+  beforeAll(async () => {
+    dataSource = await new DataSource({
+      type: 'postgres',
+      host: process.env.DB_HOST,
+      port: Number(process.env.DB_PORT || 5432),
+      username: process.env.DB_USERNAME,
+      password: process.env.DB_PASSWORD,
+      database: process.env.DB_DATABASE,
+      schema: schemaName,
+      entities: [Box, BoxLastActivity],
+      namingStrategy: new CustomNamingStrategy(),
+      entitySkipConstructor: true,
+      synchronize: false,
+      extra: { options: `-c search_path=${schemaName},public` },
+    }).initialize()
+
+    await dataSource.query(`CREATE SCHEMA "${schemaName}"`)
+    ownsSchema = true
+    await dataSource.synchronize()
+    boxes = dataSource.getRepository(Box)
+    repository = new BoxRepository(
+      dataSource,
+      { emit: jest.fn() } as any,
+      { invalidateOrgId: jest.fn(), invalidate: jest.fn() } as any,
+    )
+  })
+
+  afterAll(async () => {
+    if (!dataSource?.isInitialized) {
+      return
+    }
+    try {
+      if (ownsSchema) {
+        await dataSource.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`)
+      }
+    } finally {
+      await dataSource.destroy()
+    }
+  })
+
+  beforeEach(async () => {
+    await dataSource.query(`DELETE FROM "${schemaName}"."box_last_activity"`)
+    await dataSource.query(`DELETE FROM "${schemaName}"."box"`)
+  })
+
+  it('admits exactly one of two concurrent creates from limit minus one', async () => {
+    await boxes.insert(quotaBox('existing'))
+
+    const results = await Promise.allSettled([
+      repository.insert(quotaBox('candidate-a'), { inventoryLimit: 2 }),
+      repository.insert(quotaBox('candidate-b'), { inventoryLimit: 2 }),
+    ])
+
+    const fulfilled = results.filter((result) => result.status === 'fulfilled')
+    const rejected = results.filter((result) => result.status === 'rejected') as PromiseRejectedResult[]
+    expect(fulfilled).toHaveLength(1)
+    expect(rejected).toHaveLength(1)
+    expect(rejected[0].reason).toBeInstanceOf(BoxInventoryLimitExceededError)
+    expect(await repository.countQuotaBoxes(organizationId)).toBe(2)
+  })
+
+  it('uses the same commit fence for a fresh insert and warm-pool assignment', async () => {
+    const warmPoolBox = quotaBox('warm-pool', BOX_WARM_POOL_UNASSIGNED_ORGANIZATION)
+    await boxes.insert(warmPoolBox)
+
+    const results = await Promise.allSettled([
+      repository.insert(quotaBox('fresh'), { inventoryLimit: 1 }),
+      repository.update(warmPoolBox.id, {
+        updateData: { organizationId },
+        entity: warmPoolBox,
+        inventoryLimit: 1,
+      }),
+    ])
+
+    const fulfilled = results.filter((result) => result.status === 'fulfilled')
+    const rejected = results.filter((result) => result.status === 'rejected') as PromiseRejectedResult[]
+    expect(fulfilled).toHaveLength(1)
+    expect(rejected).toHaveLength(1)
+    expect(rejected[0].reason).toBeInstanceOf(BoxInventoryLimitExceededError)
+    expect(await repository.countQuotaBoxes(organizationId)).toBe(1)
+  })
+})

--- a/apps/api/src/box/repositories/box.repository.spec.ts
+++ b/apps/api/src/box/repositories/box.repository.spec.ts
@@ -73,6 +73,67 @@ describe('BoxRepository.countQuotaBoxes', () => {
   })
 })
 
+describe('BoxRepository inventory commit fence', () => {
+  function makeInventoryRepository(currentCount: number) {
+    const getCount = jest.fn().mockResolvedValue(currentCount)
+    const countQueryBuilder = makeQueryBuilder(jest.fn(), getCount)
+    const query = jest.fn().mockResolvedValue([{ pg_advisory_xact_lock: '' }])
+    const insert = jest.fn().mockResolvedValue(undefined)
+    const upsert = jest.fn().mockResolvedValue(undefined)
+    const entityManager = {
+      query,
+      createQueryBuilder: jest.fn(() => countQueryBuilder),
+      insert,
+      upsert,
+    }
+    const transaction = jest.fn(async (callback: (manager: typeof entityManager) => Promise<void>) =>
+      callback(entityManager),
+    )
+    const ormRepository = { createQueryBuilder: jest.fn(() => countQueryBuilder) }
+    const dataSource = { getRepository: () => ormRepository, transaction } as any
+    const repo = new BoxRepository(dataSource, {} as any, { invalidateOrgId: jest.fn() } as any)
+    const box = {
+      id: 'box-1',
+      name: 'box-1',
+      organizationId: 'org-1',
+      assertValid: jest.fn(),
+      enforceInvariants: jest.fn(),
+    } as any
+    return { repo, box, query, getCount, insert, upsert }
+  }
+
+  it('locks, recounts, and inserts in one short transaction', async () => {
+    const { repo, box, query, getCount, insert } = makeInventoryRepository(19)
+
+    await repo.insert(box, { inventoryLimit: 20 })
+
+    expect(query).toHaveBeenCalledWith(expect.stringContaining('pg_advisory_xact_lock'), ['org-1'])
+    expect(query.mock.invocationCallOrder[0]).toBeLessThan(getCount.mock.invocationCallOrder[0])
+    expect(getCount.mock.invocationCallOrder[0]).toBeLessThan(insert.mock.invocationCallOrder[0])
+  })
+
+  it('does not insert after the fenced recount reaches the limit', async () => {
+    const { repo, box, insert } = makeInventoryRepository(20)
+
+    await expect(repo.insert(box, { inventoryLimit: 20 })).rejects.toMatchObject({
+      current: 20,
+      limit: 20,
+    })
+    expect(insert).not.toHaveBeenCalled()
+  })
+
+  it('rolls back when reservation ownership is lost during insert', async () => {
+    const { repo, box, insert, upsert } = makeInventoryRepository(19)
+    const controller = new AbortController()
+    insert.mockImplementation(async () => controller.abort(new Error('reservation lost')))
+
+    await expect(repo.insert(box, { inventoryLimit: 20, admissionSignal: controller.signal })).rejects.toThrow(
+      'reservation lost',
+    )
+    expect(upsert).not.toHaveBeenCalled()
+  })
+})
+
 describe('BoxRepository.conditionalStartForProxy', () => {
   it('bounds the row-lock wait with a lock_timeout before the UPDATE', async () => {
     const execute = jest.fn().mockResolvedValue({ raw: [startedRow] })

--- a/apps/api/src/box/repositories/box.repository.spec.ts
+++ b/apps/api/src/box/repositories/box.repository.spec.ts
@@ -8,9 +8,9 @@ import { Box } from '../entities/box.entity'
 import { BoxState } from '../enums/box-state.enum'
 import { BoxDesiredState } from '../enums/box-desired-state.enum'
 
-// A chainable UPDATE query-builder stub whose terminal execute() is supplied
+// A chainable query-builder stub whose UPDATE and COUNT terminals are supplied
 // per-test. update/set/where/andWhere/returning all return the same builder.
-function makeQueryBuilder(execute: jest.Mock) {
+function makeQueryBuilder(execute: jest.Mock, getCount = jest.fn()) {
   const qb: any = {}
   qb.update = jest.fn(() => qb)
   qb.set = jest.fn(() => qb)
@@ -18,15 +18,16 @@ function makeQueryBuilder(execute: jest.Mock) {
   qb.andWhere = jest.fn(() => qb)
   qb.returning = jest.fn(() => qb)
   qb.execute = execute
+  qb.getCount = getCount
   return qb
 }
 
 // Build a BoxRepository whose `manager.transaction` runs the callback against a
-// fake entityManager. We bypass DI: only `manager` (a BaseRepository getter
-// over repository.manager) and the cache-invalidation hook are exercised here.
-function makeRepository(execute: jest.Mock) {
+// fake entityManager. We bypass DI: these tests exercise the repository query
+// builder, `manager` (a BaseRepository getter), and cache invalidation only.
+function makeRepository(execute: jest.Mock, getCount = jest.fn()) {
   const query = jest.fn().mockResolvedValue(undefined)
-  const queryBuilder = makeQueryBuilder(execute)
+  const queryBuilder = makeQueryBuilder(execute, getCount)
   // create() hydrates the RETURNING * raw row into a Box; the stub echoes the
   // row back so return-shape assertions stay on the same object.
   const create = jest.fn((_entity, raw) => raw)
@@ -38,12 +39,13 @@ function makeRepository(execute: jest.Mock) {
   const manager = {
     transaction: jest.fn(async (cb: (em: typeof entityManager) => Promise<unknown>) => cb(entityManager)),
   }
-  const dataSource = { getRepository: () => ({ manager }) } as any
+  const ormRepository = { manager, createQueryBuilder: jest.fn(() => queryBuilder) }
+  const dataSource = { getRepository: () => ormRepository } as any
   const repo = new BoxRepository(dataSource, {} as any, {} as any)
   // invalidateLookupCacheOnUpdate touches the real cache service; stub it out —
   // it is incidental to the lock-timeout behavior under test.
   jest.spyOn(repo as any, 'invalidateLookupCacheOnUpdate').mockImplementation(() => undefined)
-  return { repo, query, execute, create }
+  return { repo, query, execute, create, queryBuilder }
 }
 
 const startedRow = {
@@ -55,6 +57,21 @@ const startedRow = {
   desiredState: BoxDesiredState.STARTED,
   pending: true,
 }
+
+describe('BoxRepository.countQuotaBoxes', () => {
+  it('counts every organization box except destroyed and archived boxes', async () => {
+    const getCount = jest.fn().mockResolvedValue(7)
+    const { repo, queryBuilder } = makeRepository(jest.fn(), getCount)
+
+    await expect(repo.countQuotaBoxes('org-1')).resolves.toBe(7)
+    expect(queryBuilder.where).toHaveBeenCalledWith('box.organizationId = :organizationId', {
+      organizationId: 'org-1',
+    })
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith('box.state NOT IN (:...excludedStates)', {
+      excludedStates: [BoxState.DESTROYED, BoxState.ARCHIVED],
+    })
+  })
+})
 
 describe('BoxRepository.conditionalStartForProxy', () => {
   it('bounds the row-lock wait with a lock_timeout before the UPDATE', async () => {

--- a/apps/api/src/box/repositories/box.repository.ts
+++ b/apps/api/src/box/repositories/box.repository.ts
@@ -52,6 +52,16 @@ export class BoxRepository extends BaseRepository<Box> {
     super(dataSource, eventEmitter, Box)
   }
 
+  async countQuotaBoxes(organizationId: string): Promise<number> {
+    return this.repository
+      .createQueryBuilder('box')
+      .where('box.organizationId = :organizationId', { organizationId })
+      .andWhere('box.state NOT IN (:...excludedStates)', {
+        excludedStates: [BoxState.DESTROYED, BoxState.ARCHIVED],
+      })
+      .getCount()
+  }
+
   async insert(box: Box): Promise<Box> {
     const now = new Date()
     if (!box.createdAt) {

--- a/apps/api/src/box/repositories/box.repository.ts
+++ b/apps/api/src/box/repositories/box.repository.ts
@@ -22,6 +22,7 @@ import { BoxDesiredStateUpdatedEvent } from '../events/box-desired-state-updated
 import { BoxPublicStatusUpdatedEvent } from '../events/box-public-status-updated.event'
 import { BoxOrganizationUpdatedEvent } from '../events/box-organization-updated.event'
 import { BoxLookupCacheInvalidationService } from '../services/box-lookup-cache-invalidation.service'
+import { BoxInventoryLimitExceededError } from '../errors/box-inventory-limit-exceeded.error'
 
 // Cap how long the proxy auto-start UPDATE waits to acquire the box row's
 // write lock. Concurrent start/stop/sync go through updateWhere(), which holds
@@ -36,6 +37,11 @@ const PROXY_START_LOCK_TIMEOUT_MS = 2000
 // SQLSTATE for `lock_not_available` — raised when a statement waits longer than
 // lock_timeout to acquire a lock.
 const PG_LOCK_TIMEOUT_CODE = '55P03'
+
+interface BoxInventoryCommitOptions {
+  inventoryLimit?: number
+  admissionSignal?: AbortSignal
+}
 
 // A box the migration marker may claim, with the stamp its claim copies.
 type ParkedBox = { id: string; updatedAt: Date }
@@ -62,7 +68,7 @@ export class BoxRepository extends BaseRepository<Box> {
       .getCount()
   }
 
-  async insert(box: Box): Promise<Box> {
+  async insert(box: Box, options: BoxInventoryCommitOptions = {}): Promise<Box> {
     const now = new Date()
     if (!box.createdAt) {
       box.createdAt = now
@@ -75,8 +81,18 @@ export class BoxRepository extends BaseRepository<Box> {
     box.enforceInvariants()
 
     await this.dataSource.transaction(async (entityManager) => {
+      if (options.inventoryLimit !== undefined) {
+        await this.assertInventoryAvailable(
+          entityManager,
+          box.organizationId,
+          options.inventoryLimit,
+          options.admissionSignal,
+        )
+      }
       await entityManager.insert(Box, box)
+      options.admissionSignal?.throwIfAborted()
       await this.upsertLastActivity(entityManager, box.id, box.createdAt)
+      options.admissionSignal?.throwIfAborted()
     })
 
     this.invalidateLookupCacheOnInsert(box)
@@ -98,9 +114,17 @@ export class BoxRepository extends BaseRepository<Box> {
    *
    * @returns The updated box.
    */
-  async update(id: string, params: { updateData: Partial<Box>; entity?: Box }, raw?: false): Promise<Box>
-  async update(id: string, params: { updateData: Partial<Box>; entity?: Box }, raw = false): Promise<Box | void> {
-    const { updateData, entity } = params
+  async update(
+    id: string,
+    params: { updateData: Partial<Box>; entity?: Box } & BoxInventoryCommitOptions,
+    raw?: false,
+  ): Promise<Box>
+  async update(
+    id: string,
+    params: { updateData: Partial<Box>; entity?: Box } & BoxInventoryCommitOptions,
+    raw = false,
+  ): Promise<Box | void> {
+    const { updateData, entity, inventoryLimit, admissionSignal } = params
 
     if (raw) {
       await this.repository.update(id, updateData)
@@ -119,6 +143,9 @@ export class BoxRepository extends BaseRepository<Box> {
     const invariantChanges = box.enforceInvariants()
 
     await this.dataSource.transaction(async (entityManager) => {
+      if (inventoryLimit !== undefined && previousBox.organizationId !== box.organizationId) {
+        await this.assertInventoryAvailable(entityManager, box.organizationId, inventoryLimit, admissionSignal)
+      }
       const result = await entityManager.update(
         Box,
         {
@@ -133,11 +160,13 @@ export class BoxRepository extends BaseRepository<Box> {
       if (!result.affected) {
         throw new BoxConflictError()
       }
+      admissionSignal?.throwIfAborted()
       box.updatedAt = new Date()
 
       if (previousBox.state !== box.state || previousBox.organizationId !== box.organizationId) {
         await this.upsertLastActivity(entityManager, id, box.updatedAt)
       }
+      admissionSignal?.throwIfAborted()
     })
 
     this.emitUpdateEvents(box, previousBox)
@@ -373,6 +402,34 @@ export class BoxRepository extends BaseRepository<Box> {
       .execute()
 
     return (claimed.raw as Array<{ boxId: string }>).length
+  }
+
+  private async assertInventoryAvailable(
+    entityManager: EntityManager,
+    organizationId: string,
+    limit: number,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    // Redis reservations reject excess work early, but Redis expiry/failover
+    // cannot be the final quota authority. Serialize only this recount + write
+    // transaction so concurrent BoxService.create calls still run in parallel.
+    await entityManager.query(`SELECT pg_advisory_xact_lock(hashtextextended('box-inventory:' || $1::text, 0))`, [
+      organizationId,
+    ])
+    signal?.throwIfAborted()
+
+    const current = await entityManager
+      .createQueryBuilder(Box, 'box')
+      .where('box.organizationId = :organizationId', { organizationId })
+      .andWhere('box.state NOT IN (:...excludedStates)', {
+        excludedStates: [BoxState.DESTROYED, BoxState.ARCHIVED],
+      })
+      .getCount()
+    signal?.throwIfAborted()
+
+    if (current >= limit) {
+      throw new BoxInventoryLimitExceededError(current, limit)
+    }
   }
 
   /**

--- a/apps/api/src/box/services/box.service.spec.ts
+++ b/apps/api/src/box/services/box.service.spec.ts
@@ -372,6 +372,35 @@ describe('BoxService public defaults', () => {
     )
   })
 
+  it('passes the REST admission fence to a fresh-box insert', async () => {
+    const { service, boxRepository } = makeCreateService()
+    const signal = new AbortController().signal
+
+    await service.create({ name: 'admitted-box' } as any, { id: 'org-1' } as any, {
+      inventoryLimit: 20,
+      signal,
+    })
+
+    expect(boxRepository.insert).toHaveBeenCalledWith(expect.objectContaining({ name: 'admitted-box' }), {
+      inventoryLimit: 20,
+      admissionSignal: signal,
+    })
+  })
+
+  it('does not insert when the REST admission reservation was lost', async () => {
+    const { service, boxRepository } = makeCreateService()
+    const controller = new AbortController()
+    controller.abort(new Error('reservation lost'))
+
+    await expect(
+      service.create({ name: 'rejected-box' } as any, { id: 'org-1' } as any, {
+        inventoryLimit: 20,
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow('reservation lost')
+    expect(boxRepository.insert).not.toHaveBeenCalled()
+  })
+
   it.each([
     [undefined, false],
     [true, true],
@@ -395,6 +424,31 @@ describe('BoxService public defaults', () => {
     expect(update).toHaveBeenCalledWith(
       'warm-box',
       expect.objectContaining({ updateData: expect.objectContaining({ public: expectedPublic }) }),
+    )
+  })
+
+  it('passes the REST admission fence to a warm-pool assignment', async () => {
+    const warmPoolBox = { id: 'warm-box', runnerId: 'runner-1', name: 'warm-box' } as any
+    const update = jest.fn().mockResolvedValue(warmPoolBox)
+    const service = Object.create(BoxService.prototype) as BoxService
+    Object.assign(service as any, {
+      boxRepository: { update },
+      boxLookupCacheInvalidationService: { invalidateOrgId: jest.fn() },
+      eventEmitter: { emit: jest.fn() },
+      toBoxDto: jest.fn((box) => box),
+    })
+    const signal = new AbortController().signal
+
+    await (service as any).assignWarmPoolBox(
+      warmPoolBox,
+      { name: 'assigned-box' },
+      { id: 'org-1' },
+      { inventoryLimit: 20, signal },
+    )
+
+    expect(update).toHaveBeenCalledWith(
+      'warm-box',
+      expect.objectContaining({ inventoryLimit: 20, admissionSignal: signal }),
     )
   })
 })

--- a/apps/api/src/box/services/box.service.ts
+++ b/apps/api/src/box/services/box.service.ts
@@ -94,6 +94,11 @@ const DEFAULT_BOX_DISK = 10
 const DEFAULT_BOX_GPU = 0
 const TERMINAL_PREVIEW_PORT = 22222
 
+interface BoxCreationAdmission {
+  inventoryLimit: number
+  signal: AbortSignal
+}
+
 @Injectable()
 export class BoxService {
   private readonly logger = new Logger(BoxService.name)
@@ -197,7 +202,21 @@ export class BoxService {
     )
   }
 
-  async create(createBoxDto: CreateBoxDto, organization: Organization): Promise<BoxDto> {
+  private insertCreatedBox(box: Box, admission?: BoxCreationAdmission): Promise<Box> {
+    admission?.signal.throwIfAborted()
+    return admission
+      ? this.boxRepository.insert(box, {
+          inventoryLimit: admission.inventoryLimit,
+          admissionSignal: admission.signal,
+        })
+      : this.boxRepository.insert(box)
+  }
+
+  async create(
+    createBoxDto: CreateBoxDto,
+    organization: Organization,
+    admission?: BoxCreationAdmission,
+  ): Promise<BoxDto> {
     const region = await this.getValidatedOrDefaultRegion(organization, createBoxDto.target)
 
     try {
@@ -258,7 +277,7 @@ export class BoxService {
           })
 
           if (warmPoolBox) {
-            return await this.assignWarmPoolBox(warmPoolBox, createBoxDto, organization)
+            return await this.assignWarmPoolBox(warmPoolBox, createBoxDto, organization, admission)
           }
         }
       }
@@ -323,10 +342,10 @@ export class BoxService {
       // @Unique(['organizationId', 'name']) constraint.
       const insertedBox = await this.persistWithRunnerAssignmentFence(box, { regions: [region.id], boxClass }, () =>
         createBoxDto.name
-          ? this.boxRepository.insert(box)
+          ? this.insertCreatedBox(box, admission)
           : persistWithGeneratedBoxName(box.id, (name) => {
               box.name = name
-              return this.boxRepository.insert(box)
+              return this.insertCreatedBox(box, admission)
             }),
       )
 
@@ -352,6 +371,7 @@ export class BoxService {
     warmPoolBox: Box,
     createBoxDto: CreateBoxDto,
     organization: Organization,
+    admission?: BoxCreationAdmission,
   ): Promise<BoxDto> {
     const now = new Date()
     const updateData: Partial<Box> = {
@@ -389,12 +409,13 @@ export class BoxService {
     // the row — reusing the mutated entity would corrupt the optimistic-update
     // guard.
     const updatedBox = createBoxDto.name
-      ? await this.boxRepository.update(warmPoolBox.id, {
-          updateData: { ...updateData, name: createBoxDto.name },
-          entity: warmPoolBox,
-        })
+      ? await this.updateAssignedWarmPoolBox(
+          warmPoolBox.id,
+          { updateData: { ...updateData, name: createBoxDto.name }, entity: warmPoolBox },
+          admission,
+        )
       : await persistWithGeneratedBoxName(warmPoolBox.id, (name) =>
-          this.boxRepository.update(warmPoolBox.id, { updateData: { ...updateData, name } }),
+          this.updateAssignedWarmPoolBox(warmPoolBox.id, { updateData: { ...updateData, name } }, admission),
         )
 
     // Defensive invalidation of orgId cache since the box moved from unassigned to a real organization
@@ -411,6 +432,21 @@ export class BoxService {
       new BoxStateUpdatedEvent(updatedBox, BoxState.STARTED, BoxState.STARTED),
     )
     return this.toBoxDto(updatedBox)
+  }
+
+  private updateAssignedWarmPoolBox(
+    boxId: string,
+    params: { updateData: Partial<Box>; entity?: Box },
+    admission?: BoxCreationAdmission,
+  ): Promise<Box> {
+    admission?.signal.throwIfAborted()
+    return admission
+      ? this.boxRepository.update(boxId, {
+          ...params,
+          inventoryLimit: admission.inventoryLimit,
+          admissionSignal: admission.signal,
+        })
+      : this.boxRepository.update(boxId, params)
   }
 
   async findAllDeprecated(

--- a/apps/api/src/boxlite-rest/boxlite-box.controller.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-box.controller.spec.ts
@@ -5,10 +5,26 @@
  */
 
 import 'reflect-metadata'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { BadRequestException, ValidationPipe } from '@nestjs/common'
 import { PIPES_METADATA } from '@nestjs/common/constants'
+import { parse } from 'yaml'
 import { BoxliteBoxController } from './boxlite-box.controller'
 import { CreateBoxDto } from './dto/create-box.dto'
+import { BoxState } from '../box/enums/box-state.enum'
+
+type ApiResponses = Record<string, { description?: string }>
+const SWAGGER_API_RESPONSE_METADATA = 'swagger/apiResponse'
+type BoxOpenApiDocument = {
+  paths: {
+    '/{prefix}/boxes': {
+      post: {
+        responses: Record<string, { $ref?: string }>
+      }
+    }
+  }
+}
 
 // `openapi/box.openapi.yaml` declares `additionalProperties: false` on
 // CreateBoxRequest, and both other servers enforce it — `boxlite serve` via
@@ -132,5 +148,52 @@ describe('BoxliteBoxController request validation', () => {
     )
 
     expect(dto.volumes?.[0]?.managed_volume).toBe(selector)
+  })
+})
+
+describe('BoxliteBoxController create admission', () => {
+  it('documents the 503 admission response in Swagger metadata', () => {
+    const responses = Reflect.getMetadata(
+      SWAGGER_API_RESPONSE_METADATA,
+      BoxliteBoxController.prototype.createBox,
+    ) as ApiResponses
+
+    expect(responses['503']).toEqual(
+      expect.objectContaining({ description: 'Box creation admission temporarily unavailable' }),
+    )
+  })
+
+  it('documents the 503 admission response in the spec-first OpenAPI contract', () => {
+    const openApiPath = resolve(__dirname, '../../../../openapi/box.openapi.yaml')
+    const document = parse(readFileSync(openApiPath, 'utf8')) as BoxOpenApiDocument
+
+    expect(document.paths['/{prefix}/boxes'].post.responses['503']).toEqual({
+      $ref: '#/components/responses/ServiceUnavailableError',
+    })
+  })
+
+  it('delegates REST creation before waiting for the box to start', async () => {
+    const created = { id: 'box-1', name: 'box-1', state: BoxState.CREATING }
+    const started = { ...created, state: BoxState.STARTED }
+    const restBoxCreationService = { create: jest.fn().mockResolvedValue(created) }
+    const boxStateWaiter = { waitForStarted: jest.fn().mockResolvedValue(started) }
+    const controller = new BoxliteBoxController(
+      {} as any,
+      boxStateWaiter as any,
+      restBoxCreationService as any,
+    )
+    const organization = { id: 'org-1' }
+
+    const response = await controller.createBox(
+      { organization } as any,
+      { name: 'box-1' } as CreateBoxDto,
+    )
+
+    expect(restBoxCreationService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'box-1' }),
+      organization,
+    )
+    expect(boxStateWaiter.waitForStarted).toHaveBeenCalledWith('box-1', 'org-1', 30)
+    expect(response.box_id).toBe('box-1')
   })
 })

--- a/apps/api/src/boxlite-rest/boxlite-box.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-box.controller.ts
@@ -37,6 +37,7 @@ import { boxToBoxResponse, createBoxToCreateBox } from './mappers/box-to-box.map
 import { Audit, MASKED_AUDIT_VALUE, TypedRequest } from '../audit/decorators/audit.decorator'
 import { AuditAction } from '../audit/enums/audit-action.enum'
 import { AuditTarget } from '../audit/enums/audit-target.enum'
+import { RestBoxCreationService } from './services/rest-box-creation.service'
 
 // Spec-first surface: the contract is openapi/box.openapi.yaml, not the
 // generated product spec (which `:prefix` routes would render invalid).
@@ -67,6 +68,7 @@ export class BoxliteBoxController {
   constructor(
     private readonly boxService: BoxService,
     private readonly boxStateWaiter: BoxStateWaiterService,
+    private readonly restBoxCreationService: RestBoxCreationService,
   ) {}
 
   @Post()
@@ -75,6 +77,14 @@ export class BoxliteBoxController {
     status: 201,
     description: 'Box created',
     type: BoxResponseDto,
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Organization box limit reached',
+  })
+  @ApiResponse({
+    status: 503,
+    description: 'Box creation admission temporarily unavailable',
   })
   @Audit({
     action: AuditAction.CREATE,
@@ -114,7 +124,7 @@ export class BoxliteBoxController {
     const organization = authContext.organization
     const createBoxDto = createBoxToCreateBox(dto)
 
-    let box = await this.boxService.create(createBoxDto, organization)
+    let box = await this.restBoxCreationService.create(createBoxDto, organization)
     if (box.state !== BoxState.STARTED) {
       box = await this.boxStateWaiter.waitForStarted(box.id, organization.id, 30)
     }

--- a/apps/api/src/boxlite-rest/boxlite-rest-routing.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-rest-routing.spec.ts
@@ -10,7 +10,6 @@ import type { INestApplication } from '@nestjs/common'
 import type { AddressInfo } from 'net'
 import { CombinedAuthGuard } from '../auth/combined-auth.guard'
 import { OrganizationResourceActionGuard } from '../organization/guards/organization-resource-action.guard'
-import { RedisLockProvider } from '../box/common/redis-lock.provider'
 import { BoxRepository } from '../box/repositories/box.repository'
 import { BoxService } from '../box/services/box.service'
 import { BoxStateWaiterService } from '../box/services/box-state-waiter.service'
@@ -20,6 +19,7 @@ import { BoxliteWsProxyService } from './boxlite-ws-proxy.service'
 import { BoxliteVolumeController } from './boxlite-volume.controller'
 import { CommerceBoxLimitService } from './services/commerce-box-limit.service'
 import { RestBoxCreationService } from './services/rest-box-creation.service'
+import { BoxAdmissionReservationService } from './services/box-admission-reservation.service'
 
 jest.mock('http-proxy-middleware', () => ({
   createProxyMiddleware: jest.fn(),
@@ -61,8 +61,8 @@ describe('BoxLite REST routing', () => {
           useValue: { countQuotaBoxes: jest.fn() },
         },
         {
-          provide: RedisLockProvider,
-          useValue: { waitForLease: jest.fn().mockRejectedValue(new Error('Redis unavailable')) },
+          provide: BoxAdmissionReservationService,
+          useValue: { reserve: jest.fn().mockRejectedValue(new Error('Redis unavailable')) },
         },
       ],
     })
@@ -121,7 +121,7 @@ describe('BoxLite REST routing', () => {
     expect(await legacy.json()).toEqual({ boxes: [] })
   })
 
-  it('returns the 503 admission response when the creation lease is unavailable', async () => {
+  it('returns the 503 admission response when a reservation is unavailable', async () => {
     await startRoutingTestApp()
 
     const response = await post('/api/v1/boxes', { image: 'alpine:latest' })

--- a/apps/api/src/boxlite-rest/boxlite-rest-routing.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-rest-routing.spec.ts
@@ -10,12 +10,16 @@ import type { INestApplication } from '@nestjs/common'
 import type { AddressInfo } from 'net'
 import { CombinedAuthGuard } from '../auth/combined-auth.guard'
 import { OrganizationResourceActionGuard } from '../organization/guards/organization-resource-action.guard'
+import { RedisLockProvider } from '../box/common/redis-lock.provider'
+import { BoxRepository } from '../box/repositories/box.repository'
 import { BoxService } from '../box/services/box.service'
 import { BoxStateWaiterService } from '../box/services/box-state-waiter.service'
 import { BoxliteBoxController } from './boxlite-box.controller'
 import { BoxliteProxyController } from './boxlite-proxy.controller'
 import { BoxliteWsProxyService } from './boxlite-ws-proxy.service'
 import { BoxliteVolumeController } from './boxlite-volume.controller'
+import { CommerceBoxLimitService } from './services/commerce-box-limit.service'
+import { RestBoxCreationService } from './services/rest-box-creation.service'
 
 jest.mock('http-proxy-middleware', () => ({
   createProxyMiddleware: jest.fn(),
@@ -44,6 +48,22 @@ describe('BoxLite REST routing', () => {
           provide: BoxStateWaiterService,
           useValue: {},
         },
+        {
+          provide: RestBoxCreationService,
+          useClass: RestBoxCreationService,
+        },
+        {
+          provide: CommerceBoxLimitService,
+          useValue: { resolveLimit: jest.fn().mockResolvedValue({ kind: 'limited', value: 20 }) },
+        },
+        {
+          provide: BoxRepository,
+          useValue: { countQuotaBoxes: jest.fn() },
+        },
+        {
+          provide: RedisLockProvider,
+          useValue: { waitForLease: jest.fn().mockRejectedValue(new Error('Redis unavailable')) },
+        },
       ],
     })
       .overrideGuard(CombinedAuthGuard)
@@ -70,6 +90,15 @@ describe('BoxLite REST routing', () => {
     return fetch(`http://127.0.0.1:${address.port}${path}`)
   }
 
+  async function post(path: string, body: object): Promise<Response> {
+    const address = app.getHttpServer().address() as AddressInfo
+    return fetch(`http://127.0.0.1:${address.port}${path}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+  }
+
   afterEach(async () => {
     await app?.close()
   })
@@ -90,6 +119,18 @@ describe('BoxLite REST routing', () => {
     expect(await canonical.json()).toEqual({ boxes: [] })
     expect(legacy.status).toBe(200)
     expect(await legacy.json()).toEqual({ boxes: [] })
+  })
+
+  it('returns the 503 admission response when the creation lease is unavailable', async () => {
+    await startRoutingTestApp()
+
+    const response = await post('/api/v1/boxes', { image: 'alpine:latest' })
+
+    expect(response.status).toBe(503)
+    expect(await response.json()).toEqual({
+      message: 'Box creation admission is temporarily unavailable. Please try again.',
+      code: 'upstream_unavailable',
+    })
   })
 
   it('matches websocket attach upgrades with or without a routing prefix', () => {

--- a/apps/api/src/boxlite-rest/boxlite-rest.module.ts
+++ b/apps/api/src/boxlite-rest/boxlite-rest.module.ts
@@ -19,6 +19,7 @@ import { BoxAutoResumeService } from './box-auto-resume.service'
 import { BoxliteVolumeController } from './boxlite-volume.controller'
 import { CommerceBoxLimitService } from './services/commerce-box-limit.service'
 import { RestBoxCreationService } from './services/rest-box-creation.service'
+import { BoxAdmissionReservationService } from './services/box-admission-reservation.service'
 
 @Module({
   imports: [HttpModule, BoxModule, AuthModule, ApiKeyModule, OrganizationModule],
@@ -29,7 +30,13 @@ import { RestBoxCreationService } from './services/rest-box-creation.service'
     BoxliteProxyController,
     BoxliteVolumeController,
   ],
-  providers: [BoxliteWsProxyService, BoxAutoResumeService, CommerceBoxLimitService, RestBoxCreationService],
+  providers: [
+    BoxliteWsProxyService,
+    BoxAutoResumeService,
+    CommerceBoxLimitService,
+    BoxAdmissionReservationService,
+    RestBoxCreationService,
+  ],
   exports: [BoxliteWsProxyService],
 })
 export class BoxliteRestModule {}

--- a/apps/api/src/boxlite-rest/boxlite-rest.module.ts
+++ b/apps/api/src/boxlite-rest/boxlite-rest.module.ts
@@ -5,6 +5,7 @@
  */
 
 import { Module } from '@nestjs/common'
+import { HttpModule } from '@nestjs/axios'
 import { BoxModule } from '../box/box.module'
 import { AuthModule } from '../auth/auth.module'
 import { ApiKeyModule } from '../api-key/api-key.module'
@@ -16,9 +17,11 @@ import { BoxliteProxyController } from './boxlite-proxy.controller'
 import { BoxliteWsProxyService } from './boxlite-ws-proxy.service'
 import { BoxAutoResumeService } from './box-auto-resume.service'
 import { BoxliteVolumeController } from './boxlite-volume.controller'
+import { CommerceBoxLimitService } from './services/commerce-box-limit.service'
+import { RestBoxCreationService } from './services/rest-box-creation.service'
 
 @Module({
-  imports: [BoxModule, AuthModule, ApiKeyModule, OrganizationModule],
+  imports: [HttpModule, BoxModule, AuthModule, ApiKeyModule, OrganizationModule],
   controllers: [
     BoxliteMeController,
     BoxliteConfigController,
@@ -26,7 +29,7 @@ import { BoxliteVolumeController } from './boxlite-volume.controller'
     BoxliteProxyController,
     BoxliteVolumeController,
   ],
-  providers: [BoxliteWsProxyService, BoxAutoResumeService],
+  providers: [BoxliteWsProxyService, BoxAutoResumeService, CommerceBoxLimitService, RestBoxCreationService],
   exports: [BoxliteWsProxyService],
 })
 export class BoxliteRestModule {}

--- a/apps/api/src/boxlite-rest/services/box-admission-reservation.service.integration.spec.ts
+++ b/apps/api/src/boxlite-rest/services/box-admission-reservation.service.integration.spec.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { randomUUID } from 'node:crypto'
+import { Redis } from 'ioredis'
+import { BoxAdmissionReservation, BoxAdmissionReservationService } from './box-admission-reservation.service'
+
+const describeIfRedis = process.env.REDIS_HOST ? describe : describe.skip
+
+describeIfRedis('BoxAdmissionReservationService (integration, real Redis)', () => {
+  let redis: Redis
+  let service: BoxAdmissionReservationService
+  let organizationId: string
+  let key: string
+  let reservations: BoxAdmissionReservation[]
+
+  beforeAll(() => {
+    redis = new Redis({
+      host: process.env.REDIS_HOST,
+      port: Number(process.env.REDIS_PORT || 6379),
+      maxRetriesPerRequest: 2,
+    })
+    service = new BoxAdmissionReservationService(redis)
+  })
+
+  afterAll(async () => {
+    await redis?.quit()
+  })
+
+  beforeEach(async () => {
+    organizationId = randomUUID()
+    key = `box-create-reservations:{${organizationId}}`
+    reservations = []
+    await redis.del(key)
+  })
+
+  afterEach(async () => {
+    await Promise.all(reservations.map((reservation) => reservation.release().catch(() => undefined)))
+    await redis.del(key)
+  })
+
+  it('atomically assigns distinct pending counts to concurrent requests', async () => {
+    reservations = await Promise.all([service.reserve(organizationId), service.reserve(organizationId)])
+
+    expect(reservations.map((reservation) => reservation.pendingCount).sort()).toEqual([1, 2])
+  })
+
+  it('releases a failed creation immediately instead of waiting for TTL', async () => {
+    const failed = await service.reserve(organizationId)
+    await failed.release()
+
+    const replacement = await service.reserve(organizationId)
+    reservations = [replacement]
+
+    expect(replacement.pendingCount).toBe(1)
+  })
+
+  it('prunes expired request tokens during the next reservation', async () => {
+    await redis.zadd(key, 0, 'expired-token')
+
+    const reservation = await service.reserve(organizationId)
+    reservations = [reservation]
+
+    expect(reservation.pendingCount).toBe(1)
+    expect(await redis.zscore(key, 'expired-token')).toBeNull()
+  })
+})

--- a/apps/api/src/boxlite-rest/services/box-admission-reservation.service.spec.ts
+++ b/apps/api/src/boxlite-rest/services/box-admission-reservation.service.spec.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import {
+  BoxAdmissionReservationLostError,
+  BoxAdmissionReservationService,
+  withBoxAdmissionReservation,
+} from './box-admission-reservation.service'
+
+describe('BoxAdmissionReservationService', () => {
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('keeps a slow creation reserved beyond the original TTL', async () => {
+    jest.useFakeTimers()
+    const redis = { eval: jest.fn().mockResolvedValue(1) }
+    const service = new BoxAdmissionReservationService(redis as any)
+    const reservation = await service.reserve('org-1')
+    let finishCreation!: () => void
+
+    const creation = withBoxAdmissionReservation(
+      reservation,
+      () =>
+        new Promise<string>((resolve) => {
+          finishCreation = () => resolve('box-1')
+        }),
+    )
+
+    await jest.advanceTimersByTimeAsync(31_000)
+
+    expect(reservation.signal.aborted).toBe(false)
+    expect(redis.eval).toHaveBeenCalledTimes(3)
+    expect(redis.eval.mock.calls[1][0]).toContain("redis.call('ZADD', KEYS[1], 'XX'")
+    expect(redis.eval.mock.calls[2][0]).toContain("redis.call('ZADD', KEYS[1], 'XX'")
+
+    finishCreation()
+    await expect(creation).resolves.toBe('box-1')
+    expect(redis.eval).toHaveBeenCalledTimes(4)
+  })
+
+  it('aborts when renewal reports ownership loss', async () => {
+    jest.useFakeTimers()
+    const redis = {
+      eval: jest.fn().mockResolvedValueOnce(1).mockResolvedValueOnce(0).mockResolvedValueOnce(0),
+    }
+    const service = new BoxAdmissionReservationService(redis as any)
+    const reservation = await service.reserve('org-1')
+
+    await jest.advanceTimersByTimeAsync(15_000)
+
+    expect(reservation.signal.aborted).toBe(true)
+    expect(reservation.signal.reason).toBeInstanceOf(BoxAdmissionReservationLostError)
+    await expect(reservation.release()).rejects.toBeInstanceOf(BoxAdmissionReservationLostError)
+  })
+
+  it('aborts a stalled renewal with time remaining before token expiry', async () => {
+    jest.useFakeTimers()
+    const redis = {
+      eval: jest
+        .fn()
+        .mockResolvedValueOnce(1)
+        .mockImplementation(() => new Promise(() => undefined)),
+    }
+    const service = new BoxAdmissionReservationService(redis as any)
+    const reservation = await service.reserve('org-1')
+
+    await jest.advanceTimersByTimeAsync(16_000)
+
+    expect(reservation.signal.aborted).toBe(true)
+    expect(reservation.signal.reason).toEqual(
+      expect.objectContaining({ message: 'Redis box admission renewal timed out' }),
+    )
+    const release = expect(reservation.release()).rejects.toThrow('renewal timed out')
+    await jest.advanceTimersByTimeAsync(1_000)
+    await release
+  })
+
+  it('preserves the creation error when release also fails', async () => {
+    const creationError = new Error('creation failed')
+    const releaseError = new Error('release failed')
+    const onSuppressedReleaseError = jest.fn()
+    const reservation = {
+      signal: new AbortController().signal,
+      release: jest.fn().mockRejectedValue(releaseError),
+    }
+
+    await expect(
+      withBoxAdmissionReservation(
+        reservation as any,
+        async () => {
+          throw creationError
+        },
+        onSuppressedReleaseError,
+      ),
+    ).rejects.toBe(creationError)
+    expect(onSuppressedReleaseError).toHaveBeenCalledWith(releaseError)
+  })
+})

--- a/apps/api/src/boxlite-rest/services/box-admission-reservation.service.ts
+++ b/apps/api/src/boxlite-rest/services/box-admission-reservation.service.ts
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { InjectRedis } from '@nestjs-modules/ioredis'
+import { Injectable } from '@nestjs/common'
+import { randomUUID } from 'node:crypto'
+import { Redis } from 'ioredis'
+
+const RESERVATION_TTL_MS = 30_000
+
+const RESERVE_SCRIPT = `
+  local redisTime = redis.call('TIME')
+  local now = redisTime[1] * 1000 + math.floor(redisTime[2] / 1000)
+  local ttl = tonumber(ARGV[2])
+  redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', now)
+  local added = redis.call('ZADD', KEYS[1], 'NX', now + ttl, ARGV[1])
+  if added ~= 1 then
+    return redis.error_reply('box admission reservation token collision')
+  end
+  redis.call('PEXPIRE', KEYS[1], ttl * 2)
+  return redis.call('ZCARD', KEYS[1])
+`
+
+const RENEW_SCRIPT = `
+  local redisTime = redis.call('TIME')
+  local now = redisTime[1] * 1000 + math.floor(redisTime[2] / 1000)
+  local expiresAt = tonumber(redis.call('ZSCORE', KEYS[1], ARGV[1]))
+  if not expiresAt or expiresAt <= now then
+    redis.call('ZREM', KEYS[1], ARGV[1])
+    return 0
+  end
+  local ttl = tonumber(ARGV[2])
+  redis.call('ZADD', KEYS[1], 'XX', now + ttl, ARGV[1])
+  redis.call('PEXPIRE', KEYS[1], ttl * 2)
+  return 1
+`
+
+const RELEASE_SCRIPT = `
+  local redisTime = redis.call('TIME')
+  local now = redisTime[1] * 1000 + math.floor(redisTime[2] / 1000)
+  local expiresAt = tonumber(redis.call('ZSCORE', KEYS[1], ARGV[1]))
+  local owned = expiresAt and expiresAt > now
+  redis.call('ZREM', KEYS[1], ARGV[1])
+  if redis.call('ZCARD', KEYS[1]) == 0 then
+    redis.call('DEL', KEYS[1])
+  end
+  if owned then
+    return 1
+  end
+  return 0
+`
+
+export class BoxAdmissionReservationLostError extends Error {}
+
+export class BoxAdmissionReservation {
+  private readonly abortController = new AbortController()
+  private renewalTimer: ReturnType<typeof setTimeout> | null = null
+  private renewal: Promise<void> = Promise.resolve()
+  private renewalError: unknown
+  private isReleased = false
+
+  constructor(
+    public readonly pendingCount: number,
+    private readonly ttlMs: number,
+    private readonly renewReservation: () => Promise<void>,
+    private readonly releaseReservation: () => Promise<void>,
+  ) {
+    this.scheduleRenewal()
+  }
+
+  get signal(): AbortSignal {
+    return this.abortController.signal
+  }
+
+  async release(): Promise<void> {
+    if (this.isReleased) {
+      return
+    }
+    this.isReleased = true
+    if (this.renewalTimer) {
+      clearTimeout(this.renewalTimer)
+    }
+    await this.renewal
+
+    let releaseError: unknown
+    try {
+      await this.withTimeout(
+        this.releaseReservation(),
+        this.operationTimeoutMs,
+        'Redis box admission release timed out',
+      )
+    } catch (error) {
+      releaseError = error
+    }
+
+    if (this.renewalError) {
+      throw this.renewalError
+    }
+    if (releaseError) {
+      throw releaseError
+    }
+  }
+
+  private get operationTimeoutMs(): number {
+    return Math.min(this.ttlMs / 8, 1000)
+  }
+
+  private scheduleRenewal(): void {
+    this.renewalTimer = setTimeout(() => {
+      this.renewal = this.withTimeout(
+        this.renewReservation(),
+        this.operationTimeoutMs,
+        'Redis box admission renewal timed out',
+      )
+        .catch((error) => {
+          if (this.isReleased) {
+            return
+          }
+          this.renewalError = error
+          this.abortController.abort(error)
+        })
+        .then(() => {
+          if (!this.isReleased && !this.renewalError) {
+            this.scheduleRenewal()
+          }
+        })
+    }, this.ttlMs / 2)
+  }
+
+  private async withTimeout(operation: Promise<void>, timeoutMs: number, message: string): Promise<void> {
+    let timeout!: ReturnType<typeof setTimeout>
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeout = setTimeout(() => reject(new Error(message)), timeoutMs)
+    })
+
+    try {
+      await Promise.race([operation, timeoutPromise])
+    } finally {
+      clearTimeout(timeout)
+    }
+  }
+}
+
+export async function withBoxAdmissionReservation<T>(
+  reservation: BoxAdmissionReservation,
+  operation: (signal: AbortSignal) => Promise<T>,
+  onSuppressedReleaseError?: (error: unknown) => void,
+): Promise<T> {
+  const signal = reservation.signal
+  let result: T
+  try {
+    result = await operation(signal)
+    signal.throwIfAborted()
+  } catch (error) {
+    try {
+      await reservation.release()
+    } catch (releaseError) {
+      onSuppressedReleaseError?.(releaseError)
+    }
+    throw error
+  }
+
+  await reservation.release()
+  return result
+}
+
+@Injectable()
+export class BoxAdmissionReservationService {
+  constructor(@InjectRedis() private readonly redis: Redis) {}
+
+  async reserve(organizationId: string): Promise<BoxAdmissionReservation> {
+    const key = `box-create-reservations:{${organizationId}}`
+    const token = randomUUID()
+    const result = await this.redis.eval(RESERVE_SCRIPT, 1, key, token, RESERVATION_TTL_MS)
+    const pendingCount = Number(result)
+    if (!Number.isSafeInteger(pendingCount) || pendingCount < 1) {
+      throw new Error(`Redis returned an invalid box admission reservation count for organization ${organizationId}`)
+    }
+    return new BoxAdmissionReservation(
+      pendingCount,
+      RESERVATION_TTL_MS,
+      () => this.renewReservation(key, token, RESERVATION_TTL_MS),
+      () => this.releaseReservation(key, token),
+    )
+  }
+
+  private async renewReservation(key: string, token: string, ttlMs: number): Promise<void> {
+    const renewed = Number(await this.redis.eval(RENEW_SCRIPT, 1, key, token, ttlMs))
+    if (renewed !== 1) {
+      throw new BoxAdmissionReservationLostError(`Box admission reservation ownership was lost for ${key}`)
+    }
+  }
+
+  private async releaseReservation(key: string, token: string): Promise<void> {
+    const released = Number(await this.redis.eval(RELEASE_SCRIPT, 1, key, token))
+    if (released !== 1) {
+      throw new BoxAdmissionReservationLostError(`Box admission reservation ownership was lost for ${key}`)
+    }
+  }
+}

--- a/apps/api/src/boxlite-rest/services/commerce-box-limit.service.spec.ts
+++ b/apps/api/src/boxlite-rest/services/commerce-box-limit.service.spec.ts
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { CommerceBoxLimitService } from './commerce-box-limit.service'
+
+function config(values: Record<string, unknown>) {
+  return { get: jest.fn((key: string) => values[key]) } as any
+}
+
+function axiosError(status?: number, code?: string) {
+  return Object.assign(new Error(status ? `HTTP ${status}` : 'transport failed'), {
+    isAxiosError: true,
+    code,
+    response: status ? { status } : undefined,
+  })
+}
+
+describe('CommerceBoxLimitService', () => {
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('treats an unconfigured Commerce API as unlimited without making a request', async () => {
+    const get = jest.fn()
+    const service = new CommerceBoxLimitService({ axiosRef: { get } } as any, config({}))
+
+    await expect(service.resolveLimit('org-1')).resolves.toEqual({ kind: 'unlimited' })
+    expect(get).not.toHaveBeenCalled()
+  })
+
+  it('matches the organization plan and authenticates both Commerce requests', async () => {
+    const get = jest.fn((url: string) => {
+      if (url.includes('/organization/')) {
+        return Promise.resolve({ data: { plan: { planId: 'pro' } } })
+      }
+      if (url.endsWith('/plan')) {
+        return Promise.resolve({ data: [{ id: 'pro', concurrencyLimit: 100 }] })
+      }
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+    const service = new CommerceBoxLimitService(
+      { axiosRef: { get } } as any,
+      config({ billingApiUrl: 'https://commerce.example/api/billing', 'usageExport.token': 'internal-token' }),
+    )
+
+    await expect(service.resolveLimit('org/1')).resolves.toEqual({ kind: 'limited', value: 100 })
+    expect(get).toHaveBeenCalledTimes(2)
+    expect(get).toHaveBeenCalledWith(
+      'https://commerce.example/api/billing/plan',
+      expect.objectContaining({ headers: { authorization: 'Bearer internal-token' }, timeout: 2_000 }),
+    )
+    expect(get).toHaveBeenCalledWith(
+      'https://commerce.example/api/billing/organization/org%2F1/plan',
+      expect.objectContaining({ headers: { authorization: 'Bearer internal-token' }, timeout: 2_000 }),
+    )
+  })
+
+  it('retries a 5xx once, falls back to 20, and does not cache the failure', async () => {
+    jest.useFakeTimers()
+    let catalogCalls = 0
+    const get = jest.fn((url: string) => {
+      if (url.includes('/organization/')) {
+        return Promise.resolve({ data: {} })
+      }
+      if (url.endsWith('/plan')) {
+        catalogCalls += 1
+        return Promise.reject(axiosError(503))
+      }
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+    const service = new CommerceBoxLimitService(
+      { axiosRef: { get } } as any,
+      config({ billingApiUrl: 'https://commerce.example/api/billing', 'usageExport.token': 'internal-token' }),
+    )
+
+    const first = service.resolveLimit('org-1')
+    await jest.advanceTimersByTimeAsync(500)
+    await expect(first).resolves.toEqual({ kind: 'limited', value: 20 })
+    expect(catalogCalls).toBe(2)
+
+    const second = service.resolveLimit('org-1')
+    await jest.advanceTimersByTimeAsync(500)
+    await expect(second).resolves.toEqual({ kind: 'limited', value: 20 })
+    expect(catalogCalls).toBe(4)
+  })
+
+  it('caches a successful business fallback from an empty catalog', async () => {
+    const get = jest.fn((url: string) => {
+      if (url.includes('/organization/')) {
+        return Promise.resolve({ data: { plan: { planId: 'missing' } } })
+      }
+      return Promise.resolve({ data: [] })
+    })
+    const service = new CommerceBoxLimitService(
+      { axiosRef: { get } } as any,
+      config({ billingApiUrl: 'https://commerce.example/api/billing', 'usageExport.token': 'internal-token' }),
+    )
+
+    await expect(service.resolveLimit('org-1')).resolves.toEqual({ kind: 'limited', value: 20 })
+    await expect(service.resolveLimit('org-1')).resolves.toEqual({ kind: 'limited', value: 20 })
+    expect(get).toHaveBeenCalledTimes(2)
+  })
+
+  it('uses the first public plan when the organization has no plan', async () => {
+    const get = jest.fn((url: string) =>
+      Promise.resolve(
+        url.includes('/organization/')
+          ? { data: {} }
+          : {
+              data: [
+                { id: 'starter', concurrencyLimit: 8 },
+                { id: 'pro', concurrencyLimit: 100 },
+              ],
+            },
+      ),
+    )
+    const service = new CommerceBoxLimitService(
+      { axiosRef: { get } } as any,
+      config({ billingApiUrl: 'https://commerce.example/api/billing', 'usageExport.token': 'internal-token' }),
+    )
+
+    await expect(service.resolveLimit('org-1')).resolves.toEqual({ kind: 'limited', value: 8 })
+  })
+
+  it('maps a null concurrency limit to unlimited', async () => {
+    const get = jest.fn((url: string) =>
+      Promise.resolve(
+        url.includes('/organization/')
+          ? { data: { plan: { planId: 'enterprise' } } }
+          : { data: [{ id: 'enterprise', concurrencyLimit: null }] },
+      ),
+    )
+    const service = new CommerceBoxLimitService(
+      { axiosRef: { get } } as any,
+      config({ billingApiUrl: 'https://commerce.example/api/billing', 'usageExport.token': 'internal-token' }),
+    )
+
+    await expect(service.resolveLimit('org-1')).resolves.toEqual({ kind: 'unlimited' })
+  })
+
+  it('does not retry or cache a 4xx fallback', async () => {
+    const get = jest.fn((url: string) =>
+      url.includes('/organization/')
+        ? Promise.resolve({ data: {} })
+        : Promise.reject(axiosError(401)),
+    )
+    const service = new CommerceBoxLimitService(
+      { axiosRef: { get } } as any,
+      config({ billingApiUrl: 'https://commerce.example/api/billing', 'usageExport.token': 'internal-token' }),
+    )
+
+    await expect(service.resolveLimit('org-1')).resolves.toEqual({ kind: 'limited', value: 20 })
+    await expect(service.resolveLimit('org-1')).resolves.toEqual({ kind: 'limited', value: 20 })
+    expect(get).toHaveBeenCalledTimes(4)
+  })
+
+  it('does not make anonymous requests or cache a missing-token fallback', async () => {
+    const values: Record<string, unknown> = { billingApiUrl: 'https://commerce.example/api/billing' }
+    const get = jest.fn((url: string) =>
+      Promise.resolve(
+        url.includes('/organization/')
+          ? { data: { plan: { planId: 'pro' } } }
+          : { data: [{ id: 'pro', concurrencyLimit: 100 }] },
+      ),
+    )
+    const service = new CommerceBoxLimitService({ axiosRef: { get } } as any, config(values))
+
+    await expect(service.resolveLimit('org-1')).resolves.toEqual({ kind: 'limited', value: 20 })
+    expect(get).not.toHaveBeenCalled()
+
+    values['usageExport.token'] = 'internal-token'
+    await expect(service.resolveLimit('org-1')).resolves.toEqual({ kind: 'limited', value: 100 })
+    expect(get).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not cache a fallback caused by a malformed response', async () => {
+    let catalog: unknown = { not: 'a catalog' }
+    const get = jest.fn((url: string) =>
+      Promise.resolve(
+        url.includes('/organization/')
+          ? { data: { plan: { planId: 'pro' } } }
+          : { data: catalog },
+      ),
+    )
+    const service = new CommerceBoxLimitService(
+      { axiosRef: { get } } as any,
+      config({ billingApiUrl: 'https://commerce.example/api/billing', 'usageExport.token': 'internal-token' }),
+    )
+
+    await expect(service.resolveLimit('org-1')).resolves.toEqual({ kind: 'limited', value: 20 })
+    catalog = [{ id: 'pro', concurrencyLimit: 100 }]
+    await expect(service.resolveLimit('org-1')).resolves.toEqual({ kind: 'limited', value: 100 })
+    expect(get).toHaveBeenCalledTimes(4)
+  })
+
+  it('deduplicates concurrent limit resolutions for one organization', async () => {
+    let resolveCatalog!: (value: unknown) => void
+    let resolveOrganizationPlan!: (value: unknown) => void
+    const catalog = new Promise((resolve) => {
+      resolveCatalog = resolve
+    })
+    const organizationPlan = new Promise((resolve) => {
+      resolveOrganizationPlan = resolve
+    })
+    const get = jest.fn((url: string) =>
+      url.includes('/organization/') ? organizationPlan : catalog,
+    )
+    const service = new CommerceBoxLimitService(
+      { axiosRef: { get } } as any,
+      config({ billingApiUrl: 'https://commerce.example/api/billing', 'usageExport.token': 'internal-token' }),
+    )
+
+    const first = service.resolveLimit('org-1')
+    const second = service.resolveLimit('org-1')
+    expect(get).toHaveBeenCalledTimes(2)
+
+    resolveCatalog({ data: [{ id: 'pro', concurrencyLimit: 100 }] })
+    resolveOrganizationPlan({ data: { plan: { planId: 'pro' } } })
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { kind: 'limited', value: 100 },
+      { kind: 'limited', value: 100 },
+    ])
+  })
+
+  it('expires successful resolutions after ten seconds', async () => {
+    jest.useFakeTimers({ now: new Date('2026-08-28T00:00:00Z') })
+    const get = jest.fn((url: string) =>
+      Promise.resolve(
+        url.includes('/organization/')
+          ? { data: { plan: { planId: 'pro' } } }
+          : { data: [{ id: 'pro', concurrencyLimit: 100 }] },
+      ),
+    )
+    const service = new CommerceBoxLimitService(
+      { axiosRef: { get } } as any,
+      config({ billingApiUrl: 'https://commerce.example/api/billing', 'usageExport.token': 'internal-token' }),
+    )
+
+    await service.resolveLimit('org-1')
+    jest.advanceTimersByTime(9_999)
+    await service.resolveLimit('org-1')
+    expect(get).toHaveBeenCalledTimes(2)
+
+    jest.advanceTimersByTime(1)
+    await service.resolveLimit('org-1')
+    expect(get).toHaveBeenCalledTimes(4)
+  })
+})

--- a/apps/api/src/boxlite-rest/services/commerce-box-limit.service.ts
+++ b/apps/api/src/boxlite-rest/services/commerce-box-limit.service.ts
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { HttpService } from '@nestjs/axios'
+import { Injectable, Logger } from '@nestjs/common'
+import axios from 'axios'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { TypedConfigService } from '../../config/typed-config.service'
+
+export type BoxLimit = { kind: 'limited'; value: number } | { kind: 'unlimited' }
+
+type CatalogPlan = {
+  id: string
+  concurrencyLimit: number | null
+}
+
+type OrganizationPlan = {
+  planId: string
+}
+
+type LimitResolution = {
+  limit: BoxLimit
+  isCacheable: boolean
+}
+
+const DEFAULT_BOX_LIMIT = 20
+const LIMIT_CACHE_TTL_MS = 10_000
+const COMMERCE_REQUEST_TIMEOUT_MS = 2_000
+const COMMERCE_RETRY_DELAY_MS = 500
+
+@Injectable()
+export class CommerceBoxLimitService {
+  private readonly logger = new Logger(CommerceBoxLimitService.name)
+  private readonly cache = new Map<string, { limit: BoxLimit; expiresAt: number }>()
+  private readonly inFlight = new Map<string, Promise<BoxLimit>>()
+
+  constructor(
+    private readonly httpService: HttpService,
+    private readonly config: TypedConfigService,
+  ) {}
+
+  async resolveLimit(organizationId: string): Promise<BoxLimit> {
+    const configuredBaseUrl = this.config.get('billingApiUrl')?.trim()
+    if (!configuredBaseUrl) {
+      return { kind: 'unlimited' }
+    }
+
+    const cached = this.cache.get(organizationId)
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.limit
+    }
+    if (cached) {
+      this.cache.delete(organizationId)
+    }
+
+    const pending = this.inFlight.get(organizationId)
+    if (pending) {
+      return pending
+    }
+
+    const resolutionPromise = this.resolveConfiguredLimit(configuredBaseUrl, organizationId).then((resolution) => {
+      if (resolution.isCacheable) {
+        this.cache.set(organizationId, {
+          limit: resolution.limit,
+          expiresAt: Date.now() + LIMIT_CACHE_TTL_MS,
+        })
+      }
+      return resolution.limit
+    })
+    this.inFlight.set(organizationId, resolutionPromise)
+
+    try {
+      return await resolutionPromise
+    } finally {
+      if (this.inFlight.get(organizationId) === resolutionPromise) {
+        this.inFlight.delete(organizationId)
+      }
+    }
+  }
+
+  private async resolveConfiguredLimit(baseUrl: string, organizationId: string): Promise<LimitResolution> {
+    const token = this.config.get('usageExport.token')?.trim()
+    if (!token) {
+      this.logger.warn(`Commerce box limit fallback for organization ${organizationId}: authentication token is missing`)
+      return this.transientFallback()
+    }
+
+    let catalogUrl: string
+    let organizationPlanUrl: string
+    try {
+      const normalizedBaseUrl = this.normalizeBaseUrl(baseUrl)
+      catalogUrl = `${normalizedBaseUrl}/plan`
+      organizationPlanUrl = `${normalizedBaseUrl}/organization/${encodeURIComponent(organizationId)}/plan`
+    } catch (error) {
+      this.logger.warn(
+        `Commerce box limit fallback for organization ${organizationId}: ${this.errorSummary(error)}`,
+      )
+      return this.transientFallback()
+    }
+
+    const [catalogResult, organizationPlanResult] = await Promise.allSettled([
+      this.getCommerceJson(catalogUrl, 'plan catalog', token),
+      this.getCommerceJson(organizationPlanUrl, 'organization plan', token),
+    ])
+    if (catalogResult.status === 'rejected') {
+      this.logger.warn(
+        `Commerce box limit fallback for organization ${organizationId}: ${this.errorSummary(catalogResult.reason)}`,
+      )
+      return this.transientFallback()
+    }
+    if (organizationPlanResult.status === 'rejected') {
+      this.logger.warn(
+        `Commerce box limit fallback for organization ${organizationId}: ${this.errorSummary(organizationPlanResult.reason)}`,
+      )
+      return this.transientFallback()
+    }
+
+    try {
+      const catalog = this.parseCatalog(catalogResult.value)
+      const organizationPlan = this.parseOrganizationPlan(organizationPlanResult.value)
+      return { limit: this.matchLimit(catalog, organizationPlan), isCacheable: true }
+    } catch (error) {
+      this.logger.warn(
+        `Commerce box limit fallback for organization ${organizationId}: ${this.errorSummary(error)}`,
+      )
+      return this.transientFallback()
+    }
+  }
+
+  private async getCommerceJson(url: string, endpoint: string, token: string): Promise<unknown> {
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      try {
+        const response = await this.httpService.axiosRef.get(url, {
+          headers: { authorization: `Bearer ${token}` },
+          timeout: COMMERCE_REQUEST_TIMEOUT_MS,
+        })
+        return response.data
+      } catch (error) {
+        const status = axios.isAxiosError(error) ? error.response?.status : undefined
+        if (attempt === 0 && status !== undefined && status >= 500 && status <= 599) {
+          await sleep(COMMERCE_RETRY_DELAY_MS)
+          continue
+        }
+        throw new Error(
+          `request to ${endpoint} failed${status === undefined ? '' : ` with status ${status}`}`,
+          { cause: error },
+        )
+      }
+    }
+
+    throw new Error(`request to ${endpoint} failed`)
+  }
+
+  private normalizeBaseUrl(value: string): string {
+    let parsed: URL
+    try {
+      parsed = new URL(value)
+    } catch {
+      throw new Error('BILLING_API_URL must be an absolute http(s) URL')
+    }
+    if (
+      (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') ||
+      parsed.username ||
+      parsed.password ||
+      parsed.search ||
+      parsed.hash
+    ) {
+      throw new Error('BILLING_API_URL is not valid for authenticated Commerce requests')
+    }
+    return value.replace(/\/+$/, '')
+  }
+
+  private parseCatalog(value: unknown): CatalogPlan[] {
+    if (!Array.isArray(value)) {
+      throw new Error('plan catalog response is malformed')
+    }
+
+    return value.map((entry) => {
+      if (!this.isRecord(entry) || typeof entry.id !== 'string' || entry.id.length === 0) {
+        throw new Error('plan catalog response is malformed')
+      }
+      if (
+        entry.concurrencyLimit !== null &&
+        (!Number.isSafeInteger(entry.concurrencyLimit) || (entry.concurrencyLimit as number) < 1)
+      ) {
+        throw new Error('plan catalog response is malformed')
+      }
+      return { id: entry.id, concurrencyLimit: entry.concurrencyLimit as number | null }
+    })
+  }
+
+  private parseOrganizationPlan(value: unknown): OrganizationPlan | null {
+    if (!this.isRecord(value)) {
+      throw new Error('organization plan response is malformed')
+    }
+    if (Object.keys(value).length === 0) {
+      return null
+    }
+    if (!this.isRecord(value.plan) || typeof value.plan.planId !== 'string' || value.plan.planId.length === 0) {
+      throw new Error('organization plan response is malformed')
+    }
+    return { planId: value.plan.planId }
+  }
+
+  private matchLimit(catalog: CatalogPlan[], organizationPlan: OrganizationPlan | null): BoxLimit {
+    if (catalog.length === 0) {
+      return { kind: 'limited', value: DEFAULT_BOX_LIMIT }
+    }
+
+    const plan = organizationPlan ? catalog.find((entry) => entry.id === organizationPlan.planId) : catalog[0]
+    if (!plan) {
+      return { kind: 'limited', value: DEFAULT_BOX_LIMIT }
+    }
+    if (plan.concurrencyLimit === null) {
+      return { kind: 'unlimited' }
+    }
+    return { kind: 'limited', value: plan.concurrencyLimit }
+  }
+
+  private transientFallback(): LimitResolution {
+    return { limit: { kind: 'limited', value: DEFAULT_BOX_LIMIT }, isCacheable: false }
+  }
+
+  private isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+  }
+
+  private errorSummary(error: unknown): string {
+    return error instanceof Error ? error.message : 'unknown Commerce error'
+  }
+}

--- a/apps/api/src/boxlite-rest/services/rest-box-creation.service.spec.ts
+++ b/apps/api/src/boxlite-rest/services/rest-box-creation.service.spec.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { HttpException, ServiceUnavailableException } from '@nestjs/common'
+import { RestBoxCreationService } from './rest-box-creation.service'
+
+function makeService(params?: { count?: number; limit?: number | null }) {
+  const count = params?.count ?? 0
+  const limit = params?.limit === undefined ? 20 : params.limit
+  const lease = {
+    signal: new AbortController().signal,
+    release: jest.fn().mockResolvedValue(undefined),
+  }
+  const limitService = {
+    resolveLimit: jest
+      .fn()
+      .mockResolvedValue(limit === null ? { kind: 'unlimited' } : { kind: 'limited', value: limit }),
+  }
+  const boxRepository = { countQuotaBoxes: jest.fn().mockResolvedValue(count) }
+  const boxService = { create: jest.fn().mockResolvedValue({ id: 'box-1' }) }
+  const redisLockProvider = { waitForLease: jest.fn().mockResolvedValue(lease) }
+  const service = new RestBoxCreationService(
+    limitService as any,
+    boxRepository as any,
+    boxService as any,
+    redisLockProvider as any,
+  )
+  return { service, limitService, boxRepository, boxService, redisLockProvider, lease }
+}
+
+describe('RestBoxCreationService', () => {
+  it('rejects create with 403 when the organization is already at its limit', async () => {
+    const { service, boxService, lease } = makeService({ count: 20, limit: 20 })
+
+    const error = await service.create({} as any, { id: 'org-1' } as any).then(
+      () => null,
+      (caught: HttpException) => caught,
+    )
+
+    expect(error).toBeInstanceOf(HttpException)
+    if (!error) throw new Error('Expected box creation to be rejected')
+    expect(error.getStatus()).toBe(403)
+    expect(error.getResponse()).toEqual({
+      message:
+        'You have already created 20 boxes, reaching or exceeding the current maximum allowed number of 20. Please delete unused boxes and try again.',
+      code: 'resource_exhausted',
+    })
+    expect(boxService.create).not.toHaveBeenCalled()
+    expect(lease.release).toHaveBeenCalled()
+  })
+
+  it('counts and creates under the same organization lease', async () => {
+    const { service, boxRepository, boxService, redisLockProvider, lease } = makeService({ count: 19, limit: 20 })
+    const dto = {} as any
+    const organization = { id: 'org-1' } as any
+
+    await expect(service.create(dto, organization)).resolves.toEqual({ id: 'box-1' })
+    expect(redisLockProvider.waitForLease).toHaveBeenCalledWith(
+      'box-create-admission:org-1',
+      30,
+      expect.any(AbortSignal),
+    )
+    expect(boxRepository.countQuotaBoxes.mock.invocationCallOrder[0]).toBeLessThan(
+      boxService.create.mock.invocationCallOrder[0],
+    )
+    expect(boxService.create).toHaveBeenCalledWith(dto, organization)
+    expect(lease.release).toHaveBeenCalled()
+  })
+
+  it('skips the count and lease when Commerce resolves unlimited', async () => {
+    const { service, boxRepository, boxService, redisLockProvider } = makeService({ limit: null })
+
+    await service.create({} as any, { id: 'org-1' } as any)
+
+    expect(redisLockProvider.waitForLease).not.toHaveBeenCalled()
+    expect(boxRepository.countQuotaBoxes).not.toHaveBeenCalled()
+    expect(boxService.create).toHaveBeenCalled()
+  })
+
+  it('fails closed with 503 when the admission lease cannot be acquired', async () => {
+    const { service, redisLockProvider, boxRepository, boxService } = makeService()
+    redisLockProvider.waitForLease.mockRejectedValue(new Error('Redis unavailable'))
+
+    const error = await service.create({} as any, { id: 'org-1' } as any).then(
+      () => null,
+      (caught: ServiceUnavailableException) => caught,
+    )
+
+    expect(error).toBeInstanceOf(ServiceUnavailableException)
+    if (!error) throw new Error('Expected box creation to be rejected')
+    expect(error.getStatus()).toBe(503)
+    expect(error.getResponse()).toEqual({
+      message: 'Box creation admission is temporarily unavailable. Please try again.',
+      code: 'upstream_unavailable',
+    })
+    expect(boxRepository.countQuotaBoxes).not.toHaveBeenCalled()
+    expect(boxService.create).not.toHaveBeenCalled()
+  })
+
+  it('serializes concurrent creates so the second request observes the first commit', async () => {
+    const { service, boxRepository, boxService, redisLockProvider } = makeService({ count: 19, limit: 20 })
+    let currentBoxCount = 19
+    let grantSecondLease!: (lease: any) => void
+    const secondLease = {
+      signal: new AbortController().signal,
+      release: jest.fn().mockResolvedValue(undefined),
+    }
+    const firstLease = {
+      signal: new AbortController().signal,
+      release: jest.fn().mockImplementation(async () => grantSecondLease(secondLease)),
+    }
+    const secondAdmission = new Promise((resolve) => {
+      grantSecondLease = resolve
+    })
+    redisLockProvider.waitForLease
+      .mockResolvedValueOnce(firstLease)
+      .mockReturnValueOnce(secondAdmission)
+    boxRepository.countQuotaBoxes.mockImplementation(async () => currentBoxCount)
+    boxService.create.mockImplementation(async () => {
+      currentBoxCount += 1
+      return { id: 'box-1' }
+    })
+
+    const results = await Promise.allSettled([
+      service.create({} as any, { id: 'org-1' } as any),
+      service.create({} as any, { id: 'org-1' } as any),
+    ])
+
+    expect(results[0]).toEqual({ status: 'fulfilled', value: { id: 'box-1' } })
+    expect(results[1].status).toBe('rejected')
+    expect((results[1] as PromiseRejectedResult).reason).toBeInstanceOf(HttpException)
+    expect(boxRepository.countQuotaBoxes).toHaveBeenCalledTimes(2)
+    expect(boxService.create).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/api/src/boxlite-rest/services/rest-box-creation.service.spec.ts
+++ b/apps/api/src/boxlite-rest/services/rest-box-creation.service.spec.ts
@@ -4,15 +4,21 @@
  */
 
 import { HttpException, ServiceUnavailableException } from '@nestjs/common'
+import { BoxInventoryLimitExceededError } from '../../box/errors/box-inventory-limit-exceeded.error'
 import { RestBoxCreationService } from './rest-box-creation.service'
+
+function makeReservation(pendingCount = 1) {
+  return {
+    pendingCount,
+    signal: new AbortController().signal,
+    release: jest.fn().mockResolvedValue(undefined),
+  }
+}
 
 function makeService(params?: { count?: number; limit?: number | null }) {
   const count = params?.count ?? 0
   const limit = params?.limit === undefined ? 20 : params.limit
-  const lease = {
-    signal: new AbortController().signal,
-    release: jest.fn().mockResolvedValue(undefined),
-  }
+  const reservation = makeReservation()
   const limitService = {
     resolveLimit: jest
       .fn()
@@ -20,19 +26,19 @@ function makeService(params?: { count?: number; limit?: number | null }) {
   }
   const boxRepository = { countQuotaBoxes: jest.fn().mockResolvedValue(count) }
   const boxService = { create: jest.fn().mockResolvedValue({ id: 'box-1' }) }
-  const redisLockProvider = { waitForLease: jest.fn().mockResolvedValue(lease) }
+  const reservationService = { reserve: jest.fn().mockResolvedValue(reservation) }
   const service = new RestBoxCreationService(
     limitService as any,
     boxRepository as any,
     boxService as any,
-    redisLockProvider as any,
+    reservationService as any,
   )
-  return { service, limitService, boxRepository, boxService, redisLockProvider, lease }
+  return { service, limitService, boxRepository, boxService, reservationService, reservation }
 }
 
 describe('RestBoxCreationService', () => {
   it('rejects create with 403 when the organization is already at its limit', async () => {
-    const { service, boxService, lease } = makeService({ count: 20, limit: 20 })
+    const { service, boxService, reservation } = makeService({ count: 20, limit: 20 })
 
     const error = await service.create({} as any, { id: 'org-1' } as any).then(
       () => null,
@@ -48,40 +54,42 @@ describe('RestBoxCreationService', () => {
       code: 'resource_exhausted',
     })
     expect(boxService.create).not.toHaveBeenCalled()
-    expect(lease.release).toHaveBeenCalled()
+    expect(reservation.release).toHaveBeenCalled()
   })
 
-  it('counts and creates under the same organization lease', async () => {
-    const { service, boxRepository, boxService, redisLockProvider, lease } = makeService({ count: 19, limit: 20 })
+  it('reserves before counting and creates with a commit-time inventory guard', async () => {
+    const { service, boxRepository, boxService, reservationService, reservation } = makeService({
+      count: 19,
+      limit: 20,
+    })
     const dto = {} as any
     const organization = { id: 'org-1' } as any
 
     await expect(service.create(dto, organization)).resolves.toEqual({ id: 'box-1' })
-    expect(redisLockProvider.waitForLease).toHaveBeenCalledWith(
-      'box-create-admission:org-1',
-      30,
-      expect.any(AbortSignal),
+    expect(reservationService.reserve).toHaveBeenCalledWith('org-1')
+    expect(reservationService.reserve.mock.invocationCallOrder[0]).toBeLessThan(
+      boxRepository.countQuotaBoxes.mock.invocationCallOrder[0],
     )
-    expect(boxRepository.countQuotaBoxes.mock.invocationCallOrder[0]).toBeLessThan(
-      boxService.create.mock.invocationCallOrder[0],
-    )
-    expect(boxService.create).toHaveBeenCalledWith(dto, organization)
-    expect(lease.release).toHaveBeenCalled()
+    expect(boxService.create).toHaveBeenCalledWith(dto, organization, {
+      inventoryLimit: 20,
+      signal: reservation.signal,
+    })
+    expect(reservation.release).toHaveBeenCalled()
   })
 
-  it('skips the count and lease when Commerce resolves unlimited', async () => {
-    const { service, boxRepository, boxService, redisLockProvider } = makeService({ limit: null })
+  it('skips the count and reservation when Commerce resolves unlimited', async () => {
+    const { service, boxRepository, boxService, reservationService } = makeService({ limit: null })
 
     await service.create({} as any, { id: 'org-1' } as any)
 
-    expect(redisLockProvider.waitForLease).not.toHaveBeenCalled()
+    expect(reservationService.reserve).not.toHaveBeenCalled()
     expect(boxRepository.countQuotaBoxes).not.toHaveBeenCalled()
     expect(boxService.create).toHaveBeenCalled()
   })
 
-  it('fails closed with 503 when the admission lease cannot be acquired', async () => {
-    const { service, redisLockProvider, boxRepository, boxService } = makeService()
-    redisLockProvider.waitForLease.mockRejectedValue(new Error('Redis unavailable'))
+  it('fails closed with 503 when a reservation cannot be created', async () => {
+    const { service, reservationService, boxRepository, boxService } = makeService()
+    reservationService.reserve.mockRejectedValue(new Error('Redis unavailable'))
 
     const error = await service.create({} as any, { id: 'org-1' } as any).then(
       () => null,
@@ -99,39 +107,87 @@ describe('RestBoxCreationService', () => {
     expect(boxService.create).not.toHaveBeenCalled()
   })
 
-  it('serializes concurrent creates so the second request observes the first commit', async () => {
-    const { service, boxRepository, boxService, redisLockProvider } = makeService({ count: 19, limit: 20 })
-    let currentBoxCount = 19
-    let grantSecondLease!: (lease: any) => void
-    const secondLease = {
-      signal: new AbortController().signal,
-      release: jest.fn().mockResolvedValue(undefined),
-    }
-    const firstLease = {
-      signal: new AbortController().signal,
-      release: jest.fn().mockImplementation(async () => grantSecondLease(secondLease)),
-    }
-    const secondAdmission = new Promise((resolve) => {
-      grantSecondLease = resolve
-    })
-    redisLockProvider.waitForLease
-      .mockResolvedValueOnce(firstLease)
-      .mockReturnValueOnce(secondAdmission)
-    boxRepository.countQuotaBoxes.mockImplementation(async () => currentBoxCount)
-    boxService.create.mockImplementation(async () => {
-      currentBoxCount += 1
-      return { id: 'box-1' }
-    })
+  it('rejects the excess reservation without waiting for another create to finish', async () => {
+    const { service, boxRepository, boxService, reservationService } = makeService({ count: 19, limit: 20 })
+    const firstReservation = makeReservation(1)
+    const secondReservation = makeReservation(2)
+    reservationService.reserve.mockResolvedValueOnce(firstReservation).mockResolvedValueOnce(secondReservation)
+    boxRepository.countQuotaBoxes.mockResolvedValue(19)
 
-    const results = await Promise.allSettled([
-      service.create({} as any, { id: 'org-1' } as any),
-      service.create({} as any, { id: 'org-1' } as any),
-    ])
+    let finishFirst!: (box: { id: string }) => void
+    const firstCreate = new Promise<{ id: string }>((resolve) => {
+      finishFirst = resolve
+    })
+    boxService.create.mockReturnValueOnce(firstCreate)
+
+    let firstSettled = false
+    let secondSettled = false
+    const first = service.create({ name: 'first' } as any, { id: 'org-1' } as any).finally(() => {
+      firstSettled = true
+    })
+    const second = service.create({ name: 'second' } as any, { id: 'org-1' } as any).finally(() => {
+      secondSettled = true
+    })
+    void second.catch(() => undefined)
+
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    expect(boxService.create).toHaveBeenCalledTimes(1)
+    expect(firstSettled).toBe(false)
+    expect(secondSettled).toBe(true)
+    expect(secondReservation.release).toHaveBeenCalled()
+
+    finishFirst({ id: 'box-1' })
+    const results = await Promise.allSettled([first, second])
 
     expect(results[0]).toEqual({ status: 'fulfilled', value: { id: 'box-1' } })
     expect(results[1].status).toBe('rejected')
     expect((results[1] as PromiseRejectedResult).reason).toBeInstanceOf(HttpException)
     expect(boxRepository.countQuotaBoxes).toHaveBeenCalledTimes(2)
-    expect(boxService.create).toHaveBeenCalledTimes(1)
+    expect(firstReservation.release).toHaveBeenCalled()
+  })
+
+  it('releases the reservation immediately when creation fails', async () => {
+    const { service, boxService, reservation } = makeService({ count: 0, limit: 20 })
+    const creationError = new Error('runner unavailable')
+    boxService.create.mockRejectedValue(creationError)
+
+    await expect(service.create({} as any, { id: 'org-1' } as any)).rejects.toBe(creationError)
+    expect(reservation.release).toHaveBeenCalled()
+  })
+
+  it('maps a commit-time inventory race loss to the quota response', async () => {
+    const { service, boxService, reservation } = makeService({ count: 19, limit: 20 })
+    boxService.create.mockRejectedValue(new BoxInventoryLimitExceededError(20, 20))
+
+    const error = await service.create({} as any, { id: 'org-1' } as any).catch((caught) => caught)
+
+    expect(error).toBeInstanceOf(HttpException)
+    expect(error.getStatus()).toBe(403)
+    expect(error.getResponse()).toMatchObject({ code: 'resource_exhausted' })
+    expect(reservation.release).toHaveBeenCalled()
+  })
+
+  it('fails closed with 503 when the reservation is lost before commit', async () => {
+    const { service, boxService, reservation } = makeService({ count: 0, limit: 20 })
+    const controller = new AbortController()
+    reservation.signal = controller.signal
+    boxService.create.mockImplementation(async () => {
+      controller.abort(new Error('reservation lost'))
+      controller.signal.throwIfAborted()
+    })
+
+    const error = await service.create({} as any, { id: 'org-1' } as any).catch((caught) => caught)
+
+    expect(error).toBeInstanceOf(ServiceUnavailableException)
+    expect(error.getStatus()).toBe(503)
+    expect(reservation.release).toHaveBeenCalled()
+  })
+
+  it('returns a committed box when reservation release reports ownership loss', async () => {
+    const { service, reservation } = makeService({ count: 0, limit: 20 })
+    reservation.release.mockRejectedValue(new Error('reservation lost'))
+
+    await expect(service.create({} as any, { id: 'org-1' } as any)).resolves.toEqual({ id: 'box-1' })
   })
 })

--- a/apps/api/src/boxlite-rest/services/rest-box-creation.service.ts
+++ b/apps/api/src/boxlite-rest/services/rest-box-creation.service.ts
@@ -6,14 +6,12 @@
 import { HttpException, HttpStatus, Injectable, Logger, ServiceUnavailableException } from '@nestjs/common'
 import { BoxDto } from '../../box/dto/box.dto'
 import { CreateBoxDto } from '../../box/dto/create-box.dto'
+import { BoxInventoryLimitExceededError } from '../../box/errors/box-inventory-limit-exceeded.error'
 import { Organization } from '../../organization/entities/organization.entity'
-import { RedisLockProvider, withRedisLockLease } from '../../box/common/redis-lock.provider'
 import { BoxRepository } from '../../box/repositories/box.repository'
 import { BoxService } from '../../box/services/box.service'
+import { BoxAdmissionReservationService, withBoxAdmissionReservation } from './box-admission-reservation.service'
 import { CommerceBoxLimitService } from './commerce-box-limit.service'
-
-const ADMISSION_LEASE_TTL_SECONDS = 30
-const ADMISSION_WAIT_TIMEOUT_MS = 10_000
 
 @Injectable()
 export class RestBoxCreationService {
@@ -23,7 +21,7 @@ export class RestBoxCreationService {
     private readonly limitService: CommerceBoxLimitService,
     private readonly boxRepository: BoxRepository,
     private readonly boxService: BoxService,
-    private readonly redisLockProvider: RedisLockProvider,
+    private readonly reservationService: BoxAdmissionReservationService,
   ) {}
 
   async create(createBoxDto: CreateBoxDto, organization: Organization): Promise<BoxDto> {
@@ -32,13 +30,13 @@ export class RestBoxCreationService {
       return this.boxService.create(createBoxDto, organization)
     }
 
-    const lease = await this.acquireAdmissionLease(organization.id)
+    const reservation = await this.createReservation(organization.id)
     let createdBox: BoxDto | undefined
     let operationError: unknown
 
     try {
-      return await withRedisLockLease(
-        lease,
+      return await withBoxAdmissionReservation(
+        reservation,
         async (signal) => {
           signal.throwIfAborted()
 
@@ -46,33 +44,46 @@ export class RestBoxCreationService {
           try {
             currentBoxCount = await this.boxRepository.countQuotaBoxes(organization.id)
           } catch (error) {
-            operationError = error
+            if (!signal.aborted) {
+              operationError = error
+            }
             throw error
           }
 
-          if (currentBoxCount >= limit.value) {
-            throw this.limitExceeded(currentBoxCount, limit.value)
+          // pendingCount includes this request; only the other active
+          // reservations consume capacity before this request is admitted.
+          const effectiveBoxCount = currentBoxCount + reservation.pendingCount - 1
+          if (effectiveBoxCount >= limit.value) {
+            throw this.limitExceeded(effectiveBoxCount, limit.value)
           }
 
           signal.throwIfAborted()
           try {
-            createdBox = await this.boxService.create(createBoxDto, organization)
+            createdBox = await this.boxService.create(createBoxDto, organization, {
+              inventoryLimit: limit.value,
+              signal,
+            })
             return createdBox
           } catch (error) {
-            operationError = error
+            if (!signal.aborted) {
+              operationError = error
+            }
             throw error
           }
         },
-        (error) => this.logger.warn(`Failed to release box creation admission lease: ${this.errorSummary(error)}`),
+        (error) => this.logger.warn(`Failed to release box creation reservation: ${this.errorSummary(error)}`),
       )
     } catch (error) {
-      // The BoxService return means its database write committed. Do not turn a
-      // release/renewal failure into a retry that creates another box.
+      // A BoxService return means its database write committed. Do not turn a
+      // reservation failure into a retry that creates another box.
       if (createdBox) {
         this.logger.warn(
-          `Box ${createdBox.id} was created before its admission lease failed: ${this.errorSummary(error)}`,
+          `Box ${createdBox.id} was created before its admission reservation failed: ${this.errorSummary(error)}`,
         )
         return createdBox
+      }
+      if (error instanceof BoxInventoryLimitExceededError) {
+        throw this.limitExceeded(error.current, error.limit)
       }
       if (operationError !== undefined || error instanceof HttpException) {
         throw error
@@ -81,13 +92,9 @@ export class RestBoxCreationService {
     }
   }
 
-  private async acquireAdmissionLease(organizationId: string) {
+  private async createReservation(organizationId: string) {
     try {
-      return await this.redisLockProvider.waitForLease(
-        `box-create-admission:${organizationId}`,
-        ADMISSION_LEASE_TTL_SECONDS,
-        AbortSignal.timeout(ADMISSION_WAIT_TIMEOUT_MS),
-      )
+      return await this.reservationService.reserve(organizationId)
     } catch (error) {
       throw this.admissionUnavailable(error)
     }

--- a/apps/api/src/boxlite-rest/services/rest-box-creation.service.ts
+++ b/apps/api/src/boxlite-rest/services/rest-box-creation.service.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { HttpException, HttpStatus, Injectable, Logger, ServiceUnavailableException } from '@nestjs/common'
+import { BoxDto } from '../../box/dto/box.dto'
+import { CreateBoxDto } from '../../box/dto/create-box.dto'
+import { Organization } from '../../organization/entities/organization.entity'
+import { RedisLockProvider, withRedisLockLease } from '../../box/common/redis-lock.provider'
+import { BoxRepository } from '../../box/repositories/box.repository'
+import { BoxService } from '../../box/services/box.service'
+import { CommerceBoxLimitService } from './commerce-box-limit.service'
+
+const ADMISSION_LEASE_TTL_SECONDS = 30
+const ADMISSION_WAIT_TIMEOUT_MS = 10_000
+
+@Injectable()
+export class RestBoxCreationService {
+  private readonly logger = new Logger(RestBoxCreationService.name)
+
+  constructor(
+    private readonly limitService: CommerceBoxLimitService,
+    private readonly boxRepository: BoxRepository,
+    private readonly boxService: BoxService,
+    private readonly redisLockProvider: RedisLockProvider,
+  ) {}
+
+  async create(createBoxDto: CreateBoxDto, organization: Organization): Promise<BoxDto> {
+    const limit = await this.limitService.resolveLimit(organization.id)
+    if (limit.kind === 'unlimited') {
+      return this.boxService.create(createBoxDto, organization)
+    }
+
+    const lease = await this.acquireAdmissionLease(organization.id)
+    let createdBox: BoxDto | undefined
+    let operationError: unknown
+
+    try {
+      return await withRedisLockLease(
+        lease,
+        async (signal) => {
+          signal.throwIfAborted()
+
+          let currentBoxCount: number
+          try {
+            currentBoxCount = await this.boxRepository.countQuotaBoxes(organization.id)
+          } catch (error) {
+            operationError = error
+            throw error
+          }
+
+          if (currentBoxCount >= limit.value) {
+            throw this.limitExceeded(currentBoxCount, limit.value)
+          }
+
+          signal.throwIfAborted()
+          try {
+            createdBox = await this.boxService.create(createBoxDto, organization)
+            return createdBox
+          } catch (error) {
+            operationError = error
+            throw error
+          }
+        },
+        (error) => this.logger.warn(`Failed to release box creation admission lease: ${this.errorSummary(error)}`),
+      )
+    } catch (error) {
+      // The BoxService return means its database write committed. Do not turn a
+      // release/renewal failure into a retry that creates another box.
+      if (createdBox) {
+        this.logger.warn(
+          `Box ${createdBox.id} was created before its admission lease failed: ${this.errorSummary(error)}`,
+        )
+        return createdBox
+      }
+      if (operationError !== undefined || error instanceof HttpException) {
+        throw error
+      }
+      throw this.admissionUnavailable(error)
+    }
+  }
+
+  private async acquireAdmissionLease(organizationId: string) {
+    try {
+      return await this.redisLockProvider.waitForLease(
+        `box-create-admission:${organizationId}`,
+        ADMISSION_LEASE_TTL_SECONDS,
+        AbortSignal.timeout(ADMISSION_WAIT_TIMEOUT_MS),
+      )
+    } catch (error) {
+      throw this.admissionUnavailable(error)
+    }
+  }
+
+  private limitExceeded(current: number, limit: number): HttpException {
+    return new HttpException(
+      {
+        message: `You have already created ${current} boxes, reaching or exceeding the current maximum allowed number of ${limit}. Please delete unused boxes and try again.`,
+        code: 'resource_exhausted',
+      },
+      HttpStatus.FORBIDDEN,
+    )
+  }
+
+  private admissionUnavailable(cause: unknown): ServiceUnavailableException {
+    this.logger.warn(`Box creation admission is unavailable: ${this.errorSummary(cause)}`)
+    return new ServiceUnavailableException({
+      message: 'Box creation admission is temporarily unavailable. Please try again.',
+      code: 'upstream_unavailable',
+    })
+  }
+
+  private errorSummary(error: unknown): string {
+    return error instanceof Error ? error.message : 'unknown error'
+  }
+}

--- a/apps/infra/.env.example
+++ b/apps/infra/.env.example
@@ -239,9 +239,11 @@ OIDC_AUDIENCE=https://dev.example.com/api
 
 # 4j-2. Billing — points the API, and through GET /api/config the dashboard, at
 # a billing service. [optional]; this stack deploys none, so unset means the
-# dashboard's whole billing surface stays gated off and shows its placeholder
-# instead of advertising a service that would fail every request. Suspension
-# does not key off it (REQUIRE_PAYMENT_METHOD does).
+# dashboard's whole billing surface stays gated off and shows its placeholder.
+# It also enables the API's hosted REST box-count ceiling; successful plan
+# resolutions are cached for 10 seconds. Unset means unlimited; failed or
+# malformed Commerce reads fall back to 20 for that request without caching.
+# Suspension does not key off it (REQUIRE_PAYMENT_METHOD does).
 # BILLING_API_URL=https://billing.example.com/api/billing
 #   Setting it also arms usage export to that same service, since a stage with
 #   somewhere to bill has somewhere to send usage. USAGE_EXPORT_URL defaults to
@@ -251,7 +253,9 @@ OIDC_AUDIENCE=https://dev.example.com/api
 #   /api/billing value would 404 every batch. Override only if the two live at
 #   different origins.
 # USAGE_EXPORT_URL=https://billing.example.com
-#   [required SST secret to export] USAGE_EXPORT_TOKEN is what turns delivery on:
+#   [required SST secret to export and authenticate plan reads]
+#   USAGE_EXPORT_TOKEN is what turns delivery on and is sent as the bearer token
+#   on both plan reads used by REST box-create admission:
 #   until the stage's secret store holds one, the exporter stays off and writes no
 #   outbox rows. It must equal the string the billing service reads as
 #   USAGE_INGEST_TOKEN — for boxlite-commerce, the value its own stack keeps in

--- a/openapi/box.openapi.yaml
+++ b/openapi/box.openapi.yaml
@@ -301,10 +301,14 @@ paths:
                 $ref: "#/components/schemas/Box"
         "400":
           $ref: "#/components/responses/BadRequestError"
+        "403":
+          $ref: "#/components/responses/ResourceExhaustedError"
         "409":
           $ref: "#/components/responses/ConflictError"
         "422":
           $ref: "#/components/responses/UnprocessableEntityError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailableError"
 
     get:
       operationId: listBoxes
@@ -1275,6 +1279,19 @@ components:
               message: "invalid or missing API key"
               type: AuthError
               code: unauthenticated
+              request_id: req_01HZK4TNRPQSXYZ8WM6NCVT9R5
+
+    ResourceExhaustedError:
+      description: The organization has reached its maximum allowed number of boxes
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error:
+              message: "You have already created 20 boxes, reaching or exceeding the current maximum allowed number of 20. Please delete unused boxes and try again."
+              type: ResourceExhaustedError
+              code: resource_exhausted
               request_id: req_01HZK4TNRPQSXYZ8WM6NCVT9R5
 
     NotFoundError:


### PR DESCRIPTION
## Summary

Add Commerce-backed admission to hosted REST box creation so an organization's plan can cap its non-terminal box inventory. Limited requests now use optimistic per-request Redis reservations instead of serializing the full creation workflow. Box creation remains concurrent; PostgreSQL serializes only the final recount and write needed to keep the hosted REST limit strict.

Self-hosted and non-REST SDK creation remain outside this PR's admission scope.

## Call graph

Before

```text
createBox              (BoxliteBoxController · apps/api/src/boxlite-rest/boxlite-box.controller.ts:119) — hosted REST entry
└─ create              (BoxService · apps/api/src/box/services/box.service.ts:215) — creates without Commerce admission
```

After

```text
createBox                 (BoxliteBoxController · apps/api/src/boxlite-rest/boxlite-box.controller.ts:119) — hosted REST entry
├─ create                 (RestBoxCreationService · apps/api/src/boxlite-rest/services/rest-box-creation.service.ts:27) — coordinates admission
│  ├─ resolveLimit        (CommerceBoxLimitService · apps/api/src/boxlite-rest/services/commerce-box-limit.service.ts:44) — resolves and caches successful limits
│  └─ reserve             (BoxAdmissionReservationService · apps/api/src/boxlite-rest/services/box-admission-reservation.service.ts:173) — atomically adds a renewable request token
│     ├─ countQuotaBoxes  (BoxRepository · apps/api/src/box/repositories/box.repository.ts:61) — primary DB count plus pending reservations rejects excess work early
│     └─ create           (BoxService · apps/api/src/box/services/box.service.ts:215) — validation and warm-pool work run concurrently
│        └─ insert/update (BoxRepository · apps/api/src/box/repositories/box.repository.ts:71) — persists inside a transaction
│           └─ assertInventoryAvailable (BoxRepository · apps/api/src/box/repositories/box.repository.ts:407) — short advisory-lock recount is the final quota fence
└─ waitForStarted         (BoxStateWaiterService · apps/api/src/boxlite-rest/boxlite-box.controller.ts:128) — remains outside admission
```

## Changes

- Authenticate Commerce plan-catalog and organization-plan reads with `USAGE_EXPORT_TOKEN`, validate both response shapes, and match the organization's `concurrencyLimit`.
- Cache successful resolutions for 10 seconds, deduplicate concurrent lookups per organization, retry 5xx responses once after 500 ms, and use an uncached per-request fallback limit of 20 on final Commerce errors or malformed responses.
- Atomically reserve one Redis sorted-set token per limited request, prune expired tokens, renew slow requests, and release immediately on success or failure.
- Reject excess work from the primary PostgreSQL count plus the reservation snapshot without waiting for another `BoxService.create` call to finish.
- Enforce the final limit in the same PostgreSQL transaction as a fresh insert or warm-pool assignment; only the advisory-lock recount and write are serialized.
- Return `resource_exhausted` with HTTP 403 at the ceiling and fail closed with HTTP 503 when Redis admission or reservation ownership is unavailable.
- Keep creation unlimited when `BILLING_API_URL` is unset or the resolved plan is unlimited, and document the configuration plus the new 403 OpenAPI response.

## How to verify

- `VERSION=dev GOFLAGS=-tags=boxlite_dev make build:apps` — all 9 apps projects and 3 dependency targets succeeded.
- `make test:apps` with real Redis and PostgreSQL — all 5 apps test targets succeeded; API: 98/98 suites and 794/794 tests.
- Real PostgreSQL concurrency coverage verifies exactly one success from `limit - 1` for both two fresh inserts and a fresh insert racing a warm-pool assignment.
- Real Redis coverage verifies atomic pending counts, immediate release, and expired-token pruning; unit coverage verifies TTL renewal and reservation-loss handling.
- `make lint:apps` — 0 errors; 42 existing warnings in untouched lines.
- Changed-file Prettier check and `git diff --check` — clean.

## Risks / rollout

- A configured Commerce service that fails or returns malformed data temporarily constrains the current request to 20 boxes; these fallback results are not cached.
- Redis reservation failures return 503 before commit. A release failure after commit returns the committed box so clients do not retry and create a duplicate.
- The database commit fence makes the hosted REST path strict even if reservations expire or Redis ownership is lost. Non-REST creation paths remain unchanged and can still bypass this hosted REST limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added organization-level box creation limits based on configured billing plans.
  * Added support for unlimited plans, cached plan checks, and safe fallback handling during billing-service failures.
  * Box creation now returns clear `403` errors when limits are reached and `503` errors when admission services are unavailable.
  * New boxes are private by default unless explicitly made public.
* **Documentation**
  * Updated API and environment configuration documentation with billing, caching, fallback, and quota behavior.
* **Tests**
  * Added coverage for quota enforcement, concurrency, billing responses, retries, caching, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
