### PR TITLE
feat(lifecycle)!: enforce AutoStop/AutoDelete in serve, add CLI flags

### DIFF
--- a/.github/workflows/e2e-cloud.yml
+++ b/.github/workflows/e2e-cloud.yml
@@ -122,7 +122,7 @@ permissions:
 # A later run queues behind the in-progress one instead of cancelling it.
 # The `box` fixture's teardown is the only thing that deletes the boxes a
 # run creates: auto_remove is a no-op over REST (see
-# deprecated_auto_remove_does_not_change_rest_lifecycle_defaults) and the
+# auto_remove_is_never_transmitted_to_a_rest_runtime) and the
 # API defaults autoDelete to disabled, so a run killed mid-suite strands
 # every box it had open — they auto-stop after 15 min but are never
 # deleted. Note this bounds the damage rather than eliminating it:

--- a/docs/architecture/auto-stop-resume-design.md
+++ b/docs/architecture/auto-stop-resume-design.md
@@ -16,7 +16,9 @@ auto_delete: integer seconds, 0 disables
 auto_resume: boolean, default true; user operations resume an auto-stopped box when enabled
 ```
 
-The default `auto_stop` is `900` seconds, the default `auto_delete` is `0`, and the default `auto_resume` is `true`. Create and read APIs and the Rust, Python, Node.js, C, and Go SDK boundaries use these same modern lifecycle semantics. AutoResume is implemented by the cloud control plane; the embedded local runtime has no auto-stopped state to resume. SDKs continue to accept deprecated `auto_remove` for embedded remove-on-stop compatibility, and explicit `auto_delete` takes precedence there. The REST API does not expose `auto_remove`; leaving `auto_delete` unset preserves the remote server's default instead of translating the deprecated field to a timer.
+The default `auto_stop` is `900` seconds, the default `auto_delete` is `0`, and the default `auto_resume` is `true`. Create and read APIs and the Rust, Python, Node.js, C, and Go SDK boundaries use these same modern lifecycle semantics.
+
+`auto_remove` is a separate axis, not a deprecated spelling of `auto_delete`: it removes the box synchronously the moment it stops (docker `run --rm`) and needs no sweeper, while `auto_delete` is a deferred deadline something has to act on later. Setting one never clears the other, and the two are mutually exclusive at the CLI. The REST API does not expose `auto_remove`; leaving `auto_delete` unset preserves the remote server's default.
 
 The internal database columns are `autoStop`, `autoDelete`, `autoResume`, and `lastActivityAt`. Public names remain stable.
 
@@ -105,12 +107,13 @@ Therefore, if a user changes the policy, manually starts or stops the box, or an
 - `create` puts explicit options in the REST body;
 - `Box` responses are mapped to `BoxInfo`.
 
-The local runtime:
+A runtime accepts a deadline only when its embedder declares a lifecycle sweeper (`RuntimeCapabilities::lifecycle_sweeper`). `boxlite serve` declares one; a bare embedded runtime does not. The embedded runtime therefore:
 
-- Preserves the historical `auto_remove` remove-on-stop behavior when `auto_delete` is unset;
-- Uses `auto_delete=0` to keep a stopped box and a positive value for immediate local remove-on-stop;
-- Returns `Unsupported` when AutoStop is explicitly configured, because it has no lifecycle sweeper;
+- Applies `auto_remove` for remove-on-stop, which is synchronous and needs no sweeper;
+- Returns `Unsupported` when either `auto_stop` or `auto_delete` is set to a non-zero value, rather than storing a deadline nothing will act on — `0` stays acceptable, since it asks for no enforcement;
 - Does not implement cloud AutoResume because local boxes do not enter an AutoStopped state.
+
+`boxlite serve` enforces all three itself: an activity middleware plus a per-box idle clock in `AppState`, and a lifecycle pass on the existing reaper tick that stops idle boxes and deletes ones that have been stopped past their window. It holds the `BOXLITE_HOME` lock for its whole life, so nothing can touch its boxes behind its back and its activity view is complete. A WebSocket attach re-stamps the clock per client frame, so an active terminal keeps its box alive while an abandoned one ages out.
 
 The C ABI uses `uint32_t` for `auto_stop` and `uint32_t` for `auto_delete`, with `0` meaning disabled in both cases. The Go bridge, Python, and Node bindings use corresponding non-negative integer types.
 

--- a/docs/reference/cli/README.md
+++ b/docs/reference/cli/README.md
@@ -728,15 +728,22 @@ Used by `run` and `create` (defined at `src/cli/src/cli.rs:407-578`).
 
 ### `ManagementFlags`
 
-Used by `run` and `create` (defined at `src/cli/src/cli.rs:584-604`).
+Used by `run` and `create` (defined at `src/cli/src/cli.rs:954`).
 
 | Flag | Short | Description |
 |------|-------|-------------|
 | `--name NAME` | — | Assign a name to the box |
 | `--detach` | `-d` | Run in the background; print box ID and return |
-| `--rm` | — | Automatically remove the box when it exits |
+| `--rm` | — | Remove the box as soon as it stops; conflicts with `--auto-delete` |
+| `--auto-stop DURATION` | — | Stop the box after this much inactivity; `0` disables |
+| `--auto-delete DURATION` | — | Delete the box this long after it stops; `0` disables |
+| `--no-auto-resume` | — | Refuse operations that would implicitly wake a stopped box |
 
-> `--rm` with `--detach` on `run` is silently downgraded — `run -d` always sets `auto_remove=false` (`src/cli/src/commands/run.rs:106`) so the detached box outlives the CLI process. Use `boxlite rm` to clean up.
+`DURATION` is seconds when bare, or a suffixed value: `30s`, `15m`, `2h`, `7d`.
+
+> `--auto-stop` and `--auto-delete` are deadlines a sweeper acts on, so they need a server that runs one — `boxlite serve` or the cloud. The embedded runtime refuses a non-zero value rather than storing a policy nothing enforces.
+
+> `--rm` with `--detach` is silently downgraded — a detached box always keeps manual lifecycle control (`ManagementFlags::apply_detach_override`, `src/cli/src/cli.rs:1059`) so it outlives the CLI process. An explicit `--auto-delete` deadline survives detaching. Use `boxlite rm` to clean up.
 
 ---
 

--- a/openapi/reference-server/README.md
+++ b/openapi/reference-server/README.md
@@ -102,6 +102,15 @@ curl -s -X DELETE http://localhost:8080/v1/demo/boxes/$BOX_ID \
 
 **Not implemented:** `GET/HEAD /{prefix}/images/{id}` (SDK has no get-by-digest), WebSocket TTY.
 
+`auto_stop` / `auto_delete` are forwarded to the embedded runtime as sent. That runtime enforces
+neither — it runs no sweeper — and refuses a non-zero value, so a create carrying one returns 400.
+Responses report the box's real `auto_stop`, `auto_delete` and `auto_resume` rather than omitting
+them. All three are optional on the wire and `auto_stop` defaults to 900, so a client that finds it
+missing reads a live 15-minute idle window this server never enforces. A deadline can reach the
+store despite the create-path refusal — importing an archive does not go through that check, and a
+runtime home shared with `boxlite serve` holds whatever that server persisted — so the values are
+read back from the box rather than assumed.
+
 ## CLI Options
 
 ```

--- a/openapi/reference-server/server.py
+++ b/openapi/reference-server/server.py
@@ -347,6 +347,13 @@ def box_info_to_dict(info) -> dict:
         "cpus": info.cpus,
         "memory_mib": info.memory_mib,
         "labels": {},
+        # Report what the box actually carries. These are optional on the wire,
+        # and a client that finds them missing fills in the schema defaults —
+        # `auto_stop` defaults to 900 — so omitting them tells every caller the
+        # box has a live 15-minute window it does not have.
+        "auto_stop": info.auto_stop,
+        "auto_delete": info.auto_delete,
+        "auto_resume": info.auto_resume,
     }
 
 
@@ -396,6 +403,14 @@ def build_box_options(req: CreateBoxRequest) -> boxlite.BoxOptions:
             )
             for secret in req.secrets
         ]
+    # A server-side box outlives the request that made it, so it must not be
+    # removed the moment it stops. `auto_remove` defaults to true and is never
+    # transmitted, so it has to be said here — the same reason `boxlite serve`
+    # sets it in its own build_box_options. This preserves the behaviour a
+    # caller used to get from `auto_delete: 0`, which no longer suppresses
+    # removal now that the two axes are independent.
+    kwargs["auto_remove"] = False
+
     if req.auto_stop is not None:
         kwargs["auto_stop"] = req.auto_stop
     if req.auto_delete is not None:

--- a/openapi/reference-server/tests/test_handle_cache.py
+++ b/openapi/reference-server/tests/test_handle_cache.py
@@ -103,6 +103,12 @@ def _make_box_info(box_id: str, *, name: str = "test-box", status: str = "create
         image="alpine:latest",
         cpus=2,
         memory_mib=512,
+        # Real BoxInfo carries these (sdks/python/src/info.rs), and
+        # box_info_to_dict reports them so a client does not fall back to the
+        # schema's 900s auto_stop default.
+        auto_stop=0,
+        auto_delete=0,
+        auto_resume=True,
     )
 
 
@@ -222,6 +228,52 @@ class HandleCacheTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(options.kwargs.get("tty"), True)
 
+    def test_box_response_reports_its_lifecycle_policy(self) -> None:
+        # These are optional on the wire, so a client that finds them missing
+        # fills in the schema defaults — auto_stop defaults to 900 — and reads
+        # a live 15-minute idle window on a box that has none.
+        # Every value here differs from both the fixture's and the schema's
+        # default (auto_stop 900, auto_delete 0, auto_resume true), so the
+        # assertions fail against a mapper that hardcodes either — including one
+        # that hardcodes 900, which is precisely the wrong answer an omitted
+        # auto_stop produces. An imported archive can genuinely carry a deadline.
+        info = _make_box_info("box-abc123")
+        info.auto_stop = 1800
+        info.auto_delete = 3600
+        info.auto_resume = False
+
+        payload = SERVER.box_info_to_dict(info)
+
+        self.assertEqual(payload["auto_stop"], 1800)
+        self.assertEqual(payload["auto_delete"], 3600)
+        self.assertEqual(payload["auto_resume"], False)
+
+    def test_created_box_is_kept_after_it_stops(self) -> None:
+        # A server-side box outlives the request that made it. `auto_remove`
+        # defaults to true in BoxOptions and is never transmitted, so this
+        # server has to say it locally — the wire used to express it as
+        # `auto_delete: 0`, which no longer suppresses removal. Without this the
+        # box is deleted the instant it stops, and rest_integration.rs's
+        # stop-then-inspect tests operate on a box that is already gone.
+        request = SERVER.CreateBoxRequest.model_validate({"image": "alpine:latest"})
+
+        options = SERVER.build_box_options(request)
+
+        self.assertEqual(options.kwargs.get("auto_remove"), False)
+
+    def test_lifecycle_deadlines_are_forwarded_as_sent(self) -> None:
+        # Passed through untouched. The embedded runtime enforces neither and
+        # refuses a non-zero value, so such a create surfaces its 400 rather
+        # than being silently reshaped here.
+        request = SERVER.CreateBoxRequest.model_validate(
+            {"image": "alpine:latest", "auto_stop": 900, "auto_delete": 3600}
+        )
+
+        options = SERVER.build_box_options(request)
+
+        self.assertEqual(options.kwargs.get("auto_stop"), 900)
+        self.assertEqual(options.kwargs.get("auto_delete"), 3600)
+
     def test_create_request_omits_tty_when_not_asked_for(self) -> None:
         request = SERVER.CreateBoxRequest.model_validate({"image": "alpine:latest"})
 
@@ -272,6 +324,7 @@ class HandleCacheTests(unittest.IsolatedAsyncioTestCase):
         constructor.assert_called_once_with(
             image="alpine:latest",
             advanced=advanced,
+            auto_remove=False,
             detach=False,
         )
 

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -887,7 +887,11 @@ void boxlite_options_add_secret(CBoxliteOptions *opts,
                                 const char *const *hosts,
                                 int hosts_count);
 
-// Deprecated: use `boxlite_options_set_auto_delete_interval`.
+// Remove the box as soon as it stops (docker `run --rm`).
+//
+// A separate axis from `boxlite_options_set_auto_delete_interval`: this removes
+// the box synchronously and needs no sweeper, while the interval is a deadline
+// something has to act on later. Setting one never clears the other.
 void boxlite_options_set_auto_remove(CBoxliteOptions *opts, int val);
 
 // Set how long an idle box may remain paused before the runtime pauses it.

--- a/sdks/c/src/options.rs
+++ b/sdks/c/src/options.rs
@@ -187,7 +187,11 @@ pub unsafe extern "C" fn boxlite_options_add_secret(
     options_add_secret(opts, name, value, placeholder, hosts, hosts_count)
 }
 
-/// Deprecated: use `boxlite_options_set_auto_delete_interval`.
+/// Remove the box as soon as it stops (docker `run --rm`).
+///
+/// A separate axis from `boxlite_options_set_auto_delete_interval`: this removes
+/// the box synchronously and needs no sweeper, while the interval is a deadline
+/// something has to act on later. Setting one never clears the other.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_options_set_auto_remove(opts: *mut CBoxliteOptions, val: c_int) {
     options_set_auto_remove(opts, val)
@@ -570,11 +574,12 @@ pub unsafe fn options_add_secret(
     }
 }
 
-#[allow(deprecated)]
 pub unsafe fn options_set_auto_remove(handle: *mut OptionsHandle, val: c_int) {
     if let Some(handle) = unsafe { handle.as_mut() } {
+        // Only this axis. Clearing `auto_delete` here would silently destroy a
+        // caller's deadline — the two are independent policies, not two
+        // spellings of one.
         handle.options.auto_remove = val != 0;
-        handle.options.auto_delete = None;
     }
 }
 

--- a/sdks/c/src/tests.rs
+++ b/sdks/c/src/tests.rs
@@ -396,9 +396,11 @@ fn create_box_rejects_null_callback() {
     let _ = std::fs::remove_dir_all(home_dir);
 }
 
+/// `auto_remove` and `auto_delete` are independent axes at the ABI, not two
+/// spellings of one policy. They previously used last-call-wins, so setting
+/// remove-on-stop silently discarded a caller's delete deadline.
 #[test]
-#[allow(deprecated)]
-fn auto_remove_and_auto_delete_use_last_call_wins() {
+fn auto_remove_and_auto_delete_are_independent() {
     let image = CString::new("alpine:latest").unwrap();
     let mut opts: *mut CBoxliteOptions = ptr::null_mut();
     let mut error = FFIError::default();
@@ -410,14 +412,26 @@ fn auto_remove_and_auto_delete_use_last_call_wins() {
         boxlite_options_set_auto_delete_interval(opts, 60);
         boxlite_options_set_auto_remove(opts, 0);
         assert!(!(*opts).options.auto_remove);
-        assert_eq!((*opts).options.auto_delete, None);
+        assert_eq!(
+            (*opts).options.auto_delete,
+            Some(60),
+            "setting auto_remove must not clear the delete deadline"
+        );
 
         boxlite_options_set_auto_remove(opts, 1);
         assert!((*opts).options.auto_remove);
-        assert_eq!((*opts).options.auto_delete, None);
+        assert_eq!(
+            (*opts).options.auto_delete,
+            Some(60),
+            "the deadline survives remove-on-stop being turned on"
+        );
 
-        boxlite_options_set_auto_delete_interval(opts, 60);
-        assert_eq!((*opts).options.auto_delete, Some(60));
+        boxlite_options_set_auto_delete_interval(opts, 3600);
+        assert_eq!((*opts).options.auto_delete, Some(3600));
+        assert!(
+            (*opts).options.auto_remove,
+            "setting the deadline must not clear auto_remove either"
+        );
 
         boxlite_options_free(opts);
     }

--- a/sdks/go/options.go
+++ b/sdks/go/options.go
@@ -395,8 +395,11 @@ func WithAutoStopInterval(seconds uint32) BoxOption {
 	return func(c *boxConfig) { c.autoStop = &seconds }
 }
 
-// WithAutoDeleteInterval configures the cloud AutoDelete TTL in seconds.
-// A value of 0 disables AutoDelete. Local runtimes return Unsupported.
+// WithAutoDeleteInterval sets how long after a box stops it is deleted, in
+// seconds. A value of 0 disables AutoDelete. This is a deferred deadline that
+// needs a runtime which sweeps them (boxlite serve or the cloud); the embedded
+// runtime returns Unsupported. For immediate removal on stop use WithAutoRemove,
+// which is an independent axis and needs no sweeper.
 func WithAutoDeleteInterval(seconds uint32) BoxOption {
 	return func(c *boxConfig) { c.autoDelete = &seconds }
 }
@@ -407,8 +410,10 @@ func WithAutoResumeEnabled(enabled bool) BoxOption {
 	return func(c *boxConfig) { c.autoResume = &enabled }
 }
 
-// WithAutoRemove sets whether the box is auto-removed on stop.
-// Deprecated: use WithAutoDeleteInterval.
+// WithAutoRemove removes the box as soon as it stops (docker `run --rm`).
+// Synchronous and needs no sweeper — an independent axis from
+// WithAutoDeleteInterval, not a legacy spelling of it. Setting one never clears
+// the other. Not transmitted to remote runtimes.
 func WithAutoRemove(v bool) BoxOption {
 	return func(c *boxConfig) { c.autoRemove = &v }
 }

--- a/sdks/node/lib/native-contracts.ts
+++ b/sdks/node/lib/native-contracts.ts
@@ -185,15 +185,21 @@ export interface JsBoxOptions {
   network?: JsNetworkSpec;
   ports?: JsPortSpec[];
   /**
-   * @deprecated Use autoDelete. Preserved for embedded remove-on-stop
-   * compatibility; an explicit autoDelete value takes precedence. Remote
-   * runtimes preserve server lifecycle defaults when autoDelete is omitted.
+   * Remove the box as soon as it stops (docker `run --rm`). Synchronous, and
+   * needs no sweeper — a separate axis from autoDelete, which is a deferred
+   * deadline. Setting one never clears the other. Not sent to remote runtimes.
    */
   autoRemove?: boolean;
   detach?: boolean;
-  /** Idle time in seconds before AutoStop; 0 disables AutoStop. */
+  /**
+   * Idle time in seconds before AutoStop; 0 disables AutoStop. Needs a runtime
+   * that sweeps deadlines; the embedded runtime returns Unsupported.
+   */
   autoStop?: number;
-  /** Time in seconds after stop before AutoDelete; 0 disables AutoDelete. */
+  /**
+   * Time in seconds after stop before AutoDelete; 0 disables AutoDelete. Needs a
+   * runtime that sweeps deadlines; use autoRemove for immediate removal.
+   */
   autoDelete?: number;
   /** Whether access automatically resumes an auto-stopped box. */
   autoResume?: boolean;

--- a/sdks/node/src/options.rs
+++ b/sdks/node/src/options.rs
@@ -198,11 +198,14 @@ pub struct JsBoxOptions {
     /// Port mappings as array of port specs
     pub ports: Option<Vec<JsPortSpec>>,
 
-    /// Automatically remove box when stopped (default: false).
-    /// @deprecated Use autoDelete.
+    /// Remove the box as soon as it stops (docker `run --rm`, default: false).
+    /// Synchronous and needs no sweeper — a separate axis from autoDelete, which
+    /// is a deferred deadline. Setting one never clears the other. Not sent to
+    /// remote runtimes.
     pub auto_remove: Option<bool>,
 
-    /// Idle time in seconds before AutoStop; 0 disables AutoStop.
+    /// Idle time in seconds before AutoStop; 0 disables AutoStop. Needs a
+    /// runtime that sweeps deadlines; the embedded runtime returns Unsupported.
     #[napi(js_name = "autoStop")]
     pub auto_stop: Option<u32>,
 
@@ -480,7 +483,6 @@ impl TryFrom<JsNetworkSpec> for (NetworkSpec, NetworkSpec) {
 impl TryFrom<JsBoxOptions> for BoxOptions {
     type Error = boxlite_shared::errors::BoxliteError;
 
-    #[allow(deprecated)]
     fn try_from(js_opts: JsBoxOptions) -> Result<Self, Self::Error> {
         let auto_remove = js_opts.auto_remove.unwrap_or(false);
         let auto_delete = js_opts.auto_delete;
@@ -889,7 +891,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(deprecated)]
     fn box_options_from_js_allow_net() {
         let js = JsBoxOptions {
             image: Some("alpine:latest".into()),

--- a/sdks/python/src/options.rs
+++ b/sdks/python/src/options.rs
@@ -552,7 +552,9 @@ pub(crate) struct PyBoxOptions {
     #[pyo3(get, set)]
     pub(crate) network: Option<PyNetworkSpec>,
     pub(crate) ports: Vec<PyPortSpec>,
-    /// Deprecated compatibility option; use auto_delete.
+    /// Remove the box as soon as it stops (docker `run --rm`). Synchronous and
+    /// needs no sweeper — an independent axis from `auto_delete`, which is a
+    /// deferred deadline. Not transmitted to remote runtimes.
     #[pyo3(get, set)]
     pub(crate) auto_remove: Option<bool>,
     #[pyo3(get, set)]
@@ -683,7 +685,6 @@ impl PyBoxOptions {
 impl TryFrom<PyBoxOptions> for BoxOptions {
     type Error = boxlite::BoxliteError;
 
-    #[allow(deprecated)]
     fn try_from(py_opts: PyBoxOptions) -> Result<Self, Self::Error> {
         let auto_remove = py_opts.auto_remove;
         let auto_delete = py_opts.auto_delete;

--- a/sdks/python/tests/test_options.py
+++ b/sdks/python/tests/test_options.py
@@ -90,13 +90,31 @@ class TestBoxOptionsDefaults:
 class TestAutoRemoveBehavior:
     """Test auto_remove option behavior."""
 
-    async def test_auto_delete_overrides_auto_remove(self, runtime):
+    async def test_auto_delete_needs_a_sweeper_the_embedded_runtime_lacks(
+        self, runtime
+    ):
+        """A delete deadline is refused, not silently stored, with no sweeper.
+
+        `auto_delete` is a deferred deadline someone has to act on. The embedded
+        runtime runs no sweeper, so accepting one would report a policy back to
+        the caller that never fires. `auto_remove` is the axis that works here.
+        """
+        with pytest.raises(RuntimeError, match="AutoDelete"):
+            await runtime.create(
+                boxlite.BoxOptions(
+                    image="alpine:latest", auto_remove=False, auto_delete=60
+                )
+            )
+
+    async def test_auto_delete_zero_is_accepted_as_disabled(self, runtime):
+        """`0` asks for no enforcement, so it must not trip the sweeper gate."""
         box = await runtime.create(
-            boxlite.BoxOptions(image="alpine:latest", auto_remove=False, auto_delete=60)
+            boxlite.BoxOptions(image="alpine:latest", auto_remove=False, auto_delete=0)
         )
         box_id = box.id
         await box.stop()
-        assert await runtime.get_info(box_id) is None
+        assert await runtime.get_info(box_id) is not None
+        await runtime.remove(box_id)
 
     async def test_auto_remove_true_removes_box_on_stop(self, runtime):
         """Test that auto_remove=True removes box when stop() is called."""
@@ -164,7 +182,7 @@ class TestDetachOption:
 
     async def test_detach_true_creates_box(self, runtime):
         """Test that detach=True creates box successfully."""
-        # Detached boxes opt out of removal with the deprecated compatibility flag.
+        # A detached box outlives its creator, so synchronous removal is off.
         box = await runtime.create(
             boxlite.BoxOptions(
                 image="alpine:latest",
@@ -190,14 +208,30 @@ class TestOptionCombinations:
             auto_remove=True,
             detach=True,
         )
-        with pytest.raises(RuntimeError, match="remove-on-stop is incompatible"):
+        with pytest.raises(RuntimeError, match="auto_remove is incompatible"):
             await runtime.create(opts)
 
-    async def test_auto_delete_overrides_auto_remove_for_detach(self, runtime):
+    async def test_detach_needs_auto_remove_off_not_a_zero_deadline(self, runtime):
+        """`auto_delete=0` no longer cancels `auto_remove`.
+
+        The two are independent axes, so turning the deadline off says nothing
+        about synchronous removal — and `auto_remove` is what conflicts with
+        detach. Only clearing that axis makes the box valid.
+        """
+        with pytest.raises(RuntimeError, match="auto_remove is incompatible"):
+            await runtime.create(
+                boxlite.BoxOptions(
+                    image="alpine:latest",
+                    auto_remove=True,
+                    auto_delete=0,
+                    detach=True,
+                )
+            )
+
         box = await runtime.create(
             boxlite.BoxOptions(
                 image="alpine:latest",
-                auto_remove=True,
+                auto_remove=False,
                 auto_delete=0,
                 detach=True,
             )

--- a/src/boxlite/examples/issue_1072_boot.rs
+++ b/src/boxlite/examples/issue_1072_boot.rs
@@ -27,7 +27,7 @@ fn options(network: NetworkSpec, network_enabled: bool, jailer_enabled: bool) ->
     BoxOptions {
         network,
         rootfs: RootfsSpec::Image("alpine:latest".into()),
-        auto_delete: Some(0),
+        auto_remove: false,
         advanced,
         ..Default::default()
     }

--- a/src/boxlite/src/db/migration/mod.rs
+++ b/src/boxlite/src/db/migration/mod.rs
@@ -4,6 +4,7 @@
 //! [`all_migrations`]. Migrations run sequentially on startup when the
 //! database schema version is older than the current version.
 
+mod v10_to_v11;
 mod v2_to_v3;
 mod v3_to_v4;
 mod v4_to_v5;
@@ -83,5 +84,65 @@ fn all_migrations() -> Vec<Box<dyn Migration>> {
         Box::new(v7_to_v8::RenameNetworkSpec),
         Box::new(v8_to_v9::PreservePublishedPorts),
         Box::new(v9_to_v10::DropAmbiguousEmptyCapabilities),
+        Box::new(v10_to_v11::SplitFusedDeletionAxes),
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Registration is what actually makes a migration run: each migration's
+    /// own tests call `run` directly and would pass just the same if it were
+    /// never added to the registry. Drive the whole chain instead, starting
+    /// from the version a released build leaves behind.
+    #[test]
+    fn the_chain_reaches_the_current_schema_and_rescues_a_legacy_box() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE schema_version (
+                 id INTEGER PRIMARY KEY,
+                 version INTEGER,
+                 updated_at TEXT
+             );
+             INSERT INTO schema_version (id, version, updated_at) VALUES (1, 10, '');
+             CREATE TABLE box_config (
+                 id TEXT PRIMARY KEY,
+                 name TEXT,
+                 created_at INTEGER,
+                 json TEXT NOT NULL
+             );",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO box_config (id, name, created_at, json) VALUES ('legacy', NULL, 0, ?1)",
+            rusqlite::params![r#"{"options":{"auto_remove":true,"auto_delete":0}}"#],
+        )
+        .unwrap();
+
+        run_migrations(&conn, 10, None).unwrap();
+
+        let version: i32 = conn
+            .query_row(
+                "SELECT version FROM schema_version WHERE id = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(version, crate::db::schema::SCHEMA_VERSION);
+
+        let json: String = conn
+            .query_row(
+                "SELECT json FROM box_config WHERE id = 'legacy'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let config: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            config.pointer("/options/auto_remove"),
+            Some(&false.into()),
+            "an ordinary pre-upgrade box must not come back marked remove-on-stop"
+        );
+    }
 }

--- a/src/boxlite/src/db/migration/v10_to_v11.rs
+++ b/src/boxlite/src/db/migration/v10_to_v11.rs
@@ -1,0 +1,252 @@
+//! Migration v10 → v11: split the fused deletion axes on persisted boxes.
+//!
+//! `auto_remove` and `auto_delete` used to resolve to one policy:
+//!
+//! ```ignore
+//! auto_delete.unwrap_or(auto_remove as u32) > 0   // removes on stop
+//! ```
+//!
+//! so `auto_delete` *overrode* `auto_remove` whenever it was present, and the
+//! released CLI always made it present — `Some(0)` for an ordinary box and
+//! `Some(1)` for `--rm`. `auto_remove` was never written and so serialized as
+//! its `true` default, which the old rule then ignored.
+//!
+//! `removes_on_stop()` now reads `auto_remove` alone, so those same rows would
+//! be read as "remove this box the moment it stops": every ordinary box
+//! persisted by an older build carries `auto_remove:true` next to its
+//! `auto_delete:0`. `recover_boxes` acts on that during `initialize`, so
+//! without this migration the first command after upgrading — a bare
+//! `boxlite ls` — deletes every pre-upgrade box that was not created with
+//! `--rm`.
+//!
+//! Rewriting the rows once, here, is where the database's copy of the old
+//! shape is resolved while it can still be read as what it meant. Afterwards
+//! the two fields are independent: a `auto_delete` deadline is a real deferred
+//! deadline rather than a spelling of remove-on-stop, so the key is dropped and
+//! `auto_remove` carries the whole decision. No pre-split box can have had a
+//! deferred deadline — nothing enforced one — so nothing is lost by clearing
+//! it.
+//!
+//! The database is not the only store holding that shape: an exported archive
+//! carries the same fused `box_options` in its manifest, and
+//! `options_from_manifest` resolves it there by the same rule for anything
+//! below `SPLIT_DELETION_ARCHIVE_VERSION`. A migration cannot reach that copy,
+//! because import writes a *new* row long after this has run.
+
+use std::path::Path;
+
+use rusqlite::Connection;
+
+use boxlite_shared::errors::{BoxliteError, BoxliteResult};
+
+use super::{Migration, db_err};
+
+pub(crate) struct SplitFusedDeletionAxes;
+
+/// The pre-split rule, applied to the persisted JSON shape.
+///
+/// `auto_delete` present wins, exactly as `effective_auto_delete` did; only a
+/// missing (or null) `auto_delete` fell back to `auto_remove`, which itself
+/// defaulted to `true` when absent.
+fn removed_on_stop(options: &serde_json::Map<String, serde_json::Value>) -> bool {
+    match options
+        .get("auto_delete")
+        .and_then(serde_json::Value::as_u64)
+    {
+        Some(seconds) => seconds > 0,
+        None => options
+            .get("auto_remove")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(true),
+    }
+}
+
+impl Migration for SplitFusedDeletionAxes {
+    fn source_version(&self) -> i32 {
+        10
+    }
+
+    fn target_version(&self) -> i32 {
+        11
+    }
+
+    fn description(&self) -> &str {
+        "Split the fused auto_remove/auto_delete policy on legacy box configs"
+    }
+
+    fn run(&self, conn: &Connection, _home_dir: Option<&Path>) -> BoxliteResult<()> {
+        let configs = {
+            let mut statement = db_err!(conn.prepare("SELECT id, json FROM box_config"))?;
+            let rows = db_err!(statement.query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            }))?;
+            db_err!(rows.collect::<Result<Vec<_>, _>>())?
+        };
+
+        let mut updates = Vec::new();
+
+        for (id, json) in configs {
+            let mut config: serde_json::Value = serde_json::from_str(&json).map_err(|error| {
+                BoxliteError::Database(format!(
+                    "parse box_config {id} while splitting deletion axes: {error}"
+                ))
+            })?;
+
+            let Some(options) = config.pointer_mut("/options") else {
+                continue;
+            };
+            let Some(options) = options.as_object_mut() else {
+                continue;
+            };
+
+            let removes = removed_on_stop(options);
+            options.insert("auto_remove".to_string(), serde_json::Value::Bool(removes));
+            options.remove("auto_delete");
+
+            let json = serde_json::to_string(&config).map_err(|error| {
+                BoxliteError::Database(format!(
+                    "serialize box_config {id} while splitting deletion axes: {error}"
+                ))
+            })?;
+            updates.push((id, json));
+        }
+
+        let transaction = db_err!(conn.unchecked_transaction())?;
+        for (id, json) in &updates {
+            db_err!(transaction.execute(
+                "UPDATE box_config SET json = ?1 WHERE id = ?2",
+                rusqlite::params![json, id],
+            ))?;
+        }
+        db_err!(transaction.commit())?;
+
+        if !updates.is_empty() {
+            tracing::info!(
+                boxes = updates.len(),
+                "Split fused deletion policy on legacy box configs"
+            );
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn open_with_box_config(rows: &[(&str, &str)]) -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE box_config (
+                id TEXT PRIMARY KEY,
+                name TEXT,
+                created_at INTEGER,
+                json TEXT NOT NULL
+            )",
+        )
+        .unwrap();
+        for (id, json) in rows {
+            conn.execute(
+                "INSERT INTO box_config (id, name, created_at, json) VALUES (?1, NULL, 0, ?2)",
+                rusqlite::params![id, json],
+            )
+            .unwrap();
+        }
+        conn
+    }
+
+    fn load_json(conn: &Connection, id: &str) -> serde_json::Value {
+        let json: String = conn
+            .query_row("SELECT json FROM box_config WHERE id = ?1", [id], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        serde_json::from_str(&json).unwrap()
+    }
+
+    #[test]
+    fn an_ordinary_legacy_box_survives_the_upgrade() {
+        // The shape every `boxlite run` / `create` without `--rm` persisted:
+        // an explicit `auto_delete:0` beside the untouched `auto_remove:true`
+        // default. Read under the new rule this says "delete on stop", and
+        // recovery would destroy the box on the next command.
+        let conn = open_with_box_config(&[(
+            "ordinary",
+            r#"{"options":{"auto_remove":true,"auto_delete":0}}"#,
+        )]);
+
+        SplitFusedDeletionAxes.run(&conn, None).unwrap();
+
+        let value = load_json(&conn, "ordinary");
+        assert_eq!(value.pointer("/options/auto_remove"), Some(&false.into()));
+        assert!(
+            value.pointer("/options/auto_delete").is_none(),
+            "the fused sentinel must not survive as a deferred deadline"
+        );
+
+        // Read the migrated row back through the type whose reading of it is
+        // the actual bug: `recover_boxes` asks `removes_on_stop()`, not the
+        // JSON, and that is what must now answer "keep".
+        let options: crate::runtime::options::BoxOptions =
+            serde_json::from_value(value.pointer("/options").unwrap().clone())
+                .expect("a migrated row must still deserialize");
+        assert!(
+            !options.removes_on_stop(),
+            "recovery must not treat a migrated legacy box as ephemeral"
+        );
+    }
+
+    #[test]
+    fn a_legacy_rm_box_keeps_removing_on_stop() {
+        // `--rm` was spelled `auto_delete:1`; that must land on the synchronous
+        // axis rather than becoming a 1-second deadline.
+        let conn = open_with_box_config(&[(
+            "ephemeral",
+            r#"{"options":{"auto_remove":true,"auto_delete":1}}"#,
+        )]);
+
+        SplitFusedDeletionAxes.run(&conn, None).unwrap();
+
+        let value = load_json(&conn, "ephemeral");
+        assert_eq!(value.pointer("/options/auto_remove"), Some(&true.into()));
+        assert!(value.pointer("/options/auto_delete").is_none());
+    }
+
+    #[test]
+    fn a_row_without_auto_delete_falls_back_to_auto_remove() {
+        // Only a missing `auto_delete` ever consulted `auto_remove`, so both
+        // spellings of that fallback must be preserved.
+        let conn = open_with_box_config(&[
+            ("kept", r#"{"options":{"auto_remove":false}}"#),
+            ("removed", r#"{"options":{"auto_remove":true}}"#),
+            ("defaulted", r#"{"options":{}}"#),
+        ]);
+
+        SplitFusedDeletionAxes.run(&conn, None).unwrap();
+
+        assert_eq!(
+            load_json(&conn, "kept").pointer("/options/auto_remove"),
+            Some(&false.into())
+        );
+        assert_eq!(
+            load_json(&conn, "removed").pointer("/options/auto_remove"),
+            Some(&true.into())
+        );
+        // An absent `auto_remove` deserialized as its `true` default.
+        assert_eq!(
+            load_json(&conn, "defaulted").pointer("/options/auto_remove"),
+            Some(&true.into())
+        );
+    }
+
+    #[test]
+    fn leaves_a_config_with_no_options_section_alone() {
+        let conn = open_with_box_config(&[("bare", r#"{"id":"bare"}"#)]);
+
+        // Must not error when there's nothing to migrate.
+        SplitFusedDeletionAxes.run(&conn, None).unwrap();
+
+        assert!(load_json(&conn, "bare").pointer("/options").is_none());
+    }
+}

--- a/src/boxlite/src/db/schema.rs
+++ b/src/boxlite/src/db/schema.rs
@@ -7,7 +7,7 @@
 //! Each table has queryable columns for efficient filtering + JSON blob for full data.
 
 /// Current schema version.
-pub const SCHEMA_VERSION: i32 = 10;
+pub const SCHEMA_VERSION: i32 = 11;
 
 /// Schema version tracking table.
 pub const SCHEMA_VERSION_TABLE: &str = r#"

--- a/src/boxlite/src/experimental.rs
+++ b/src/boxlite/src/experimental.rs
@@ -105,12 +105,31 @@ impl ExperimentalFeatures {
     }
 }
 
+/// Runtime-scoped capability declarations supplied by the embedder.
+///
+/// Grouped into one type so adding a capability does not grow every runtime
+/// constructor's argument list.
+#[derive(Clone, Debug, Default)]
+pub struct RuntimeCapabilities {
+    /// Release-candidate options this runtime will accept.
+    pub features: ExperimentalFeatures,
+
+    /// Whether the embedder runs a lifecycle sweeper that will act on the
+    /// `auto_stop` / `auto_delete` deadlines.
+    ///
+    /// The engine never sweeps on its own. Accepting a deadline nothing acts on
+    /// would store policy that is silently inert, so a runtime without a sweeper
+    /// refuses an explicit deadline instead of pretending to honour it.
+    /// `boxlite serve` sets this; a bare embedded runtime leaves it false.
+    pub lifecycle_sweeper: bool,
+}
+
 /// Builder for a local runtime with explicit release-candidate capabilities.
 #[derive(Clone, Debug)]
 #[must_use]
 pub struct RuntimeBuilder {
     options: BoxliteOptions,
-    features: ExperimentalFeatures,
+    capabilities: RuntimeCapabilities,
 }
 
 impl RuntimeBuilder {
@@ -118,25 +137,34 @@ impl RuntimeBuilder {
     pub fn new(options: BoxliteOptions) -> Self {
         Self {
             options,
-            features: ExperimentalFeatures::default(),
+            capabilities: RuntimeCapabilities::default(),
         }
     }
 
     /// Enable one release-candidate capability for this runtime.
     pub fn enable(mut self, feature: ExperimentalFeature) -> Self {
-        self.features.enabled.insert(feature);
+        self.capabilities.features.enabled.insert(feature);
         self
     }
 
     /// Replace the capabilities enabled for this runtime.
     pub fn with_features(mut self, features: ExperimentalFeatures) -> Self {
-        self.features = features;
+        self.capabilities.features = features;
+        self
+    }
+
+    /// Declare that this embedder enforces lifecycle deadlines.
+    ///
+    /// Without this, `auto_stop` and `auto_delete` are refused rather than
+    /// stored inertly. Set it only when a sweeper really runs.
+    pub fn with_lifecycle_sweeper(mut self, enabled: bool) -> Self {
+        self.capabilities.lifecycle_sweeper = enabled;
         self
     }
 
     /// Construct the local runtime with the selected capabilities.
     pub fn build(self) -> BoxliteResult<BoxliteRuntime> {
-        BoxliteRuntime::new_with_experimental_features(self.options, self.features)
+        BoxliteRuntime::new_with_capabilities(self.options, self.capabilities)
     }
 }
 

--- a/src/boxlite/src/lib.rs
+++ b/src/boxlite/src/lib.rs
@@ -64,7 +64,7 @@ pub use runtime::id::{BaseDiskID, BaseDiskIDMint, BoxID, BoxIDMint};
 pub use runtime::types::ContainerID;
 pub use runtime::types::{
     BoxInfo, BoxLifecyclePolicy, BoxState, BoxStateInfo, BoxStatus, NetworkDirectionInfo,
-    NetworkInfo, PublishedPort,
+    NetworkInfo, PublishedPort, Seconds,
 };
 
 #[cfg(feature = "rest")]

--- a/src/boxlite/src/litebox/archive.rs
+++ b/src/boxlite/src/litebox/archive.rs
@@ -34,8 +34,39 @@ pub(crate) const CAPABILITY_POLICY_ARCHIVE_VERSION: u32 = 4;
 /// v5, and the importer canonicalizes anything below it.
 pub(crate) const PUBLISHED_PORTS_ARCHIVE_VERSION: u32 = 5;
 
+/// First archive version whose deletion axes are split.
+///
+/// Up to v5 `auto_remove` and `auto_delete` resolved to one policy, with
+/// `auto_delete` taking precedence: `Some(0)` meant "keep the box", any
+/// non-zero value meant "remove it as soon as it stops", and no deferred
+/// deadline could be expressed at all. A pre-split importer reading a v6
+/// archive's real `auto_delete` deadline under that rule would delete the box
+/// the moment it stopped instead of after the deadline, so an archive that
+/// carries a deadline is stamped v6 and such an importer refuses it.
+pub(crate) const SPLIT_DELETION_ARCHIVE_VERSION: u32 = 6;
+
 /// Maximum archive version this build can import.
-pub(crate) const MAX_SUPPORTED_VERSION: u32 = PUBLISHED_PORTS_ARCHIVE_VERSION;
+pub(crate) const MAX_SUPPORTED_VERSION: u32 = SPLIT_DELETION_ARCHIVE_VERSION;
+
+/// Whether a pre-split importer would act on these options differently.
+///
+/// Such an importer resolves the two deletion fields as
+/// `auto_delete.unwrap_or(auto_remove) > 0`, and cannot represent a deferred
+/// deadline at all. This must stay the exact complement of the rewrite window
+/// in `options_from_manifest`: anything left below v6 is re-read through that
+/// old rule by this build too, so a shape the two disagree about would be
+/// silently rewritten on its own round trip.
+fn pre_split_importer_disagrees(options: &crate::runtime::options::BoxOptions) -> bool {
+    match options.auto_delete {
+        // A real deadline. The old rule removes the box the moment it stops
+        // instead of waiting for it.
+        Some(seconds) if seconds > 0 => true,
+        // An explicit `0` overrode `auto_remove` under the old rule, so an
+        // importer reads "keep" exactly where this build removes on stop.
+        Some(_) => options.auto_remove,
+        None => false,
+    }
+}
 
 /// Pick the archive format an exported box needs.
 ///
@@ -45,7 +76,9 @@ pub(crate) const MAX_SUPPORTED_VERSION: u32 = PUBLISHED_PORTS_ARCHIVE_VERSION;
 /// rather than silently drop. Only `None` (the caller never touched the
 /// field) is indistinguishable from what a v3 importer already does.
 pub(crate) fn archive_version_for_options(options: &crate::runtime::options::BoxOptions) -> u32 {
-    if !options.ports.is_empty() {
+    if pre_split_importer_disagrees(options) {
+        SPLIT_DELETION_ARCHIVE_VERSION
+    } else if !options.ports.is_empty() {
         PUBLISHED_PORTS_ARCHIVE_VERSION
     } else if options.advanced.capabilities().is_none() {
         ARCHIVE_VERSION
@@ -61,9 +94,10 @@ pub(crate) fn archive_version_for_options(options: &crate::runtime::options::Box
 /// v3: adds `box_options` for full configuration preservation
 /// v4: `box_options.advanced` carries a custom capability policy
 /// v5: `ports` carry publication semantics (automatic host port, bind IP)
+/// v6: `auto_remove` and `auto_delete` are independent axes
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ArchiveManifest {
-    /// Archive format version (1 through 5).
+    /// Archive format version (1 through 6).
     pub version: u32,
     /// Original box name (optional, may be renamed on import).
     pub box_name: Option<String>,
@@ -417,6 +451,64 @@ mod tests {
             "an export carrying ports must be stamped at or above the version \
              below which the importer rewrites them"
         );
+    }
+
+    /// The same invariant for the deletion axes: anything left below v6 is
+    /// re-read through the pre-split rule by this build too, so a shape that
+    /// rule disagrees about would be rewritten on its own round trip. The one
+    /// that bit: `auto_remove` beside an explicit `auto_delete: 0` stamped v3,
+    /// and re-importing took the `Some(0) => false` arm and silently dropped
+    /// remove-on-stop.
+    #[test]
+    fn this_builds_deletion_exports_are_never_rewritten_on_import() {
+        for options in [
+            crate::runtime::options::BoxOptions {
+                auto_remove: true,
+                auto_delete: Some(0),
+                ..Default::default()
+            },
+            crate::runtime::options::BoxOptions {
+                auto_remove: false,
+                auto_delete: Some(3_600),
+                ..Default::default()
+            },
+        ] {
+            assert!(
+                archive_version_for_options(&options) >= SPLIT_DELETION_ARCHIVE_VERSION,
+                "an export a pre-split importer would misread must be stamped at \
+                 or above the version below which the importer rewrites it: \
+                 auto_remove={} auto_delete={:?}",
+                options.auto_remove,
+                options.auto_delete,
+            );
+        }
+    }
+
+    /// The complement: a shape both rules agree on must stay at the lowest
+    /// version that is safe, so ordinary boxes keep importing into older
+    /// builds.
+    #[test]
+    fn an_agreed_deletion_shape_is_not_pushed_to_v6() {
+        for options in [
+            crate::runtime::options::BoxOptions {
+                auto_remove: true,
+                auto_delete: None,
+                ..Default::default()
+            },
+            crate::runtime::options::BoxOptions {
+                auto_remove: false,
+                auto_delete: Some(0),
+                ..Default::default()
+            },
+        ] {
+            assert!(
+                archive_version_for_options(&options) < SPLIT_DELETION_ARCHIVE_VERSION,
+                "a pre-split importer reads this shape correctly and must not be \
+                 locked out of it: auto_remove={} auto_delete={:?}",
+                options.auto_remove,
+                options.auto_delete,
+            );
+        }
     }
 
     #[test]

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -1745,7 +1745,7 @@ mod tests {
             options: BoxOptions {
                 rootfs: RootfsSpec::Image("alpine:latest".into()),
                 detach: true,
-                auto_delete: Some(0),
+                auto_remove: false,
                 ..Default::default()
             },
             engine_kind: VmmKind::Libkrun,
@@ -1995,7 +1995,7 @@ mod tests {
             options: BoxOptions {
                 rootfs: RootfsSpec::Image("alpine:latest".into()),
                 detach: false,
-                auto_delete: Some(0),
+                auto_remove: false,
                 ..Default::default()
             },
             engine_kind: VmmKind::Libkrun,
@@ -2074,7 +2074,9 @@ mod tests {
             options: BoxOptions {
                 rootfs: RootfsSpec::Image("alpine:latest".into()),
                 detach: false,
-                auto_delete: Some(u32::from(removes_on_stop)),
+                // Synchronous removal is `auto_remove`'s axis; `auto_delete` is a
+                // deferred deadline that needs a sweeper this runtime has none of.
+                auto_remove: removes_on_stop,
                 ports,
                 ..Default::default()
             },

--- a/src/boxlite/src/litebox/init/mod.rs
+++ b/src/boxlite/src/litebox/init/mod.rs
@@ -192,7 +192,7 @@ impl BoxBuilder {
         // validate only their stored shape here; the boot-assets task reopens a
         // source only when no complete box-scoped generation exists.
         let options = &config.options;
-        validate_persisted_options(&runtime.experimental_features, options)?;
+        validate_persisted_options(&runtime.capabilities.features, options)?;
 
         Ok(Self {
             runtime,

--- a/src/boxlite/src/litebox/state.rs
+++ b/src/boxlite/src/litebox/state.rs
@@ -63,6 +63,17 @@ impl BoxStatus {
         matches!(self, BoxStatus::Running)
     }
 
+    /// Whether the box has come to rest, and so is subject to an AutoDelete
+    /// deadline measured from that transition.
+    ///
+    /// `Failed` counts: it will never run again on its own, so excluding it
+    /// would leak exactly the boxes nobody goes back to clean up. Anything that
+    /// acts on a deadline and anything that reports one read this same rule, so
+    /// the schedule a box is on and the deadline it shows cannot drift apart.
+    pub fn is_at_rest(&self) -> bool {
+        matches!(self, BoxStatus::Stopped | BoxStatus::Failed)
+    }
+
     pub fn is_configured(&self) -> bool {
         matches!(self, BoxStatus::Configured)
     }

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -208,9 +208,10 @@ impl CreateBoxRequest {
                     capabilities: capabilities.clone(),
                 }
             }),
-            // The deprecated remove-on-stop flag was never applied by the cloud
-            // control-plane mapper. Keep remote defaults unchanged and only send
-            // the modern lifecycle fields when callers explicitly configure them.
+            // `auto_remove` is deliberately absent: it is the synchronous
+            // remove-on-stop axis, which the wire contract does not carry and
+            // the server could not honour. Keep remote defaults unchanged and
+            // send a lifecycle field only when the caller configured it.
             auto_stop: options.auto_stop,
             auto_delete: options.auto_delete,
             auto_resume: options.auto_resume,
@@ -915,8 +916,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(deprecated)]
-    fn deprecated_auto_remove_does_not_change_rest_lifecycle_defaults() {
+    fn auto_remove_is_never_transmitted_to_a_rest_runtime() {
         for auto_remove in [false, true] {
             let opts = BoxOptions {
                 auto_remove,

--- a/src/boxlite/src/runtime/core.rs
+++ b/src/boxlite/src/runtime/core.rs
@@ -3,7 +3,6 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 
-use crate::experimental::ExperimentalFeatures;
 use crate::litebox::LiteBox;
 use crate::metrics::RuntimeMetrics;
 use crate::runtime::backend::RuntimeBackend;
@@ -91,13 +90,11 @@ impl BoxliteRuntime {
         Ok(Self::from_local(local))
     }
 
-    pub(crate) fn new_with_experimental_features(
+    pub(crate) fn new_with_capabilities(
         options: BoxliteOptions,
-        features: ExperimentalFeatures,
+        capabilities: crate::experimental::RuntimeCapabilities,
     ) -> BoxliteResult<Self> {
-        let local = LocalRuntime(RuntimeImpl::new_with_experimental_features(
-            options, features,
-        )?);
+        let local = LocalRuntime(RuntimeImpl::new_with_capabilities(options, capabilities)?);
         Ok(Self::from_local(local))
     }
 
@@ -561,11 +558,14 @@ mod tests {
 
     #[tokio::test]
     async fn create_rejects_detached_remove_on_stop() {
-        // Remove-on-stop (auto_delete>0) with detach=true is contradictory. The
-        // create boundary must reject it up front rather than deferring to start().
+        // Remove-on-stop (`auto_remove`) with detach=true is contradictory: the box
+        // is meant to outlive its creator, yet would be deleted the moment it
+        // stops. The create boundary must reject it up front rather than deferring
+        // to start(). A deferred `auto_delete` deadline is the compatible spelling
+        // and is covered separately.
         let (runtime, _dir) = local_runtime();
         let opts = BoxOptions {
-            auto_delete: Some(1),
+            auto_remove: true,
             detach: true,
             ..Default::default()
         };
@@ -582,7 +582,7 @@ mod tests {
             "expected an InvalidArgument error, got: {err:?}"
         );
         assert!(
-            err.to_string().contains("remove-on-stop is incompatible"),
+            err.to_string().contains("auto_remove is incompatible"),
             "unexpected message: {err}"
         );
     }

--- a/src/boxlite/src/runtime/import.rs
+++ b/src/boxlite/src/runtime/import.rs
@@ -9,7 +9,7 @@ use crate::disk::constants::filenames as disk_filenames;
 use crate::litebox::LiteBox;
 use crate::litebox::archive::{
     ArchiveManifest, MANIFEST_FILENAME, MAX_SUPPORTED_VERSION, PUBLISHED_PORTS_ARCHIVE_VERSION,
-    extract_archive, move_file, sha256_file,
+    SPLIT_DELETION_ARCHIVE_VERSION, extract_archive, move_file, sha256_file,
 };
 use crate::runtime::advanced_options::SecurityOptions;
 use crate::runtime::options::{
@@ -93,6 +93,21 @@ fn options_from_manifest(
                 "Canonicalized legacy archive port mappings"
             );
         }
+    }
+    // Up to v5 the two deletion axes shared one integer, with `auto_delete`
+    // taking precedence: `Some(0)` meant "keep the box after stop" and any
+    // non-zero value meant "remove it as soon as it stops". Every archive an
+    // older build wrote therefore carries `auto_delete:0` beside the
+    // `auto_remove:true` default it never wrote. Read under the split rule that
+    // says remove-on-stop, which — since such a box is also detached — sanitize
+    // rejects outright, making those archives unimportable. Resolve them the
+    // way the build that wrote them did, before validating.
+    if manifest.version < SPLIT_DELETION_ARCHIVE_VERSION {
+        options.auto_remove = match options.auto_delete {
+            Some(seconds) => seconds > 0,
+            None => options.auto_remove,
+        };
+        options.auto_delete = None;
     }
     options.sanitize().map_err(|error| {
         BoxliteError::InvalidArgument(format!("invalid archive box_options: {error}"))
@@ -321,6 +336,71 @@ mod tests {
             preserved.ports, options.ports,
             "a v5 archive carries publication semantics and must survive import intact"
         );
+    }
+
+    /// Every archive an older build wrote carries the fused shape: an explicit
+    /// `auto_delete:0` beside the `auto_remove:true` default it never wrote,
+    /// on a box `create` had already detached. Read under the split rule that
+    /// is remove-on-stop, which sanitize refuses next to `detach`, so the
+    /// archive stops being importable at all.
+    #[test]
+    fn a_pre_split_archive_keeps_the_box_it_asked_to_keep() {
+        let options = BoxOptions {
+            auto_remove: true,
+            auto_delete: Some(0),
+            detach: true,
+            ..Default::default()
+        };
+
+        let mut legacy = v3_manifest(options);
+        legacy.version = SPLIT_DELETION_ARCHIVE_VERSION - 1;
+
+        let imported = options_from_manifest(&legacy, ArchiveImportPolicy::Trusted)
+            .expect("a legacy archive must stay importable");
+
+        assert!(
+            !imported.auto_remove,
+            "auto_delete:0 meant keep the box, so it must not become remove-on-stop"
+        );
+        assert_eq!(imported.auto_delete, None);
+    }
+
+    /// The `--rm` spelling has to land on the synchronous axis, not become a
+    /// one-second deadline that outlives the import.
+    #[test]
+    fn a_pre_split_rm_archive_still_removes_on_stop() {
+        let options = BoxOptions {
+            auto_remove: false,
+            auto_delete: Some(1),
+            ..Default::default()
+        };
+
+        let mut legacy = v3_manifest(options);
+        legacy.version = SPLIT_DELETION_ARCHIVE_VERSION - 1;
+
+        let imported = options_from_manifest(&legacy, ArchiveImportPolicy::Trusted).unwrap();
+
+        assert!(imported.auto_remove);
+        assert_eq!(imported.auto_delete, None);
+    }
+
+    /// A current archive's deadline is a real deferred deadline and must not be
+    /// collapsed onto the synchronous axis.
+    #[test]
+    fn a_split_archive_keeps_its_deferred_deadline() {
+        let options = BoxOptions {
+            auto_remove: false,
+            auto_delete: Some(3_600),
+            ..Default::default()
+        };
+
+        let mut current = v3_manifest(options);
+        current.version = SPLIT_DELETION_ARCHIVE_VERSION;
+
+        let imported = options_from_manifest(&current, ArchiveImportPolicy::Trusted).unwrap();
+
+        assert_eq!(imported.auto_delete, Some(3_600));
+        assert!(!imported.auto_remove);
     }
 
     #[test]

--- a/src/boxlite/src/runtime/options.rs
+++ b/src/boxlite/src/runtime/options.rs
@@ -343,28 +343,29 @@ pub struct BoxOptions {
     /// Remote runtimes reject port mappings; use a box network tunnel for
     /// portable local/remote access to a guest service.
     pub ports: Vec<PortSpec>,
-    /// Automatically remove the box when stopped.
+    /// Remove the box synchronously as soon as it stops (`--rm` semantics).
     ///
-    /// Deprecated: use [`BoxOptions::auto_delete`]. When `auto_delete` is set,
-    /// it takes precedence over this field. REST runtimes do not transmit this
-    /// legacy field and preserve the remote server's lifecycle defaults.
-    #[deprecated(note = "use auto_delete instead")]
+    /// A separate axis from [`BoxOptions::auto_delete`], not a legacy spelling
+    /// of it: this one removes the box the moment `stop()` returns, while
+    /// `auto_delete` is a deadline a sweeper acts on later. REST runtimes do not
+    /// transmit this field — the wire contract carries only `auto_delete`.
     #[serde(default = "default_auto_remove")]
     pub auto_remove: bool,
 
     /// Idle time in seconds before AutoStop. `Some(0)` disables AutoStop.
-    /// Only REST runtimes implement AutoStop; local runtimes return
-    /// `Unsupported`.
+    ///
+    /// Enforced by whoever runs a lifecycle sweeper — `boxlite serve` or the
+    /// cloud control plane. A runtime with no sweeper returns `Unsupported`
+    /// rather than storing a deadline nothing will act on.
     #[serde(default)]
     pub auto_stop: Option<u32>,
 
     /// Time in seconds after a successful stop before AutoDelete.
     ///
-    /// - `Some(0)`: keep the box after stop.
-    /// - `Some(n>0)`: REST runtimes delete after `n` seconds; local runtimes
-    ///   remove immediately on stop because they have no sweeper.
-    /// - `None` (default): local runtimes fall back to deprecated `auto_remove`;
-    ///   REST runtimes preserve the remote server's AutoDelete default.
+    /// `Some(0)` (or `None`) disables it. Like [`BoxOptions::auto_stop`], this
+    /// needs a sweeper, and a runtime without one returns `Unsupported`. For
+    /// immediate removal on stop, use [`BoxOptions::auto_remove`] instead —
+    /// that is a different axis and needs no sweeper.
     #[serde(default)]
     pub auto_delete: Option<u32>,
 
@@ -522,7 +523,6 @@ fn default_detach() -> bool {
     false
 }
 
-#[allow(deprecated)]
 impl Default for BoxOptions {
     fn default() -> Self {
         Self {
@@ -552,25 +552,27 @@ impl Default for BoxOptions {
 }
 
 impl BoxOptions {
-    /// Resolve the modern and deprecated deletion inputs to one policy.
-    #[allow(deprecated)]
-    pub(crate) fn effective_auto_delete(&self) -> u32 {
-        self.auto_delete
-            .unwrap_or_else(|| u32::from(self.auto_remove))
+    /// The AutoDelete deadline in seconds; `0` when there is none.
+    pub(crate) fn auto_delete_seconds(&self) -> u32 {
+        self.auto_delete.unwrap_or(0)
     }
 
-    /// Whether the box is removed when it stops.
+    /// Whether the box is removed synchronously as soon as it stops.
     ///
-    /// Explicit `auto_delete` takes precedence over deprecated `auto_remove`.
+    /// This is `--rm` / docker semantics and is a *different axis* from
+    /// [`BoxOptions::auto_delete`], which is a deferred deadline a sweeper acts
+    /// on later. Keeping them separate is what lets a detached box outlive the
+    /// process that made it and still be swept on its own schedule; while one
+    /// integer carried both meanings, `auto_delete = 1` was spent as the `--rm`
+    /// sentinel and no real deadline could coexist with it.
     pub(crate) fn removes_on_stop(&self) -> bool {
-        self.effective_auto_delete() > 0
+        self.auto_remove
     }
 
     /// Sanitize and validate options.
     ///
     /// Validates option combinations:
-    /// - effective remove-on-stop (`auto_delete>0`, or deprecated `auto_remove`)
-    ///   with `detach=true` is invalid
+    /// - remove-on-stop (`auto_remove`) with `detach=true` is invalid
     /// - `advanced.isolate_mounts=true` is only supported on Linux
     /// - `advanced.capabilities` contains well-formed Linux capability names
     /// - `advanced.security.network_enabled=false` is not mistaken for a
@@ -578,8 +580,9 @@ impl BoxOptions {
     pub(crate) fn sanitize_common(&self) -> BoxliteResult<()> {
         if self.removes_on_stop() && self.detach {
             return Err(boxlite_shared::errors::BoxliteError::InvalidArgument(
-                "remove-on-stop is incompatible with detach=true. Detached boxes should use \
-                 auto_delete=0 (or deprecated auto_remove=false) for manual lifecycle control."
+                "auto_remove is incompatible with detach=true. A detached box outlives the \
+                 process that created it, so use auto_delete=<seconds> for a deferred deadline \
+                 or auto_remove=false for manual lifecycle control."
                     .to_string(),
             ));
         }
@@ -1198,13 +1201,12 @@ mod tests {
     }
 
     #[test]
-    #[allow(deprecated)]
     fn test_box_options_defaults() {
         let opts = BoxOptions::default();
         assert!(opts.removes_on_stop());
         assert!(
             opts.auto_remove,
-            "auto_remove should keep its legacy default"
+            "auto_remove should keep its default of true"
         );
         assert!(!opts.detach, "detach should default to false");
         assert!(
@@ -1486,29 +1488,51 @@ mod tests {
         assert!(error.contains("regular file"), "unexpected error: {error}");
     }
 
+    /// `auto_remove` and `auto_delete` are independent axes: one removes the box
+    /// synchronously on stop, the other is a deadline a sweeper acts on later.
+    /// Neither may be inferred from the other — while they were fused, a `--rm`
+    /// box was indistinguishable from one with a 1-second deadline, and a real
+    /// deadline forced synchronous deletion the moment the box stopped.
     #[test]
-    #[allow(deprecated)]
-    fn explicit_auto_delete_takes_precedence_over_auto_remove() {
-        let keep = BoxOptions {
-            auto_remove: true,
-            auto_delete: Some(0),
-            ..Default::default()
-        };
-        assert!(!keep.removes_on_stop());
+    fn remove_on_stop_and_the_delete_deadline_are_independent() {
+        for auto_delete in [None, Some(0), Some(1), Some(604_800)] {
+            for auto_remove in [false, true] {
+                let opts = BoxOptions {
+                    auto_remove,
+                    auto_delete,
+                    ..Default::default()
+                };
 
-        let remove = BoxOptions {
-            auto_remove: false,
-            auto_delete: Some(60),
-            ..Default::default()
-        };
-        assert!(remove.removes_on_stop());
+                assert_eq!(
+                    opts.removes_on_stop(),
+                    auto_remove,
+                    "removes_on_stop must track auto_remove alone \
+                     (auto_delete={auto_delete:?}, auto_remove={auto_remove})"
+                );
+                assert_eq!(
+                    opts.auto_delete_seconds(),
+                    auto_delete.unwrap_or(0),
+                    "the deadline must track auto_delete alone \
+                     (auto_delete={auto_delete:?}, auto_remove={auto_remove})"
+                );
+            }
+        }
+    }
 
-        let legacy_keep = BoxOptions {
+    /// The pairing that was previously unrepresentable: a detached box that
+    /// deletes itself a week after it stops. Fused, this failed validation
+    /// because any deadline implied synchronous removal, which detach forbids.
+    #[test]
+    fn a_detached_box_may_carry_a_delete_deadline() {
+        let opts = BoxOptions {
             auto_remove: false,
-            auto_delete: None,
+            auto_delete: Some(604_800),
+            detach: true,
             ..Default::default()
         };
-        assert!(!legacy_keep.removes_on_stop());
+
+        opts.sanitize_common()
+            .expect("a deferred deadline is compatible with detach");
     }
 
     #[test]
@@ -1633,7 +1657,7 @@ mod tests {
     #[test]
     fn test_box_options_roundtrip() {
         let opts = BoxOptions {
-            auto_delete: Some(0),
+            auto_remove: false,
             detach: true,
             ..Default::default()
         };
@@ -1834,7 +1858,7 @@ mod tests {
     #[test]
     fn test_sanitize_remove_on_stop_detach_incompatible() {
         let mut opts = BoxOptions {
-            auto_delete: Some(1),
+            auto_remove: true,
             detach: true,
             ..Default::default()
         };
@@ -1844,21 +1868,36 @@ mod tests {
 
     #[test]
     fn test_sanitize_valid_combinations() {
-        let mut remove = BoxOptions {
-            auto_delete: Some(1),
+        // Attached + remove-on-stop: the `docker run --rm` shape.
+        let mut remove_attached = BoxOptions {
+            auto_remove: true,
+            detach: false,
             ..Default::default()
         };
-        assert!(remove.sanitize().is_ok());
+        assert!(remove_attached.sanitize().is_ok());
 
+        // Detached + kept: `docker run -d`. Only `auto_remove` conflicts with
+        // detach, so it must be off here.
         let mut keep_detached = BoxOptions {
-            auto_delete: Some(0),
+            auto_remove: false,
             detach: true,
             ..Default::default()
         };
         assert!(keep_detached.sanitize().is_ok());
 
+        // Detached + a deferred deadline: valid, and the whole point of keeping
+        // the two axes apart.
+        let mut swept_detached = BoxOptions {
+            auto_remove: false,
+            auto_delete: Some(3600),
+            detach: true,
+            ..Default::default()
+        };
+        assert!(swept_detached.sanitize().is_ok());
+
         let mut keep_attached = BoxOptions {
-            auto_delete: Some(0),
+            auto_remove: false,
+            detach: false,
             ..Default::default()
         };
         assert!(keep_attached.sanitize().is_ok());

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -1,5 +1,5 @@
 use crate::db::{BoxStore, Database};
-use crate::experimental::ExperimentalFeatures;
+use crate::experimental::RuntimeCapabilities;
 use crate::images::{ImageDiskManager, ImageManager};
 use crate::litebox::config::BoxConfig;
 use crate::litebox::{BoxManager, LiteBox, LocalSnapshotBackend, SharedBoxImpl};
@@ -148,8 +148,9 @@ pub struct RuntimeImpl {
     /// Runtime-wide metrics (AtomicU64 based, lock-free)
     pub(crate) runtime_metrics: RuntimeMetricsStorage,
 
-    /// Immutable release-candidate capability opt-ins for this runtime.
-    pub(crate) experimental_features: ExperimentalFeatures,
+    /// Immutable capability declarations for this runtime: release-candidate
+    /// feature opt-ins, and whether the embedder sweeps lifecycle deadlines.
+    pub(crate) capabilities: RuntimeCapabilities,
 
     /// Base disk manager for clone base lifecycle and ref-count tracking.
     pub(crate) base_disk_mgr: crate::disk::BaseDiskManager,
@@ -223,27 +224,27 @@ impl RuntimeImpl {
     ///
     /// Performs all initialization: filesystem setup, locks, managers, and box recovery.
     pub fn new(options: BoxliteOptions) -> BoxliteResult<SharedRuntimeImpl> {
-        Self::new_with_experimental_features(options, ExperimentalFeatures::default())
+        Self::new_with_capabilities(options, RuntimeCapabilities::default())
     }
 
-    pub(crate) fn new_with_experimental_features(
+    pub(crate) fn new_with_capabilities(
         options: BoxliteOptions,
-        experimental_features: ExperimentalFeatures,
+        capabilities: RuntimeCapabilities,
     ) -> BoxliteResult<SharedRuntimeImpl> {
         let _sys = crate::system_check::SystemCheck::run()?;
-        Self::initialize(options, experimental_features)
+        Self::initialize(options, capabilities)
     }
 
     /// Build a runtime without host validation. Tests using this must not exercise
     /// VM or hypervisor operations.
     #[cfg(test)]
     pub(crate) fn new_for_test(options: BoxliteOptions) -> BoxliteResult<SharedRuntimeImpl> {
-        Self::initialize(options, ExperimentalFeatures::default())
+        Self::initialize(options, RuntimeCapabilities::default())
     }
 
     fn initialize(
         options: BoxliteOptions,
-        experimental_features: ExperimentalFeatures,
+        capabilities: RuntimeCapabilities,
     ) -> BoxliteResult<SharedRuntimeImpl> {
         // Validate Early: Check preconditions before expensive work
         if !options.home_dir.is_absolute() {
@@ -355,7 +356,7 @@ impl RuntimeImpl {
             guest_rootfs_mgr,
             guest_rootfs: Arc::new(OnceCell::new()),
             runtime_metrics: RuntimeMetricsStorage::new(),
-            experimental_features,
+            capabilities,
             base_disk_mgr,
             snapshot_mgr,
             lock_manager,
@@ -1293,7 +1294,7 @@ impl RuntimeImpl {
         let persisted = self.box_manager.all_boxes(true)?;
 
         // Phase 1: Clean up boxes that shouldn't persist
-        // - remove-on-stop boxes (auto_delete): ephemeral, shouldn't survive restarts
+        // - remove-on-stop boxes (auto_remove): ephemeral, shouldn't survive restarts
         // - Orphaned active boxes: was Running but directory is missing (crashed mid-operation)
         //
         // Note: We don't remove Configured or Stopped boxes without directories because:
@@ -1740,13 +1741,29 @@ impl std::fmt::Debug for RuntimeImpl {
 /// Trait methods use `&self`. This newtype holds the Arc as a field to bridge the gap.
 pub(crate) struct LocalRuntime(pub(crate) SharedRuntimeImpl);
 
-fn reject_local_unsupported_options(options: &BoxOptions) -> BoxliteResult<()> {
-    // Local runtimes support auto_delete as a remove-on-stop policy, but AutoStop
-    // needs a sweeper that the local runtime does not have, so it stays REST-only.
-    if options.auto_stop.is_some_and(|seconds| seconds > 0) {
-        return Err(BoxliteError::Unsupported(
-            "AutoStop is only supported by REST runtimes".into(),
-        ));
+fn reject_local_unsupported_options(
+    options: &BoxOptions,
+    lifecycle_sweeper: bool,
+) -> BoxliteResult<()> {
+    // Both deadlines need something to act on them. Storing one that nothing
+    // sweeps would report a policy back to the caller that never fires, so a
+    // runtime whose embedder declared no sweeper refuses it outright. Use
+    // `auto_remove` for synchronous removal on stop — that needs no sweeper.
+    if !lifecycle_sweeper {
+        if options.auto_stop.is_some_and(|seconds| seconds > 0) {
+            return Err(BoxliteError::Unsupported(
+                "AutoStop needs a lifecycle sweeper; this runtime has none. Use a REST runtime \
+                 (`boxlite serve` or the cloud) to enforce it."
+                    .into(),
+            ));
+        }
+        if options.auto_delete.is_some_and(|seconds| seconds > 0) {
+            return Err(BoxliteError::Unsupported(
+                "AutoDelete needs a lifecycle sweeper; this runtime has none. Use a REST runtime \
+                 to enforce it, or auto_remove=true to delete the box as soon as it stops."
+                    .into(),
+            ));
+        }
     }
 
     // `resolve_user_volumes` catches this too, but only once boot is under way
@@ -1767,11 +1784,11 @@ fn reject_local_unsupported_options(options: &BoxOptions) -> BoxliteResult<()> {
 }
 
 async fn sanitize_local_options(
-    features: &ExperimentalFeatures,
+    capabilities: &RuntimeCapabilities,
     options: BoxOptions,
 ) -> BoxliteResult<BoxOptions> {
-    reject_local_unsupported_options(&options)?;
-    features.require_for_options(&options)?;
+    reject_local_unsupported_options(&options, capabilities.lifecycle_sweeper)?;
+    capabilities.features.require_for_options(&options)?;
     tokio::task::spawn_blocking(move || {
         let mut options = options;
         options.sanitize()?;
@@ -1788,7 +1805,7 @@ async fn sanitize_local_options(
 #[async_trait::async_trait]
 impl super::backend::RuntimeBackend for LocalRuntime {
     async fn create(&self, options: BoxOptions, name: Option<String>) -> BoxliteResult<LiteBox> {
-        let options = sanitize_local_options(&self.0.experimental_features, options).await?;
+        let options = sanitize_local_options(&self.0.capabilities, options).await?;
         self.0.create(options, name).await
     }
 
@@ -1797,7 +1814,7 @@ impl super::backend::RuntimeBackend for LocalRuntime {
         options: BoxOptions,
         name: Option<String>,
     ) -> BoxliteResult<(LiteBox, bool)> {
-        let options = sanitize_local_options(&self.0.experimental_features, options).await?;
+        let options = sanitize_local_options(&self.0.capabilities, options).await?;
         self.0.get_or_create(options, name).await
     }
 
@@ -1917,6 +1934,7 @@ impl Drop for RuntimeImpl {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::experimental::ExperimentalFeatures;
     use crate::experimental::custom_kernel::KernelOptions;
     use crate::litebox::config::{BoxConfig, ContainerRuntimeConfig};
     use crate::runtime::backend::RuntimeBackend;
@@ -1949,31 +1967,75 @@ mod tests {
         );
     }
 
+    /// Without a sweeper, *both* deadlines must be refused rather than stored:
+    /// a policy nothing acts on is reported back to the caller as if it were
+    /// live. The disable sentinel `0` stays acceptable — it asks for nothing.
     #[tokio::test]
-    async fn local_runtime_rejects_explicit_lifecycle_policy() {
-        let features = ExperimentalFeatures::default();
+    async fn a_runtime_without_a_sweeper_refuses_both_deadlines() {
+        let no_sweeper = RuntimeCapabilities::default();
         let mut options = BoxOptions::default();
         assert!(
-            sanitize_local_options(&features, options.clone())
+            sanitize_local_options(&no_sweeper, options.clone())
                 .await
                 .is_ok()
         );
 
-        options.auto_stop = Some(0);
-        assert!(
-            sanitize_local_options(&features, options.clone())
-                .await
-                .is_ok()
-        );
+        for disabled in [Some(0), None] {
+            options.auto_stop = disabled;
+            options.auto_delete = disabled;
+            assert!(
+                sanitize_local_options(&no_sweeper, options.clone())
+                    .await
+                    .is_ok(),
+                "a disabled deadline asks for no enforcement: {disabled:?}"
+            );
+        }
 
         options.auto_stop = Some(1);
-        assert!(matches!(
-            sanitize_local_options(&features, options.clone()).await,
-            Err(BoxliteError::Unsupported(_))
-        ));
+        options.auto_delete = None;
+        let error = sanitize_local_options(&no_sweeper, options.clone())
+            .await
+            .expect_err("AutoStop with no sweeper must be refused, not stored");
+        assert!(matches!(error, BoxliteError::Unsupported(_)), "{error:?}");
+        assert!(error.to_string().contains("AutoStop"), "{error}");
+
         options.auto_stop = None;
         options.auto_delete = Some(3600);
-        assert!(sanitize_local_options(&features, options).await.is_ok());
+        let error = sanitize_local_options(&no_sweeper, options.clone())
+            .await
+            .expect_err("AutoDelete with no sweeper must be refused, not stored");
+        assert!(matches!(error, BoxliteError::Unsupported(_)), "{error:?}");
+        assert!(error.to_string().contains("AutoDelete"), "{error}");
+    }
+
+    /// The mirror of the above: an embedder that declared a sweeper (`boxlite
+    /// serve`) must be able to create the very boxes it intends to sweep.
+    #[tokio::test]
+    async fn a_runtime_with_a_sweeper_accepts_both_deadlines() {
+        let with_sweeper = RuntimeCapabilities {
+            lifecycle_sweeper: true,
+            ..Default::default()
+        };
+        let options = BoxOptions {
+            auto_stop: Some(900),
+            auto_delete: Some(604_800),
+            detach: true,
+            // The other axis must be off: `auto_remove` would delete the box the
+            // instant it stopped, leaving the deadline nothing to sweep.
+            auto_remove: false,
+            ..Default::default()
+        };
+
+        let sanitized = sanitize_local_options(&with_sweeper, options)
+            .await
+            .expect("a declared sweeper makes both deadlines enforceable");
+
+        assert_eq!(sanitized.auto_stop, Some(900));
+        assert_eq!(sanitized.auto_delete, Some(604_800));
+        assert!(
+            sanitized.detach,
+            "a swept box must be able to outlive the process that created it"
+        );
     }
 
     /// The local runtime has no volume backend. `resolve_user_volumes` also
@@ -1985,18 +2047,22 @@ mod tests {
     async fn local_runtime_rejects_managed_volumes_before_boot() {
         use crate::runtime::options::VolumeSpec;
 
-        let features = ExperimentalFeatures::default();
+        let capabilities = RuntimeCapabilities::default();
         let host_bind = BoxOptions {
             volumes: vec![VolumeSpec::bind_mount("/tmp/data", "/data")],
             ..Default::default()
         };
-        assert!(sanitize_local_options(&features, host_bind).await.is_ok());
+        assert!(
+            sanitize_local_options(&capabilities, host_bind)
+                .await
+                .is_ok()
+        );
 
         let managed = BoxOptions {
             volumes: vec![VolumeSpec::managed_volume("my-data", "/data")],
             ..Default::default()
         };
-        let error = sanitize_local_options(&features, managed)
+        let error = sanitize_local_options(&capabilities, managed)
             .await
             .expect_err("a managed volume has no local backend to resolve against");
 
@@ -2091,7 +2157,7 @@ mod tests {
         options.advanced.kernel = Some(KernelOptions::new("/definitely/missing/vmlinux"));
 
         let disabled_error =
-            sanitize_local_options(&ExperimentalFeatures::default(), options.clone())
+            sanitize_local_options(&RuntimeCapabilities::default(), options.clone())
                 .await
                 .expect_err("custom kernel must be disabled by default");
         assert!(
@@ -2100,7 +2166,10 @@ mod tests {
                 .contains("BOXLITE_EXPERIMENTAL=custom-kernel")
         );
 
-        let enabled = ExperimentalFeatures::parse("custom-kernel").unwrap();
+        let enabled = RuntimeCapabilities {
+            features: ExperimentalFeatures::parse("custom-kernel").unwrap(),
+            ..Default::default()
+        };
         let validation_error = sanitize_local_options(&enabled, options)
             .await
             .expect_err("enabled feature should continue to kernel validation");
@@ -2120,7 +2189,7 @@ mod tests {
             ..Default::default()
         };
 
-        let error = sanitize_local_options(&ExperimentalFeatures::default(), options.clone())
+        let error = sanitize_local_options(&RuntimeCapabilities::default(), options.clone())
             .await
             .expect_err("nested virtualization must be disabled by default");
         assert!(
@@ -2129,7 +2198,10 @@ mod tests {
                 .contains("BOXLITE_EXPERIMENTAL=nested-virtualization")
         );
 
-        let enabled = ExperimentalFeatures::parse("nested-virtualization").unwrap();
+        let enabled = RuntimeCapabilities {
+            features: ExperimentalFeatures::parse("nested-virtualization").unwrap(),
+            ..Default::default()
+        };
         sanitize_local_options(&enabled, options).await.unwrap();
     }
 
@@ -2142,7 +2214,7 @@ mod tests {
             ..Default::default()
         };
 
-        sanitize_local_options(&ExperimentalFeatures::default(), options)
+        sanitize_local_options(&RuntimeCapabilities::default(), options)
             .await
             .expect("privileged mode should be available without an experimental opt-in");
     }
@@ -2164,7 +2236,7 @@ mod tests {
             home_dir: temp_dir.path().to_path_buf(),
             image_registries: vec![],
         };
-        let runtime = RuntimeImpl::initialize(options, ExperimentalFeatures::default())
+        let runtime = RuntimeImpl::initialize(options, RuntimeCapabilities::default())
             .expect("Failed to create test runtime");
         (runtime, temp_dir)
     }
@@ -2181,7 +2253,7 @@ mod tests {
             options: BoxOptions {
                 rootfs: RootfsSpec::Image("alpine:latest".into()),
                 detach,
-                auto_delete: Some(0),
+                auto_remove: false,
                 ..Default::default()
             },
             engine_kind: VmmKind::Libkrun,
@@ -2244,7 +2316,7 @@ mod tests {
             options: BoxOptions {
                 rootfs: RootfsSpec::Image("alpine:latest".into()),
                 detach,
-                auto_delete: Some(0),
+                auto_remove: false,
                 ..Default::default()
             },
             engine_kind: VmmKind::Libkrun,

--- a/src/boxlite/src/runtime/types.rs
+++ b/src/boxlite/src/runtime/types.rs
@@ -180,7 +180,11 @@ impl From<Seconds> for u64 {
 
 impl fmt::Display for Seconds {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.0 >= 3600 && self.0.is_multiple_of(3600) {
+        // Days first: lifecycle windows are routinely set a week out, and
+        // "168 hours" is a worse answer than "7 days" for the same number.
+        if self.0 >= 86_400 && self.0.is_multiple_of(86_400) {
+            write!(f, "{} days", self.0 / 86_400)
+        } else if self.0 >= 3600 && self.0.is_multiple_of(3600) {
             write!(f, "{} hours", self.0 / 3600)
         } else if self.0 >= 60 && self.0.is_multiple_of(60) {
             write!(f, "{} minutes", self.0 / 60)
@@ -533,10 +537,11 @@ impl BoxInfo {
                 crate::litebox::ports::resolved_from_state(config, state),
             )),
             labels: HashMap::new(),
-            // Local runtimes do not sweep lifecycle deadlines, but metadata keeps
-            // the configured values so callers can inspect the effective policy.
+            // The deadlines a sweeper acts on. `auto_remove` is deliberately not
+            // folded in here: it is a separate, synchronous axis and reporting it
+            // as a deadline would tell a client a timer exists when none does.
             auto_stop: config.options.auto_stop.unwrap_or(0),
-            auto_delete: config.options.effective_auto_delete(),
+            auto_delete: config.options.auto_delete_seconds(),
             auto_resume: config.options.auto_resume.unwrap_or(true),
             health_status: state.health_status,
             exit_code: state.exit_code,
@@ -1084,6 +1089,16 @@ mod tests {
 
         // Non-even values show in seconds
         assert_eq!(format!("{}", Seconds::from_seconds(90)), "90 seconds");
+
+        // Days win over hours for exact multiples — lifecycle windows are
+        // routinely set a week out, and "168 hours" is a worse answer than
+        // "7 days" for the same number.
+        assert_eq!(format!("{}", Seconds::from_seconds(86_400)), "1 days");
+        assert_eq!(format!("{}", Seconds::from_seconds(604_800)), "7 days");
+
+        // A span longer than a day that is not a whole number of days falls
+        // back to the largest unit it *is* an exact multiple of.
+        assert_eq!(format!("{}", Seconds::from_seconds(90_000)), "25 hours");
     }
 
     #[test]

--- a/src/boxlite/tests/common/mod.rs
+++ b/src/boxlite/tests/common/mod.rs
@@ -5,8 +5,8 @@
 //! - [`PerTestBoxHome::isolated()`]: Per-test home without cache (for non-VM tests).
 //!
 //! Helper functions:
-//! - [`alpine_opts()`]: Default `BoxOptions` with `alpine:latest`, `auto_delete=0`
-//! - [`alpine_opts_auto()`]: Same but `auto_delete>0`
+//! - [`alpine_opts()`]: Default `BoxOptions` with `alpine:latest`, kept on stop
+//! - [`alpine_opts_auto()`]: Same but removed as soon as it stops (`--rm`)
 
 #![allow(dead_code)]
 
@@ -19,20 +19,20 @@ use boxlite::runtime::options::{BoxOptions, RootfsSpec};
 // BOX OPTIONS HELPERS
 // ============================================================================
 
-/// Default test box options: `alpine:latest`, `auto_delete=0`.
+/// Default test box options: `alpine:latest`, kept when it stops.
 pub fn alpine_opts() -> BoxOptions {
     BoxOptions {
         rootfs: RootfsSpec::Image("alpine:latest".into()),
-        auto_delete: Some(0),
+        auto_remove: false,
         ..Default::default()
     }
 }
 
-/// Alpine box with `auto_delete>0` (cleaned up on stop).
+/// Alpine box removed as soon as it stops (`--rm` semantics).
 pub fn alpine_opts_auto() -> BoxOptions {
     BoxOptions {
         rootfs: RootfsSpec::Image("alpine:latest".into()),
-        auto_delete: Some(1),
+        auto_remove: true,
         ..Default::default()
     }
 }

--- a/src/boxlite/tests/copy_ownership.rs
+++ b/src/boxlite/tests/copy_ownership.rs
@@ -47,7 +47,7 @@ async fn copy_in_hands_files_to_the_box_user() {
 
     let opts = BoxOptions {
         rootfs: RootfsSpec::Image("alpine:latest".into()),
-        auto_delete: Some(0),
+        auto_remove: false,
         user: Some(format!("{BOX_UID}:{BOX_GID}")),
         ..Default::default()
     };

--- a/src/boxlite/tests/execution_shutdown.rs
+++ b/src/boxlite/tests/execution_shutdown.rs
@@ -1084,7 +1084,7 @@ async fn create_concurrent_box(runtime: &BoxliteRuntime) -> Arc<LiteBox> {
             BoxOptions {
                 rootfs: RootfsSpec::Image("alpine:latest".into()),
                 cpus: Some(2),
-                auto_delete: Some(0),
+                auto_remove: false,
                 ..Default::default()
             },
             None,

--- a/src/boxlite/tests/health_check.rs
+++ b/src/boxlite/tests/health_check.rs
@@ -34,7 +34,7 @@ fn health_check_opts(
     BoxOptions {
         rootfs: RootfsSpec::Image("alpine:latest".into()),
         advanced,
-        auto_delete: Some(0),
+        auto_remove: false,
         ..Default::default()
     }
 }

--- a/src/boxlite/tests/lifecycle.rs
+++ b/src/boxlite/tests/lifecycle.rs
@@ -4,7 +4,7 @@ mod common;
 
 use boxlite::BoxliteRuntime;
 use boxlite::runtime::id::{BoxID, BoxIDMint};
-use boxlite::runtime::options::{BoxOptions, BoxliteOptions};
+use boxlite::runtime::options::{BoxOptions, BoxliteOptions, RootfsSpec};
 use boxlite::runtime::types::BoxStatus;
 
 // ============================================================================
@@ -600,16 +600,23 @@ async fn multiple_boxes_persist_and_recover_without_lock_errors() {
 // AUTO_DELETE TESTS
 // ============================================================================
 
+/// `BoxOptions::default()` still removes the box on stop: `auto_remove` defaults
+/// to true, and that is now the only field that decides this. `auto_delete` is a
+/// deferred deadline and says nothing about the synchronous path — leaving it
+/// unset must not change the default behaviour either way.
 #[tokio::test]
-async fn auto_delete_default_removes_box_on_stop() {
+async fn default_options_remove_box_on_stop() {
     let home = boxlite_test_utils::home::PerTestBoxHome::isolated();
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
         image_registries: common::test_registries(),
     })
     .expect("create runtime");
-    let mut options = common::alpine_opts();
-    options.auto_delete = None;
+    let options = BoxOptions {
+        rootfs: RootfsSpec::Image("alpine:latest".into()),
+        auto_delete: None,
+        ..Default::default()
+    };
     let handle = runtime.create(options, None).await.unwrap();
     let box_id = handle.id().clone();
 
@@ -617,11 +624,11 @@ async fn auto_delete_default_removes_box_on_stop() {
 
     assert!(
         !runtime.exists(box_id.as_str()).await.unwrap(),
-        "Box should be auto-removed when auto_delete is unset"
+        "Box should be auto-removed when auto_remove keeps its default of true"
     );
 }
 #[tokio::test]
-async fn auto_delete_removes_box_on_stop() {
+async fn auto_remove_removes_box_on_stop() {
     let home = boxlite_test_utils::home::PerTestBoxHome::isolated();
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
@@ -643,12 +650,12 @@ async fn auto_delete_removes_box_on_stop() {
     // Box should no longer exist
     assert!(
         !runtime.exists(box_id.as_str()).await.unwrap(),
-        "Box should be auto-removed when auto_delete>0"
+        "Box should be auto-removed when auto_remove is true"
     );
 }
 
 #[tokio::test]
-async fn auto_delete_zero_preserves_box_on_stop() {
+async fn auto_remove_off_preserves_box_on_stop() {
     let home = boxlite_test_utils::home::PerTestBoxHome::new();
     let runtime = BoxliteRuntime::new(BoxliteOptions {
         home_dir: home.path.clone(),
@@ -667,7 +674,7 @@ async fn auto_delete_zero_preserves_box_on_stop() {
     // Box should still exist
     assert!(
         runtime.exists(box_id.as_str()).await.unwrap(),
-        "Box should be preserved when auto_delete=0"
+        "Box should be preserved when auto_remove is false"
     );
 
     // Status should be Stopped

--- a/src/boxlite/tests/mount_security.rs
+++ b/src/boxlite/tests/mount_security.rs
@@ -87,7 +87,7 @@ async fn mount_security_integration() {
                     read_only: false,
                 }],
                 rootfs: RootfsSpec::Image("alpine:latest".into()),
-                auto_delete: Some(0),
+                auto_remove: false,
                 ..Default::default()
             },
             None,

--- a/src/boxlite/tests/recovery.rs
+++ b/src/boxlite/tests/recovery.rs
@@ -431,15 +431,15 @@ async fn successful_start_stashes_stale_exit_file() {
 // ============================================================================
 
 #[tokio::test]
-async fn recovery_removes_auto_delete_boxes() {
-    // Test that boxes with auto_delete>0 are removed during recovery
+async fn recovery_removes_auto_remove_boxes() {
+    // Test that boxes with auto_remove are removed during recovery
     // This simulates a crash scenario where boxes weren't properly cleaned up
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let home_dir = temp_dir.path().to_path_buf();
 
     let persistent_box_id: BoxID;
 
-    // Create two boxes: one with auto_delete>0, one with auto_delete=0
+    // Create two boxes: one with auto_remove, one without
     {
         let options = BoxliteOptions {
             home_dir: home_dir.clone(),
@@ -447,13 +447,13 @@ async fn recovery_removes_auto_delete_boxes() {
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime");
 
-        // Create auto_delete>0 box (should be cleaned up on recovery)
+        // Create the auto_remove box (should be cleaned up on recovery)
         let ephemeral_box = runtime
             .create(common::alpine_opts_auto(), None)
             .await
             .unwrap();
 
-        // Create auto_delete=0 box (should persist)
+        // Create the kept box (should persist)
         let persistent_box = runtime.create(common::alpine_opts(), None).await.unwrap();
         persistent_box_id = persistent_box.id().clone();
 
@@ -479,8 +479,8 @@ async fn recovery_removes_auto_delete_boxes() {
         };
         let runtime = BoxliteRuntime::new(options).expect("Failed to create runtime after restart");
 
-        // auto_delete>0 box should be removed during recovery
-        // auto_delete=0 box should be recovered
+        // the auto_remove box should be removed during recovery
+        // the kept box should be recovered
         let boxes = runtime.list_info().await.unwrap();
         assert_eq!(
             boxes.len(),

--- a/src/boxlite/tests/rest_integration.rs
+++ b/src/boxlite/tests/rest_integration.rs
@@ -115,7 +115,11 @@ async fn test_rest_box_exists() {
 async fn test_rest_start_stop_box() {
     let rt = rest_runtime();
     let opts = BoxOptions {
-        auto_delete: Some(0), // Keep box after stop so we can inspect status
+        // Inert on this path — `auto_remove` is never transmitted, so it says
+        // nothing to the server. The box survives its stop because the server
+        // itself creates boxes with remove-on-stop off; this states the intent
+        // locally so the options read the same as the box that comes back.
+        auto_remove: false,
         ..Default::default()
     };
 
@@ -242,7 +246,7 @@ async fn test_rest_not_found() {
 async fn test_rest_snapshot_lifecycle() {
     let rt = rest_runtime();
     let opts = BoxOptions {
-        auto_delete: Some(0),
+        auto_remove: false,
         ..Default::default()
     };
 
@@ -302,7 +306,7 @@ async fn test_rest_snapshot_lifecycle() {
 async fn test_rest_clone_from_snapshot() {
     let rt = rest_runtime();
     let opts = BoxOptions {
-        auto_delete: Some(0),
+        auto_remove: false,
         ..Default::default()
     };
 
@@ -336,7 +340,7 @@ async fn test_rest_clone_from_snapshot() {
 async fn test_rest_export_box() {
     let rt = rest_runtime();
     let opts = BoxOptions {
-        auto_delete: Some(0),
+        auto_remove: false,
         ..Default::default()
     };
 

--- a/src/boxlite/tests/run_main_command.rs
+++ b/src/boxlite/tests/run_main_command.rs
@@ -15,7 +15,7 @@ use tokio_stream::StreamExt;
 fn main_command_opts(cmd: &[&str], tty: bool) -> BoxOptions {
     BoxOptions {
         rootfs: RootfsSpec::Image("alpine:latest".into()),
-        auto_delete: Some(0),
+        auto_remove: false,
         cmd: Some(cmd.iter().map(|s| s.to_string()).collect()),
         tty,
         ..Default::default()
@@ -245,7 +245,7 @@ async fn a_stopped_box_without_a_main_command_still_restarts_on_exec() {
     // No `cmd`: init is the image default, exactly as a cloud box is created.
     let opts = BoxOptions {
         rootfs: RootfsSpec::Image("alpine:latest".into()),
-        auto_delete: Some(0),
+        auto_remove: false,
         ..Default::default()
     };
     let handle = runtime.create(opts, None).await.expect("create box");
@@ -298,7 +298,7 @@ async fn a_stopped_no_command_box_refuses_to_serve_its_dead_vm() {
     // No `cmd` and no `entrypoint`: the gate lets this box's exec through.
     let opts = BoxOptions {
         rootfs: RootfsSpec::Image("alpine:latest".into()),
-        auto_delete: Some(0),
+        auto_remove: false,
         ..Default::default()
     };
     let handle = runtime.create(opts, None).await.expect("create box");

--- a/src/boxlite/tests/security_enforcement.rs
+++ b/src/boxlite/tests/security_enforcement.rs
@@ -90,7 +90,7 @@ async fn virtiofs_readonly_and_capabilities() {
                     },
                 ],
                 rootfs: RootfsSpec::Image("alpine:latest".into()),
-                auto_delete: Some(0),
+                auto_remove: false,
                 ..Default::default()
             },
             None,
@@ -357,7 +357,7 @@ async fn disabled_network_blocks_tsi_socket_forwarding() {
             BoxOptions {
                 network: NetworkSpec::Disabled,
                 rootfs: RootfsSpec::Image("alpine:latest".into()),
-                auto_delete: Some(0),
+                auto_remove: false,
                 ..Default::default()
             },
             None,

--- a/src/boxlite/tests/timing_profile.rs
+++ b/src/boxlite/tests/timing_profile.rs
@@ -189,7 +189,7 @@ async fn boot_timing_profile_no_jailer() {
     };
     let opts = BoxOptions {
         rootfs: boxlite::runtime::options::RootfsSpec::Image("alpine:latest".into()),
-        auto_delete: Some(0),
+        auto_remove: false,
         advanced,
         ..Default::default()
     };

--- a/src/boxlite/tests/zygote_integration.rs
+++ b/src/boxlite/tests/zygote_integration.rs
@@ -45,7 +45,7 @@ async fn create_concurrent_box(runtime: &BoxliteRuntime) -> Arc<LiteBox> {
             BoxOptions {
                 rootfs: RootfsSpec::Image("alpine:latest".into()),
                 cpus: Some(2),
-                auto_delete: Some(0),
+                auto_remove: false,
                 ..Default::default()
             },
             None,

--- a/src/cli/src/cli.rs
+++ b/src/cli/src/cli.rs
@@ -194,9 +194,57 @@ pub(crate) fn experimental_features_from_env() -> boxlite::BoxliteResult<Experim
     }
 }
 
+/// Parse a lifecycle duration into whole seconds.
+///
+/// A bare integer is seconds, which is exactly the unit the SDKs and the wire
+/// contract use, so the flags stay consistent with them. Suffixes are sugar for
+/// the long windows these deadlines are typically set to — `7d` rather than
+/// `604800`. Mirrors `serve`'s env-var duration parser and adds `d`.
+pub(crate) fn parse_duration_seconds(raw: &str) -> Result<u32, String> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Err("expected a duration such as 900, 30m, 2h or 7d".into());
+    }
+
+    let (digits, multiplier) = match raw.strip_suffix(['s', 'm', 'h', 'd']) {
+        Some(rest) => {
+            let unit = raw.as_bytes()[raw.len() - 1];
+            let multiplier = match unit {
+                b's' => 1,
+                b'm' => 60,
+                b'h' => 3_600,
+                _ => 86_400,
+            };
+            (rest, multiplier)
+        }
+        None => (raw, 1),
+    };
+
+    let value: u32 = digits
+        .parse()
+        .map_err(|_| format!("invalid duration {raw:?}: expected 900, 30m, 2h or 7d"))?;
+    value
+        .checked_mul(multiplier)
+        .ok_or_else(|| format!("duration {raw:?} is too large"))
+}
+
 // ============================================================================
 // GLOBAL FLAGS
 // ============================================================================
+
+/// The runtime `serve` will drive, together with whether this process is the
+/// one enforcing lifecycle deadlines on it.
+pub struct ServeRuntime {
+    pub runtime: BoxliteRuntime,
+
+    /// False when a `--url`, `BOXLITE_REST_URL` or stored credential profile
+    /// points this `serve` at another server. That server runs its own sweeper
+    /// over boxes this process cannot see, so sweeping from here would stop and
+    /// delete boxes on someone else's host — driven by an idle map that starts
+    /// empty, which reads every remote box as untouched since this process
+    /// began.
+    pub enforces_lifecycle: bool,
+}
 
 #[derive(Args, Debug, Clone)]
 pub struct GlobalFlags {
@@ -299,21 +347,62 @@ impl GlobalFlags {
     }
 
     pub fn create_runtime(&self) -> anyhow::Result<BoxliteRuntime> {
+        Ok(self.build_runtime(false)?.runtime)
+    }
+
+    /// Runtime for `boxlite serve`, which runs its own lifecycle sweeper.
+    ///
+    /// The embedded runtime refuses AutoStop / AutoDelete unless something will
+    /// actually enforce them; `serve` does, so it says so here. A `--url`
+    /// invocation proxies to a server that enforces its own and is left alone.
+    pub fn create_serve_runtime(&self) -> anyhow::Result<ServeRuntime> {
+        self.build_runtime(true)
+    }
+
+    /// Resolves the backend once, so the runtime and the answer to "does this
+    /// process enforce deadlines on it" can never disagree.
+    fn build_runtime(&self, lifecycle_sweeper: bool) -> anyhow::Result<ServeRuntime> {
+        match self.rest_options() {
+            Some(opts) => Ok(ServeRuntime {
+                runtime: BoxliteRuntime::rest(opts).map_err(anyhow::Error::from)?,
+                enforces_lifecycle: false,
+            }),
+            None => {
+                // No URL anywhere → local runtime, unchanged behavior.
+                let options = self.resolve_runtime_options()?;
+                let runtime = RuntimeBuilder::new(options)
+                    .with_features(self.experimental_features.clone())
+                    .with_lifecycle_sweeper(lifecycle_sweeper)
+                    .build()
+                    .map_err(anyhow::Error::from)?;
+                Ok(ServeRuntime {
+                    runtime,
+                    enforces_lifecycle: lifecycle_sweeper,
+                })
+            }
+        }
+    }
+
+    /// Resolved REST connection options, or `None` when this invocation targets
+    /// the embedded runtime.
+    fn rest_options(&self) -> Option<BoxliteRestOptions> {
         let stored = crate::credentials::load_named(&self.resolved_profile())
             .ok()
             .flatten();
         // Clap reads BOXLITE_REST_URL into `self.url`; BOXLITE_API_KEY is the
         // one credential env we still consult directly here.
         let env_api_key = std::env::var("BOXLITE_API_KEY").ok();
+        self.resolve_rest_options(stored, env_api_key)
+    }
 
-        match self.resolve_rest_options(stored, env_api_key) {
-            Some(opts) => BoxliteRuntime::rest(opts).map_err(Into::into),
-            None => {
-                // No URL anywhere → local runtime, unchanged behavior.
-                let options = self.resolve_runtime_options()?;
-                self.create_runtime_with_options(options)
-            }
-        }
+    /// Whether this invocation talks to a REST server rather than the embedded
+    /// runtime.
+    ///
+    /// `--rm` is spelled differently for each: the wire contract carries only
+    /// the `auto_delete` deadline, while the embedded runtime deletes
+    /// synchronously through `auto_remove` and has no sweeper for a deadline.
+    pub fn targets_rest(&self) -> bool {
+        self.rest_options().is_some()
     }
 
     /// Build REST connection options from the selected credential profile and
@@ -872,8 +961,25 @@ pub struct ManagementFlags {
     pub detach: bool,
 
     /// Automatically remove the box when it exits
-    #[arg(long)]
+    #[arg(long, conflicts_with = "auto_delete")]
     pub rm: bool,
+
+    /// Stop the box after this much idle time; `0` disables.
+    ///
+    /// Accepts seconds (`900`) or a suffixed duration (`30m`, `2h`, `7d`).
+    #[arg(long, value_name = "DURATION", value_parser = parse_duration_seconds)]
+    pub auto_stop: Option<u32>,
+
+    /// Delete the box this long after it stops; `0` disables.
+    ///
+    /// Unlike `--rm`, which deletes as soon as the box stops, this is a deadline
+    /// a server sweeps later — so it is compatible with `--detach`.
+    #[arg(long, value_name = "DURATION", value_parser = parse_duration_seconds)]
+    pub auto_delete: Option<u32>,
+
+    /// Do not restart this box automatically when an operation targets it.
+    #[arg(long)]
+    pub no_auto_resume: bool,
 
     /// Sandbox security: `enable` (default) or `disable` (case-insensitive).
     /// Absent → the box uses `SecurityOptions::default()` = enable, the
@@ -897,11 +1003,32 @@ impl ManagementFlags {
         features.require(ExperimentalFeature::NestedVirtualization)
     }
 
-    pub fn apply_to(&self, opts: &mut BoxOptions) -> anyhow::Result<()> {
+    pub fn apply_to(&self, opts: &mut BoxOptions, targets_rest: bool) -> anyhow::Result<()> {
         opts.detach = self.detach;
-        // `--rm` is the CLI spelling of "delete when stopped"; the CLI
-        // default (like `docker run`) is to keep the box.
-        opts.auto_delete = Some(if self.rm { 1 } else { 0 });
+
+        // `--rm` is "delete as soon as it stops". The embedded runtime does that
+        // synchronously through `auto_remove`; the wire contract has no such
+        // field, so against a server the nearest honest spelling is the shortest
+        // possible deadline, which its sweeper acts on. Sending nothing would
+        // leave `--rm` silently doing nothing remotely.
+        if targets_rest {
+            opts.auto_remove = false;
+            if self.rm {
+                opts.auto_delete = Some(1);
+            }
+        } else {
+            opts.auto_remove = self.rm;
+        }
+
+        if let Some(seconds) = self.auto_stop {
+            opts.auto_stop = Some(seconds);
+        }
+        if let Some(seconds) = self.auto_delete {
+            opts.auto_delete = Some(seconds);
+        }
+        if self.no_auto_resume {
+            opts.auto_resume = Some(false);
+        }
         if let Some(ref preset) = self.security {
             // Bubble the typo'd-preset error all the way back to the
             // CLI exit so the operator sees the offending value.
@@ -913,6 +1040,31 @@ impl ManagementFlags {
         }
         Ok(())
     }
+
+    /// Reconcile the two deletion axes with the box's effective detach state.
+    ///
+    /// Detached boxes keep manual lifecycle control, so detach silently
+    /// overrides `--rm` (historical CLI behaviour). Only the synchronous axis
+    /// conflicts: an explicit `--auto-delete` deadline is deliberately left
+    /// alone, because a deferred deadline on a detached box is exactly the
+    /// pairing this feature exists to make expressible.
+    ///
+    /// Keyed on `opts.detach`, not on the `--detach` flag: `create` detaches
+    /// every box it makes without the flag being passed, and it needs the same
+    /// reconciliation `run -d` gets.
+    ///
+    /// Runs after [`Self::apply_to`], so it also clears the `Some(1)` deadline
+    /// that the REST encoding of `--rm` writes there — left in place, the
+    /// server's sweeper would delete the box a second after it stopped.
+    pub fn apply_detach_override(&self, opts: &mut BoxOptions) {
+        if !opts.detach {
+            return;
+        }
+        opts.auto_remove = false;
+        if self.auto_delete.is_none() {
+            opts.auto_delete = None;
+        }
+    }
 }
 
 #[cfg(test)]
@@ -923,6 +1075,194 @@ mod tests {
     use std::fs;
     use std::path::PathBuf;
     use tempfile::TempDir;
+
+    // --- Lifecycle duration parsing ---
+
+    #[test]
+    fn a_bare_integer_is_seconds() {
+        // The unit the SDKs and the wire contract use. If this ever became
+        // minutes, `--auto-stop 900` would silently mean 15 hours.
+        assert_eq!(parse_duration_seconds("900"), Ok(900));
+        assert_eq!(parse_duration_seconds("0"), Ok(0));
+    }
+
+    #[test]
+    fn suffixed_durations_convert_to_seconds() {
+        assert_eq!(parse_duration_seconds("45s"), Ok(45));
+        assert_eq!(parse_duration_seconds("30m"), Ok(1_800));
+        assert_eq!(parse_duration_seconds("2h"), Ok(7_200));
+        assert_eq!(parse_duration_seconds("7d"), Ok(604_800));
+        assert_eq!(parse_duration_seconds("  15m  "), Ok(900));
+    }
+
+    #[test]
+    fn a_malformed_duration_is_rejected_not_silently_zero() {
+        // Parsing failures must reach the user as a flag error. Falling back to
+        // 0 would read as "disabled" and quietly drop the policy they asked for.
+        for raw in ["", "  ", "abc", "10x", "1.5h", "-5", "m", "9999999999999d"] {
+            assert!(
+                parse_duration_seconds(raw).is_err(),
+                "{raw:?} must be rejected"
+            );
+        }
+    }
+
+    // --- `--rm` encoding per backend ---
+
+    fn rm_flags(rm: bool) -> ManagementFlags {
+        ManagementFlags {
+            name: None,
+            detach: false,
+            rm,
+            auto_stop: None,
+            auto_delete: None,
+            no_auto_resume: false,
+            security: None,
+            nested_virtualization: false,
+        }
+    }
+
+    #[test]
+    fn rm_uses_the_synchronous_axis_against_the_embedded_runtime() {
+        let mut opts = BoxOptions::default();
+        rm_flags(true).apply_to(&mut opts, false).unwrap();
+        assert!(opts.auto_remove, "--rm must set the synchronous axis");
+        assert_eq!(
+            opts.auto_delete, None,
+            "the embedded runtime has no sweeper, so --rm must not become a deadline"
+        );
+
+        let mut kept = BoxOptions::default();
+        rm_flags(false).apply_to(&mut kept, false).unwrap();
+        assert!(!kept.auto_remove, "without --rm the box is kept");
+    }
+
+    #[test]
+    fn rm_becomes_a_deadline_against_a_rest_server() {
+        // The wire contract carries no synchronous-removal field, so sending
+        // nothing would make `--rm` a silent no-op against a server.
+        let mut opts = BoxOptions::default();
+        rm_flags(true).apply_to(&mut opts, true).unwrap();
+        assert_eq!(opts.auto_delete, Some(1));
+        assert!(
+            !opts.auto_remove,
+            "auto_remove is never transmitted; leaving it set would be a lie"
+        );
+
+        let mut kept = BoxOptions::default();
+        rm_flags(false).apply_to(&mut kept, true).unwrap();
+        assert_eq!(
+            kept.auto_delete, None,
+            "no --rm must leave the server's own default alone"
+        );
+        assert!(!kept.auto_remove);
+    }
+
+    #[test]
+    fn explicit_lifecycle_flags_reach_box_options() {
+        let flags = ManagementFlags {
+            auto_stop: Some(1_800),
+            auto_delete: Some(604_800),
+            no_auto_resume: true,
+            ..rm_flags(false)
+        };
+        let mut opts = BoxOptions::default();
+        flags.apply_to(&mut opts, false).unwrap();
+
+        assert_eq!(opts.auto_stop, Some(1_800));
+        assert_eq!(opts.auto_delete, Some(604_800));
+        assert_eq!(opts.auto_resume, Some(false));
+    }
+
+    #[test]
+    fn serve_against_a_remote_server_does_not_claim_the_sweep() {
+        // The remote enforces its own deadlines over boxes this process cannot
+        // see, and `last_activity` here starts empty — so sweeping from this
+        // side would stop and delete another host's boxes on the first tick.
+        let cli = Cli::try_parse_from(["boxlite", "--url", "http://127.0.0.1:1", "serve"])
+            .expect("serve should parse");
+        let serve = cli
+            .global
+            .create_serve_runtime()
+            .expect("a REST runtime should build without contacting the server");
+
+        assert!(
+            !serve.enforces_lifecycle,
+            "a proxying serve must leave the sweep to the server that owns the boxes"
+        );
+    }
+
+    #[test]
+    fn detach_overrides_rm_on_both_backends() {
+        // A detached box keeps manual lifecycle control, so `--rm` is dropped
+        // rather than deleting the box the moment the foreground call returns.
+        // The REST path needs this too: `apply_to` spelled `--rm` as a 1-second
+        // deadline there, and leaving that in place would delete the box almost
+        // immediately — the opposite of what detaching asks for.
+        //
+        // This pins the intent for the `--detach` flag. The regression guard for
+        // boxes detached *without* the flag is in create.rs, since keying this
+        // on the flag rather than on `opts.detach` is what broke `create --rm`.
+        for targets_rest in [false, true] {
+            let flags = ManagementFlags {
+                detach: true,
+                ..rm_flags(true)
+            };
+            let mut opts = BoxOptions::default();
+            flags.apply_to(&mut opts, targets_rest).unwrap();
+            flags.apply_detach_override(&mut opts);
+
+            assert!(!opts.auto_remove, "targets_rest={targets_rest}");
+            assert_eq!(
+                opts.auto_delete, None,
+                "the REST encoding of --rm must be cleared too (targets_rest={targets_rest})"
+            );
+        }
+    }
+
+    #[test]
+    fn an_explicit_delete_deadline_survives_detach() {
+        // The pairing the split exists to make expressible: detach the box and
+        // still have it aged out on schedule. Clearing the deadline here would
+        // silently leak every detached box that asked to be cleaned up.
+        let flags = ManagementFlags {
+            detach: true,
+            auto_delete: Some(3_600),
+            ..rm_flags(true)
+        };
+        let mut opts = BoxOptions::default();
+        flags.apply_to(&mut opts, true).unwrap();
+        flags.apply_detach_override(&mut opts);
+
+        assert_eq!(opts.auto_delete, Some(3_600));
+        assert!(!opts.auto_remove);
+    }
+
+    #[test]
+    fn the_detach_override_leaves_an_attached_box_alone() {
+        let flags = rm_flags(true);
+        let mut opts = BoxOptions::default();
+        flags.apply_to(&mut opts, false).unwrap();
+        flags.apply_detach_override(&mut opts);
+        assert!(opts.auto_remove, "--rm must still work without --detach");
+    }
+
+    #[test]
+    fn rm_and_auto_delete_cannot_be_combined() {
+        // Enforced by clap so the collision is a parse error with a real
+        // message, not a silent precedence rule the user has to guess.
+        let error = Cli::command()
+            .try_get_matches_from(vec![
+                "boxlite",
+                "run",
+                "--rm",
+                "--auto-delete",
+                "1h",
+                "alpine",
+            ])
+            .expect_err("--rm and --auto-delete are mutually exclusive");
+        assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
 
     #[test]
     fn test_apply_env_vars_with_lookup() {
@@ -1182,6 +1522,9 @@ mod tests {
             name: None,
             detach: false,
             rm: false,
+            auto_stop: None,
+            auto_delete: None,
+            no_auto_resume: false,
             security: None,
         };
 
@@ -1855,11 +2198,16 @@ mod tests {
             name: None,
             detach: false,
             rm: false,
+            auto_stop: None,
+            auto_delete: None,
+            no_auto_resume: false,
             security: Some("disable".to_string()),
             nested_virtualization: false,
         };
         let mut opts = BoxOptions::default();
-        flags.apply_to(&mut opts).expect("setting must apply");
+        flags
+            .apply_to(&mut opts, false)
+            .expect("setting must apply");
         assert_eq!(
             opts.advanced.security,
             boxlite::SecurityOptions::disabled(),
@@ -1873,12 +2221,15 @@ mod tests {
             name: None,
             detach: false,
             rm: false,
+            auto_stop: None,
+            auto_delete: None,
+            no_auto_resume: false,
             security: None,
             nested_virtualization: false,
         };
         let mut opts = BoxOptions::default();
         flags
-            .apply_to(&mut opts)
+            .apply_to(&mut opts, false)
             .expect("absent preset must succeed");
         assert_eq!(
             opts.advanced.security,
@@ -1893,12 +2244,15 @@ mod tests {
             name: None,
             detach: false,
             rm: false,
+            auto_stop: None,
+            auto_delete: None,
+            no_auto_resume: false,
             security: Some("ultra".to_string()),
             nested_virtualization: false,
         };
         let mut opts = BoxOptions::default();
         let err = flags
-            .apply_to(&mut opts)
+            .apply_to(&mut opts, false)
             .expect_err("unknown preset must reject at apply_to");
         let msg = err.to_string();
         assert!(msg.contains("ultra"), "got {msg}");
@@ -1916,7 +2270,7 @@ mod tests {
         let mut opts = BoxOptions::default();
         assert!(!opts.advanced.nested_virtualization);
         args.management
-            .apply_to(&mut opts)
+            .apply_to(&mut opts, false)
             .expect("nested virtualization should apply");
 
         assert!(opts.advanced.nested_virtualization);

--- a/src/cli/src/commands/create.rs
+++ b/src/cli/src/commands/create.rs
@@ -75,7 +75,8 @@ impl CreateArgs {
         self.resource.apply_to(&mut options);
         self.capability.apply_to(&mut options);
         self.boot.apply_to(&mut options);
-        self.management.apply_to(&mut options)?;
+        self.management
+            .apply_to(&mut options, global.targets_rest())?;
         self.publish.apply_to(&mut options)?;
         self.volume.apply_to(&mut options, global.home.as_deref())?;
         self.network.apply_to(&mut options)?;
@@ -87,11 +88,11 @@ impl CreateArgs {
         // non-detached created box is killed by the exiting `start` CLI (its
         // watchdog + the runtime's drop-time auto-stop) before its main command
         // records an exit code — the box then reports 0 instead of its real
-        // code. Detached boxes have no foreground watcher, so auto-remove cannot
-        // apply — the same rule `run -d` enforces (remove-on-stop with detach is
-        // rejected at sanitize).
+        // code. Detached boxes have no foreground watcher, so remove-on-stop
+        // cannot apply; `apply_detach_override` drops it on both backends, the
+        // same reconciliation `run -d` gets.
         options.detach = true;
-        options.auto_delete = Some(0);
+        self.management.apply_detach_override(&mut options);
         options.working_dir = self.workdir.clone();
         if let Some(ref exec) = self.entrypoint {
             options.entrypoint = Some(vec![exec.clone()]);
@@ -136,6 +137,52 @@ mod tests {
             RootfsSpec::RootfsPath(path) => assert_eq!(path, "/tmp/rootfs"),
             other => panic!("expected RootfsPath, got {other:?}"),
         }
+    }
+
+    /// A `create`d box always detaches, so `--rm` can never apply to it. The
+    /// two backends spell `--rm` differently, so both need checking: the
+    /// embedded runtime uses the synchronous `auto_remove`, while the REST
+    /// encoding turns it into `auto_delete = Some(1)`. Leaving that deadline in
+    /// place would have the server's sweeper delete the box one second after it
+    /// stops — the opposite of what `create` promises.
+    fn created_options(args: &[&str]) -> BoxOptions {
+        let cli = Cli::try_parse_from(args).expect("create should parse");
+        let Commands::Create(args) = cli.command else {
+            panic!("expected create command");
+        };
+        args.to_box_options(&cli.global)
+            .expect("options should build")
+    }
+
+    #[test]
+    fn create_rm_never_survives_as_a_deadline_against_a_server() {
+        let opts = created_options(&[
+            "boxlite",
+            "--url",
+            "http://127.0.0.1:1",
+            "create",
+            "--rm",
+            "alpine:latest",
+        ]);
+
+        assert!(opts.detach, "create always detaches");
+        assert!(!opts.auto_remove);
+        assert_eq!(
+            opts.auto_delete, None,
+            "--rm must not reach the sweeper as a 1s deadline on a detached box"
+        );
+    }
+
+    #[test]
+    fn create_rm_is_dropped_whichever_backend_is_configured() {
+        // No `--url`, so the backend follows ambient credentials and env: this
+        // pins only what must hold either way. The REST sentinel gets its own
+        // deterministic guard above, which passes `--url` explicitly.
+        let opts = created_options(&["boxlite", "create", "--rm", "alpine:latest"]);
+
+        assert!(opts.detach, "create always detaches");
+        assert!(!opts.auto_remove, "detach drops --rm");
+        assert_eq!(opts.auto_delete, None);
     }
 
     #[test]

--- a/src/cli/src/commands/list.rs
+++ b/src/cli/src/commands/list.rs
@@ -1,6 +1,7 @@
 use crate::cli::GlobalFlags;
 use crate::formatter::{self, OutputFormat};
-use boxlite::BoxInfo;
+use boxlite::{BoxInfo, Seconds};
+use chrono::Utc;
 use clap::Args;
 use serde::Serialize;
 use tabled::Tabled;
@@ -42,16 +43,63 @@ struct BoxPresenter {
     #[tabled(rename = "NAMES")]
     #[serde(rename = "Names")]
     names: String,
+
+    #[tabled(rename = "AUTO-STOP")]
+    #[serde(rename = "AutoStop")]
+    auto_stop: String,
+
+    #[tabled(rename = "AUTO-DELETE")]
+    #[serde(rename = "AutoDelete")]
+    auto_delete: String,
+}
+
+/// Render a lifecycle window, or `off` when the deadline is disabled.
+fn window(seconds: u32) -> String {
+    if seconds == 0 {
+        "off".to_string()
+    } else {
+        Seconds::from_seconds(u64::from(seconds)).to_string()
+    }
+}
+
+/// Render the AutoDelete cell.
+///
+/// A pending deletion is state, not configuration, so a box at rest shows how
+/// long it actually has left rather than the window it was configured with —
+/// the deadline is the thing the reader needs to act on.
+fn delete_cell(info: &BoxInfo) -> String {
+    delete_cell_at(info, Utc::now())
+}
+
+/// `now` is injected so tests measure against a fixed instant. Reading the clock
+/// twice — once to build the box, once inside — makes the remaining time depend
+/// on how long the test took, which turns "in 6 hours" into a seconds string
+/// whenever the two readings straddle a second boundary.
+fn delete_cell_at(info: &BoxInfo, now: chrono::DateTime<Utc>) -> String {
+    if info.auto_delete == 0 {
+        return "off".to_string();
+    }
+    if !info.status.is_at_rest() {
+        return window(info.auto_delete);
+    }
+
+    let elapsed = (now - info.last_updated).num_seconds().max(0) as u64;
+    match u64::from(info.auto_delete).checked_sub(elapsed) {
+        Some(0) | None => "due".to_string(),
+        Some(remaining) => format!("in {}", Seconds::from_seconds(remaining)),
+    }
 }
 
 impl From<BoxInfo> for BoxPresenter {
     fn from(info: BoxInfo) -> Self {
         Self {
             id: info.id.to_string(),
-            image: info.image,
+            image: info.image.clone(),
             status: format!("{:?}", info.status),
             created: formatter::format_time(&info.created_at),
-            names: info.name.unwrap_or_default(),
+            auto_stop: window(info.auto_stop),
+            auto_delete: delete_cell(&info),
+            names: info.name.clone().unwrap_or_default(),
         }
     }
 }
@@ -91,4 +139,106 @@ fn print_boxes(writer: &mut dyn std::io::Write, boxes: &[BoxPresenter]) -> anyho
     let table = formatter::create_table(boxes).to_string();
     writeln!(writer, "{}", table)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use boxlite::{BoxID, BoxStatus, HealthStatus};
+    use chrono::Duration;
+    use std::collections::HashMap;
+
+    #[test]
+    fn a_disabled_deadline_reads_as_off_not_zero() {
+        // "0 seconds" would read as a deadline that fires immediately, which is
+        // the opposite of what the sentinel means.
+        assert_eq!(window(0), "off");
+        assert_eq!(window(900), "15 minutes");
+        assert_eq!(window(7_200), "2 hours");
+        assert_eq!(window(604_800), "7 days");
+    }
+
+    /// A fixed reference instant, so the assertions never straddle a real
+    /// second boundary between building the box and rendering it.
+    fn fixed_now() -> chrono::DateTime<Utc> {
+        chrono::DateTime::from_timestamp(1_700_000_000, 0).expect("valid timestamp")
+    }
+
+    /// Build a stopped box that stopped `stopped_ago` before [`fixed_now`].
+    fn stopped_box(auto_delete: u32, stopped_ago: Duration) -> BoxInfo {
+        let now = fixed_now();
+        BoxInfo {
+            id: BoxID::parse("list-cell-box").unwrap(),
+            name: None,
+            status: BoxStatus::Stopped,
+            created_at: now,
+            last_updated: now - stopped_ago,
+            pid: None,
+            image: "alpine:latest".into(),
+            cpus: 1,
+            memory_mib: 512,
+            network: None,
+            labels: HashMap::new(),
+            auto_stop: 0,
+            auto_delete,
+            auto_resume: true,
+            health_status: HealthStatus::new(),
+            exit_code: None,
+            started_at: None,
+        }
+    }
+
+    #[test]
+    fn a_running_box_shows_its_configured_delete_window() {
+        let mut info = stopped_box(3_600, Duration::zero());
+        info.status = BoxStatus::Running;
+        assert_eq!(delete_cell_at(&info, fixed_now()), "1 hours");
+    }
+
+    #[test]
+    fn a_stopped_box_shows_the_time_it_has_left() {
+        // The operator needs the deadline, not the setting: this box was
+        // configured for a day and has six hours of that left.
+        let info = stopped_box(86_400, Duration::hours(18));
+        assert_eq!(delete_cell_at(&info, fixed_now()), "in 6 hours");
+    }
+
+    #[test]
+    fn a_failed_box_shows_the_time_it_has_left() {
+        // The sweeper counts Failed as at rest (`BoxStatus::is_at_rest`) and deletes
+        // it on schedule, so ls must show the same countdown it shows for a Stopped
+        // box. Rendering the configured window here would misreport exactly the
+        // boxes nobody goes back to clean up.
+        let mut info = stopped_box(86_400, Duration::hours(18));
+        info.status = BoxStatus::Failed;
+        assert_eq!(delete_cell_at(&info, fixed_now()), "in 6 hours");
+
+        let mut overdue = stopped_box(3_600, Duration::hours(5));
+        overdue.status = BoxStatus::Failed;
+        assert_eq!(delete_cell_at(&overdue, fixed_now()), "due");
+    }
+
+    #[test]
+    fn an_elapsed_deadline_reads_as_due_not_as_a_wrapped_duration() {
+        // `checked_sub` guards this: unsigned arithmetic would otherwise wrap a
+        // passed deadline into an enormous remaining time.
+        let info = stopped_box(3_600, Duration::hours(5));
+        assert_eq!(delete_cell_at(&info, fixed_now()), "due");
+
+        let exactly_now = stopped_box(3_600, Duration::seconds(3_600));
+        assert_eq!(delete_cell_at(&exactly_now, fixed_now()), "due");
+    }
+
+    #[test]
+    fn autodelete_off_reads_as_off_in_every_state() {
+        for status in [BoxStatus::Running, BoxStatus::Stopped] {
+            let mut info = stopped_box(0, Duration::hours(100));
+            info.status = status;
+            assert_eq!(
+                delete_cell_at(&info, fixed_now()),
+                "off",
+                "status {status:?}"
+            );
+        }
+    }
 }

--- a/src/cli/src/commands/run.rs
+++ b/src/cli/src/commands/run.rs
@@ -65,14 +65,23 @@ struct BoxRunner {
     args: RunArgs,
     rt: BoxliteRuntime,
     home: Option<std::path::PathBuf>,
+    /// Whether this invocation talks to a REST server, which decides how `--rm`
+    /// is spelled on the way out — see `ManagementFlags::apply_to`.
+    targets_rest: bool,
 }
 
 impl BoxRunner {
     fn new(args: RunArgs, global: &GlobalFlags) -> anyhow::Result<Self> {
+        let targets_rest = global.targets_rest();
         let rt = global.create_runtime()?;
         let home = global.home.clone();
 
-        Ok(Self { args, rt, home })
+        Ok(Self {
+            args,
+            rt,
+            home,
+            targets_rest,
+        })
     }
 
     async fn run(&mut self, rootfs: RootfsSpec, command_args: Vec<String>) -> anyhow::Result<i32> {
@@ -132,7 +141,9 @@ impl BoxRunner {
         self.args.resource.apply_to(&mut options);
         self.args.capability.apply_to(&mut options);
         self.args.boot.apply_to(&mut options);
-        self.args.management.apply_to(&mut options)?;
+        self.args
+            .management
+            .apply_to(&mut options, self.targets_rest)?;
         self.args.publish.apply_to(&mut options)?;
         self.args
             .volume
@@ -140,11 +151,7 @@ impl BoxRunner {
         self.args.network.apply_to(&mut options)?;
         self.args.process.apply_to(&mut options)?;
 
-        // Detached boxes keep manual lifecycle control: detach silently
-        // overrides --rm (historical CLI behavior).
-        if self.args.management.detach {
-            options.auto_delete = Some(0);
-        }
+        self.args.management.apply_detach_override(&mut options);
 
         // Docker semantics: the user COMMAND replaces the image CMD (the image
         // ENTRYPOINT is preserved and prepended) and the result runs as the

--- a/src/cli/src/commands/serve/README.md
+++ b/src/cli/src/commands/serve/README.md
@@ -27,11 +27,14 @@ let rt = BoxliteRuntime::rest(BoxliteRestOptions::new("http://localhost:8100"))?
 ```
 execute(ServeArgs, GlobalFlags)
   │
-  ├─ GlobalFlags::create_runtime()          — build local BoxliteRuntime
-  │
-  ├─ Arc::new(AppState { runtime, boxes, executions })
+  ├─ GlobalFlags::create_serve_runtime()     — local BoxliteRuntime, declaring
+  │                                            a lifecycle sweeper so AutoStop /
+  │                                            AutoDelete are accepted
+  ├─ Arc::new(AppState { runtime, boxes, executions, last_activity,
+  │                      api_key, enforces_lifecycle })
   │                                          — shared state for all handlers
-  ├─ tokio::spawn(reaper_loop(state))       — background orphan reaper (30 s tick)
+  ├─ tokio::spawn(reaper_loop(state))       — orphan reaper + lifecycle sweep
+  │                                            (30 s tick)
   │
   ├─ build_router(state)                    — register 26 routes on axum::Router
   │
@@ -84,7 +87,25 @@ execute(ServeArgs, GlobalFlags)
 
 `AppState.boxes` is a lazy cache — `get_or_fetch_box()` populates it from `runtime.get()` on first
 access. `AppState.executions` maps execution IDs to `Arc<ActiveExecution>` for the active-session
-registry.
+registry. `AppState.last_activity` is the per-box idle clock AutoStop sweeps against, keyed by the URL segment
+the client used — which the contract lets be either a box id or its name, so the sweep reads both
+spellings. `AppState.enforces_lifecycle` is false when this `serve` proxies to another server, which
+owns those boxes and sweeps them itself.
+
+Two resolvers, split by whether the handler needs the VM **up**:
+
+| Resolver             | AutoResume gate | Used by                                              |
+|----------------------|-----------------|------------------------------------------------------|
+| `get_or_fetch_box()` | yes — 409       | exec, files, attach, metrics                          |
+| `fetch_box()`        | no              | start, stop, snapshots, clone, export                 |
+
+`get_or_fetch_box()` implements **AutoResume**: a stopped box is handed back as a fresh handle that
+boots on first use, unless it was created with `auto_resume: false`, in which case the call returns
+**409** — the caller asked that no operation wake it behind their back.
+
+`fetch_box()` is deliberately ungated. `auto_resume: false` means "nothing may wake this box
+implicitly", not "this box may never be touched again". Gating `/start` would make the 409's own
+advice impossible to follow, and gating snapshot listing would answer a pure metadata read with it.
 
 ## Handler Reference
 
@@ -310,7 +331,27 @@ reaper_loop(state)
   ├─ resolve_duration("BOXLITE_SHUTDOWN_GRACE",   30 s)
   ├─ resolve_duration("BOXLITE_MAX_SESSION_LIFETIME", 86400 s)
   │
-  └─ loop { ticker.tick(); run_reap_once(...) }
+  └─ loop { ticker.tick(); run_reap_once(...); run_lifecycle_once(...) }
+
+run_lifecycle_once(state, now) -> bool             — false when not ours
+  │
+  ├─ state.enforces_lifecycle                  — a proxying serve sweeps
+  │                                              nothing; the server that
+  │                                              owns the boxes does
+  ├─ runtime.list_info()                       — every box and its policy
+  ├─ decide_lifecycle(status, auto_stop, auto_delete, idle, since_stop)
+  │    │                                        — Stop / Delete / Leave
+  │    └─ idle = newest last_activity[alias] over {id, name} (monotonic);
+  │              an unseen box is seeded at this tick, never measured
+  │              against BoxInfo.last_updated
+  │    └─ since_stop = now - BoxInfo.last_updated (the stop transition)
+  ├─ Stop   → box.stop()
+  ├─ Delete → evict state.boxes, runtime.remove(box, force = false),
+  │           forget_box_activity()          — a removed box is never
+  │                                            re-fetched, so nothing else
+  │                                            would drop its handle
+  └─ retain_box_activity(live)                 — drop clocks for ids no
+                                                 box answers to
 
 run_reap_once(state, now, ...)
   │

--- a/src/cli/src/commands/serve/handlers/advanced.rs
+++ b/src/cli/src/commands/serve/handlers/advanced.rs
@@ -11,16 +11,14 @@ use axum::response::{IntoResponse, Response};
 use boxlite::{BoxArchive, CloneOptions, ExportOptions};
 
 use super::super::types::{CloneRequest, ImportQuery};
-use super::super::{
-    AppState, box_info_to_response, error_from_boxlite, error_response, get_or_fetch_box,
-};
+use super::super::{AppState, box_info_to_response, error_from_boxlite, error_response, fetch_box};
 
 pub(in crate::commands::serve) async fn clone_box(
     State(state): State<Arc<AppState>>,
     Path(box_id): Path<String>,
     Json(req): Json<CloneRequest>,
 ) -> Response {
-    let litebox = match get_or_fetch_box(&state, &box_id).await {
+    let litebox = match fetch_box(&state, &box_id).await {
         Ok(b) => b,
         Err(resp) => return resp,
     };
@@ -48,7 +46,7 @@ pub(in crate::commands::serve) async fn export_box(
     State(state): State<Arc<AppState>>,
     Path(box_id): Path<String>,
 ) -> Response {
-    let litebox = match get_or_fetch_box(&state, &box_id).await {
+    let litebox = match fetch_box(&state, &box_id).await {
         Ok(b) => b,
         Err(resp) => return resp,
     };

--- a/src/cli/src/commands/serve/handlers/boxes.rs
+++ b/src/cli/src/commands/serve/handlers/boxes.rs
@@ -10,7 +10,7 @@ use axum::response::{IntoResponse, Response};
 use super::super::types::{CreateBoxRequest, ListBoxesResponse, RemoveQuery};
 use super::super::{
     AppState, box_info_to_response, build_box_options, error_from_boxlite, error_response,
-    get_or_fetch_box,
+    fetch_box,
 };
 
 pub(in crate::commands::serve) async fn create_box(
@@ -111,7 +111,8 @@ pub(in crate::commands::serve) async fn start_box(
         }
     }
 
-    let litebox = match get_or_fetch_box(&state, &box_id).await {
+    // Explicit start: never gated on auto_resume, which governs implicit wakes.
+    let litebox = match fetch_box(&state, &box_id).await {
         Ok(b) => b,
         Err(resp) => return resp,
     };
@@ -131,7 +132,8 @@ pub(in crate::commands::serve) async fn stop_box(
     State(state): State<Arc<AppState>>,
     Path(box_id): Path<String>,
 ) -> Response {
-    let litebox = match get_or_fetch_box(&state, &box_id).await {
+    // Explicit stop: likewise ungated.
+    let litebox = match fetch_box(&state, &box_id).await {
         Ok(b) => b,
         Err(resp) => return resp,
     };
@@ -161,7 +163,12 @@ pub(in crate::commands::serve) async fn remove_box(
     let force = query.force.unwrap_or(true);
 
     match state.runtime.remove(&box_id, force).await {
-        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Ok(()) => {
+            // Drop the idle clock with the box, or the map keeps an entry per
+            // deleted box for the lifetime of the process.
+            state.forget_box_activity(&box_id).await;
+            StatusCode::NO_CONTENT.into_response()
+        }
         Err(e) => error_from_boxlite(&e),
     }
 }

--- a/src/cli/src/commands/serve/handlers/executions.rs
+++ b/src/cli/src/commands/serve/handlers/executions.rs
@@ -255,7 +255,7 @@ pub(in crate::commands::serve) async fn attach_execution(
         );
     }
 
-    upgrade_to_attach_session(ws, active)
+    upgrade_to_attach_session(ws, active, state)
 }
 
 /// Attach to the box's **main command session** — the container's init.
@@ -305,7 +305,7 @@ pub(in crate::commands::serve) async fn attach_box(
         }
     };
 
-    let mut response = upgrade_to_attach_session(ws, active);
+    let mut response = upgrade_to_attach_session(ws, active, state);
     response
         .headers_mut()
         .insert(MAIN_SESSION_ID_HEADER, header_value);
@@ -318,7 +318,11 @@ pub(in crate::commands::serve) async fn attach_box(
 /// permanently unattachable and unreapable.
 ///
 /// The caller must have already claimed the slot with `mark_connected()`.
-fn upgrade_to_attach_session(ws: WebSocketUpgrade, active: Arc<ActiveExecution>) -> Response {
+fn upgrade_to_attach_session(
+    ws: WebSocketUpgrade,
+    active: Arc<ActiveExecution>,
+    state: Arc<AppState>,
+) -> Response {
     let failed_active = Arc::clone(&active);
     ws.on_failed_upgrade(move |_err| {
         tokio::spawn(async move {
@@ -326,11 +330,11 @@ fn upgrade_to_attach_session(ws: WebSocketUpgrade, active: Arc<ActiveExecution>)
         });
     })
     .on_upgrade(move |socket| async move {
-        run_attach_session(socket, active).await;
+        run_attach_session(socket, active, state).await;
     })
 }
 
-async fn run_attach_session(socket: WebSocket, active: Arc<ActiveExecution>) {
+async fn run_attach_session(socket: WebSocket, active: Arc<ActiveExecution>, state: Arc<AppState>) {
     let mut stdout_rx = active.stdout_bus().subscribe();
     let mut stderr_rx = active.stderr_bus().subscribe();
     let mut done_rx = active.done_rx();
@@ -341,8 +345,21 @@ async fn run_attach_session(socket: WebSocket, active: Arc<ActiveExecution>) {
     let (ctrl_tx, mut ctrl_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
 
     let reader_active = Arc::clone(&active);
+    let reader_state = Arc::clone(&state);
     let mut reader = tokio::spawn(async move {
         while let Some(msg) = stream.next().await {
+            // Client *data* frames renew the lease. The upgrade itself is
+            // stamped once, like any other box request, but that alone would
+            // only hold the box for a single window: a terminal left open
+            // overnight must be allowed to idle out, while one someone is
+            // typing into must keep its box alive past the AutoStop window. A
+            // Close frame or a transport error ends the session rather than
+            // using it, so neither renews the lease.
+            if matches!(msg, Ok(Message::Binary(_)) | Ok(Message::Text(_))) {
+                reader_state
+                    .record_box_activity(reader_active.box_id())
+                    .await;
+            }
             match msg {
                 Ok(Message::Binary(bytes)) => {
                     let mut guard = reader_active.stdin().lock().await;

--- a/src/cli/src/commands/serve/handlers/snapshots.rs
+++ b/src/cli/src/commands/serve/handlers/snapshots.rs
@@ -10,7 +10,7 @@ use axum::response::{IntoResponse, Response};
 use boxlite::SnapshotOptions;
 
 use super::super::types::{CreateSnapshotRequest, ListSnapshotsResponse, SnapshotResponse};
-use super::super::{AppState, error_from_boxlite, error_response, get_or_fetch_box};
+use super::super::{AppState, error_from_boxlite, error_response, fetch_box};
 
 fn snapshot_to_response(info: &boxlite::SnapshotInfo) -> SnapshotResponse {
     SnapshotResponse {
@@ -28,7 +28,7 @@ pub(in crate::commands::serve) async fn create_snapshot(
     Path(box_id): Path<String>,
     Json(req): Json<CreateSnapshotRequest>,
 ) -> Response {
-    let litebox = match get_or_fetch_box(&state, &box_id).await {
+    let litebox = match fetch_box(&state, &box_id).await {
         Ok(b) => b,
         Err(resp) => return resp,
     };
@@ -47,7 +47,7 @@ pub(in crate::commands::serve) async fn list_snapshots(
     State(state): State<Arc<AppState>>,
     Path(box_id): Path<String>,
 ) -> Response {
-    let litebox = match get_or_fetch_box(&state, &box_id).await {
+    let litebox = match fetch_box(&state, &box_id).await {
         Ok(b) => b,
         Err(resp) => return resp,
     };
@@ -65,7 +65,7 @@ pub(in crate::commands::serve) async fn get_snapshot(
     State(state): State<Arc<AppState>>,
     Path((box_id, name)): Path<(String, String)>,
 ) -> Response {
-    let litebox = match get_or_fetch_box(&state, &box_id).await {
+    let litebox = match fetch_box(&state, &box_id).await {
         Ok(b) => b,
         Err(resp) => return resp,
     };
@@ -86,7 +86,7 @@ pub(in crate::commands::serve) async fn delete_snapshot(
     State(state): State<Arc<AppState>>,
     Path((box_id, name)): Path<(String, String)>,
 ) -> Response {
-    let litebox = match get_or_fetch_box(&state, &box_id).await {
+    let litebox = match fetch_box(&state, &box_id).await {
         Ok(b) => b,
         Err(resp) => return resp,
     };
@@ -101,7 +101,7 @@ pub(in crate::commands::serve) async fn restore_snapshot(
     State(state): State<Arc<AppState>>,
     Path((box_id, name)): Path<(String, String)>,
 ) -> Response {
-    let litebox = match get_or_fetch_box(&state, &box_id).await {
+    let litebox = match fetch_box(&state, &box_id).await {
         Ok(b) => b,
         Err(resp) => return resp,
     };

--- a/src/cli/src/commands/serve/mod.rs
+++ b/src/cli/src/commands/serve/mod.rs
@@ -25,8 +25,8 @@ use tower_http::request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetReques
 
 use boxlite::runtime::options::{InboundNetworkConfig, NetworkMode, OutboundNetworkConfig};
 use boxlite::{
-    BoxCommand, BoxInfo, BoxOptions, BoxliteRuntime, ExecStdin, Execution, LiteBox, NetworkSpec,
-    RootfsSpec,
+    BoxCommand, BoxInfo, BoxOptions, BoxStatus, BoxliteRuntime, ExecStdin, Execution, LiteBox,
+    NetworkSpec, RootfsSpec,
 };
 
 use crate::cli::GlobalFlags;
@@ -68,9 +68,74 @@ struct AppState {
     /// `Arc` so attach sessions can drop the map lock before doing
     /// long-running WS pumping while keeping the exec alive.
     executions: RwLock<HashMap<String, Arc<ActiveExecution>>>,
+    /// Last observed user activity per box, for AutoStop.
+    ///
+    /// In-memory and deliberately not persisted: `serve` holds the
+    /// `BOXLITE_HOME` lock for its whole life, so while it runs nothing else can
+    /// touch these boxes and this map is a complete record.
+    ///
+    /// Across a restart it starts empty, and the sweep must not fall back to
+    /// `BoxInfo.last_updated` for idleness. That field is written by state
+    /// transitions and health checks only — never by exec, files or attach — so
+    /// on a box that has been up and busy for hours it reports the *boot* time.
+    /// Using it would over-estimate idle and stop exactly the boxes that are in
+    /// use. Instead the sweep seeds an unseen running box at the current tick,
+    /// giving it a full window to prove itself idle.
+    last_activity: RwLock<HashMap<String, Instant>>,
     /// Optional expected API key (`--api-key` / `$BOXLITE_SERVE_API_KEY`).
     /// `None` ⇒ permissive (no auth enforced).
     api_key: Option<String>,
+    /// Whether this process sweeps the boxes it serves.
+    ///
+    /// False when `serve` is itself proxying to another server: that server
+    /// enforces its own deadlines over boxes this one cannot see, and
+    /// `last_activity` above would report all of them as untouched.
+    enforces_lifecycle: bool,
+}
+
+impl AppState {
+    /// Mark a box as used right now, resetting its AutoStop window.
+    ///
+    /// The single write site for the idle clock, so every caller — the request
+    /// middleware and the WebSocket session loop — agrees on what "used" means.
+    pub(in crate::commands::serve) async fn record_box_activity(&self, box_id: &str) {
+        // The clock exists only to feed this process's sweep. When another
+        // server owns these boxes nothing reads it and nothing prunes it, so
+        // recording would grow the map for the life of the process.
+        if !self.enforces_lifecycle {
+            return;
+        }
+        self.last_activity
+            .write()
+            .await
+            .insert(box_id.to_string(), Instant::now());
+    }
+
+    /// Forget a removed box's idle clock.
+    ///
+    /// Without this the map grows for the lifetime of the process: a box deleted
+    /// through `DELETE /boxes/{id}` would leave its entry behind forever.
+    pub(in crate::commands::serve) async fn forget_box_activity(&self, box_id: &str) {
+        self.last_activity.write().await.remove(box_id);
+    }
+
+    /// Drop idle clocks for boxes that no longer exist.
+    ///
+    /// `forget_box_activity` covers the boxes this server deletes, but not the
+    /// ones that were never there: the activity middleware stamps a clock from
+    /// the request path, before any handler can reject an unknown id, so a
+    /// client looping over made-up ids would otherwise grow this map for the
+    /// life of the process. The sweep already holds the authoritative list, so
+    /// it reconciles against it on every tick.
+    pub(in crate::commands::serve) async fn retain_box_activity(
+        &self,
+        live: &std::collections::HashSet<String>,
+    ) {
+        self.last_activity
+            .write()
+            .await
+            .retain(|box_id, _| live.contains(box_id));
+    }
 }
 
 /// Which stdio session an [`ActiveExecution`] fronts.
@@ -565,14 +630,9 @@ async fn reaper_loop(state: Arc<AppState>) {
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     loop {
         ticker.tick().await;
-        run_reap_once(
-            &state,
-            Instant::now(),
-            reconnect_grace,
-            shutdown_grace,
-            max_lifetime,
-        )
-        .await;
+        let now = Instant::now();
+        run_reap_once(&state, now, reconnect_grace, shutdown_grace, max_lifetime).await;
+        run_lifecycle_once(&state, now).await;
     }
 }
 
@@ -835,7 +895,6 @@ fn build_box_options(req: &CreateBoxRequest) -> Result<BoxOptions, boxlite::Boxl
         })
         .unwrap_or_default();
 
-    let auto_delete = req.auto_delete.unwrap_or(0);
     Ok(BoxOptions {
         rootfs,
         cpus: req.cpus,
@@ -862,11 +921,18 @@ fn build_box_options(req: &CreateBoxRequest) -> Result<BoxOptions, boxlite::Boxl
             advanced
         },
         auto_stop: req.auto_stop,
-        auto_delete: Some(auto_delete),
+        auto_delete: req.auto_delete,
         auto_resume: req.auto_resume,
-        // Preserve the serve API's historical detached default for persistent
-        // boxes, but do not synthesize an invalid detached remove-on-stop box.
-        detach: req.detach.unwrap_or(auto_delete == 0),
+        // The wire contract has no synchronous-removal field, and this server
+        // sweeps deadlines instead — so never inherit `BoxOptions`' local
+        // remove-on-stop default, which would delete the box the moment it
+        // stopped and leave any deadline nothing to act on.
+        auto_remove: false,
+        // Boxes served over REST always outlive the request that made them.
+        // Previously derived from `auto_delete`, which forced any box with a
+        // deadline to be non-detached — it could then not survive a restart,
+        // making a long deadline unreachable.
+        detach: req.detach.unwrap_or(true),
         ..Default::default()
     })
 }
@@ -990,6 +1056,239 @@ async fn require_api_key(State(state): State<Arc<AppState>>, req: Request, next:
     }
 }
 
+// ============================================================================
+// Lifecycle deadlines — AutoStop / AutoDelete
+// ============================================================================
+
+/// What the lifecycle sweep decided for one box.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LifecycleAction {
+    Leave,
+    Stop,
+    Delete,
+}
+
+/// Decide one box's fate from its policy and observed clocks alone.
+///
+/// Split out from the sweep so the rule is testable without a VM, a runtime, or
+/// a clock: the sweep's job is only to gather these inputs and apply the answer.
+/// `0` disables either deadline, matching the wire contract.
+fn decide_lifecycle(
+    status: BoxStatus,
+    auto_stop_secs: u32,
+    auto_delete_secs: u32,
+    idle: std::time::Duration,
+    since_stop: std::time::Duration,
+) -> LifecycleAction {
+    // A running box is stopped once it has been idle for the whole window.
+    if status == BoxStatus::Running
+        && auto_stop_secs > 0
+        && idle >= std::time::Duration::from_secs(u64::from(auto_stop_secs))
+    {
+        return LifecycleAction::Stop;
+    }
+
+    // A box that has come to rest is deleted once it has been at rest for the
+    // whole window. Anchored on that transition, not on last activity: a box
+    // that was busy right before it stopped must still age out on schedule.
+    if status.is_at_rest()
+        && auto_delete_secs > 0
+        && since_stop >= std::time::Duration::from_secs(u64::from(auto_delete_secs))
+    {
+        return LifecycleAction::Delete;
+    }
+
+    LifecycleAction::Leave
+}
+
+/// Whether a request path is user activity on a box, and if so which box.
+///
+/// Box-scoped paths count by default. Defaulting to "counts" means a newly added
+/// box operation cannot silently become invisible to the idle clock and get its
+/// box stopped mid-flight.
+///
+/// `/start` counts, and must: it is the one operation whose whole purpose is to
+/// make a box usable again. Treating it as a mere state change left the previous
+/// stamp in place, so a box explicitly restarted long after it was AutoStopped
+/// was immediately stopped again by the next sweep, measuring from the stamp it
+/// carried into the stop.
+///
+/// The exclusions are the paths a poller hits on a timer — `/metrics`, and a
+/// bare `GET`/`HEAD`/`DELETE` on the box — which must never be able to hold a
+/// box open forever. `/stop` is excluded because it cannot matter: AutoStop
+/// ignores a box that is already stopped, and AutoDelete measures from
+/// `last_updated`, not from this clock.
+fn activity_box_id(path: &str) -> Option<&str> {
+    let rest = path.strip_prefix("/v1/boxes/")?;
+    // No suffix means a bare `/v1/boxes/{id}` — get, head, delete. Not activity.
+    // This also covers `/v1/boxes/import`, which has no suffix of its own.
+    let (box_id, suffix) = rest.split_once('/')?;
+    if box_id.is_empty() {
+        return None;
+    }
+    match suffix {
+        "metrics" | "stop" => None,
+        _ => Some(box_id),
+    }
+}
+
+/// Activity middleware: stamps the idle clock before the handler runs.
+///
+/// Before, not after: a long exec or a large upload must not look idle for its
+/// whole duration. A WebSocket attach re-stamps per client frame from inside the
+/// session loop ([`handlers::executions`]), because the upgrade alone would only
+/// keep the box alive for one window while someone was still typing.
+async fn record_activity(State(state): State<Arc<AppState>>, req: Request, next: Next) -> Response {
+    if let Some(box_id) = activity_box_id(req.uri().path()) {
+        state.record_box_activity(box_id).await;
+    }
+    next.run(req).await
+}
+
+/// How long a box has been idle, seeding the clock if this `serve` has not seen
+/// it before.
+///
+/// Idle comes only from the monotonic in-memory stamp. A box with no stamp — the
+/// state after a restart — is seeded at `now` and reported as freshly used, so it
+/// gets a full window to prove itself idle. It is deliberately *not* measured
+/// against `BoxInfo.last_updated`, which tracks state transitions rather than
+/// use and would report a long-running box as idle since boot.
+///
+/// Split out from the sweep so the lock discipline is testable on its own: the
+/// read guard must be released before taking the write lock. Holding it across
+/// the `.write().await` — which is what a `match` on the read guard does, since
+/// the scrutinee temporary outlives the arms — self-deadlocks on `tokio`'s
+/// `RwLock` and hangs the whole reaper loop, orphan-exec reaping included.
+/// `aliases` are the spellings the wire contract blesses — the canonical id
+/// first, then the box's name. (`lookup_box` additionally resolves a unique id
+/// prefix, which the contract does not bless: it tells clients to pass the
+/// identifier back verbatim, and no first-party client sends anything else.)
+/// The middleware stamps the raw `{box_id}` URL segment,
+/// and the wire contract lets that be either the id or the box's name — so a
+/// box driven as `/v1/boxes/web/exec` writes its clock under `web` while the
+/// sweep knows it as its id. Reading only one spelling loses the other's
+/// activity entirely and stops a box that is in continuous use.
+async fn idle_or_seed(
+    last_activity: &RwLock<HashMap<String, Instant>>,
+    aliases: &[String],
+    now: Instant,
+) -> std::time::Duration {
+    // Most recent wins: activity under any spelling is activity on the box.
+    let stamped = {
+        let clocks = last_activity.read().await;
+        aliases
+            .iter()
+            .filter_map(|alias| clocks.get(alias).copied())
+            .max()
+    };
+    match stamped {
+        Some(stamped) => now.saturating_duration_since(stamped),
+        None => {
+            last_activity.write().await.insert(aliases[0].clone(), now);
+            std::time::Duration::ZERO
+        }
+    }
+}
+
+/// One lifecycle pass: stop idle boxes, delete boxes that have been stopped
+/// long enough. Runs on the same tick as the orphan-exec reaper.
+///
+/// Returns whether the sweep actually ran, so the "this process does not own
+/// these boxes" branch is observable to a test. Sweeping boxes owned by another
+/// server would stop and delete them on the first tick, since `last_activity`
+/// here has never seen them.
+async fn run_lifecycle_once(state: &AppState, now: Instant) -> bool {
+    if !state.enforces_lifecycle {
+        return false;
+    }
+
+    let boxes = match state.runtime.list_info().await {
+        Ok(boxes) => boxes,
+        Err(error) => {
+            tracing::warn!(%error, "lifecycle sweep could not list boxes");
+            return true;
+        }
+    };
+
+    let now_utc = chrono::Utc::now();
+    let mut live: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for info in boxes {
+        let box_id = info.id.to_string();
+
+        // Every spelling a client could address this box by, canonical id
+        // first. Both must count as activity and both must survive the prune.
+        let mut aliases = vec![box_id.clone()];
+        if let Some(name) = info.name.as_ref().filter(|name| *name != &box_id) {
+            aliases.push(name.clone());
+        }
+        live.extend(aliases.iter().cloned());
+
+        let idle = idle_or_seed(&state.last_activity, &aliases, now).await;
+
+        // The delete deadline does use `last_updated`: for a stopped box that
+        // transition *is* the stop, which is exactly the anchor AutoDelete wants.
+        let since_stop = (now_utc - info.last_updated)
+            .to_std()
+            .unwrap_or(std::time::Duration::ZERO);
+
+        match decide_lifecycle(
+            info.status,
+            info.auto_stop,
+            info.auto_delete,
+            idle,
+            since_stop,
+        ) {
+            LifecycleAction::Leave => {}
+            LifecycleAction::Stop => {
+                tracing::info!(
+                    box_id = %box_id,
+                    idle_secs = idle.as_secs(),
+                    auto_stop = info.auto_stop,
+                    "AutoStop deadline reached, stopping box"
+                );
+                match state.runtime.get(&box_id).await {
+                    Ok(Some(bx)) => {
+                        if let Err(error) = bx.stop().await {
+                            tracing::warn!(box_id = %box_id, %error, "AutoStop failed to stop box");
+                        }
+                    }
+                    Ok(None) => {}
+                    Err(error) => {
+                        tracing::warn!(box_id = %box_id, %error, "AutoStop could not fetch box")
+                    }
+                }
+            }
+            LifecycleAction::Delete => {
+                tracing::info!(
+                    box_id = %box_id,
+                    stopped_secs = since_stop.as_secs(),
+                    auto_delete = info.auto_delete,
+                    "AutoDelete deadline reached, removing box"
+                );
+                // Evict the cached handle before removing, as `remove_box`
+                // does. `get_or_fetch_box` self-heals a merely *stopped* box by
+                // replacing any non-active handle, but a removed box is never
+                // fetched again, so nothing would ever revalidate this entry and
+                // its `Arc<LiteBox>` would be held for the life of the process.
+                // Keyed by the canonical id: that is what every insert site uses.
+                state.boxes.write().await.remove(&box_id);
+                if let Err(error) = state.runtime.remove(&box_id, false).await {
+                    tracing::warn!(box_id = %box_id, %error, "AutoDelete failed to remove box");
+                } else {
+                    for alias in &aliases {
+                        state.forget_box_activity(alias).await;
+                        live.remove(alias);
+                    }
+                }
+            }
+        }
+    }
+
+    state.retain_box_activity(&live).await;
+
+    true
+}
+
 /// Length-checked constant-time byte compare — avoids a timing oracle on the
 /// configured token without pulling in a crate.
 fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
@@ -1007,8 +1306,86 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 // Box Handle Cache Helper
 // ============================================================================
 
+/// 409 for an operation that would have to wake a box whose owner turned
+/// AutoResume off. Conflict, not error: the box exists and the request is
+/// well-formed — it just needs an explicit `POST /boxes/{id}/start` first.
+fn auto_resume_disabled(box_id: &str) -> Response {
+    error_response(
+        StatusCode::CONFLICT,
+        format!(
+            "box {box_id} is not running and auto_resume is disabled; start it explicitly first"
+        ),
+        "InvalidStateError",
+        "invalid_state",
+    )
+}
+
+/// Resolve a box for an operation that needs it *running*, waking it if it is
+/// not. Refuses with 409 when the box is stopped and its owner turned AutoResume
+/// off.
+///
+/// Use this only where the handler will actually drive the guest — exec, file
+/// transfer, attach, live metrics. Anything that reads or manipulates a box
+/// without needing the VM up (start, stop, snapshots, clone, export) must use
+/// [`fetch_box`]: gating those turns a read-only request on a stopped box into a
+/// 409 telling the caller to start a box they never asked to run.
+///
+/// `/metrics` sits on this side because `LiteBox::metrics` reaches `live_state`
+/// and so does boot a stopped box. That diverges from the control plane's own
+/// activity policy, which lists Metrics as neither activity nor a resume trigger
+/// (`docs/architecture/auto-stop-resume-design.md`) — there the proxy answers
+/// without waking anything. Gating it is the safer of the two routings available
+/// here: it is what stops a metrics scrape from waking a box whose owner
+/// disabled AutoResume. Making a scrape return stale metrics instead of booting
+/// is the real fix, and belongs with `box_metrics`, not with this resolver.
 #[allow(clippy::result_large_err)]
 async fn get_or_fetch_box(state: &AppState, box_id: &str) -> Result<Arc<LiteBox>, Response> {
+    let handle = fetch_box(state, box_id).await?;
+
+    // A second read, on purpose. `fetch_box` reads `info` to decide whether a
+    // *cached* handle is still live and then discards it, and on the uncached
+    // path reads it only for the box id — `auto_resume` is part of neither
+    // decision. Sharing the value would mean threading it through a function
+    // whose other callers have no use for it.
+    //
+    // What matters here is that `info()` cannot wake the box: it reads the
+    // persisted state, and where it consults live state at all it does so
+    // through a non-initializing `OnceCell::get`. That is the property this gate
+    // depends on — asking is never itself the wake it is deciding whether to
+    // allow.
+    let info = handle.info().await.map_err(|e| error_from_boxlite(&e))?;
+    if !autoresume_allows(info.status, info.auto_resume) {
+        return Err(auto_resume_disabled(box_id));
+    }
+    Ok(handle)
+}
+
+/// Whether an operation that needs the VM up may proceed on a box in this state.
+///
+/// Split out from [`get_or_fetch_box`] for the same reason as
+/// [`decide_lifecycle`]: this is access-control branching, and inline it could
+/// only be exercised through a live runtime. As a pure function its whole truth
+/// table is testable, so inverting or deleting the rule fails a test rather than
+/// silently opening the gate.
+///
+/// A box that is already up needs no wake, so `auto_resume` does not apply to it
+/// — the flag governs *waking*, not *using*.
+fn autoresume_allows(status: BoxStatus, auto_resume: bool) -> bool {
+    status.is_active() || auto_resume
+}
+
+/// Resolve a box without waking it, for operations that do not need the VM up.
+///
+/// Deliberately ungated: `auto_resume: false` means "no operation may wake this
+/// box behind my back", not "this box may never be touched again". Routing
+/// `/start` through the gate made the 409's own advice — start it explicitly —
+/// impossible to follow; routing snapshot listing through it answered a
+/// metadata read with the same nonsense.
+#[allow(clippy::result_large_err)]
+pub(in crate::commands::serve) async fn fetch_box(
+    state: &AppState,
+    box_id: &str,
+) -> Result<Arc<LiteBox>, Response> {
     // Check cache first.
     //
     // A cached handle is only good while its box is up. A box can now stop
@@ -1271,6 +1648,12 @@ fn build_router(state: Arc<AppState>) -> Router {
             "/v1/boxes/{box_id}/export",
             post(advanced::export_box),
         )
+        // Activity is stamped inside the auth boundary: an unauthenticated
+        // request must not be able to keep someone else's box alive.
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            record_activity,
+        ))
         .layer(middleware::from_fn_with_state(
             state.clone(),
             require_api_key,
@@ -1300,13 +1683,15 @@ fn build_router(state: Arc<AppState>) -> Router {
 // ============================================================================
 
 pub async fn execute(args: ServeArgs, global: &GlobalFlags) -> anyhow::Result<()> {
-    let runtime = global.create_runtime()?;
+    let serve_runtime = global.create_serve_runtime()?;
 
     let state = Arc::new(AppState {
-        runtime,
+        runtime: serve_runtime.runtime,
         boxes: RwLock::new(HashMap::new()),
         executions: RwLock::new(HashMap::new()),
+        last_activity: RwLock::new(HashMap::new()),
         api_key: args.api_key.clone(),
+        enforces_lifecycle: serve_runtime.enforces_lifecycle,
     });
 
     // Phase 5.7: spawn the orphan reaper. Same escalation policy as the
@@ -1339,6 +1724,328 @@ mod tests {
     use super::*;
     use boxlite::runtime::options::NetworkSpec;
     use std::time::Duration;
+
+    // --- Lifecycle deadlines (pure; no runtime, VM or clock needed) ---
+
+    const RUNNING: BoxStatus = BoxStatus::Running;
+    const STOPPED: BoxStatus = BoxStatus::Stopped;
+
+    #[test]
+    fn a_zero_deadline_never_fires() {
+        // `0` is the disable sentinel on the wire, so an enormous idle time must
+        // still leave the box alone. Getting this wrong would delete every box
+        // that never configured a policy.
+        let forever = Duration::from_secs(86_400 * 365);
+        assert_eq!(
+            decide_lifecycle(RUNNING, 0, 0, forever, forever),
+            LifecycleAction::Leave
+        );
+        assert_eq!(
+            decide_lifecycle(STOPPED, 0, 0, forever, forever),
+            LifecycleAction::Leave
+        );
+    }
+
+    #[test]
+    fn autostop_fires_only_on_a_running_box_past_its_idle_window() {
+        // One second short of the window: still busy enough to keep.
+        assert_eq!(
+            decide_lifecycle(RUNNING, 900, 0, Duration::from_secs(899), Duration::ZERO),
+            LifecycleAction::Leave
+        );
+        // Exactly at the window — `>=`, so it fires.
+        assert_eq!(
+            decide_lifecycle(RUNNING, 900, 0, Duration::from_secs(900), Duration::ZERO),
+            LifecycleAction::Stop
+        );
+        // A box that is already stopped is not stopped again.
+        assert_eq!(
+            decide_lifecycle(STOPPED, 900, 0, Duration::from_secs(9_000), Duration::ZERO),
+            LifecycleAction::Leave
+        );
+    }
+
+    #[test]
+    fn autodelete_fires_only_on_a_stopped_box_past_its_window() {
+        assert_eq!(
+            decide_lifecycle(STOPPED, 0, 3600, Duration::ZERO, Duration::from_secs(3_599)),
+            LifecycleAction::Leave
+        );
+        assert_eq!(
+            decide_lifecycle(STOPPED, 0, 3600, Duration::ZERO, Duration::from_secs(3_600)),
+            LifecycleAction::Delete
+        );
+        // A running box is never deleted, however long it has been up: deletion
+        // is anchored on the stop, and it has not stopped.
+        assert_eq!(
+            decide_lifecycle(
+                RUNNING,
+                0,
+                3600,
+                Duration::ZERO,
+                Duration::from_secs(86_400)
+            ),
+            LifecycleAction::Leave
+        );
+    }
+
+    #[test]
+    fn stopping_takes_precedence_over_deleting_for_a_running_box() {
+        // Both deadlines configured and both elapsed: the box is running, so it
+        // must be stopped now and only become deletable afterwards. Deleting a
+        // running box here would destroy a live workload.
+        assert_eq!(
+            decide_lifecycle(
+                RUNNING,
+                900,
+                3600,
+                Duration::from_secs(10_000),
+                Duration::from_secs(10_000)
+            ),
+            LifecycleAction::Stop
+        );
+    }
+
+    // --- Idle clock (the sweep's lock discipline) ---
+
+    /// The seeding path must not deadlock. Holding the read guard across the
+    /// `.write().await` — which a `match` on the guard does, since the scrutinee
+    /// temporary outlives the arms — hangs `tokio`'s RwLock forever and takes the
+    /// whole reaper loop with it, orphan-exec reaping included. The timeout is
+    /// the assertion: without the fix this call never returns.
+    #[tokio::test]
+    async fn seeding_an_unseen_box_does_not_deadlock() {
+        let map: RwLock<HashMap<String, Instant>> = RwLock::new(HashMap::new());
+        let now = Instant::now();
+
+        let idle = tokio::time::timeout(
+            std::time::Duration::from_secs(3),
+            idle_or_seed(&map, &["fresh".to_string()], now),
+        )
+        .await
+        .expect("idle_or_seed must not hold the read guard across the write lock");
+
+        assert_eq!(idle, std::time::Duration::ZERO);
+        assert!(
+            map.read().await.contains_key("fresh"),
+            "the box must be seeded so the next tick measures from here"
+        );
+    }
+
+    /// A box `serve` has never seen reads as freshly used, not as idle since
+    /// boot — otherwise the first tick after a restart stops every long-running
+    /// box whose window is shorter than its uptime.
+    ///
+    /// Timeout-wrapped for the same reason as the test above: the seeding path
+    /// deadlocks rather than returning a wrong answer when the lock discipline
+    /// regresses, and a test that hangs stalls CI instead of failing it.
+    #[tokio::test]
+    async fn an_unseen_box_starts_its_window_now_rather_than_looking_idle() {
+        let map: RwLock<HashMap<String, Instant>> = RwLock::new(HashMap::new());
+        let now = Instant::now();
+        let budget = std::time::Duration::from_secs(3);
+
+        let first = tokio::time::timeout(budget, idle_or_seed(&map, &["b".to_string()], now))
+            .await
+            .expect("seeding must not deadlock");
+        assert_eq!(first, std::time::Duration::ZERO);
+
+        // A later tick measures from the seed, not from zero again.
+        let later = now + std::time::Duration::from_secs(600);
+        let second = tokio::time::timeout(budget, idle_or_seed(&map, &["b".to_string()], later))
+            .await
+            .expect("reading a seeded box must not deadlock");
+        assert_eq!(second, std::time::Duration::from_secs(600));
+    }
+
+    /// Which resolver each handler uses is a policy decision, so pin it in the
+    /// source rather than trusting prose. The gate belongs only where the
+    /// handler drives the guest; on anything else it turns a request that never
+    /// needed a running box — a snapshot listing, an export — into a 409 telling
+    /// the caller to start a box they did not ask to run. Fixing `/start` and
+    /// `/stop` while leaving those siblings gated is exactly the bug this pins.
+    #[test]
+    fn only_handlers_that_need_a_running_box_use_the_gated_resolver() {
+        // Count *calls*, not mentions: a leftover `use` import would otherwise
+        // satisfy a `contains` check and let a re-gated handler slip through.
+        fn gated_calls(src: &str) -> usize {
+            src.matches("get_or_fetch_box(").count()
+        }
+
+        for (name, src, why) in [
+            (
+                "snapshots",
+                include_str!("handlers/snapshots.rs"),
+                "read metadata and must not be AutoResume-gated",
+            ),
+            (
+                "advanced",
+                include_str!("handlers/advanced.rs"),
+                "clone/export do not need the VM up",
+            ),
+            (
+                "boxes",
+                include_str!("handlers/boxes.rs"),
+                "explicit start/stop must never be gated",
+            ),
+        ] {
+            assert_eq!(gated_calls(src), 0, "{name}: {why}");
+        }
+
+        // ...and the gate must still be in force where a wake really happens.
+        for (name, src) in [
+            ("executions", include_str!("handlers/executions.rs")),
+            ("files", include_str!("handlers/files.rs")),
+            ("metrics", include_str!("handlers/metrics.rs")),
+        ] {
+            assert!(
+                gated_calls(src) > 0,
+                "{name} drives the guest and must stay AutoResume-gated"
+            );
+        }
+
+        // The main-session attach resolver lives in this module, not a handler
+        // file, so pin it here too rather than leaving it uncovered.
+        //
+        // `include_str!("mod.rs")` pulls in this test module as well, where both
+        // needles appear verbatim — so scanning the whole file would satisfy the
+        // assertion from its own source no matter what the resolver does. Slice
+        // the resolver's body out of the production half and count calls there.
+        // Ends at the function's own closing brace: a top-level `}` is the first
+        // one at column 0, since everything nested inside is indented. Stopping
+        // at the next `async fn` instead would swallow the rest of the file
+        // whenever this is the last one, and any unrelated gated call added
+        // later would then satisfy the assertion.
+        fn body_of<'a>(src: &'a str, signature: &str) -> &'a str {
+            let after = src
+                .split_once(signature)
+                .unwrap_or_else(|| panic!("{signature} must exist in this module"))
+                .1;
+            after
+                .split_once("\n}\n")
+                .map(|(body, _)| body)
+                .unwrap_or(after)
+        }
+
+        let production = include_str!("mod.rs")
+            .split_once("\n#[cfg(test)]")
+            .expect("this module must have a test module")
+            .0;
+        assert!(
+            gated_calls(body_of(production, "async fn get_or_attach_main_session")) > 0,
+            "attach must keep resolving through the gated path"
+        );
+    }
+
+    // --- AutoResume gate ---
+
+    /// The whole truth table, so inverting or dropping the rule fails here.
+    /// `is_active()` is Running | Paused; every other state needs a wake.
+    #[test]
+    fn autoresume_gates_only_states_that_would_need_waking() {
+        // Already up: no wake is involved, so the flag must not block use. A box
+        // whose owner disabled AutoResume is still perfectly usable while running.
+        for auto_resume in [true, false] {
+            assert!(
+                autoresume_allows(BoxStatus::Running, auto_resume),
+                "a running box needs no wake (auto_resume={auto_resume})"
+            );
+            assert!(
+                autoresume_allows(BoxStatus::Paused, auto_resume),
+                "a paused box is active and needs no boot (auto_resume={auto_resume})"
+            );
+        }
+
+        // Not up: the flag decides. These are exactly the states where
+        // proceeding would boot the box behind the caller's back.
+        for status in [
+            BoxStatus::Stopped,
+            BoxStatus::Configured,
+            BoxStatus::Failed,
+            BoxStatus::Stopping,
+            BoxStatus::Unknown,
+        ] {
+            assert!(
+                autoresume_allows(status, true),
+                "{status:?} + auto_resume must be allowed to wake"
+            );
+            assert!(
+                !autoresume_allows(status, false),
+                "{status:?} + no auto_resume must be refused, not silently booted"
+            );
+        }
+    }
+
+    // --- Activity classification ---
+
+    #[test]
+    fn user_operations_on_a_box_count_as_activity() {
+        for path in [
+            "/v1/boxes/abc/exec",
+            "/v1/boxes/abc/executions/e1",
+            "/v1/boxes/abc/executions/e1/attach",
+            "/v1/boxes/abc/attach",
+            "/v1/boxes/abc/files",
+            "/v1/boxes/abc/snapshots",
+            "/v1/boxes/abc/clone",
+        ] {
+            assert_eq!(activity_box_id(path), Some("abc"), "{path} must count");
+        }
+    }
+
+    #[test]
+    fn polling_and_lifecycle_paths_are_not_activity() {
+        // A dashboard refreshing `ls` or scraping metrics must not be able to
+        // keep every box alive forever — that would silently defeat AutoStop.
+        for path in [
+            "/v1/boxes/abc/metrics",
+            "/v1/boxes/abc/stop",
+            "/v1/boxes/abc",
+            "/v1/boxes",
+            "/v1/boxes/import",
+            "/v1/metrics",
+            "/v1/config",
+            "/v1/me",
+        ] {
+            assert_eq!(activity_box_id(path), None, "{path} must not count");
+        }
+    }
+
+    /// Starting a box must reset its clock. Without this the stamp from before
+    /// the AutoStop survives, and the next sweep — up to 30s later — reads the
+    /// box as idle for however long it sat stopped and stops it again, killing
+    /// an explicit start with no error.
+    #[test]
+    fn starting_a_box_counts_as_activity() {
+        assert_eq!(activity_box_id("/v1/boxes/abc/start"), Some("abc"));
+    }
+
+    /// A box that failed will never run again on its own, so it must still age
+    /// out — otherwise exactly the boxes nobody returns to clean up leak.
+    #[test]
+    fn a_failed_box_still_reaches_its_delete_deadline() {
+        assert_eq!(
+            decide_lifecycle(
+                BoxStatus::Failed,
+                0,
+                3600,
+                Duration::ZERO,
+                Duration::from_secs(3_600)
+            ),
+            LifecycleAction::Delete
+        );
+        // ...but not before it.
+        assert_eq!(
+            decide_lifecycle(
+                BoxStatus::Failed,
+                0,
+                3600,
+                Duration::ZERO,
+                Duration::from_secs(3_599)
+            ),
+            LifecycleAction::Leave
+        );
+    }
 
     // --- API-key auth decision (pure; no runtime/network needed) ---
 
@@ -1535,7 +2242,7 @@ mod tests {
     }
 
     #[test]
-    fn build_box_options_carries_lifecycle_policy_and_uses_compatible_detach_default() {
+    fn build_box_options_carries_lifecycle_policy_and_stays_detached() {
         let req: super::types::CreateBoxRequest = serde_json::from_str(
             r#"{"auto_stop": 900, "auto_delete": 3600, "auto_resume": false}"#,
         )
@@ -1544,7 +2251,26 @@ mod tests {
         assert_eq!(opts.auto_stop, Some(900));
         assert_eq!(opts.auto_delete, Some(3600));
         assert_eq!(opts.auto_resume, Some(false));
-        assert!(!opts.detach, "remove-on-stop must not default to detached");
+
+        // A box with a delete deadline must still be detached. Detach used to be
+        // derived from `auto_delete`, which forced exactly these boxes to be
+        // non-detached — they then could not survive a `serve` restart, making a
+        // long deadline unreachable.
+        assert!(
+            opts.detach,
+            "a swept box must outlive the request that created it"
+        );
+        // And the synchronous axis must be off, or the box would be deleted the
+        // moment it stopped and the deadline would never be reached.
+        assert!(
+            !opts.auto_remove,
+            "serve sweeps deadlines; it must never inherit remove-on-stop"
+        );
+        // The pairing above is only representable because the axes are separate:
+        // prove it actually validates rather than trusting the field values.
+        opts.clone()
+            .sanitize()
+            .expect("a detached box with a delete deadline must be valid");
 
         let persistent: super::types::CreateBoxRequest =
             serde_json::from_str(r#"{"auto_delete": 0}"#).expect("body must deserialize");
@@ -1780,7 +2506,9 @@ mod tests {
             runtime: runtime.clone(),
             boxes: RwLock::new(HashMap::new()),
             executions: RwLock::new(HashMap::new()),
+            last_activity: RwLock::new(HashMap::new()),
             api_key: None,
+            enforces_lifecycle: true,
         });
         let (control_status, control_error) =
             upload_v3_archive(state.clone(), serde_json::json!({})).await;
@@ -2015,7 +2743,9 @@ mod tests {
             runtime,
             boxes: RwLock::new(HashMap::new()),
             executions: RwLock::new(HashMap::new()),
+            last_activity: RwLock::new(HashMap::new()),
             api_key: None,
+            enforces_lifecycle: true,
         });
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -2265,6 +2995,182 @@ mod tests {
         );
     }
 
+    /// An auto-deleted box must not leave its handle in the cache.
+    ///
+    /// `get_or_fetch_box` self-heals a merely *stopped* box by replacing any
+    /// non-active handle, but a removed box is never fetched again — so nothing
+    /// revalidates its entry, and the `Arc<LiteBox>` (with the VM resources it
+    /// holds) stays for the life of the process. The handle here is built by
+    /// production code from a real HTTP response, so the seed is not something
+    /// the test made up.
+    #[tokio::test]
+    async fn an_auto_deleted_box_leaves_no_cached_handle() {
+        // Stopped long ago with a 1s delete deadline, so the sweep must delete.
+        let box_json = serde_json::json!({
+            "box_id": "box1",
+            "name": null,
+            "status": "stopped",
+            "created_at": "2020-01-01T00:00:00Z",
+            "updated_at": "2020-01-01T00:00:00Z",
+            "pid": null,
+            "image": "alpine:latest",
+            "cpus": 1,
+            "memory_mib": 512,
+            "auto_delete": 1,
+        });
+        let list_json = serde_json::json!({ "boxes": [box_json.clone()] });
+
+        let stub = axum::Router::new()
+            .route(
+                "/v1/boxes",
+                axum::routing::get(move || {
+                    let body = list_json.clone();
+                    async move { axum::Json(body) }
+                }),
+            )
+            .route(
+                "/v1/boxes/box1",
+                axum::routing::get(move || {
+                    let body = box_json.clone();
+                    async move { axum::Json(body) }
+                })
+                .delete(|| async { axum::http::StatusCode::NO_CONTENT }),
+            );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let _ = axum::serve(listener, stub).await;
+        });
+
+        let runtime = BoxliteRuntime::rest(boxlite::BoxliteRestOptions::new(format!(
+            "http://127.0.0.1:{port}"
+        )))
+        .expect("rest runtime");
+        let state = AppState {
+            runtime,
+            boxes: RwLock::new(HashMap::new()),
+            executions: RwLock::new(HashMap::new()),
+            last_activity: RwLock::new(HashMap::new()),
+            api_key: None,
+            enforces_lifecycle: true,
+        };
+
+        get_or_fetch_box(&state, "box1")
+            .await
+            .expect("the stub must hand back a box");
+        assert!(
+            state.boxes.read().await.contains_key("box1"),
+            "precondition: fetching must cache the handle, or this proves nothing"
+        );
+
+        run_lifecycle_once(&state, Instant::now()).await;
+
+        assert!(
+            state.boxes.read().await.is_empty(),
+            "a swept box must not keep its handle cached"
+        );
+        server.abort();
+    }
+
+    /// Activity under a box's *name* must count as activity on that box.
+    ///
+    /// The middleware stamps the raw `{box_id}` URL segment, and the wire
+    /// contract lets that be either the id or a user-defined name, which
+    /// `runtime.get(id_or_name)` resolves. The sweep knows the box by its
+    /// canonical id, so reading only that spelling loses every request made by
+    /// name — and AutoStop then stops a box in continuous use, one window after
+    /// the sweep seeded it.
+    #[tokio::test]
+    async fn a_box_driven_by_name_is_not_idle_under_its_id() {
+        let map: RwLock<HashMap<String, Instant>> = RwLock::new(HashMap::new());
+        let now = Instant::now();
+        let aliases = ["box-abc123".to_string(), "web".to_string()];
+
+        // The client has been driving `/v1/boxes/web/...` all along.
+        map.write().await.insert("web".to_string(), now);
+
+        let idle = tokio::time::timeout(
+            std::time::Duration::from_secs(3),
+            idle_or_seed(&map, &aliases, now + std::time::Duration::from_secs(30)),
+        )
+        .await
+        .expect("reading must not deadlock");
+
+        assert_eq!(
+            idle,
+            std::time::Duration::from_secs(30),
+            "the name-keyed stamp is this box's activity and must be measured from"
+        );
+    }
+
+    /// The idle map must not grow on ids that were never boxes.
+    ///
+    /// `record_activity` stamps a clock straight off the request path, before
+    /// any handler can reject an unknown id, and `forget_box_activity` only
+    /// fires on a real delete — so a client looping over made-up ids would grow
+    /// this map for the life of the process.
+    #[tokio::test]
+    async fn the_idle_clock_drops_ids_that_are_not_boxes() {
+        let runtime = BoxliteRuntime::rest(boxlite::BoxliteRestOptions::new(
+            "http://127.0.0.1:1".to_string(),
+        ))
+        .expect("rest runtime");
+        let state = AppState {
+            runtime,
+            boxes: RwLock::new(HashMap::new()),
+            executions: RwLock::new(HashMap::new()),
+            last_activity: RwLock::new(HashMap::new()),
+            api_key: None,
+            enforces_lifecycle: true,
+        };
+
+        state.record_box_activity("real-box").await;
+        state.record_box_activity("never-existed").await;
+
+        let live = std::collections::HashSet::from(["real-box".to_string()]);
+        state.retain_box_activity(&live).await;
+
+        let clocks = state.last_activity.read().await;
+        assert!(
+            clocks.contains_key("real-box"),
+            "a live box keeps its clock"
+        );
+        assert!(
+            !clocks.contains_key("never-existed"),
+            "an id the runtime does not know must not hold a clock forever"
+        );
+    }
+
+    /// A `serve` that proxies to another server must not sweep that server's
+    /// boxes.
+    ///
+    /// The remote enforces its own deadlines, and `last_activity` here has
+    /// never seen those boxes — so a sweep from this side reads every one of
+    /// them as idle since this process started and stops or deletes them on the
+    /// first tick. Pinning the branch, not just the flag: without the guard the
+    /// sweep proceeds to `list_info` and this returns true.
+    #[tokio::test]
+    async fn a_proxying_serve_never_sweeps_the_boxes_it_does_not_own() {
+        let runtime = BoxliteRuntime::rest(boxlite::BoxliteRestOptions::new(
+            "http://127.0.0.1:1".to_string(),
+        ))
+        .expect("rest runtime");
+        let state = AppState {
+            runtime,
+            boxes: RwLock::new(HashMap::new()),
+            executions: RwLock::new(HashMap::new()),
+            last_activity: RwLock::new(HashMap::new()),
+            api_key: None,
+            enforces_lifecycle: false,
+        };
+
+        assert!(
+            !run_lifecycle_once(&state, Instant::now()).await,
+            "a proxying serve must leave the sweep to the server that owns the boxes"
+        );
+    }
+
     /// The reaper must never reap the box's main session.
     ///
     /// That session is the container's init, so killing it powers the VM off
@@ -2284,7 +3190,9 @@ mod tests {
             runtime,
             boxes: RwLock::new(HashMap::new()),
             executions: RwLock::new(HashMap::new()),
+            last_activity: RwLock::new(HashMap::new()),
             api_key: None,
+            enforces_lifecycle: true,
         };
 
         // The box's main command, and an ordinary exec running beside it.

--- a/src/test-utils/src/box_test.rs
+++ b/src/test-utils/src/box_test.rs
@@ -43,7 +43,7 @@ impl BoxTestBase {
     pub async fn new() -> Self {
         let t = Self::with_options(BoxOptions {
             rootfs: RootfsSpec::Image("alpine:latest".into()),
-            auto_delete: Some(0),
+            auto_remove: false,
             ..Default::default()
         })
         .await;
@@ -95,7 +95,7 @@ impl BoxTestBase {
             .create(
                 BoxOptions {
                     rootfs: RootfsSpec::Image("alpine:latest".into()),
-                    auto_delete: Some(0),
+                    auto_remove: false,
                     ..Default::default()
                 },
                 None,

--- a/src/test-utils/src/cache.rs
+++ b/src/test-utils/src/cache.rs
@@ -219,7 +219,7 @@ impl SharedResources {
                     .create(
                         BoxOptions {
                             rootfs: RootfsSpec::Image("alpine:latest".into()),
-                            auto_delete: Some(0),
+                            auto_remove: false,
                             ..Default::default()
                         },
                         None,

--- a/src/test-utils/src/config_matrix.rs
+++ b/src/test-utils/src/config_matrix.rs
@@ -80,7 +80,7 @@ pub struct BoxConfig {
 /// - `jailer_disabled` — jailer off (development mode)
 /// - `small_memory` — 256 MiB memory
 /// - `large_disk` — 4 GB disk
-/// - `auto_delete_zero` — keep box after stop
+/// - `auto_remove_off` — keep box after stop
 /// - `detach_mode` — detached box
 /// - `max_security` — maximum security preset
 pub fn default_configs() -> Vec<BoxConfig> {
@@ -97,7 +97,7 @@ pub fn default_configs() -> Vec<BoxConfig> {
             name: "jailer_enabled",
             options: BoxOptions {
                 rootfs: RootfsSpec::Image("alpine:latest".into()),
-                auto_delete: Some(0),
+                auto_remove: false,
                 advanced: {
                     let mut advanced = AdvancedBoxOptions::default();
                     advanced.security = SecurityOptions::enabled();
@@ -111,7 +111,7 @@ pub fn default_configs() -> Vec<BoxConfig> {
             name: "jailer_disabled",
             options: BoxOptions {
                 rootfs: RootfsSpec::Image("alpine:latest".into()),
-                auto_delete: Some(0),
+                auto_remove: false,
                 advanced: {
                     let mut advanced = AdvancedBoxOptions::default();
                     advanced.security = SecurityOptions::disabled();
@@ -126,7 +126,7 @@ pub fn default_configs() -> Vec<BoxConfig> {
             options: BoxOptions {
                 rootfs: RootfsSpec::Image("alpine:latest".into()),
                 memory_mib: Some(256),
-                auto_delete: Some(0),
+                auto_remove: false,
                 ..Default::default()
             },
             skip_on: SkipCondition::default(),
@@ -136,16 +136,16 @@ pub fn default_configs() -> Vec<BoxConfig> {
             options: BoxOptions {
                 rootfs: RootfsSpec::Image("alpine:latest".into()),
                 disk_size_gb: Some(4),
-                auto_delete: Some(0),
+                auto_remove: false,
                 ..Default::default()
             },
             skip_on: SkipCondition::default(),
         },
         BoxConfig {
-            name: "auto_delete_zero",
+            name: "auto_remove_off",
             options: BoxOptions {
                 rootfs: RootfsSpec::Image("alpine:latest".into()),
-                auto_delete: Some(0),
+                auto_remove: false,
                 ..Default::default()
             },
             skip_on: SkipCondition::default(),
@@ -154,7 +154,7 @@ pub fn default_configs() -> Vec<BoxConfig> {
             name: "detach_mode",
             options: BoxOptions {
                 rootfs: RootfsSpec::Image("alpine:latest".into()),
-                auto_delete: Some(0),
+                auto_remove: false,
                 detach: true,
                 ..Default::default()
             },
@@ -164,7 +164,7 @@ pub fn default_configs() -> Vec<BoxConfig> {
             name: "max_security",
             options: BoxOptions {
                 rootfs: RootfsSpec::Image("alpine:latest".into()),
-                auto_delete: Some(0),
+                auto_remove: false,
                 advanced: {
                     let mut advanced = AdvancedBoxOptions::default();
                     advanced.security = SecurityOptions::enabled();


### PR DESCRIPTION
The `auto_stop` / `auto_delete` / `auto_resume` fields already existed in the wire
contract, in `BoxOptions` and in every SDK, but nothing below the cloud control plane
ever read them back. `boxlite serve` now enforces them and the CLI can reach them.

Two deletion axes had been sharing one integer:

- `auto_remove` (bool) removes the box synchronously when it stops (`--rm`).
- `auto_delete` (seconds) is a deferred deadline a sweeper acts on later.

While fused, `auto_delete=1` was spent as the `--rm` sentinel, any deadline forced the
box non-detached, and `recover_boxes` destroyed pending deadlines at startup — so
"delete N seconds after stop" could not be expressed at all. The C ABI fused them too:
setting `auto_remove` cleared a caller's deadline.

## Call graph

Before

```
create_box                          (serve · src/cli/src/commands/serve/handlers/boxes.rs:16)  — accepts auto_stop/auto_delete
  └─ build_box_options              (serve · src/cli/src/commands/serve/mod.rs:789)            — copies the fields through
       └─ removes_on_stop           (BoxOptions · src/boxlite/src/runtime/options.rs:568)      ← BUG: auto_delete overrode auto_remove, so Some(1) was the --rm sentinel and no real deadline could coexist
  └─ reaper_loop                    (serve · src/cli/src/commands/serve/mod.rs:623)            ← BUG: reaped exited processes only; never consulted either deadline
recover_boxes                       (RuntimeImpl · src/boxlite/src/runtime/rt_impl.rs:1277)    ← BUG: destroyed pending deadlines at startup
```

After

```
create_box                          (serve · src/cli/src/commands/serve/handlers/boxes.rs:16)  — unchanged entry
  └─ build_box_options              (serve · src/cli/src/commands/serve/mod.rs:789)            — sets auto_remove:false, always detached
       └─ reject_local_unsupported_options (RuntimeImpl · src/boxlite/src/runtime/rt_impl.rs:1744) — refuses a deadline no sweeper will act on
            └─ with_lifecycle_sweeper (RuntimeBuilder · src/boxlite/src/experimental.rs:160)   — serve declares one; the embedded runtime does not
record_activity                     (middleware · src/cli/src/commands/serve/mod.rs:1141)      — stamps the per-box idle clock
  └─ record_box_activity            (AppState · src/cli/src/commands/serve/mod.rs:101)         — no-ops when this serve does not sweep
reaper_loop                         (serve · src/cli/src/commands/serve/mod.rs:623)            — same 30s tick, no new persisted state
  └─ run_lifecycle_once             (serve · src/cli/src/commands/serve/mod.rs:1200)           — returns false when another server owns the boxes
       └─ idle_or_seed              (serve · src/cli/src/commands/serve/mod.rs:1171)           — newest clock across {id, name}; an unseen box is seeded now
       └─ decide_lifecycle          (serve · src/cli/src/commands/serve/mod.rs:1076)           — pure: Stop | Delete | Leave
            └─ is_at_rest           (BoxStatus · src/boxlite/src/litebox/state.rs:73)          — one at-rest rule, shared with ls
       └─ retain_box_activity       (AppState · src/cli/src/commands/serve/mod.rs:130)         — drops clocks no box answers to
autoresume_allows                   (serve · src/cli/src/commands/serve/mod.rs:1373)           — pure gate; 409 only on implicit wake
SplitFusedDeletionAxes              (Migration · src/boxlite/src/db/migration/v10_to_v11.rs:44) — rewrites persisted boxes once
options_from_manifest               (import · src/boxlite/src/runtime/import.rs:76)            — same rewrite for archives below v6
  └─ archive_version_for_options    (archive · src/boxlite/src/litebox/archive.rs:78)          — stamps v6 when a pre-split importer would misread
```

**Key:** `serve` is the sole enforcer, and its exclusive `flock` on `$BOXLITE_HOME/.lock`
is what makes that sound — no second process can hold boxes it cannot see, so its
activity view is total. Idle comes only from the in-memory clock, so a restart grants
every box a full window instead of reading it as idle since boot. A `serve` that itself
proxies to another server leaves that server's boxes alone.

`AutoResume` gates only the operations that would wake a box implicitly — exec, files,
attach, metrics — returning 409 when disabled. Start, stop, snapshots, clone and export
resolve through an ungated path: they never need the VM up, and gating them answered a
metadata read with advice to start a box the caller had not asked to run.

CLI `run`/`create` gain `--auto-stop`, `--auto-delete` and `--no-auto-resume`, accepting
seconds or a suffixed duration, and `ls` shows both deadlines.

## Migrating the fused shape

The old meaning is stored in two places, and both are translated once, while the shape
can still be read as what it meant:

| Store | Mechanism |
|---|---|
| `box_config` (SQLite) | migration v10 → v11, `SplitFusedDeletionAxes` |
| archive manifest | `options_from_manifest` rewrite below archive **v6** |

Without the first, `recover_boxes` would delete every pre-upgrade box that was not
created with `--rm`, on the first command after upgrading — they carry `auto_delete:0`
beside the `auto_remove:true` default the old CLI never wrote. Without the second, an
archive of any created box becomes unimportable, because its `auto_remove:true` now
contradicts the `detach:true` beside it. An export carrying a deadline a pre-split
importer would misread is stamped v6 so that importer refuses it rather than acting on
the wrong policy.

## Breaking change

On the embedded runtime, `auto_delete>0` previously meant "remove the box the moment it
stops" and now means a deferred deadline, which that runtime refuses with `Unsupported`
because it runs no sweeper. `auto_delete=Some(0)` also no longer suppresses removal:
`auto_delete` used to take precedence over `auto_remove`, so `Some(0)` overrode it and
meant "keep the box after stop", while `removes_on_stop` now reads `auto_remove` alone,
which defaults to true. Callers wanting the old behaviour set `auto_remove` explicitly.

## Testing

| Suite | Result |
|---|---|
| Engine unit (`test:unit:rust`) | 1097/1097 |
| Shared | 57/57 |
| CLI unit | 230/230 |
| Reference server | 36/36 |
| clippy / fmt (`lint:fix`) | clean |

`lint:fix` covers the Rust and SDK sources; nothing lints `openapi/reference-server`
(ruff is scoped to `sdks/python`), so it is not evidence about that part of the diff.

The reference-server suite is not discovered by any make target (`make/test.mk` globs
`test_error*.py`, deliberately — nothing installs fastapi/pydantic), so it never runs in
CI. Concretely: an earlier commit on this branch had CI green while that suite was red on
a stale `BoxOptions(...)` expectation. It does run locally once its PEP 723 deps are
supplied:

```
uv run --with fastapi --with sse-starlette --with PyJWT --with python-multipart \
       --with python-dotenv --with uvicorn \
       python -m unittest discover -s openapi/reference-server/tests -p 'test_*.py'
```

**Never executed, by CI or locally:** `src/boxlite/tests/rest_integration.rs`, which this
PR modifies — it needs a hand-started reference server, and `BOXLITE_REST_URL` appears
nowhere in `.github/` or `make/`. Also unrun locally: the SDK binding suites and
`sdks/c/src/tests.rs`, which CI does cover.

The local pre-push matrix was skipped for this branch (`SKIP=full-test-matrix`) because
two tests fail for reasons unrelated to this diff, neither file being among the 54
changed:

- `ws_watchdog_fires_when_idle` (`src/boxlite/src/rest/litebox.rs:1710`) reproduces
  identically at the clean parent commit `446e9aece` with none of this diff applied
  (84 passed / 1 failed, 6.74s there vs 6.82s here), and still fails with all proxy
  environment variables cleared.
- `test_pull_nonexistent` (`src/cli/tests/pull.rs:31`) needs 18.4s of its own 30s budget
  when run alone and is killed mid-flight under the full 417-test parallel run.

## Known follow-ups

- Import bypasses the sweeper gate (`options_from_manifest` calls `sanitize()`, not
  `sanitize_local_options`), so an archived deadline can still reach a sweeperless
  runtime — the one hole in this PR's own "creating a box accepts a deadline only when
  the embedder declares a sweeper". Not closed here because `import.rs` deliberately
  *resolves* the fused legacy shape rather than rejecting it, so a refusal on that path
  needs its own design pass.
- Nothing installs the reference server's test dependencies, so
  `openapi/reference-server/tests/` is permanently CI-uncovered. That is how a stale
  `BoxOptions(...)` expectation in it went unnoticed until this PR. The fix is a setup
  target that installs the deps, not widening the discovery glob.
- `remove_box` / `stop_box` evict `state.boxes` by URL segment while every insert keys by
  canonical id, so a delete-by-name leaves the handle cached. Pre-existing on main.
- The idle clock reconciles the id and name spellings only; a unique id prefix or a
  percent-encoded name still stamps a key the sweep does not read. Out of contract —
  `box.openapi.yaml` tells clients to pass the identifier back verbatim.
- `openapi/box.openapi.yaml` documents `auto_stop` default 900 and `detach` default
  false; `serve` reads an omitted `auto_stop` as disabled and always detaches. Needs a
  product call rather than a patch.
