### PR TITLE
docs: index the REST API contract from the reference docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ How BoxLite embeds a runtime and runs OCI containers inside micro-VMs. Details �
 
 ## Documentation
 
-- [API & CLI Reference](./docs/reference/) — SDK API references (Python, Node.js, Rust, C) and the `boxlite` CLI reference
+- [API & CLI Reference](./docs/reference/) — SDK API references (Python, Node.js, Rust, C), the `boxlite` CLI reference, and the REST API contract ([`openapi/box.openapi.yaml`](./openapi/box.openapi.yaml))
 - [Using BoxLite with AI agents](./docs/guides/ai-agent-integration.md) — concurrency, timeouts, security, file transfer
 - [Examples](./examples/) — Sample code for common use cases
 - [Architecture](./docs/architecture/) — How BoxLite works under the hood

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -19,6 +19,42 @@ Complete API documentation for each SDK:
 |---------|---------------|-------------|
 | **`boxlite`** | [CLI Reference](cli/README.md) | All subcommands, global flags, volume/port grammar, installation & verification, exit codes |
 
+## HTTP API Reference
+
+| Surface | Documentation | Description |
+|---------|---------------|-------------|
+| **Box API** | [`openapi/box.openapi.yaml`](../../openapi/box.openapi.yaml) | The portable REST contract, 26 paths. Groups: configuration & discovery, authentication, volumes, boxes, box lifecycle, snapshot/portability, execution, files, network, metrics, images |
+| **Reference server** | [`openapi/reference-server/`](../../openapi/reference-server/README.md) | A partial implementation used as a client test fixture, not a conformance target |
+
+The spec is the contract, not an inventory of any one server, and no
+implementation currently serves all 26 paths:
+
+| Server | Serves | Does not serve |
+|--------|--------|----------------|
+| `boxlite serve` | boxes, lifecycle, exec, files, snapshots, clone/export/import, metrics, config, me | `network/tunnel`, the three `images/*` paths. Volume routes are registered but every operation answers `400 UnsupportedError` |
+| reference server | boxes, lifecycle, exec, files, snapshots, clone/export/import, metrics, config, me | volumes, images, `network/tunnel`, attach, and `DELETE …/executions/{exec_id}` (kill) |
+
+Read each server's routes rather than either README — both under-report.
+`GET /config` does not close this gap: it carries feature flags
+(`tty_enabled`, `streaming_enabled`, `snapshots_enabled`, `clone_enabled`,
+`export_enabled`, `import_enabled`), not route availability, has no flag at all
+for volumes, images or tunnel, and can disagree with the routes — the reference
+server advertises `streaming_enabled: true` while serving no attach route.
+
+`{prefix}` is a deployment-defined routing slot, opaque to the client, published
+by a server as `Principal.path_prefix`. A single-tenant server may omit the
+segment entirely — that is the contract's null-prefix case, and what `boxlite
+serve` does, so its `/v1/boxes/…` routes are conformant. The field name is not:
+both servers serialize it as `prefix` (`serve/handlers/me.rs`,
+`reference-server/server.py`) where the contract says `path_prefix`. The Rust
+client sidesteps discovery altogether and takes `path_prefix` from its own
+options. Treat the segment as server-supplied configuration; never hardcode one.
+
+A deployed BoxLite platform also runs services of its own — control plane,
+runner, preview proxy, telemetry collector — catalogued separately in
+[`apps/API.md`](../../apps/API.md). Those are deployment internals, not part of
+the portable contract above.
+
 ---
 
 ## Quick Reference


### PR DESCRIPTION
## Summary

- add an HTTP API section to the reference index, pointing at `openapi/box.openapi.yaml` and its reference server
- record which paths each server actually serves, and where a server's advertised capabilities disagree with its routes
- link the REST contract from the root README's Documentation list

## Why

The Box API spec is referenced from `apps/API.md`, `apps/runner/README.md` and the reference server's own README — but not from either place a reader looks first. The reference index covered SDKs, CLI, configuration, errors and file formats; the root README names a REST API in prose without linking the contract.

## Before

```text
README.md      -> docs/reference/ -> SDKs | CLI | config | errors | formats
apps/API.md    -> openapi/box.openapi.yaml
runner/README  -> openapi/box.openapi.yaml   reachable only from apps/
```

## After

```text
README.md      -> docs/reference/ -> SDKs | CLI | config | errors | formats
                                  -> openapi/box.openapi.yaml
                                  -> openapi/reference-server/
                                  -> apps/API.md (deployment internals)
                                  -> per-server route coverage table
```

## What the coverage table records

Neither server's README enumerates its own omissions, so the table is derived from the routers themselves:

| Server | Gaps |
|---|---|
| `boxlite serve` | `network/tunnel`, the three `images/*` paths; volume routes are registered but every operation answers `400 UnsupportedError` (`serve/handlers/volumes.rs`) |
| reference server | volumes, images, `network/tunnel`, attach, and `DELETE …/executions/{exec_id}` |

Two contract deviations worth knowing, both verified in source rather than taken from docs:

- `GET /config` carries feature flags (`tty_enabled`, `clone_enabled`, …), not route availability, and has no flag at all for volumes, images or tunnel. The reference server advertises `streaming_enabled: true` while serving no attach route.
- Both servers serialize the principal's routing slot as `prefix` where the contract says `path_prefix` (`serve/handlers/me.rs`, `reference-server/server.py`). `boxlite serve` omitting the segment entirely is *not* a deviation — that is the contract's null-prefix case.

## Validation

- documentation only; no code paths change
- every route claim derived from `serve/mod.rs`, `serve/handlers/`, and `reference-server/server.py`, not from prose


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the HTTP API Reference with details about the portable REST contract and its available routes.
  * Added guidance on route availability across supported servers, feature flags, and deployment-specific URL prefixes.
  * Documented additional services provided by deployed BoxLite platforms.
  * Updated the main documentation index to link directly to the REST API contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->