### PR TITLE
feat(files): stream file copy end-to-end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,6 +721,7 @@ dependencies = [
 name = "boxlite-shared"
 version = "0.10.0"
 dependencies = [
+ "futures",
  "proptest",
  "prost",
  "serde",
@@ -729,6 +730,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
  "tonic",
  "tonic-build",
 ]

--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.spec.ts
@@ -70,6 +70,43 @@ describe('BoxliteProxyController', () => {
     expect(execOptions.proxyTimeout).toBe(300000)
   })
 
+  // This hook is the only hop carrying the archive-shape hint through the
+  // hosted API. If it stops forwarding, every hosted copy_out silently
+  // degrades to Unknown and the client re-peeks the archive instead of
+  // trusting the guest — a correctness loss with no error to notice.
+  it('forwards the archive-shape hint from the runner response', async () => {
+    jest.mocked(createProxyMiddleware).mockReturnValue(jest.fn() as never)
+    const { controller } = makeHarness()
+
+    await controller.proxyFiles(activeAuth as never, 'public-box', { url: '/files' } as never, {} as never, jest.fn())
+
+    const proxyOptions = jest.mocked(createProxyMiddleware).mock.calls[0][0]
+    const proxyRes = proxyOptions.on?.proxyRes as (p: unknown, q: unknown, r: unknown) => void
+    const res = { setHeader: jest.fn() }
+
+    proxyRes({ headers: { 'x-boxlite-source-is-dir': 'true' } }, {}, res)
+
+    expect(res.setHeader).toHaveBeenCalledWith('x-boxlite-source-is-dir', 'true')
+  })
+
+  // A runner that predates the hint sends no header. Forwarding a fabricated
+  // one would tell the client "single file" for a directory stream, so absence
+  // must stay absence rather than become a default.
+  it('sets no shape header when the runner sends none', async () => {
+    jest.mocked(createProxyMiddleware).mockReturnValue(jest.fn() as never)
+    const { controller } = makeHarness()
+
+    await controller.proxyFiles(activeAuth as never, 'public-box', { url: '/files' } as never, {} as never, jest.fn())
+
+    const proxyOptions = jest.mocked(createProxyMiddleware).mock.calls[0][0]
+    const proxyRes = proxyOptions.on?.proxyRes as (p: unknown, q: unknown, r: unknown) => void
+    const res = { setHeader: jest.fn() }
+
+    proxyRes({ headers: {} }, {}, res)
+
+    expect(res.setHeader).not.toHaveBeenCalled()
+  })
+
   it('returns the public endpoint for JSON tunnel requests', async () => {
     const { controller, boxService } = makeHarness()
 

--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
@@ -301,6 +301,14 @@ export class BoxliteProxyController {
           proxyReq.setHeader('Authorization', `Bearer ${runner.apiKey}`)
           fixRequestBody(proxyReq, originalReq)
         },
+        proxyRes: (proxyRes: any, _req: any, res: any) => {
+          // Carry the file-download archive-shape hint through the proxy so the
+          // client's copy_out can distinguish single-file vs directory streams.
+          const shape = proxyRes.headers?.['x-boxlite-source-is-dir']
+          if (shape) {
+            res.setHeader('x-boxlite-source-is-dir', shape)
+          }
+        },
       },
       proxyTimeout: opts?.proxyTimeoutMs ?? 5 * 60 * 1000,
     }

--- a/apps/libs/common-go/pkg/errors/middleware.go
+++ b/apps/libs/common-go/pkg/errors/middleware.go
@@ -175,8 +175,12 @@ func Recovery() gin.HandlerFunc {
 		defer func() {
 			if err := recover(); err != nil {
 				if errType, ok := err.(error); ok && errors.Is(errType, http.ErrAbortHandler) {
-					// Do nothing, the request was aborted
-					return
+					// net/http's contract for this sentinel is "sever the
+					// connection, log nothing". Recovering it here would let
+					// net/http finish the response normally, so a client
+					// reading a half-written streaming body would see a clean
+					// EOF and take the truncated payload for a complete one.
+					panic(errType)
 				}
 
 				slog.Error("panic recovered", "panic", err)

--- a/apps/libs/common-go/pkg/errors/middleware_test.go
+++ b/apps/libs/common-go/pkg/errors/middleware_test.go
@@ -1,0 +1,48 @@
+// Copyright 2025 BoxLite AI (originally Daytona Platforms Inc.)
+// Modified by BoxLite AI, 2025-2026
+// SPDX-License-Identifier: Apache-2.0
+
+package errors
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Recovery must hand http.ErrAbortHandler back to net/http. If it swallows the
+// panic (as it used to), net/http finishes the response cleanly and a client
+// reading a half-written streaming body sees a clean EOF — indistinguishable
+// from a whole body. Severing the connection is the only way to say "this is
+// not the whole thing".
+func TestRecoveryRepanicsErrAbortHandler(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	r := gin.New()
+	r.Use(Recovery())
+	r.GET("/abort", func(c *gin.Context) {
+		c.Header("Content-Type", "application/x-tar")
+		// Enough to exceed net/http's 2 KiB auto-buffer so the response is
+		// chunked and the abort severs a body already on the wire.
+		_, _ = c.Writer.Write(make([]byte, 64*1024))
+		c.Writer.Flush()
+		panic(http.ErrAbortHandler)
+	})
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/abort")
+	if err != nil {
+		// Connection reset before a response completed is the transport signal.
+		return
+	}
+	defer resp.Body.Close()
+
+	_, readErr := io.ReadAll(resp.Body)
+	if readErr == nil {
+		t.Fatalf("Recovery() swallowed http.ErrAbortHandler: client read a clean body")
+	}
+}

--- a/apps/runner/pkg/api/controllers/boxlite_files.go
+++ b/apps/runner/pkg/api/controllers/boxlite_files.go
@@ -1,13 +1,10 @@
 package controllers
 
 import (
-	"archive/tar"
 	"errors"
-	"fmt"
-	"io"
+	"log/slog"
 	"net/http"
-	"os"
-	"path/filepath"
+	"strconv"
 
 	boxlite "github.com/boxlite-ai/boxlite/sdks/go"
 	"github.com/boxlite-ai/runner/pkg/runner"
@@ -28,108 +25,16 @@ func BoxliteFileUpload(ctx *gin.Context) {
 		return
 	}
 
-	// The SDK uploads a tar archive (Content-Type: application/x-tar) so
-	// that copy_in(host_dir, ...) can move trees in a single request.
-	// We MUST extract the archive into a staging dir on the runner host
-	// before handing it to the Go SDK's CopyInto — that lower-level call
-	// expects a *real path*, not a tar file, and would otherwise dump the
-	// entire .tar blob into the guest as a single binary file (which
-	// silently breaks both single-file and directory uploads).
-	stagingDir, err := os.MkdirTemp("", "boxlite-upload-stage-*")
-	if err != nil {
-		respondError(ctx, http.StatusInternalServerError, "failed to create staging dir", "InternalError", "internal")
-		return
-	}
-	defer os.RemoveAll(stagingDir)
-
-	stagedPath, isSingleFile, err := extractTarToDir(ctx.Request.Body, stagingDir)
-	if err != nil {
-		respondError(ctx, http.StatusBadRequest, fmt.Sprintf("failed to extract upload tar: %s", err), "InvalidArgumentError", "invalid_argument")
-		return
-	}
-
-	// If the archive contained exactly one regular file, CopyInto its
-	// extracted path (a real file) so the guest sees the file at destPath.
-	// Otherwise CopyInto the staging dir as a whole — the Go SDK's
-	// recursive copy handles directories natively.
-	src := stagingDir
-	if isSingleFile {
-		src = stagedPath
-	}
-
-	if err := r.Boxlite.CopyInto(ctx.Request.Context(), boxId, src, destPath); err != nil {
+	// Newer clients carry the archive shape; older clients omit it. Either way
+	// we stream straight into the guest — hint=Unknown makes the guest peek
+	// the archive to decide (its pre-hint behavior). No runner-side staging.
+	kind := parseSourceIsDir(ctx.Query("source_is_dir"))
+	if err := r.Boxlite.CopyInStream(ctx.Request.Context(), boxId, destPath, kind, ctx.Request.Body); err != nil {
 		respondCopyError(ctx, err)
 		return
 	}
 
 	ctx.Status(http.StatusNoContent)
-}
-
-// extractTarToDir reads a tar archive from r and writes every entry into
-// destDir, preserving the relative layout. Returns:
-//   - lastFilePath: path to the most-recently extracted file (only
-//     meaningful when isSingleFile is true)
-//   - isSingleFile: true when the archive contained exactly one regular
-//     file entry (no directories, no symlinks, no multi-file payload).
-//     This is the canonical signal for "the caller copy_in'd a single
-//     file" so the upload handler can pass that exact path on to
-//     CopyInto, rather than passing a wrapping directory.
-//
-// Entries with paths that escape destDir (zip-slip) are refused.
-func extractTarToDir(r io.Reader, destDir string) (lastFilePath string, isSingleFile bool, err error) {
-	tr := tar.NewReader(r)
-	fileCount := 0
-	otherCount := 0 // dirs, symlinks, anything that's not a regular file
-
-	for {
-		header, hdrErr := tr.Next()
-		if hdrErr == io.EOF {
-			break
-		}
-		if hdrErr != nil {
-			return "", false, fmt.Errorf("tar.Next: %w", hdrErr)
-		}
-
-		// Defend against absolute paths and traversal — the SDK should
-		// only ever send relative entries, but a malformed client could
-		// craft an archive that writes outside destDir.
-		cleanName := filepath.Clean(header.Name)
-		if filepath.IsAbs(cleanName) || cleanName == ".." || (len(cleanName) >= 3 && cleanName[:3] == "../") {
-			return "", false, fmt.Errorf("tar entry escapes staging dir: %q", header.Name)
-		}
-		target := filepath.Join(destDir, cleanName)
-
-		switch header.Typeflag {
-		case tar.TypeDir:
-			if mkErr := os.MkdirAll(target, 0o755); mkErr != nil {
-				return "", false, fmt.Errorf("mkdir %s: %w", target, mkErr)
-			}
-			otherCount++
-		case tar.TypeReg, tar.TypeRegA:
-			if mkErr := os.MkdirAll(filepath.Dir(target), 0o755); mkErr != nil {
-				return "", false, fmt.Errorf("mkdir parent of %s: %w", target, mkErr)
-			}
-			f, openErr := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(header.Mode&0o7777))
-			if openErr != nil {
-				return "", false, fmt.Errorf("create %s: %w", target, openErr)
-			}
-			if _, copyErr := io.Copy(f, tr); copyErr != nil {
-				f.Close()
-				return "", false, fmt.Errorf("write %s: %w", target, copyErr)
-			}
-			f.Close()
-			lastFilePath = target
-			fileCount++
-		default:
-			// symlinks, hardlinks, devices — preserve as best-effort by
-			// counting them in otherCount so single-file detection stays
-			// pessimistic (any non-regular entry forces "treat as dir").
-			otherCount++
-		}
-	}
-
-	isSingleFile = fileCount == 1 && otherCount == 0
-	return lastFilePath, isSingleFile, nil
 }
 
 func BoxliteFileDownload(ctx *gin.Context) {
@@ -146,45 +51,51 @@ func BoxliteFileDownload(ctx *gin.Context) {
 		return
 	}
 
-	tmpDir, err := os.MkdirTemp("", "boxlite-download-*")
-	if err != nil {
-		respondError(ctx, http.StatusInternalServerError, "failed to create temp dir", "InternalError", "internal")
+	ctx.Header("Content-Type", "application/x-tar")
+
+	// Stream straight from the guest into the response. onMeta sets the
+	// archive-shape header before the first body byte; it is not invoked when
+	// the guest predates the hint.
+	err = r.Boxlite.CopyOutStream(ctx.Request.Context(), boxId, srcPath, ctx.Writer, func(sourceIsDir bool) {
+		ctx.Header("X-Boxlite-Source-Is-Dir", strconv.FormatBool(sourceIsDir))
+	})
+	if err == nil {
 		return
 	}
-	defer os.RemoveAll(tmpDir)
-
-	if err := r.Boxlite.CopyOut(ctx.Request.Context(), boxId, srcPath, tmpDir); err != nil {
+	if !ctx.Writer.Written() {
+		// The copy failed before any body byte was produced (e.g. the source
+		// does not exist) — the response is not yet committed, so we can still
+		// surface an error status.
+		ctx.Writer.Header().Del("Content-Type")
+		ctx.Writer.Header().Del("X-Boxlite-Source-Is-Dir")
 		respondCopyError(ctx, err)
 		return
 	}
+	// A 200 is already on the wire and the archive is incomplete. Returning
+	// normally would finish the body cleanly, which the client cannot tell
+	// apart from a whole archive — a tar cut on a 512-byte block boundary
+	// extracts without error, just missing entries. Severing the connection is
+	// the only remaining way to say "this is not the whole thing".
+	slog.Error("boxlite copy_out failed mid-stream, aborting the response",
+		"boxId", boxId, "path", srcPath, "error", err)
+	panic(http.ErrAbortHandler)
+}
 
-	ctx.Header("Content-Type", "application/x-tar")
-	ctx.Status(http.StatusOK)
-
-	tw := tar.NewWriter(ctx.Writer)
-	defer tw.Close()
-
-	filepath.Walk(tmpDir, func(path string, info os.FileInfo, err error) error {
-		if err != nil || info.IsDir() {
-			return err
-		}
-		relPath, _ := filepath.Rel(tmpDir, path)
-		header, err := tar.FileInfoHeader(info, "")
-		if err != nil {
-			return err
-		}
-		header.Name = relPath
-		if err := tw.WriteHeader(header); err != nil {
-			return err
-		}
-		f, err := os.Open(path)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-		_, err = io.Copy(tw, f)
-		return err
-	})
+// parseSourceIsDir maps the optional source_is_dir query parameter to a
+// copy-source kind. Absent or malformed values mean the client predates the
+// hint → Unknown, which makes the guest peek the archive to decide.
+func parseSourceIsDir(raw string) boxlite.CopySourceKind {
+	if raw == "" {
+		return boxlite.CopySourceUnknown
+	}
+	b, err := strconv.ParseBool(raw)
+	if err != nil {
+		return boxlite.CopySourceUnknown
+	}
+	if b {
+		return boxlite.CopySourceDir
+	}
+	return boxlite.CopySourceFile
 }
 
 // copyErrorClass is the (status, type, code) triple a BoxLite error crosses the

--- a/apps/runner/pkg/api/controllers/boxlite_files_test.go
+++ b/apps/runner/pkg/api/controllers/boxlite_files_test.go
@@ -1,229 +1,29 @@
 package controllers
 
 import (
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
-	"strings"
 	"testing"
 
 	boxlite "github.com/boxlite-ai/boxlite/sdks/go"
-	"github.com/gin-gonic/gin"
 )
 
-// renderCopyError drives the production renderer and hands back what a client
-// would actually receive.
-func renderCopyError(t *testing.T, err error) (int, map[string]any) {
-	t.Helper()
-	gin.SetMode(gin.TestMode)
-	recorder := httptest.NewRecorder()
-	ctx, _ := gin.CreateTestContext(recorder)
-	ctx.Request = httptest.NewRequest(http.MethodPut, "/v1/boxes/b/files?path=/tmp/x", nil)
-
-	respondCopyError(ctx, err)
-
-	var body map[string]any
-	if unmarshalErr := json.Unmarshal(recorder.Body.Bytes(), &body); unmarshalErr != nil {
-		t.Fatalf("response body is not JSON (%v): %s", unmarshalErr, recorder.Body.String())
-	}
-	return recorder.Code, body
-}
-
-// errorEnvelope pulls the (message, type, code) triple out of the wire shape
-// openapi/box.openapi.yaml declares for these routes. Reports absence rather
-// than failing, so a test can say which part is missing.
-func errorEnvelope(body map[string]any) (message, errorType, code string, ok bool) {
-	inner, isObject := body["error"].(map[string]any)
-	if !isObject {
-		return "", "", "", false
-	}
-	message, _ = inner["message"].(string)
-	errorType, _ = inner["type"].(string)
-	code, _ = inner["code"].(string)
-	return message, errorType, code, true
-}
-
-// A path the guest refuses because a mount hides it is the caller's mistake,
-// and openapi/box.openapi.yaml documents it as `400` on both file routes.
-//
-// The class survives every hop up to here — the guest answers
-// FailedPrecondition, map_tonic_err turns that into BoxliteError::Unsupported,
-// and the FFI hands Go an *Error carrying ErrUnsupported — and then the runner
-// used to throw it away and call every copy failure a 500. That is a server
-// fault reported for a request only the caller can fix, and it is the same
-// flattening already fixed on the two client-side backends
-// (src/boxlite/src/portal/interfaces/files.rs, src/boxlite/src/rest/litebox.rs)
-// whose decoder has nothing to read without the envelope below.
-func TestRefusedCopyKeepsItsClass(t *testing.T) {
-	const refusal = "unsupported: /tmp/x is under the container's '/tmp' mount, " +
-		"which file transfer cannot reach"
-
-	status, body := renderCopyError(t, &boxlite.Error{
-		Code:    boxlite.ErrUnsupported,
-		Message: refusal,
-	})
-
-	if status != http.StatusBadRequest {
-		t.Fatalf("status = %d, want %d (body: %v)", status, http.StatusBadRequest, body)
-	}
-	message, errorType, code, ok := errorEnvelope(body)
-	if !ok {
-		t.Fatalf("body is not the {error:{message,type,code}} envelope the client decodes: %v", body)
-	}
-	if code != "unsupported" {
-		t.Errorf("code = %q, want %q", code, "unsupported")
-	}
-	if errorType != "UnsupportedError" {
-		t.Errorf("type = %q, want %q", errorType, "UnsupportedError")
-	}
-	// The examples fail closed on this exact fragment, so the wording has to
-	// reach the caller intact and not just the class.
-	if !strings.Contains(message, "'/tmp' mount") {
-		t.Errorf("message dropped the mount fragment the examples match: %q", message)
-	}
-}
-
-// Every code the Go SDK can return, against the table BoxliteError::http()
-// keeps in src/shared/src/errors.rs. Pinned whole rather than for the refusal
-// alone: a copy also reports missing sources, oversized uploads and stopped
-// boxes, and each was flattened the same way.
-func TestCopyErrorsMapToTheirCanonicalHTTPClass(t *testing.T) {
+// Absent or malformed values mean the client predates the hint → Unknown,
+// which relays the body with the guest peeking the archive to decide.
+func TestParseSourceIsDir(t *testing.T) {
 	cases := []struct {
-		code      boxlite.ErrorCode
-		status    int
-		errorType string
-		wireCode  string
+		raw  string
+		want boxlite.CopySourceKind
 	}{
-		{boxlite.ErrInternal, http.StatusInternalServerError, "InternalError", "internal"},
-		{boxlite.ErrNotFound, http.StatusNotFound, "NotFoundError", "not_found"},
-		{boxlite.ErrAlreadyExists, http.StatusConflict, "AlreadyExistsError", "already_exists"},
-		{boxlite.ErrInvalidState, http.StatusConflict, "InvalidStateError", "invalid_state"},
-		{boxlite.ErrInvalidArgument, http.StatusBadRequest, "InvalidArgumentError", "invalid_argument"},
-		{boxlite.ErrConfig, http.StatusInternalServerError, "ConfigError", "config_error"},
-		{boxlite.ErrStorage, http.StatusInternalServerError, "StorageError", "storage_error"},
-		{boxlite.ErrImage, http.StatusUnprocessableEntity, "ImageError", "image_pull_failed"},
-		{boxlite.ErrNetwork, http.StatusServiceUnavailable, "NetworkError", "network_unavailable"},
-		{boxlite.ErrExecution, http.StatusUnprocessableEntity, "ExecutionError", "execution_failed"},
-		{boxlite.ErrStopped, http.StatusConflict, "StoppedError", "stopped"},
-		{boxlite.ErrEngine, http.StatusServiceUnavailable, "EngineError", "engine_unavailable"},
-		{boxlite.ErrUnsupported, http.StatusBadRequest, "UnsupportedError", "unsupported"},
-		{boxlite.ErrDatabase, http.StatusInternalServerError, "DatabaseError", "database_error"},
-		{boxlite.ErrPortal, http.StatusServiceUnavailable, "UpstreamUnavailableError", "upstream_unavailable"},
-		{boxlite.ErrRpc, http.StatusServiceUnavailable, "UpstreamUnavailableError", "upstream_unavailable"},
-		{boxlite.ErrRpcTransport, http.StatusServiceUnavailable, "UpstreamUnavailableError", "upstream_unavailable"},
-		{boxlite.ErrMetadata, http.StatusInternalServerError, "MetadataError", "metadata_error"},
-		{boxlite.ErrUnsupportedEngine, http.StatusBadRequest, "UnsupportedError", "unsupported"},
-		{boxlite.ErrResourceExhausted, http.StatusTooManyRequests, "ResourceExhaustedError", "resource_exhausted"},
-		{boxlite.ErrSessionReaped, http.StatusGone, "SessionReapedError", "session_reaped"},
+		{"", boxlite.CopySourceUnknown},
+		{"true", boxlite.CopySourceDir},
+		{"false", boxlite.CopySourceFile},
+		{"1", boxlite.CopySourceDir},
+		{"0", boxlite.CopySourceFile},
+		{"bogus", boxlite.CopySourceUnknown},
 	}
-
-	for _, want := range cases {
-		status, body := renderCopyError(t, &boxlite.Error{Code: want.code, Message: "boom"})
-		_, errorType, wireCode, ok := errorEnvelope(body)
-		if !ok {
-			t.Errorf("code %d: body is not the error envelope: %v", want.code, body)
-			continue
-		}
-		if status != want.status || errorType != want.errorType || wireCode != want.wireCode {
-			t.Errorf("code %d: got (%d, %q, %q), want (%d, %q, %q)",
-				want.code, status, errorType, wireCode,
-				want.status, want.errorType, want.wireCode)
+	for _, c := range cases {
+		got := parseSourceIsDir(c.raw)
+		if got != c.want {
+			t.Errorf("parseSourceIsDir(%q) = %d, want %d", c.raw, got, c.want)
 		}
 	}
 }
-
-// A failure that never crossed the FFI — a staging or transport fault on the
-// runner itself — has no class to preserve, so it stays a server fault. Pinned
-// so the mapping cannot start guessing 400 for errors the runtime never
-// classified.
-func TestUnclassifiedCopyFailureStaysInternal(t *testing.T) {
-	status, body := renderCopyError(t, errPlain("staging dir vanished"))
-
-	if status != http.StatusInternalServerError {
-		t.Fatalf("status = %d, want %d", status, http.StatusInternalServerError)
-	}
-	message, _, code, ok := errorEnvelope(body)
-	if !ok {
-		t.Fatalf("body is not the error envelope: %v", body)
-	}
-	if code != "internal" {
-		t.Errorf("code = %q, want %q", code, "internal")
-	}
-	if !strings.Contains(message, "staging dir vanished") {
-		t.Errorf("message dropped the cause: %q", message)
-	}
-}
-
-// A code from an FFI newer than this table is the one case where answering
-// 500 is right — a server cannot invent a status for a class it has no name
-// for. What it must not do is answer with the zero value the map lookup
-// returns, which is HTTP status 0 and an empty type. The runtime's own
-// wording still has to reach the caller.
-func TestACodeThisTableDoesNotKnowStaysInternal(t *testing.T) {
-	const unknown = boxlite.ErrorCode(9999)
-
-	status, body := renderCopyError(t, &boxlite.Error{
-		Code:    unknown,
-		Message: "a class this build has no name for",
-	})
-
-	if status != http.StatusInternalServerError {
-		t.Fatalf("status = %d, want %d (body: %v)", status, http.StatusInternalServerError, body)
-	}
-	message, errorType, code, ok := errorEnvelope(body)
-	if !ok {
-		t.Fatalf("body is not the error envelope: %v", body)
-	}
-	if code != "internal" || errorType != "InternalError" {
-		t.Errorf("got (%q, %q), want (%q, %q)", errorType, code, "InternalError", "internal")
-	}
-	if !strings.Contains(message, "a class this build has no name for") {
-		t.Errorf("message dropped the runtime's wording: %q", message)
-	}
-}
-
-// The routes answer in one shape or the client can only read some of them.
-//
-// Both handlers also report failures of their own — an uninitialised runtime, a
-// missing `path`, a staging directory that could not be made, a tar that would
-// not extract. Each used to answer `{"error": "<text>"}`, which names no class,
-// so the client fell back to reading the status alone and reported them exactly
-// the way it reported a refusal: as a server fault. Driven through the real
-// handlers, which reach their first failure with no runner instance configured.
-func TestFilesRoutesAnswerInTheDeclaredEnvelope(t *testing.T) {
-	routes := map[string]struct {
-		handle func(*gin.Context)
-		method string
-	}{
-		"upload":   {BoxliteFileUpload, http.MethodPut},
-		"download": {BoxliteFileDownload, http.MethodGet},
-	}
-
-	for name, route := range routes {
-		gin.SetMode(gin.TestMode)
-		recorder := httptest.NewRecorder()
-		ctx, _ := gin.CreateTestContext(recorder)
-		ctx.Request = httptest.NewRequest(route.method, "/v1/boxes/b/files?path=/tmp/x", nil)
-
-		route.handle(ctx)
-
-		var body map[string]any
-		if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
-			t.Errorf("%s: response body is not JSON (%v): %s", name, err, recorder.Body.String())
-			continue
-		}
-		message, errorType, code, ok := errorEnvelope(body)
-		if !ok {
-			t.Errorf("%s: body is not the {error:{message,type,code}} envelope: %v", name, body)
-			continue
-		}
-		if message == "" || errorType == "" || code == "" {
-			t.Errorf("%s: envelope is missing a field: message=%q type=%q code=%q",
-				name, message, errorType, code)
-		}
-	}
-}
-
-type errPlain string
-
-func (e errPlain) Error() string { return string(e) }

--- a/apps/runner/pkg/api/controllers/boxlite_files_test.go
+++ b/apps/runner/pkg/api/controllers/boxlite_files_test.go
@@ -1,10 +1,228 @@
 package controllers
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	boxlite "github.com/boxlite-ai/boxlite/sdks/go"
+	"github.com/gin-gonic/gin"
 )
+
+// renderCopyError drives the production renderer and hands back what a client
+// would actually receive.
+func renderCopyError(t *testing.T, err error) (int, map[string]any) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPut, "/v1/boxes/b/files?path=/tmp/x", nil)
+
+	respondCopyError(ctx, err)
+
+	var body map[string]any
+	if unmarshalErr := json.Unmarshal(recorder.Body.Bytes(), &body); unmarshalErr != nil {
+		t.Fatalf("response body is not JSON (%v): %s", unmarshalErr, recorder.Body.String())
+	}
+	return recorder.Code, body
+}
+
+// errorEnvelope pulls the (message, type, code) triple out of the wire shape
+// openapi/box.openapi.yaml declares for these routes. Reports absence rather
+// than failing, so a test can say which part is missing.
+func errorEnvelope(body map[string]any) (message, errorType, code string, ok bool) {
+	inner, isObject := body["error"].(map[string]any)
+	if !isObject {
+		return "", "", "", false
+	}
+	message, _ = inner["message"].(string)
+	errorType, _ = inner["type"].(string)
+	code, _ = inner["code"].(string)
+	return message, errorType, code, true
+}
+
+// A path the guest refuses because a mount hides it is the caller's mistake,
+// and openapi/box.openapi.yaml documents it as `400` on both file routes.
+//
+// The class survives every hop up to here — the guest answers
+// FailedPrecondition, map_tonic_err turns that into BoxliteError::Unsupported,
+// and the FFI hands Go an *Error carrying ErrUnsupported — and then the runner
+// used to throw it away and call every copy failure a 500. That is a server
+// fault reported for a request only the caller can fix, and it is the same
+// flattening already fixed on the two client-side backends
+// (src/boxlite/src/portal/interfaces/files.rs, src/boxlite/src/rest/litebox.rs)
+// whose decoder has nothing to read without the envelope below.
+func TestRefusedCopyKeepsItsClass(t *testing.T) {
+	const refusal = "unsupported: /tmp/x is under the container's '/tmp' mount, " +
+		"which file transfer cannot reach"
+
+	status, body := renderCopyError(t, &boxlite.Error{
+		Code:    boxlite.ErrUnsupported,
+		Message: refusal,
+	})
+
+	if status != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (body: %v)", status, http.StatusBadRequest, body)
+	}
+	message, errorType, code, ok := errorEnvelope(body)
+	if !ok {
+		t.Fatalf("body is not the {error:{message,type,code}} envelope the client decodes: %v", body)
+	}
+	if code != "unsupported" {
+		t.Errorf("code = %q, want %q", code, "unsupported")
+	}
+	if errorType != "UnsupportedError" {
+		t.Errorf("type = %q, want %q", errorType, "UnsupportedError")
+	}
+	// The examples fail closed on this exact fragment, so the wording has to
+	// reach the caller intact and not just the class.
+	if !strings.Contains(message, "'/tmp' mount") {
+		t.Errorf("message dropped the mount fragment the examples match: %q", message)
+	}
+}
+
+// Every code the Go SDK can return, against the table BoxliteError::http()
+// keeps in src/shared/src/errors.rs. Pinned whole rather than for the refusal
+// alone: a copy also reports missing sources, oversized uploads and stopped
+// boxes, and each was flattened the same way.
+func TestCopyErrorsMapToTheirCanonicalHTTPClass(t *testing.T) {
+	cases := []struct {
+		code      boxlite.ErrorCode
+		status    int
+		errorType string
+		wireCode  string
+	}{
+		{boxlite.ErrInternal, http.StatusInternalServerError, "InternalError", "internal"},
+		{boxlite.ErrNotFound, http.StatusNotFound, "NotFoundError", "not_found"},
+		{boxlite.ErrAlreadyExists, http.StatusConflict, "AlreadyExistsError", "already_exists"},
+		{boxlite.ErrInvalidState, http.StatusConflict, "InvalidStateError", "invalid_state"},
+		{boxlite.ErrInvalidArgument, http.StatusBadRequest, "InvalidArgumentError", "invalid_argument"},
+		{boxlite.ErrConfig, http.StatusInternalServerError, "ConfigError", "config_error"},
+		{boxlite.ErrStorage, http.StatusInternalServerError, "StorageError", "storage_error"},
+		{boxlite.ErrImage, http.StatusUnprocessableEntity, "ImageError", "image_pull_failed"},
+		{boxlite.ErrNetwork, http.StatusServiceUnavailable, "NetworkError", "network_unavailable"},
+		{boxlite.ErrExecution, http.StatusUnprocessableEntity, "ExecutionError", "execution_failed"},
+		{boxlite.ErrStopped, http.StatusConflict, "StoppedError", "stopped"},
+		{boxlite.ErrEngine, http.StatusServiceUnavailable, "EngineError", "engine_unavailable"},
+		{boxlite.ErrUnsupported, http.StatusBadRequest, "UnsupportedError", "unsupported"},
+		{boxlite.ErrDatabase, http.StatusInternalServerError, "DatabaseError", "database_error"},
+		{boxlite.ErrPortal, http.StatusServiceUnavailable, "UpstreamUnavailableError", "upstream_unavailable"},
+		{boxlite.ErrRpc, http.StatusServiceUnavailable, "UpstreamUnavailableError", "upstream_unavailable"},
+		{boxlite.ErrRpcTransport, http.StatusServiceUnavailable, "UpstreamUnavailableError", "upstream_unavailable"},
+		{boxlite.ErrMetadata, http.StatusInternalServerError, "MetadataError", "metadata_error"},
+		{boxlite.ErrUnsupportedEngine, http.StatusBadRequest, "UnsupportedError", "unsupported"},
+		{boxlite.ErrResourceExhausted, http.StatusTooManyRequests, "ResourceExhaustedError", "resource_exhausted"},
+		{boxlite.ErrSessionReaped, http.StatusGone, "SessionReapedError", "session_reaped"},
+	}
+
+	for _, want := range cases {
+		status, body := renderCopyError(t, &boxlite.Error{Code: want.code, Message: "boom"})
+		_, errorType, wireCode, ok := errorEnvelope(body)
+		if !ok {
+			t.Errorf("code %d: body is not the error envelope: %v", want.code, body)
+			continue
+		}
+		if status != want.status || errorType != want.errorType || wireCode != want.wireCode {
+			t.Errorf("code %d: got (%d, %q, %q), want (%d, %q, %q)",
+				want.code, status, errorType, wireCode,
+				want.status, want.errorType, want.wireCode)
+		}
+	}
+}
+
+// A failure that never crossed the FFI — a staging or transport fault on the
+// runner itself — has no class to preserve, so it stays a server fault. Pinned
+// so the mapping cannot start guessing 400 for errors the runtime never
+// classified.
+func TestUnclassifiedCopyFailureStaysInternal(t *testing.T) {
+	status, body := renderCopyError(t, errPlain("staging dir vanished"))
+
+	if status != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", status, http.StatusInternalServerError)
+	}
+	message, _, code, ok := errorEnvelope(body)
+	if !ok {
+		t.Fatalf("body is not the error envelope: %v", body)
+	}
+	if code != "internal" {
+		t.Errorf("code = %q, want %q", code, "internal")
+	}
+	if !strings.Contains(message, "staging dir vanished") {
+		t.Errorf("message dropped the cause: %q", message)
+	}
+}
+
+// A code from an FFI newer than this table is the one case where answering
+// 500 is right — a server cannot invent a status for a class it has no name
+// for. What it must not do is answer with the zero value the map lookup
+// returns, which is HTTP status 0 and an empty type. The runtime's own
+// wording still has to reach the caller.
+func TestACodeThisTableDoesNotKnowStaysInternal(t *testing.T) {
+	const unknown = boxlite.ErrorCode(9999)
+
+	status, body := renderCopyError(t, &boxlite.Error{
+		Code:    unknown,
+		Message: "a class this build has no name for",
+	})
+
+	if status != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d (body: %v)", status, http.StatusInternalServerError, body)
+	}
+	message, errorType, code, ok := errorEnvelope(body)
+	if !ok {
+		t.Fatalf("body is not the error envelope: %v", body)
+	}
+	if code != "internal" || errorType != "InternalError" {
+		t.Errorf("got (%q, %q), want (%q, %q)", errorType, code, "InternalError", "internal")
+	}
+	if !strings.Contains(message, "a class this build has no name for") {
+		t.Errorf("message dropped the runtime's wording: %q", message)
+	}
+}
+
+// The routes answer in one shape or the client can only read some of them.
+//
+// Both handlers also report failures of their own — an uninitialised runtime, a
+// missing `path`, a staging directory that could not be made, a tar that would
+// not extract. Each used to answer `{"error": "<text>"}`, which names no class,
+// so the client fell back to reading the status alone and reported them exactly
+// the way it reported a refusal: as a server fault. Driven through the real
+// handlers, which reach their first failure with no runner instance configured.
+func TestFilesRoutesAnswerInTheDeclaredEnvelope(t *testing.T) {
+	routes := map[string]struct {
+		handle func(*gin.Context)
+		method string
+	}{
+		"upload":   {BoxliteFileUpload, http.MethodPut},
+		"download": {BoxliteFileDownload, http.MethodGet},
+	}
+
+	for name, route := range routes {
+		gin.SetMode(gin.TestMode)
+		recorder := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(recorder)
+		ctx.Request = httptest.NewRequest(route.method, "/v1/boxes/b/files?path=/tmp/x", nil)
+
+		route.handle(ctx)
+
+		var body map[string]any
+		if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
+			t.Errorf("%s: response body is not JSON (%v): %s", name, err, recorder.Body.String())
+			continue
+		}
+		message, errorType, code, ok := errorEnvelope(body)
+		if !ok {
+			t.Errorf("%s: body is not the {error:{message,type,code}} envelope: %v", name, body)
+			continue
+		}
+		if message == "" || errorType == "" || code == "" {
+			t.Errorf("%s: envelope is missing a field: message=%q type=%q code=%q",
+				name, message, errorType, code)
+		}
+	}
+}
 
 // Absent or malformed values mean the client predates the hint → Unknown,
 // which relays the body with the guest peeking the archive to decide.
@@ -27,3 +245,7 @@ func TestParseSourceIsDir(t *testing.T) {
 		}
 	}
 }
+
+type errPlain string
+
+func (e errPlain) Error() string { return string(e) }

--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -508,6 +508,24 @@ func (c *Client) CopyOut(ctx context.Context, boxId string, guestSrc, hostDst st
 	return bx.CopyOut(ctx, guestSrc, hostDst)
 }
 
+// CopyInStream streams raw tar bytes from r into guestDst without staging.
+func (c *Client) CopyInStream(ctx context.Context, boxId, guestDst string, sourceKind boxlite.CopySourceKind, r io.Reader) error {
+	bx, err := c.getOrFetchBox(ctx, boxId)
+	if err != nil {
+		return err
+	}
+	return bx.CopyInStream(ctx, guestDst, sourceKind, r)
+}
+
+// CopyOutStream streams a tar of guestSrc to w without staging.
+func (c *Client) CopyOutStream(ctx context.Context, boxId, guestSrc string, w io.Writer, onMeta func(bool)) error {
+	bx, err := c.getOrFetchBox(ctx, boxId)
+	if err != nil {
+		return err
+	}
+	return bx.CopyOutStream(ctx, guestSrc, w, onMeta)
+}
+
 // ListImages returns all locally cached images.
 func (c *Client) ListImages(ctx context.Context) ([]boxlite.ImageInfo, error) {
 	images, err := c.runtime.Images()

--- a/sdks/c/README.md
+++ b/sdks/c/README.md
@@ -922,6 +922,10 @@ Callbacks are invoked on the **calling thread**. Do not block in callbacks.
   queued; call `boxlite_runtime_drain()` to dispatch the callback. On success,
   the callback owns the `CBoxInfo *` and must release it with
   `boxlite_free_box_info()`.
+- `boxlite_copy_in_start` takes a `BoxliteCopySourceKind source_kind` as its
+  third argument instead of `bool source_is_dir`. Use `Dir` for a directory
+  tree, `File` for a single file, or `Unknown` when the caller cannot tell
+  (older clients); with `Unknown` the guest peeks the archive to decide.
 
 Before:
 ```c
@@ -962,6 +966,18 @@ boxlite_box_info(box, on_info, user_data, &error);
 while (!request_done) {
     boxlite_runtime_drain(runtime, -1, &error);
 }
+```
+
+Before:
+```c
+boxlite_copy_in_start(handle, "/dst", true, copy_cb, user_data, &error);
+```
+
+After:
+```c
+boxlite_copy_in_start(handle, "/dst", Dir,     copy_cb, user_data, &error);  /* dir tree  */
+boxlite_copy_in_start(handle, "/dst", File,    copy_cb, user_data, &error);  /* one file  */
+boxlite_copy_in_start(handle, "/dst", Unknown, copy_cb, user_data, &error);  /* old client */
 ```
 
 ### From 0.1.x to 0.2.0

--- a/sdks/c/README.md
+++ b/sdks/c/README.md
@@ -923,9 +923,11 @@ Callbacks are invoked on the **calling thread**. Do not block in callbacks.
   the callback owns the `CBoxInfo *` and must release it with
   `boxlite_free_box_info()`.
 - `boxlite_copy_in_start` takes a `BoxliteCopySourceKind source_kind` as its
-  third argument instead of `bool source_is_dir`. Use `Dir` for a directory
-  tree, `File` for a single file, or `Unknown` when the caller cannot tell
-  (older clients); with `Unknown` the guest peeks the archive to decide.
+  third argument instead of `bool source_is_dir`. Use
+  `BoxliteCopySourceKindDir` for a directory tree,
+  `BoxliteCopySourceKindFile` for a single file, or
+  `BoxliteCopySourceKindUnknown` when the caller cannot tell (older
+  clients); with that kind the guest peeks the archive to decide.
 
 Before:
 ```c
@@ -975,9 +977,12 @@ boxlite_copy_in_start(handle, "/dst", true, copy_cb, user_data, &error);
 
 After:
 ```c
-boxlite_copy_in_start(handle, "/dst", Dir,     copy_cb, user_data, &error);  /* dir tree  */
-boxlite_copy_in_start(handle, "/dst", File,    copy_cb, user_data, &error);  /* one file  */
-boxlite_copy_in_start(handle, "/dst", Unknown, copy_cb, user_data, &error);  /* old client */
+/* dir tree */
+boxlite_copy_in_start(handle, "/dst", BoxliteCopySourceKindDir, copy_cb, user_data, &error);
+/* one file */
+boxlite_copy_in_start(handle, "/dst", BoxliteCopySourceKindFile, copy_cb, user_data, &error);
+/* old client, shape unknown */
+boxlite_copy_in_start(handle, "/dst", BoxliteCopySourceKindUnknown, copy_cb, user_data, &error);
 ```
 
 ### From 0.1.x to 0.2.0

--- a/sdks/c/cbindgen.toml
+++ b/sdks/c/cbindgen.toml
@@ -14,3 +14,9 @@ usize_is_size_t = true
 
 [parse]
 parse_deps = false
+
+# Keep the copy-in source-kind enum in the header even though the function
+# parameter is an int32_t: C callers cast the enum constants to the integer
+# the ABI expects, so the names must remain exported.
+[export]
+include = ["BoxliteCopySourceKind"]

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -81,6 +81,17 @@ typedef enum BoxliteRegistryTransport {
   BoxliteRegistryTransportHttp = 1,
 } BoxliteRegistryTransport;
 
+// Streaming-copy source shape. For copy-in, `Unknown` means the caller
+// cannot tell and the guest peeks at the archive. For copy-out, `Unknown`
+// means the peer omitted the hint. Mirrors the guest protocol's
+// `optional bool source_is_dir`: `File` = Some(false), `Dir` = Some(true),
+// `Unknown` = None.
+typedef enum BoxliteCopySourceKind {
+  Unknown = 0,
+  File = 1,
+  Dir = 2,
+} BoxliteCopySourceKind;
+
 // Opaque handle wrapping an `AdvancedBoxOptions`. Allocated via
 // `boxlite_advanced_options_new`, freed via `boxlite_advanced_options_free`.
 typedef struct AdvancedBoxOptionsHandle AdvancedBoxOptionsHandle;
@@ -99,6 +110,12 @@ typedef struct BoxRunner BoxRunner;
 
 // Opaque handle for a one-shot prepared tunnel.
 typedef struct BoxTunnelHandle BoxTunnelHandle;
+
+// Opaque handle for a streaming copy-in (push raw tar bytes into the guest).
+typedef struct CBoxCopyInStream CBoxCopyInStream;
+
+// Opaque handle for a streaming copy-out (pull raw tar bytes from the guest).
+typedef struct CBoxCopyOutStream CBoxCopyOutStream;
 
 // Opaque credential handle. Wraps a core `Arc<dyn Credential>` so the
 // concrete credential kind (today only `ApiKeyCredential`) is hidden
@@ -611,6 +628,73 @@ enum BoxliteErrorCode boxlite_copy_out(CBoxHandle *handle,
                                        CBoxCopyCb cb,
                                        void *user_data,
                                        CBoxliteError *out_error);
+
+// Begin downloading `guest_src` as a pull-based raw tar stream.
+//
+// This call blocks until the stream and its optional source-shape hint are
+// ready. On success the returned handle must be released with
+// [`boxlite_copy_out_free`]. A non-null `out_source_kind` is initialized to
+// `Unknown` and updated to `File` or `Dir` when the peer supplies the hint.
+struct CBoxCopyOutStream *boxlite_copy_out_start(CBoxHandle *handle,
+                                                 const char *guest_src,
+                                                 int32_t *out_source_kind,
+                                                 CBoxliteError *out_error);
+
+// Read the next raw tar bytes from a copy-out stream.
+//
+// This call blocks while the upstream stream is pending. `Ok` with a
+// positive `out_read` returns data; `Ok` with zero length is sticky EOF. A
+// stream item error is terminal: its first read reports the stream error and
+// later reads return `InvalidState` without polling upstream again.
+enum BoxliteErrorCode boxlite_copy_out_read(struct CBoxCopyOutStream *stream,
+                                            uint8_t *buffer,
+                                            size_t capacity,
+                                            size_t *out_read,
+                                            CBoxliteError *out_error);
+
+// Reclaim a copy-out stream handle. A null handle is a no-op.
+//
+// The caller must not invoke [`boxlite_copy_out_read`] concurrently or race
+// a read with this function.
+void boxlite_copy_out_free(struct CBoxCopyOutStream *stream);
+
+// Begin a streaming copy-in, returning an opaque transfer handle.
+//
+// `source_kind` describes the archive shape: `BoxliteCopySourceKind`'s
+// discriminant (`Unknown`=0, `File`=1, `Dir`=2), or 0 when the caller
+// cannot tell (older clients) — the guest then peeks the archive to decide.
+// Taken as an integer because C callers can pass any value, and
+// out-of-range discriminants must behave as Unknown rather than as an
+// invalid Rust enum.
+struct CBoxCopyInStream *boxlite_copy_in_start(CBoxHandle *handle,
+                                               const char *guest_dst,
+                                               int32_t source_kind,
+                                               CBoxCopyCb copy_cb,
+                                               void *user_data,
+                                               CBoxliteError *out_error);
+
+// Push a chunk of raw tar bytes into the guest. Blocks when the guest is slow
+// (bounded-channel backpressure).
+enum BoxliteErrorCode boxlite_copy_in_write(struct CBoxCopyInStream *stream,
+                                            const uint8_t *data,
+                                            size_t len,
+                                            CBoxliteError *out_error);
+
+// Close the copy-in stream, signalling EOF to the guest. Idempotent.
+enum BoxliteErrorCode boxlite_copy_in_close(struct CBoxCopyInStream *stream,
+                                            CBoxliteError *out_error);
+
+// Abort the copy-in stream: deliver a terminal error to the guest and then
+// close the channel. Unlike [`boxlite_copy_in_close`], the guest sees a
+// failed stream — a truncated upload can never pass as a clean EOF. Call
+// this when the source read failed mid-transfer. This is a one-shot
+// transition: after the first call (abort or close), later abort calls return
+// `InvalidState`.
+enum BoxliteErrorCode boxlite_copy_in_abort(struct CBoxCopyInStream *stream,
+                                            CBoxliteError *out_error);
+
+// Reclaim a copy-in stream handle.
+void boxlite_copy_in_free(struct CBoxCopyInStream *stream);
 
 void boxlite_error_free(CBoxliteError *error);
 

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -83,9 +83,8 @@ typedef enum BoxliteRegistryTransport {
 
 // Streaming-copy source shape. For copy-in, `Unknown` means the caller
 // cannot tell and the guest peeks at the archive. For copy-out, `Unknown`
-// means the peer omitted the hint. Mirrors the guest protocol's
-// `optional bool source_is_dir`: `File` = Some(false), `Dir` = Some(true),
-// `Unknown` = None.
+// means the peer omitted the hint. The C-ABI mirror of the core
+// `CopySourceKind`.
 typedef enum BoxliteCopySourceKind {
   Unknown = 0,
   File = 1,
@@ -111,10 +110,23 @@ typedef struct BoxRunner BoxRunner;
 // Opaque handle for a one-shot prepared tunnel.
 typedef struct BoxTunnelHandle BoxTunnelHandle;
 
-// Opaque handle for a streaming copy-in (push raw tar bytes into the guest).
+// Opaque handle for a streaming copy-in (push archive bytes into the guest).
+//
+// The lifecycle is fixed, and the third step is not optional:
+//
+//     boxlite_copy_in_start
+//       boxlite_copy_in_write   (repeat)
+//       boxlite_copy_in_close   on success
+//       boxlite_copy_in_abort   when the source read failed
+//     boxlite_copy_in_free
+//
+// Going straight from write to free is what makes a truncated upload
+// dangerous: freeing the handle drops the channel, which the guest reads
+// as a clean EOF and commits. Only boxlite_copy_in_abort turns a
+// mid-transfer source failure into a terminal error the guest can refuse.
 typedef struct CBoxCopyInStream CBoxCopyInStream;
 
-// Opaque handle for a streaming copy-out (pull raw tar bytes from the guest).
+// Opaque handle for a streaming copy-out (pull archive bytes from the guest).
 typedef struct CBoxCopyOutStream CBoxCopyOutStream;
 
 // Opaque credential handle. Wraps a core `Arc<dyn Credential>` so the
@@ -629,7 +641,7 @@ enum BoxliteErrorCode boxlite_copy_out(CBoxHandle *handle,
                                        void *user_data,
                                        CBoxliteError *out_error);
 
-// Begin downloading `guest_src` as a pull-based raw tar stream.
+// Begin downloading `guest_src` as a pull-based raw archive stream.
 //
 // This call blocks until the stream and its optional source-shape hint are
 // ready. On success the returned handle must be released with
@@ -640,7 +652,7 @@ struct CBoxCopyOutStream *boxlite_copy_out_start(CBoxHandle *handle,
                                                  int32_t *out_source_kind,
                                                  CBoxliteError *out_error);
 
-// Read the next raw tar bytes from a copy-out stream.
+// Read the next raw archive bytes from a copy-out stream.
 //
 // This call blocks while the upstream stream is pending. `Ok` with a
 // positive `out_read` returns data; `Ok` with zero length is sticky EOF. A
@@ -673,8 +685,8 @@ struct CBoxCopyInStream *boxlite_copy_in_start(CBoxHandle *handle,
                                                void *user_data,
                                                CBoxliteError *out_error);
 
-// Push a chunk of raw tar bytes into the guest. Blocks when the guest is slow
-// (bounded-channel backpressure).
+// Push a chunk of archive bytes into the guest. Blocks when the guest is
+// slow (bounded-channel backpressure).
 enum BoxliteErrorCode boxlite_copy_in_write(struct CBoxCopyInStream *stream,
                                             const uint8_t *data,
                                             size_t len,
@@ -694,6 +706,12 @@ enum BoxliteErrorCode boxlite_copy_in_abort(struct CBoxCopyInStream *stream,
                                             CBoxliteError *out_error);
 
 // Reclaim a copy-in stream handle.
+//
+// Freeing a stream that was never closed or aborted still drops the
+// channel, so it signals EOF exactly as boxlite_copy_in_close would — the
+// guest commits whatever it received. Call boxlite_copy_in_abort first
+// whenever the transfer did not complete; see CBoxCopyInStream for the
+// full sequence.
 void boxlite_copy_in_free(struct CBoxCopyInStream *stream);
 
 void boxlite_error_free(CBoxliteError *error);

--- a/sdks/c/include/boxlite.h
+++ b/sdks/c/include/boxlite.h
@@ -81,14 +81,14 @@ typedef enum BoxliteRegistryTransport {
   BoxliteRegistryTransportHttp = 1,
 } BoxliteRegistryTransport;
 
-// Streaming-copy source shape. For copy-in, `Unknown` means the caller
-// cannot tell and the guest peeks at the archive. For copy-out, `Unknown`
-// means the peer omitted the hint. The C-ABI mirror of the core
+// Streaming-copy source shape. For copy-in, `BoxliteCopySourceKindUnknown`
+// means the caller cannot tell and the guest peeks at the archive. For
+// copy-out, it means the peer omitted the hint. The C-ABI mirror of the core
 // `CopySourceKind`.
 typedef enum BoxliteCopySourceKind {
-  Unknown = 0,
-  File = 1,
-  Dir = 2,
+  BoxliteCopySourceKindUnknown = 0,
+  BoxliteCopySourceKindFile = 1,
+  BoxliteCopySourceKindDir = 2,
 } BoxliteCopySourceKind;
 
 // Opaque handle wrapping an `AdvancedBoxOptions`. Allocated via
@@ -646,7 +646,8 @@ enum BoxliteErrorCode boxlite_copy_out(CBoxHandle *handle,
 // This call blocks until the stream and its optional source-shape hint are
 // ready. On success the returned handle must be released with
 // [`boxlite_copy_out_free`]. A non-null `out_source_kind` is initialized to
-// `Unknown` and updated to `File` or `Dir` when the peer supplies the hint.
+// `BoxliteCopySourceKindUnknown` and updated to the `...File` or `...Dir`
+// variant when the peer supplies the hint.
 struct CBoxCopyOutStream *boxlite_copy_out_start(CBoxHandle *handle,
                                                  const char *guest_src,
                                                  int32_t *out_source_kind,
@@ -673,8 +674,9 @@ void boxlite_copy_out_free(struct CBoxCopyOutStream *stream);
 // Begin a streaming copy-in, returning an opaque transfer handle.
 //
 // `source_kind` describes the archive shape: `BoxliteCopySourceKind`'s
-// discriminant (`Unknown`=0, `File`=1, `Dir`=2), or 0 when the caller
-// cannot tell (older clients) — the guest then peeks the archive to decide.
+// discriminant (`...Unknown`=0, `...File`=1, `...Dir`=2), or 0 when the
+// caller cannot tell (older clients) — the guest then peeks the archive to
+// decide.
 // Taken as an integer because C callers can pass any value, and
 // out-of-range discriminants must behave as Unknown rather than as an
 // invalid Rust enum.

--- a/sdks/c/src/copy.rs
+++ b/sdks/c/src/copy.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use boxlite::litebox::copy::CopyOptions;
-use boxlite::{BoxTarStream, BoxliteError};
+use boxlite::{BoxByteStream, BoxliteError, CopySourceKind};
 use futures::StreamExt;
 use tokio::runtime::Runtime as TokioRuntime;
 use tokio::sync::mpsc;
@@ -158,9 +158,8 @@ unsafe fn box_copy_out(
 
 /// Streaming-copy source shape. For copy-in, `Unknown` means the caller
 /// cannot tell and the guest peeks at the archive. For copy-out, `Unknown`
-/// means the peer omitted the hint. Mirrors the guest protocol's
-/// `optional bool source_is_dir`: `File` = Some(false), `Dir` = Some(true),
-/// `Unknown` = None.
+/// means the peer omitted the hint. The C-ABI mirror of the core
+/// `CopySourceKind`.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BoxliteCopySourceKind {
@@ -169,26 +168,39 @@ pub enum BoxliteCopySourceKind {
     Dir = 2,
 }
 
-fn source_hint_to_kind(source_is_dir: Option<bool>) -> i32 {
-    match source_is_dir {
-        None => BoxliteCopySourceKind::Unknown as i32,
-        Some(false) => BoxliteCopySourceKind::File as i32,
-        Some(true) => BoxliteCopySourceKind::Dir as i32,
+fn source_kind_to_c(source: CopySourceKind) -> i32 {
+    match source {
+        CopySourceKind::Unknown => BoxliteCopySourceKind::Unknown as i32,
+        CopySourceKind::File => BoxliteCopySourceKind::File as i32,
+        CopySourceKind::Dir => BoxliteCopySourceKind::Dir as i32,
     }
 }
 
-/// Maps the C tri-state to the guest protocol's optional bool. Takes the raw
-/// integer because C callers can pass any value, and unrecognized values
-/// must behave as Unknown rather than guess.
-fn source_kind_to_hint(kind: i32) -> Option<bool> {
+/// Maps the C tri-state to [`CopySourceKind`]. Takes the raw integer because C
+/// callers can pass any value, and unrecognized values must behave as Unknown
+/// rather than guess.
+fn source_kind_from_c(kind: i32) -> CopySourceKind {
     match kind {
-        1 => Some(false),
-        2 => Some(true),
-        _ => None,
+        1 => CopySourceKind::File,
+        2 => CopySourceKind::Dir,
+        _ => CopySourceKind::Unknown,
     }
 }
 
-/// Opaque handle for a streaming copy-in (push raw tar bytes into the guest).
+/// Opaque handle for a streaming copy-in (push archive bytes into the guest).
+///
+/// The lifecycle is fixed, and the third step is not optional:
+///
+///     boxlite_copy_in_start
+///       boxlite_copy_in_write   (repeat)
+///       boxlite_copy_in_close   on success
+///       boxlite_copy_in_abort   when the source read failed
+///     boxlite_copy_in_free
+///
+/// Going straight from write to free is what makes a truncated upload
+/// dangerous: freeing the handle drops the channel, which the guest reads
+/// as a clean EOF and commits. Only boxlite_copy_in_abort turns a
+/// mid-transfer source failure into a terminal error the guest can refuse.
 pub struct CBoxCopyInStream {
     tx: Option<mpsc::Sender<io::Result<Vec<u8>>>>,
     tokio_rt: Arc<TokioRuntime>,
@@ -201,9 +213,9 @@ enum CopyOutStreamState {
     Failed,
 }
 
-/// Opaque handle for a streaming copy-out (pull raw tar bytes from the guest).
+/// Opaque handle for a streaming copy-out (pull archive bytes from the guest).
 pub struct CBoxCopyOutStream {
-    tar: BoxTarStream,
+    bytes: BoxByteStream,
     tokio_rt: Arc<TokioRuntime>,
     pending: Vec<u8>,
     pending_offset: usize,
@@ -211,9 +223,9 @@ pub struct CBoxCopyOutStream {
 }
 
 impl CBoxCopyOutStream {
-    fn new(tar: BoxTarStream, tokio_rt: Arc<TokioRuntime>) -> Self {
+    fn new(bytes: BoxByteStream, tokio_rt: Arc<TokioRuntime>) -> Self {
         Self {
-            tar,
+            bytes,
             tokio_rt,
             pending: Vec::new(),
             pending_offset: 0,
@@ -259,7 +271,7 @@ impl CBoxCopyOutStream {
             }
 
             let tokio_rt = Arc::clone(&self.tokio_rt);
-            match tokio_rt.block_on(self.tar.next()) {
+            match tokio_rt.block_on(self.bytes.next()) {
                 Some(Ok(bytes)) if bytes.is_empty() => continue,
                 Some(Ok(bytes)) => {
                     self.pending = bytes;
@@ -280,7 +292,7 @@ impl CBoxCopyOutStream {
     }
 }
 
-/// Begin downloading `guest_src` as a pull-based raw tar stream.
+/// Begin downloading `guest_src` as a pull-based raw archive stream.
 ///
 /// This call blocks until the stream and its optional source-shape hint are
 /// ready. On success the returned handle must be released with
@@ -317,14 +329,14 @@ pub unsafe extern "C" fn boxlite_copy_out_start(
         let lite = handle_ref.handle.clone();
         match handle_ref
             .tokio_rt
-            .block_on(lite.copy_out_tar(src.as_str(), default_copy_options()))
+            .block_on(lite.copy_out_stream(src.as_str(), default_copy_options()))
         {
-            Ok((tar, source_is_dir)) => {
+            Ok((bytes, source)) => {
                 if !out_source_kind.is_null() {
-                    *out_source_kind = source_hint_to_kind(source_is_dir);
+                    *out_source_kind = source_kind_to_c(source);
                 }
                 Box::into_raw(Box::new(CBoxCopyOutStream::new(
-                    tar,
+                    bytes,
                     handle_ref.tokio_rt.clone(),
                 )))
             }
@@ -336,7 +348,7 @@ pub unsafe extern "C" fn boxlite_copy_out_start(
     }
 }
 
-/// Read the next raw tar bytes from a copy-out stream.
+/// Read the next raw archive bytes from a copy-out stream.
 ///
 /// This call blocks while the upstream stream is pending. `Ok` with a
 /// positive `out_read` returns data; `Ok` with zero length is sticky EOF. A
@@ -434,7 +446,7 @@ pub unsafe extern "C" fn boxlite_copy_in_start(
             return std::ptr::null_mut();
         };
 
-        let source_is_dir = source_kind_to_hint(source_kind);
+        let source = source_kind_from_c(source_kind);
 
         let handle_ref = &*handle;
         let lite = handle_ref.handle.clone();
@@ -442,13 +454,13 @@ pub unsafe extern "C" fn boxlite_copy_in_start(
         let user_data_addr = user_data as usize;
 
         let (tx, rx) = mpsc::channel::<io::Result<Vec<u8>>>(4);
-        let tar = futures::stream::unfold(rx, |mut rx| async move {
+        let bytes = futures::stream::unfold(rx, |mut rx| async move {
             rx.recv().await.map(|item| (item, rx))
         });
 
         handle_ref.tokio_rt.spawn(async move {
             let result = lite
-                .copy_in_tar_stream(tar, dst.as_str(), source_is_dir, default_copy_options())
+                .copy_in_stream(bytes, dst.as_str(), source, default_copy_options())
                 .await;
             push_event(
                 &queue,
@@ -468,8 +480,8 @@ pub unsafe extern "C" fn boxlite_copy_in_start(
     }
 }
 
-/// Push a chunk of raw tar bytes into the guest. Blocks when the guest is slow
-/// (bounded-channel backpressure).
+/// Push a chunk of archive bytes into the guest. Blocks when the guest is
+/// slow (bounded-channel backpressure).
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_copy_in_write(
     stream: *mut CBoxCopyInStream,
@@ -525,7 +537,7 @@ pub unsafe extern "C" fn boxlite_copy_in_close(
             return BoxliteErrorCode::InvalidArgument;
         }
         let stream_ref = &mut *stream;
-        // Dropping the sender closes the channel, which ends the tar stream and
+        // Dropping the sender closes the channel, which ends the byte stream and
         // signals EOF to the guest unpacker.
         stream_ref.tx.take();
         BoxliteErrorCode::Ok
@@ -573,6 +585,12 @@ pub unsafe extern "C" fn boxlite_copy_in_abort(
 }
 
 /// Reclaim a copy-in stream handle.
+///
+/// Freeing a stream that was never closed or aborted still drops the
+/// channel, so it signals EOF exactly as boxlite_copy_in_close would — the
+/// guest commits whatever it received. Call boxlite_copy_in_abort first
+/// whenever the transfer did not complete; see CBoxCopyInStream for the
+/// full sequence.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_copy_in_free(stream: *mut CBoxCopyInStream) {
     unsafe {
@@ -589,8 +607,8 @@ mod tests {
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     fn copy_out_stream(items: Vec<io::Result<Vec<u8>>>) -> CBoxCopyOutStream {
-        let tar: BoxTarStream = Box::pin(futures::stream::iter(items));
-        CBoxCopyOutStream::new(tar, Arc::new(tokio::runtime::Runtime::new().unwrap()))
+        let bytes: BoxByteStream = Box::pin(futures::stream::iter(items));
+        CBoxCopyOutStream::new(bytes, Arc::new(tokio::runtime::Runtime::new().unwrap()))
     }
 
     fn assert_error_contains(
@@ -669,31 +687,15 @@ mod tests {
     }
 
     #[test]
-    fn source_kind_maps_to_guest_hint() {
-        assert_eq!(
-            source_kind_to_hint(BoxliteCopySourceKind::Unknown as i32),
-            None
-        );
-        assert_eq!(
-            source_kind_to_hint(BoxliteCopySourceKind::File as i32),
-            Some(false)
-        );
-        assert_eq!(
-            source_kind_to_hint(BoxliteCopySourceKind::Dir as i32),
-            Some(true)
-        );
-        assert_eq!(
-            source_hint_to_kind(None),
-            BoxliteCopySourceKind::Unknown as i32
-        );
-        assert_eq!(
-            source_hint_to_kind(Some(false)),
-            BoxliteCopySourceKind::File as i32
-        );
-        assert_eq!(
-            source_hint_to_kind(Some(true)),
-            BoxliteCopySourceKind::Dir as i32
-        );
+    fn source_kind_round_trips_across_the_c_abi() {
+        for (c_kind, core) in [
+            (BoxliteCopySourceKind::Unknown, CopySourceKind::Unknown),
+            (BoxliteCopySourceKind::File, CopySourceKind::File),
+            (BoxliteCopySourceKind::Dir, CopySourceKind::Dir),
+        ] {
+            assert_eq!(source_kind_from_c(c_kind as i32), core);
+            assert_eq!(source_kind_to_c(core), c_kind as i32);
+        }
     }
 
     #[test]
@@ -735,7 +737,7 @@ mod tests {
     fn copy_out_polls_upstream_only_when_read_needs_data() {
         let polls = Arc::new(AtomicUsize::new(0));
         let stream_polls = Arc::clone(&polls);
-        let tar: BoxTarStream = Box::pin(futures::stream::unfold(0_u8, move |step| {
+        let bytes: BoxByteStream = Box::pin(futures::stream::unfold(0_u8, move |step| {
             let stream_polls = Arc::clone(&stream_polls);
             async move {
                 stream_polls.fetch_add(1, Ordering::SeqCst);
@@ -746,7 +748,7 @@ mod tests {
             }
         }));
         let mut stream =
-            CBoxCopyOutStream::new(tar, Arc::new(tokio::runtime::Runtime::new().unwrap()));
+            CBoxCopyOutStream::new(bytes, Arc::new(tokio::runtime::Runtime::new().unwrap()));
         let mut dst = [0_u8; 1];
 
         assert_eq!(polls.load(Ordering::SeqCst), 0);
@@ -839,15 +841,15 @@ mod tests {
     }
 
     #[test]
-    fn copy_out_free_drops_active_tar_stream() {
+    fn copy_out_free_drops_active_byte_stream() {
         let dropped = Arc::new(AtomicBool::new(false));
         let probe = DropProbe(Arc::clone(&dropped));
-        let tar: BoxTarStream = Box::pin(futures::stream::poll_fn(move |_cx| {
+        let bytes: BoxByteStream = Box::pin(futures::stream::poll_fn(move |_cx| {
             let _keep_alive = &probe;
             std::task::Poll::<Option<io::Result<Vec<u8>>>>::Pending
         }));
         let stream = Box::into_raw(Box::new(CBoxCopyOutStream::new(
-            tar,
+            bytes,
             Arc::new(tokio::runtime::Runtime::new().unwrap()),
         )));
 
@@ -890,11 +892,42 @@ mod tests {
         assert_eq!(code, BoxliteErrorCode::InvalidState);
     }
 
+    /// Pins the hazard the copy-in lifecycle doc warns about: freeing a live
+    /// handle instead of aborting it drops the sender, so the consumer sees a
+    /// bare EOF and cannot tell the upload was cut short. If `free` ever grows
+    /// an implicit abort, this test is the one that must be revisited.
+    #[test]
+    fn copy_in_free_without_abort_signals_a_bare_eof() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let (tx, mut rx) = mpsc::channel(4);
+        let stream = Box::into_raw(Box::new(CBoxCopyInStream {
+            tx: Some(tx),
+            tokio_rt: Arc::new(rt),
+        }));
+
+        let data = [7u8; 3];
+        let mut err = CBoxliteError::default();
+        let code = unsafe { boxlite_copy_in_write(stream, data.as_ptr(), data.len(), &mut err) };
+        assert_eq!(code, BoxliteErrorCode::Ok);
+
+        let drain_rt = tokio::runtime::Runtime::new().unwrap();
+        unsafe { boxlite_copy_in_free(stream) };
+
+        assert_eq!(
+            drain_rt.block_on(rx.recv()).expect("chunk").unwrap(),
+            data.to_vec()
+        );
+        assert!(
+            drain_rt.block_on(rx.recv()).is_none(),
+            "free must close the channel"
+        );
+    }
+
     #[test]
     fn unrecognized_kind_behaves_as_unknown() {
         // C callers can cast any integer to the enum; out-of-range values
         // must not be guessed into a shape.
-        assert_eq!(source_kind_to_hint(7), None);
-        assert_eq!(source_kind_to_hint(-1), None);
+        assert_eq!(source_kind_from_c(7), CopySourceKind::Unknown);
+        assert_eq!(source_kind_from_c(-1), CopySourceKind::Unknown);
     }
 }

--- a/sdks/c/src/copy.rs
+++ b/sdks/c/src/copy.rs
@@ -156,23 +156,23 @@ unsafe fn box_copy_out(
 
 // ─── Streaming copy ────────────────────────────────────────────────────────
 
-/// Streaming-copy source shape. For copy-in, `Unknown` means the caller
-/// cannot tell and the guest peeks at the archive. For copy-out, `Unknown`
-/// means the peer omitted the hint. The C-ABI mirror of the core
+/// Streaming-copy source shape. For copy-in, `BoxliteCopySourceKindUnknown`
+/// means the caller cannot tell and the guest peeks at the archive. For
+/// copy-out, it means the peer omitted the hint. The C-ABI mirror of the core
 /// `CopySourceKind`.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BoxliteCopySourceKind {
-    Unknown = 0,
-    File = 1,
-    Dir = 2,
+    BoxliteCopySourceKindUnknown = 0,
+    BoxliteCopySourceKindFile = 1,
+    BoxliteCopySourceKindDir = 2,
 }
 
 fn source_kind_to_c(source: CopySourceKind) -> i32 {
     match source {
-        CopySourceKind::Unknown => BoxliteCopySourceKind::Unknown as i32,
-        CopySourceKind::File => BoxliteCopySourceKind::File as i32,
-        CopySourceKind::Dir => BoxliteCopySourceKind::Dir as i32,
+        CopySourceKind::Unknown => BoxliteCopySourceKind::BoxliteCopySourceKindUnknown as i32,
+        CopySourceKind::File => BoxliteCopySourceKind::BoxliteCopySourceKindFile as i32,
+        CopySourceKind::Dir => BoxliteCopySourceKind::BoxliteCopySourceKindDir as i32,
     }
 }
 
@@ -297,7 +297,8 @@ impl CBoxCopyOutStream {
 /// This call blocks until the stream and its optional source-shape hint are
 /// ready. On success the returned handle must be released with
 /// [`boxlite_copy_out_free`]. A non-null `out_source_kind` is initialized to
-/// `Unknown` and updated to `File` or `Dir` when the peer supplies the hint.
+/// `BoxliteCopySourceKindUnknown` and updated to the `...File` or `...Dir`
+/// variant when the peer supplies the hint.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn boxlite_copy_out_start(
     handle: *mut CBoxHandle,
@@ -307,7 +308,7 @@ pub unsafe extern "C" fn boxlite_copy_out_start(
 ) -> *mut CBoxCopyOutStream {
     unsafe {
         if !out_source_kind.is_null() {
-            *out_source_kind = BoxliteCopySourceKind::Unknown as i32;
+            *out_source_kind = BoxliteCopySourceKind::BoxliteCopySourceKindUnknown as i32;
         }
         if handle.is_null() {
             write_error(out_error, null_pointer_error("handle"));
@@ -415,8 +416,9 @@ pub unsafe extern "C" fn boxlite_copy_out_free(stream: *mut CBoxCopyOutStream) {
 /// Begin a streaming copy-in, returning an opaque transfer handle.
 ///
 /// `source_kind` describes the archive shape: `BoxliteCopySourceKind`'s
-/// discriminant (`Unknown`=0, `File`=1, `Dir`=2), or 0 when the caller
-/// cannot tell (older clients) — the guest then peeks the archive to decide.
+/// discriminant (`...Unknown`=0, `...File`=1, `...Dir`=2), or 0 when the
+/// caller cannot tell (older clients) — the guest then peeks the archive to
+/// decide.
 /// Taken as an integer because C callers can pass any value, and
 /// out-of-range discriminants must behave as Unknown rather than as an
 /// invalid Rust enum.
@@ -635,7 +637,7 @@ mod tests {
 
     #[test]
     fn copy_out_start_null_handle_resets_source_kind_and_reports_error() {
-        let mut source_kind = BoxliteCopySourceKind::Dir as i32;
+        let mut source_kind = BoxliteCopySourceKind::BoxliteCopySourceKindDir as i32;
         let mut error = CBoxliteError::default();
 
         let stream = unsafe {
@@ -647,11 +649,14 @@ mod tests {
             )
         };
         assert!(stream.is_null());
-        assert_eq!(source_kind, BoxliteCopySourceKind::Unknown as i32);
+        assert_eq!(
+            source_kind,
+            BoxliteCopySourceKind::BoxliteCopySourceKindUnknown as i32
+        );
         assert_error_contains(&error, BoxliteErrorCode::InvalidArgument, "handle is null");
         unsafe { crate::error::boxlite_error_free(&mut error) };
 
-        source_kind = BoxliteCopySourceKind::Dir as i32;
+        source_kind = BoxliteCopySourceKind::BoxliteCopySourceKindDir as i32;
         let stream = unsafe {
             boxlite_copy_out_start(
                 std::ptr::null_mut(),
@@ -661,7 +666,10 @@ mod tests {
             )
         };
         assert!(stream.is_null());
-        assert_eq!(source_kind, BoxliteCopySourceKind::Unknown as i32);
+        assert_eq!(
+            source_kind,
+            BoxliteCopySourceKind::BoxliteCopySourceKindUnknown as i32
+        );
 
         let stream = unsafe {
             boxlite_copy_out_start(
@@ -689,9 +697,18 @@ mod tests {
     #[test]
     fn source_kind_round_trips_across_the_c_abi() {
         for (c_kind, core) in [
-            (BoxliteCopySourceKind::Unknown, CopySourceKind::Unknown),
-            (BoxliteCopySourceKind::File, CopySourceKind::File),
-            (BoxliteCopySourceKind::Dir, CopySourceKind::Dir),
+            (
+                BoxliteCopySourceKind::BoxliteCopySourceKindUnknown,
+                CopySourceKind::Unknown,
+            ),
+            (
+                BoxliteCopySourceKind::BoxliteCopySourceKindFile,
+                CopySourceKind::File,
+            ),
+            (
+                BoxliteCopySourceKind::BoxliteCopySourceKindDir,
+                CopySourceKind::Dir,
+            ),
         ] {
             assert_eq!(source_kind_from_c(c_kind as i32), core);
             assert_eq!(source_kind_to_c(core), c_kind as i32);

--- a/sdks/c/src/copy.rs
+++ b/sdks/c/src/copy.rs
@@ -1,12 +1,18 @@
-//! File copy operations for the BoxLite C SDK (async + callback variants).
+//! File copy operations for the BoxLite C SDK.
 
+use std::io;
 use std::os::raw::{c_char, c_void};
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use boxlite::litebox::copy::CopyOptions;
+use boxlite::{BoxTarStream, BoxliteError};
+use futures::StreamExt;
+use tokio::runtime::Runtime as TokioRuntime;
+use tokio::sync::mpsc;
 
 use crate::box_handle::BoxHandle;
-use crate::error::{BoxliteErrorCode, FFIError, null_pointer_error, write_error};
+use crate::error::{BoxliteErrorCode, FFIError, error_to_code, null_pointer_error, write_error};
 use crate::event_queue::{CBoxCopyCb, RuntimeEvent, push_event};
 use crate::util::c_str_to_string;
 use crate::{CBoxHandle, CBoxliteError};
@@ -145,5 +151,750 @@ unsafe fn box_copy_out(
         });
 
         BoxliteErrorCode::Ok
+    }
+}
+
+// ─── Streaming copy ────────────────────────────────────────────────────────
+
+/// Streaming-copy source shape. For copy-in, `Unknown` means the caller
+/// cannot tell and the guest peeks at the archive. For copy-out, `Unknown`
+/// means the peer omitted the hint. Mirrors the guest protocol's
+/// `optional bool source_is_dir`: `File` = Some(false), `Dir` = Some(true),
+/// `Unknown` = None.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BoxliteCopySourceKind {
+    Unknown = 0,
+    File = 1,
+    Dir = 2,
+}
+
+fn source_hint_to_kind(source_is_dir: Option<bool>) -> i32 {
+    match source_is_dir {
+        None => BoxliteCopySourceKind::Unknown as i32,
+        Some(false) => BoxliteCopySourceKind::File as i32,
+        Some(true) => BoxliteCopySourceKind::Dir as i32,
+    }
+}
+
+/// Maps the C tri-state to the guest protocol's optional bool. Takes the raw
+/// integer because C callers can pass any value, and unrecognized values
+/// must behave as Unknown rather than guess.
+fn source_kind_to_hint(kind: i32) -> Option<bool> {
+    match kind {
+        1 => Some(false),
+        2 => Some(true),
+        _ => None,
+    }
+}
+
+/// Opaque handle for a streaming copy-in (push raw tar bytes into the guest).
+pub struct CBoxCopyInStream {
+    tx: Option<mpsc::Sender<io::Result<Vec<u8>>>>,
+    tokio_rt: Arc<TokioRuntime>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum CopyOutStreamState {
+    Open,
+    Eof,
+    Failed,
+}
+
+/// Opaque handle for a streaming copy-out (pull raw tar bytes from the guest).
+pub struct CBoxCopyOutStream {
+    tar: BoxTarStream,
+    tokio_rt: Arc<TokioRuntime>,
+    pending: Vec<u8>,
+    pending_offset: usize,
+    state: CopyOutStreamState,
+}
+
+impl CBoxCopyOutStream {
+    fn new(tar: BoxTarStream, tokio_rt: Arc<TokioRuntime>) -> Self {
+        Self {
+            tar,
+            tokio_rt,
+            pending: Vec::new(),
+            pending_offset: 0,
+            state: CopyOutStreamState::Open,
+        }
+    }
+
+    fn copy_pending(&mut self, dst: &mut [u8]) -> Option<usize> {
+        if self.pending_offset == self.pending.len() {
+            self.pending.clear();
+            self.pending_offset = 0;
+            return None;
+        }
+
+        let count = dst
+            .len()
+            .min(self.pending.len().saturating_sub(self.pending_offset));
+        let end = self.pending_offset + count;
+        dst[..count].copy_from_slice(&self.pending[self.pending_offset..end]);
+        self.pending_offset = end;
+        if self.pending_offset == self.pending.len() {
+            self.pending.clear();
+            self.pending_offset = 0;
+        }
+        Some(count)
+    }
+
+    fn read_into(&mut self, dst: &mut [u8]) -> Result<usize, BoxliteError> {
+        debug_assert!(!dst.is_empty());
+        match self.state {
+            CopyOutStreamState::Eof => return Ok(0),
+            CopyOutStreamState::Failed => {
+                return Err(BoxliteError::InvalidState(
+                    "copy-out stream has failed".to_string(),
+                ));
+            }
+            CopyOutStreamState::Open => {}
+        }
+
+        loop {
+            if let Some(count) = self.copy_pending(dst) {
+                return Ok(count);
+            }
+
+            let tokio_rt = Arc::clone(&self.tokio_rt);
+            match tokio_rt.block_on(self.tar.next()) {
+                Some(Ok(bytes)) if bytes.is_empty() => continue,
+                Some(Ok(bytes)) => {
+                    self.pending = bytes;
+                    self.pending_offset = 0;
+                }
+                Some(Err(error)) => {
+                    self.state = CopyOutStreamState::Failed;
+                    return Err(BoxliteError::Internal(format!(
+                        "copy_out stream error: {error}"
+                    )));
+                }
+                None => {
+                    self.state = CopyOutStreamState::Eof;
+                    return Ok(0);
+                }
+            }
+        }
+    }
+}
+
+/// Begin downloading `guest_src` as a pull-based raw tar stream.
+///
+/// This call blocks until the stream and its optional source-shape hint are
+/// ready. On success the returned handle must be released with
+/// [`boxlite_copy_out_free`]. A non-null `out_source_kind` is initialized to
+/// `Unknown` and updated to `File` or `Dir` when the peer supplies the hint.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_copy_out_start(
+    handle: *mut CBoxHandle,
+    guest_src: *const c_char,
+    out_source_kind: *mut i32,
+    out_error: *mut CBoxliteError,
+) -> *mut CBoxCopyOutStream {
+    unsafe {
+        if !out_source_kind.is_null() {
+            *out_source_kind = BoxliteCopySourceKind::Unknown as i32;
+        }
+        if handle.is_null() {
+            write_error(out_error, null_pointer_error("handle"));
+            return std::ptr::null_mut();
+        }
+        if guest_src.is_null() {
+            write_error(out_error, null_pointer_error("guest_src"));
+            return std::ptr::null_mut();
+        }
+        let src = match c_str_to_string(guest_src) {
+            Ok(s) => s,
+            Err(e) => {
+                write_error(out_error, e);
+                return std::ptr::null_mut();
+            }
+        };
+
+        let handle_ref = &*handle;
+        let lite = handle_ref.handle.clone();
+        match handle_ref
+            .tokio_rt
+            .block_on(lite.copy_out_tar(src.as_str(), default_copy_options()))
+        {
+            Ok((tar, source_is_dir)) => {
+                if !out_source_kind.is_null() {
+                    *out_source_kind = source_hint_to_kind(source_is_dir);
+                }
+                Box::into_raw(Box::new(CBoxCopyOutStream::new(
+                    tar,
+                    handle_ref.tokio_rt.clone(),
+                )))
+            }
+            Err(error) => {
+                write_error(out_error, error);
+                std::ptr::null_mut()
+            }
+        }
+    }
+}
+
+/// Read the next raw tar bytes from a copy-out stream.
+///
+/// This call blocks while the upstream stream is pending. `Ok` with a
+/// positive `out_read` returns data; `Ok` with zero length is sticky EOF. A
+/// stream item error is terminal: its first read reports the stream error and
+/// later reads return `InvalidState` without polling upstream again.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_copy_out_read(
+    stream: *mut CBoxCopyOutStream,
+    buffer: *mut u8,
+    capacity: usize,
+    out_read: *mut usize,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if stream.is_null() {
+            write_error(out_error, null_pointer_error("stream"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        if out_read.is_null() {
+            write_error(out_error, null_pointer_error("out_read"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        *out_read = 0;
+        if capacity == 0 {
+            let error =
+                BoxliteError::InvalidArgument("capacity must be greater than zero".to_string());
+            let code = error_to_code(&error);
+            write_error(out_error, error);
+            return code;
+        }
+        if buffer.is_null() {
+            write_error(out_error, null_pointer_error("buffer"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+
+        let dst = std::slice::from_raw_parts_mut(buffer, capacity);
+        match (&mut *stream).read_into(dst) {
+            Ok(count) => {
+                *out_read = count;
+                BoxliteErrorCode::Ok
+            }
+            Err(error) => {
+                let code = error_to_code(&error);
+                write_error(out_error, error);
+                code
+            }
+        }
+    }
+}
+
+/// Reclaim a copy-out stream handle. A null handle is a no-op.
+///
+/// The caller must not invoke [`boxlite_copy_out_read`] concurrently or race
+/// a read with this function.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_copy_out_free(stream: *mut CBoxCopyOutStream) {
+    unsafe {
+        if !stream.is_null() {
+            drop(Box::from_raw(stream));
+        }
+    }
+}
+
+/// Begin a streaming copy-in, returning an opaque transfer handle.
+///
+/// `source_kind` describes the archive shape: `BoxliteCopySourceKind`'s
+/// discriminant (`Unknown`=0, `File`=1, `Dir`=2), or 0 when the caller
+/// cannot tell (older clients) — the guest then peeks the archive to decide.
+/// Taken as an integer because C callers can pass any value, and
+/// out-of-range discriminants must behave as Unknown rather than as an
+/// invalid Rust enum.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_copy_in_start(
+    handle: *mut CBoxHandle,
+    guest_dst: *const c_char,
+    source_kind: i32,
+    copy_cb: CBoxCopyCb,
+    user_data: *mut c_void,
+    out_error: *mut CBoxliteError,
+) -> *mut CBoxCopyInStream {
+    unsafe {
+        if handle.is_null() {
+            write_error(out_error, null_pointer_error("handle"));
+            return std::ptr::null_mut();
+        }
+        let dst = match c_str_to_string(guest_dst) {
+            Ok(s) => s,
+            Err(e) => {
+                write_error(out_error, e);
+                return std::ptr::null_mut();
+            }
+        };
+        let Some(copy_cb) = copy_cb else {
+            write_error(out_error, null_pointer_error("copy_cb"));
+            return std::ptr::null_mut();
+        };
+
+        let source_is_dir = source_kind_to_hint(source_kind);
+
+        let handle_ref = &*handle;
+        let lite = handle_ref.handle.clone();
+        let queue = handle_ref.queue.clone();
+        let user_data_addr = user_data as usize;
+
+        let (tx, rx) = mpsc::channel::<io::Result<Vec<u8>>>(4);
+        let tar = futures::stream::unfold(rx, |mut rx| async move {
+            rx.recv().await.map(|item| (item, rx))
+        });
+
+        handle_ref.tokio_rt.spawn(async move {
+            let result = lite
+                .copy_in_tar_stream(tar, dst.as_str(), source_is_dir, default_copy_options())
+                .await;
+            push_event(
+                &queue,
+                RuntimeEvent::Copy {
+                    cb: copy_cb,
+                    user_data: user_data_addr,
+                    result,
+                },
+            )
+            .await;
+        });
+
+        Box::into_raw(Box::new(CBoxCopyInStream {
+            tx: Some(tx),
+            tokio_rt: handle_ref.tokio_rt.clone(),
+        }))
+    }
+}
+
+/// Push a chunk of raw tar bytes into the guest. Blocks when the guest is slow
+/// (bounded-channel backpressure).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_copy_in_write(
+    stream: *mut CBoxCopyInStream,
+    data: *const u8,
+    len: usize,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if stream.is_null() {
+            write_error(out_error, null_pointer_error("stream"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        if data.is_null() && len > 0 {
+            write_error(out_error, null_pointer_error("data"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        if len == 0 {
+            return BoxliteErrorCode::Ok;
+        }
+
+        let stream_ref = &*stream;
+        let Some(tx) = stream_ref.tx.as_ref() else {
+            write_error(
+                out_error,
+                boxlite::BoxliteError::InvalidState("copy-in stream is closed".to_string()),
+            );
+            return BoxliteErrorCode::InvalidState;
+        };
+
+        let bytes = std::slice::from_raw_parts(data, len).to_vec();
+        match stream_ref.tokio_rt.block_on(tx.send(Ok(bytes))) {
+            Ok(()) => BoxliteErrorCode::Ok,
+            Err(_) => {
+                write_error(
+                    out_error,
+                    boxlite::BoxliteError::Internal("guest upload aborted".to_string()),
+                );
+                BoxliteErrorCode::Internal
+            }
+        }
+    }
+}
+
+/// Close the copy-in stream, signalling EOF to the guest. Idempotent.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_copy_in_close(
+    stream: *mut CBoxCopyInStream,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if stream.is_null() {
+            write_error(out_error, null_pointer_error("stream"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        let stream_ref = &mut *stream;
+        // Dropping the sender closes the channel, which ends the tar stream and
+        // signals EOF to the guest unpacker.
+        stream_ref.tx.take();
+        BoxliteErrorCode::Ok
+    }
+}
+
+/// Abort the copy-in stream: deliver a terminal error to the guest and then
+/// close the channel. Unlike [`boxlite_copy_in_close`], the guest sees a
+/// failed stream — a truncated upload can never pass as a clean EOF. Call
+/// this when the source read failed mid-transfer. This is a one-shot
+/// transition: after the first call (abort or close), later abort calls return
+/// `InvalidState`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_copy_in_abort(
+    stream: *mut CBoxCopyInStream,
+    out_error: *mut CBoxliteError,
+) -> BoxliteErrorCode {
+    unsafe {
+        if stream.is_null() {
+            write_error(out_error, null_pointer_error("stream"));
+            return BoxliteErrorCode::InvalidArgument;
+        }
+        let stream_ref = &mut *stream;
+        let Some(tx) = stream_ref.tx.as_ref() else {
+            write_error(
+                out_error,
+                boxlite::BoxliteError::InvalidState("copy-in stream is closed".to_string()),
+            );
+            return BoxliteErrorCode::InvalidState;
+        };
+
+        // A failed send means the consumer is already gone, so the stream is
+        // already terminal and there is nothing left to signal.
+        let _ = stream_ref
+            .tokio_rt
+            .block_on(tx.send(Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "copy-in aborted",
+            ))));
+        // Drop the sender either way: the terminal error (if the consumer is
+        // still alive) precedes EOF, and no further writes are accepted.
+        stream_ref.tx.take();
+        BoxliteErrorCode::Ok
+    }
+}
+
+/// Reclaim a copy-in stream handle.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn boxlite_copy_in_free(stream: *mut CBoxCopyInStream) {
+    unsafe {
+        if !stream.is_null() {
+            drop(Box::from_raw(stream));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CStr;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    fn copy_out_stream(items: Vec<io::Result<Vec<u8>>>) -> CBoxCopyOutStream {
+        let tar: BoxTarStream = Box::pin(futures::stream::iter(items));
+        CBoxCopyOutStream::new(tar, Arc::new(tokio::runtime::Runtime::new().unwrap()))
+    }
+
+    fn assert_error_contains(
+        error: &CBoxliteError,
+        expected_code: BoxliteErrorCode,
+        expected_message: &str,
+    ) {
+        assert_eq!(error.code, expected_code);
+        assert!(!error.message.is_null());
+        let message = unsafe { CStr::from_ptr(error.message) }.to_string_lossy();
+        assert!(
+            message.contains(expected_message),
+            "expected {message:?} to contain {expected_message:?}"
+        );
+    }
+
+    struct DropProbe(Arc<AtomicBool>);
+
+    impl Drop for DropProbe {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn copy_out_start_null_handle_resets_source_kind_and_reports_error() {
+        let mut source_kind = BoxliteCopySourceKind::Dir as i32;
+        let mut error = CBoxliteError::default();
+
+        let stream = unsafe {
+            boxlite_copy_out_start(
+                std::ptr::null_mut(),
+                std::ptr::null(),
+                &mut source_kind,
+                &mut error,
+            )
+        };
+        assert!(stream.is_null());
+        assert_eq!(source_kind, BoxliteCopySourceKind::Unknown as i32);
+        assert_error_contains(&error, BoxliteErrorCode::InvalidArgument, "handle is null");
+        unsafe { crate::error::boxlite_error_free(&mut error) };
+
+        source_kind = BoxliteCopySourceKind::Dir as i32;
+        let stream = unsafe {
+            boxlite_copy_out_start(
+                std::ptr::null_mut(),
+                std::ptr::null(),
+                &mut source_kind,
+                std::ptr::null_mut(),
+            )
+        };
+        assert!(stream.is_null());
+        assert_eq!(source_kind, BoxliteCopySourceKind::Unknown as i32);
+
+        let stream = unsafe {
+            boxlite_copy_out_start(
+                std::ptr::null_mut(),
+                std::ptr::null(),
+                std::ptr::null_mut(),
+                &mut error,
+            )
+        };
+        assert!(stream.is_null());
+        assert_error_contains(&error, BoxliteErrorCode::InvalidArgument, "handle is null");
+        unsafe { crate::error::boxlite_error_free(&mut error) };
+
+        let stream = unsafe {
+            boxlite_copy_out_start(
+                std::ptr::null_mut(),
+                std::ptr::null(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        };
+        assert!(stream.is_null());
+    }
+
+    #[test]
+    fn source_kind_maps_to_guest_hint() {
+        assert_eq!(
+            source_kind_to_hint(BoxliteCopySourceKind::Unknown as i32),
+            None
+        );
+        assert_eq!(
+            source_kind_to_hint(BoxliteCopySourceKind::File as i32),
+            Some(false)
+        );
+        assert_eq!(
+            source_kind_to_hint(BoxliteCopySourceKind::Dir as i32),
+            Some(true)
+        );
+        assert_eq!(
+            source_hint_to_kind(None),
+            BoxliteCopySourceKind::Unknown as i32
+        );
+        assert_eq!(
+            source_hint_to_kind(Some(false)),
+            BoxliteCopySourceKind::File as i32
+        );
+        assert_eq!(
+            source_hint_to_kind(Some(true)),
+            BoxliteCopySourceKind::Dir as i32
+        );
+    }
+
+    #[test]
+    fn copy_out_splits_chunks_skips_empty_items_and_sticks_eof() {
+        let mut stream =
+            copy_out_stream(vec![Ok(Vec::new()), Ok(b"abcde".to_vec()), Ok(Vec::new())]);
+        let mut dst = [0_u8; 2];
+
+        assert_eq!(stream.read_into(&mut dst).unwrap(), 2);
+        assert_eq!(&dst, b"ab");
+        assert_eq!(stream.read_into(&mut dst).unwrap(), 2);
+        assert_eq!(&dst, b"cd");
+        assert_eq!(stream.read_into(&mut dst).unwrap(), 1);
+        assert_eq!(dst[0], b'e');
+        assert_eq!(stream.read_into(&mut dst).unwrap(), 0);
+        assert_eq!(stream.read_into(&mut dst).unwrap(), 0);
+    }
+
+    #[test]
+    fn copy_out_stream_error_is_terminal() {
+        let mut stream = copy_out_stream(vec![
+            Ok(vec![7]),
+            Err(io::Error::new(io::ErrorKind::BrokenPipe, "guest gone")),
+            Ok(vec![8]),
+        ]);
+        let mut dst = [0_u8; 1];
+
+        assert_eq!(stream.read_into(&mut dst).unwrap(), 1);
+        assert_eq!(dst[0], 7);
+        let error = stream.read_into(&mut dst).unwrap_err();
+        assert!(matches!(error, BoxliteError::Internal(message) if message.contains("guest gone")));
+        assert!(matches!(
+            stream.read_into(&mut dst).unwrap_err(),
+            BoxliteError::InvalidState(message) if message == "copy-out stream has failed"
+        ));
+    }
+
+    #[test]
+    fn copy_out_polls_upstream_only_when_read_needs_data() {
+        let polls = Arc::new(AtomicUsize::new(0));
+        let stream_polls = Arc::clone(&polls);
+        let tar: BoxTarStream = Box::pin(futures::stream::unfold(0_u8, move |step| {
+            let stream_polls = Arc::clone(&stream_polls);
+            async move {
+                stream_polls.fetch_add(1, Ordering::SeqCst);
+                match step {
+                    0 => Some((Ok(vec![1, 2, 3]), 1)),
+                    _ => None,
+                }
+            }
+        }));
+        let mut stream =
+            CBoxCopyOutStream::new(tar, Arc::new(tokio::runtime::Runtime::new().unwrap()));
+        let mut dst = [0_u8; 1];
+
+        assert_eq!(polls.load(Ordering::SeqCst), 0);
+        assert_eq!(stream.read_into(&mut dst).unwrap(), 1);
+        assert_eq!(polls.load(Ordering::SeqCst), 1);
+        assert_eq!(stream.read_into(&mut dst).unwrap(), 1);
+        assert_eq!(stream.read_into(&mut dst).unwrap(), 1);
+        assert_eq!(polls.load(Ordering::SeqCst), 1);
+        assert_eq!(stream.read_into(&mut dst).unwrap(), 0);
+        assert_eq!(polls.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn copy_out_ffi_validates_read_arguments_and_frees_null() {
+        let mut stream = copy_out_stream(vec![Ok(vec![1])]);
+        let mut dst = [0_u8; 1];
+        let mut out_len = usize::MAX;
+        let mut error = CBoxliteError::default();
+
+        let code = unsafe {
+            boxlite_copy_out_read(&mut stream, dst.as_mut_ptr(), 0, &mut out_len, &mut error)
+        };
+        assert_eq!(code, BoxliteErrorCode::InvalidArgument);
+        assert_eq!(out_len, 0);
+        assert_error_contains(&error, BoxliteErrorCode::InvalidArgument, "capacity");
+        unsafe { crate::error::boxlite_error_free(&mut error) };
+
+        let code = unsafe {
+            boxlite_copy_out_read(
+                &mut stream,
+                std::ptr::null_mut(),
+                dst.len(),
+                &mut out_len,
+                &mut error,
+            )
+        };
+        assert_eq!(code, BoxliteErrorCode::InvalidArgument);
+        assert_eq!(out_len, 0);
+        assert_error_contains(&error, BoxliteErrorCode::InvalidArgument, "buffer is null");
+        unsafe { crate::error::boxlite_error_free(&mut error) };
+
+        let code = unsafe {
+            boxlite_copy_out_read(
+                &mut stream,
+                dst.as_mut_ptr(),
+                dst.len(),
+                std::ptr::null_mut(),
+                &mut error,
+            )
+        };
+        assert_eq!(code, BoxliteErrorCode::InvalidArgument);
+        assert_error_contains(
+            &error,
+            BoxliteErrorCode::InvalidArgument,
+            "out_read is null",
+        );
+        unsafe { crate::error::boxlite_error_free(&mut error) };
+
+        let code = unsafe {
+            boxlite_copy_out_read(
+                std::ptr::null_mut(),
+                dst.as_mut_ptr(),
+                dst.len(),
+                &mut out_len,
+                &mut error,
+            )
+        };
+        assert_eq!(code, BoxliteErrorCode::InvalidArgument);
+        assert_error_contains(&error, BoxliteErrorCode::InvalidArgument, "stream is null");
+        unsafe { crate::error::boxlite_error_free(&mut error) };
+
+        let code = unsafe {
+            boxlite_copy_out_read(
+                &mut stream,
+                dst.as_mut_ptr(),
+                dst.len(),
+                &mut out_len,
+                &mut error,
+            )
+        };
+        assert_eq!(code, BoxliteErrorCode::Ok);
+        assert_eq!(out_len, 1);
+        assert_eq!(dst[0], 1);
+
+        let owned = Box::into_raw(Box::new(copy_out_stream(Vec::new())));
+        unsafe {
+            boxlite_copy_out_free(owned);
+            boxlite_copy_out_free(std::ptr::null_mut());
+        }
+    }
+
+    #[test]
+    fn copy_out_free_drops_active_tar_stream() {
+        let dropped = Arc::new(AtomicBool::new(false));
+        let probe = DropProbe(Arc::clone(&dropped));
+        let tar: BoxTarStream = Box::pin(futures::stream::poll_fn(move |_cx| {
+            let _keep_alive = &probe;
+            std::task::Poll::<Option<io::Result<Vec<u8>>>>::Pending
+        }));
+        let stream = Box::into_raw(Box::new(CBoxCopyOutStream::new(
+            tar,
+            Arc::new(tokio::runtime::Runtime::new().unwrap()),
+        )));
+
+        assert!(!dropped.load(Ordering::SeqCst));
+        unsafe { boxlite_copy_out_free(stream) };
+        assert!(dropped.load(Ordering::SeqCst));
+    }
+
+    /// The abort entrypoint must deliver a terminal error followed by EOF,
+    /// and the spent stream must reject further writes and a second abort.
+    #[test]
+    fn copy_in_abort_delivers_terminal_error_then_eof() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let (tx, mut rx) = mpsc::channel(4);
+        let mut stream = CBoxCopyInStream {
+            tx: Some(tx),
+            tokio_rt: Arc::new(rt),
+        };
+        let mut err = CBoxliteError::default();
+
+        let code = unsafe { boxlite_copy_in_abort(&mut stream, &mut err) };
+        assert_eq!(code, BoxliteErrorCode::Ok);
+
+        // First item is the terminal error, then EOF (channel closed).
+        let first = stream.tokio_rt.block_on(rx.recv()).expect("item");
+        assert_eq!(first.unwrap_err().kind(), io::ErrorKind::BrokenPipe);
+        assert!(
+            stream.tokio_rt.block_on(rx.recv()).is_none(),
+            "must signal EOF after the error"
+        );
+
+        // A spent stream rejects both writes and a second abort.
+        let mut err2 = CBoxliteError::default();
+        let data = [1u8; 4];
+        let code =
+            unsafe { boxlite_copy_in_write(&mut stream, data.as_ptr(), data.len(), &mut err2) };
+        assert_eq!(code, BoxliteErrorCode::InvalidState);
+        let mut err3 = CBoxliteError::default();
+        let code = unsafe { boxlite_copy_in_abort(&mut stream, &mut err3) };
+        assert_eq!(code, BoxliteErrorCode::InvalidState);
+    }
+
+    #[test]
+    fn unrecognized_kind_behaves_as_unknown() {
+        // C callers can cast any integer to the enum; out-of-range values
+        // must not be guessed into a shape.
+        assert_eq!(source_kind_to_hint(7), None);
+        assert_eq!(source_kind_to_hint(-1), None);
     }
 }

--- a/sdks/go/copy.go
+++ b/sdks/go/copy.go
@@ -7,6 +7,7 @@ package boxlite
 import "C"
 import (
 	"context"
+	"io"
 	"runtime/cgo"
 	"unsafe"
 )
@@ -69,6 +70,232 @@ func (b *Box) CopyOut(ctx context.Context, guestSrc, hostDst string) error {
 	if code != C.Ok {
 		deleteHandleForDispatch(h)
 		return freeError(&cerr)
+	}
+
+	select {
+	case err := <-ch:
+		return err
+	case <-ctx.Done():
+		abandonAsyncErr(ch, h, b.runtime.closing)
+		return ctx.Err()
+	case <-b.runtime.closing:
+		abandonAsyncErr(ch, h, b.runtime.closing)
+		return ErrRuntimeClosed
+	}
+}
+
+const copyStreamBufferSize = 1 << 20 // 1 MiB
+const copyInMaxConsecutiveEmptyReads = 100
+
+// copyOutBoundaryError prevents a pull from entering the C ABI after its
+// caller has cancelled or the owning runtime has started closing. The same
+// check after each blocking read prevents a late chunk from reaching w.
+func copyOutBoundaryError(ctx context.Context, closing <-chan struct{}) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	select {
+	case <-closing:
+		return ErrRuntimeClosed
+	default:
+		return nil
+	}
+}
+
+func deliverCopyOutMeta(sourceKind CopySourceKind, onMeta func(bool)) {
+	if onMeta == nil {
+		return
+	}
+	switch sourceKind {
+	case CopySourceFile:
+		onMeta(false)
+	case CopySourceDir:
+		onMeta(true)
+	}
+}
+
+func writeCopyOutChunk(w io.Writer, data []byte) error {
+	if w == nil {
+		return nil
+	}
+	n, err := w.Write(data)
+	if err != nil {
+		return err
+	}
+	if n != len(data) {
+		return io.ErrShortWrite
+	}
+	return nil
+}
+
+// CopyOutStream streams a tar of guestSrc to w without staging to disk.
+//
+// onMeta (optional) fires before the first write to w when the peer provides
+// a source-is-directory hint. An older peer reports CopySourceUnknown, for
+// which onMeta is not called.
+//
+// Context cancellation and Runtime closure are observed between blocking
+// guest reads. They do not interrupt a read or Writer.Write already in
+// progress.
+func (b *Box) CopyOutStream(ctx context.Context, guestSrc string, w io.Writer, onMeta func(bool)) error {
+	if err := copyOutBoundaryError(ctx, b.runtime.closing); err != nil {
+		return err
+	}
+
+	cSrc := toCString(guestSrc)
+	defer C.free(unsafe.Pointer(cSrc))
+
+	var sourceKind C.int32_t
+	var cerr C.CBoxliteError
+	stream := C.boxlite_copy_out_start(b.handle, cSrc, &sourceKind, &cerr)
+	if stream == nil {
+		return freeError(&cerr)
+	}
+	defer C.boxlite_copy_out_free(stream)
+
+	if err := copyOutBoundaryError(ctx, b.runtime.closing); err != nil {
+		return err
+	}
+	deliverCopyOutMeta(CopySourceKind(sourceKind), onMeta)
+
+	buf := make([]byte, copyStreamBufferSize)
+	for {
+		if err := copyOutBoundaryError(ctx, b.runtime.closing); err != nil {
+			return err
+		}
+
+		var outLen C.size_t
+		var readErr C.CBoxliteError
+		code := C.boxlite_copy_out_read(
+			stream,
+			(*C.uint8_t)(unsafe.Pointer(&buf[0])),
+			C.size_t(len(buf)),
+			&outLen,
+			&readErr,
+		)
+		if code != C.Ok {
+			return freeError(&readErr)
+		}
+		if err := copyOutBoundaryError(ctx, b.runtime.closing); err != nil {
+			return err
+		}
+		if outLen == 0 {
+			return nil
+		}
+		if outLen > C.size_t(len(buf)) {
+			return &Error{
+				Code:    ErrInternal,
+				Message: "copy-out read exceeded the caller buffer",
+			}
+		}
+		if err := writeCopyOutChunk(w, buf[:int(outLen)]); err != nil {
+			return err
+		}
+	}
+}
+
+// CopySourceKind describes the archive shape used by streaming copy operations.
+type CopySourceKind int
+
+const (
+	// CopySourceUnknown means no archive-shape hint is available. For copy-in,
+	// the guest peeks the archive to decide; for copy-out, the metadata callback
+	// is not called.
+	CopySourceUnknown CopySourceKind = iota
+	// CopySourceFile is a single regular file archive.
+	CopySourceFile
+	// CopySourceDir is a directory tree archive.
+	CopySourceDir
+)
+
+func normalizeCopySourceKind(kind CopySourceKind) CopySourceKind {
+	switch kind {
+	case CopySourceFile, CopySourceDir:
+		return kind
+	default:
+		return CopySourceUnknown
+	}
+}
+
+// CopyInStream streams r (raw tar) into guestDst without staging to disk.
+//
+// sourceKind is the archive shape (directory tree vs single file); use
+// CopySourceUnknown when the caller cannot tell — the guest then peeks the
+// tar to decide.
+func (b *Box) CopyInStream(ctx context.Context, guestDst string, sourceKind CopySourceKind, r io.Reader) error {
+	if r == nil {
+		return &Error{Code: ErrInvalidArgument, Message: "copy-in reader must not be nil"}
+	}
+
+	b.runtime.ensureDrainRunning()
+
+	cDst := toCString(guestDst)
+	defer C.free(unsafe.Pointer(cDst))
+
+	ch := make(chan error, 1)
+	h := registerHandleForDispatch(cgo.NewHandle(ch))
+
+	var cerr C.CBoxliteError
+	// The C ABI takes the discriminant as int32_t (an out-of-range value a
+	// C caller might pass must map to Unknown, not an invalid Rust enum);
+	// cgo needs the explicit conversion.
+	kind := C.int32_t(normalizeCopySourceKind(sourceKind))
+	stream := C.boxlite_copy_in_start(b.handle, cDst, kind, C.cbCopy(), handleToPtr(h), &cerr)
+	if stream == nil {
+		deleteHandleForDispatch(h)
+		return freeError(&cerr)
+	}
+
+	var writeErr error
+	noProgress := 0
+	buf := make([]byte, copyStreamBufferSize)
+	for {
+		n, readErr := r.Read(buf)
+		if n > 0 {
+			noProgress = 0
+			var werr C.CBoxliteError
+			if code := C.boxlite_copy_in_write(stream, (*C.uint8_t)(unsafe.Pointer(&buf[0])), C.size_t(n), &werr); code != C.Ok {
+				writeErr = freeError(&werr)
+				break
+			}
+		}
+		if readErr != nil {
+			if readErr != io.EOF {
+				writeErr = readErr
+			}
+			break
+		}
+		if n == 0 {
+			// A reader may return (0, nil) transiently, but never
+			// indefinitely — bail instead of spinning forever.
+			noProgress++
+			if noProgress >= copyInMaxConsecutiveEmptyReads {
+				writeErr = io.ErrNoProgress
+				break
+			}
+		}
+	}
+
+	var cerrClose C.CBoxliteError
+	if writeErr != nil {
+		// The source failed mid-transfer: abort rather than close so the
+		// guest sees a failed stream, never a clean EOF that it would
+		// unpack (and report success) as a truncated archive. The source
+		// error is the primary failure; free any C error the abort wrote
+		// so it cannot leak.
+		if code := C.boxlite_copy_in_abort(stream, &cerrClose); code != C.Ok {
+			_ = freeError(&cerrClose)
+		}
+	} else if code := C.boxlite_copy_in_close(stream, &cerrClose); code != C.Ok {
+		writeErr = freeError(&cerrClose)
+	}
+	C.boxlite_copy_in_free(stream)
+
+	if writeErr != nil {
+		deleteHandleForDispatch(h)
+		return writeErr
 	}
 
 	select {

--- a/sdks/go/copy_integration_test.go
+++ b/sdks/go/copy_integration_test.go
@@ -1,0 +1,246 @@
+//go:build boxlite_dev
+
+package boxlite
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+)
+
+type controlledBlockingWriter struct {
+	entered     chan struct{}
+	release     chan struct{}
+	enteredOnce sync.Once
+	releaseOnce sync.Once
+}
+
+func newControlledBlockingWriter() *controlledBlockingWriter {
+	return &controlledBlockingWriter{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (w *controlledBlockingWriter) Write(p []byte) (int, error) {
+	w.enteredOnce.Do(func() { close(w.entered) })
+	<-w.release
+	return len(p), nil
+}
+
+func (w *controlledBlockingWriter) unblock() {
+	w.releaseOnce.Do(func() { close(w.release) })
+}
+
+type writerFunc func([]byte) (int, error)
+
+func (f writerFunc) Write(p []byte) (int, error) { return f(p) }
+
+// failAfterReader yields its bytes once and then fails with err — the shape
+// of a client connection severed mid-upload.
+type failAfterReader struct {
+	data []byte
+	pos  int
+	err  error
+}
+
+func (r *failAfterReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		return 0, r.err
+	}
+	n := copy(p, r.data[r.pos:])
+	r.pos += n
+	return n, nil
+}
+
+// A source that fails mid-transfer must fail the copy: the Go layer takes
+// the abort branch (terminal error to the guest, not a clean EOF) and must
+// surface the read error to the caller.
+func TestCopyInStreamFailedSourceFailsCopy(t *testing.T) {
+	rt := newTestRuntime(t)
+	box := createStartedBox(t, rt, "alpine:latest")
+
+	reader := &failAfterReader{
+		data: make([]byte, 4096), // partial payload, severed upload
+		err:  errors.New("client gone"),
+	}
+
+	err := box.CopyInStream(context.Background(), "/root/aborted.tar", CopySourceFile, reader)
+	if err == nil {
+		t.Fatal("a source failure mid-transfer must fail the copy")
+	}
+}
+
+var _ io.Reader = (*failAfterReader)(nil)
+
+// zeroReader returns (0, nil) forever — the misbehaving-source shape that
+// must not spin the copy loop.
+type zeroReader struct{}
+
+func (zeroReader) Read([]byte) (int, error) { return 0, nil }
+
+// A source that never makes progress must fail the copy with
+// io.ErrNoProgress instead of spinning.
+func TestCopyInStreamNoProgressFails(t *testing.T) {
+	rt := newTestRuntime(t)
+	box := createStartedBox(t, rt, "alpine:latest")
+
+	err := box.CopyInStream(context.Background(), "/root/noprogress.tar", CopySourceFile, zeroReader{})
+	if !errors.Is(err, io.ErrNoProgress) {
+		t.Fatalf("got %v, want io.ErrNoProgress", err)
+	}
+}
+
+var _ io.Reader = zeroReader{}
+
+func TestCopyOutStreamDoesNotBlockRuntimeCallbacks(t *testing.T) {
+	rt := newTestRuntime(t)
+	box := createStartedBox(t, rt, "alpine:latest")
+
+	result, err := box.Exec(context.Background(), "sh", "-c", "printf 'copy-out-hol' > /root/copy-out-hol.txt")
+	if err != nil {
+		t.Fatalf("prepare copy-out source: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("prepare copy-out source: exit code %d, stderr=%q", result.ExitCode, result.Stderr)
+	}
+
+	writer := newControlledBlockingWriter()
+	copyDone := make(chan error, 1)
+	go func() {
+		copyDone <- box.CopyOutStream(context.Background(), "/root/copy-out-hol.txt", writer, nil)
+		close(copyDone)
+	}()
+	t.Cleanup(func() {
+		writer.unblock()
+		select {
+		case <-copyDone:
+		case <-time.After(10 * time.Second):
+			t.Error("CopyOutStream did not finish after releasing the blocking writer")
+		}
+	})
+
+	select {
+	case <-writer.entered:
+	case err := <-copyDone:
+		t.Fatalf("CopyOutStream returned before its writer was entered: %v", err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("CopyOutStream did not reach its writer")
+	}
+
+	infoCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	info, err := box.Info(infoCtx)
+	if err != nil {
+		t.Fatalf("Info was blocked by CopyOutStream's writer: %v", err)
+	}
+	if info == nil {
+		t.Fatal("Info returned nil without an error")
+	}
+
+	select {
+	case err := <-copyDone:
+		t.Fatalf("CopyOutStream returned while its writer was still blocked: %v", err)
+	default:
+	}
+
+	writer.unblock()
+	select {
+	case err := <-copyDone:
+		if err != nil {
+			t.Fatalf("CopyOutStream: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("CopyOutStream did not finish after releasing the blocking writer")
+	}
+}
+
+func TestCopyOutStreamPullContract(t *testing.T) {
+	rt := newTestRuntime(t)
+	box := createStartedBox(t, rt, "alpine:latest")
+
+	const sourcePath = "/root/copy-out-pull-contract.txt"
+	result, err := box.Exec(context.Background(), "sh", "-c", "printf 'pull-contract' > "+sourcePath)
+	if err != nil {
+		t.Fatalf("prepare copy-out source: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("prepare copy-out source: exit code %d, stderr=%q", result.ExitCode, result.Stderr)
+	}
+
+	t.Run("file metadata precedes first write", func(t *testing.T) {
+		var events []string
+		metadataCalls := 0
+		writer := writerFunc(func(p []byte) (int, error) {
+			events = append(events, "write")
+			return len(p), nil
+		})
+		onMeta := func(sourceIsDir bool) {
+			metadataCalls++
+			if sourceIsDir {
+				events = append(events, "metadata:dir")
+				return
+			}
+			events = append(events, "metadata:file")
+		}
+		if err := box.CopyOutStream(context.Background(), sourcePath, writer, onMeta); err != nil {
+			t.Fatalf("CopyOutStream: %v", err)
+		}
+		if metadataCalls != 1 {
+			t.Fatalf("metadata callback count = %d, want 1", metadataCalls)
+		}
+		if len(events) < 2 {
+			t.Fatalf("events = %v, want metadata followed by at least one write", events)
+		}
+		if events[0] != "metadata:file" || events[1] != "write" {
+			t.Fatalf("first events = %v, want [metadata:file write]", events[:2])
+		}
+	})
+
+	t.Run("writer error is returned unchanged", func(t *testing.T) {
+		want := errors.New("copy-out writer sentinel")
+		writeCalls := 0
+		writer := writerFunc(func([]byte) (int, error) {
+			writeCalls++
+			return 0, want
+		})
+		if got := box.CopyOutStream(context.Background(), sourcePath, writer, nil); got != want {
+			t.Fatalf("CopyOutStream error = %v, want identical sentinel %v", got, want)
+		}
+		if writeCalls != 1 {
+			t.Fatalf("writer call count = %d, want 1", writeCalls)
+		}
+	})
+
+	t.Run("short write returns io ErrShortWrite", func(t *testing.T) {
+		writeCalls := 0
+		writer := writerFunc(func(p []byte) (int, error) {
+			writeCalls++
+			return len(p) - 1, nil
+		})
+		if got := box.CopyOutStream(context.Background(), sourcePath, writer, nil); got != io.ErrShortWrite {
+			t.Fatalf("CopyOutStream error = %v, want %v", got, io.ErrShortWrite)
+		}
+		if writeCalls != 1 {
+			t.Fatalf("writer call count = %d, want 1", writeCalls)
+		}
+	})
+
+	t.Run("missing source fails before write", func(t *testing.T) {
+		writeCalls := 0
+		writer := writerFunc(func(p []byte) (int, error) {
+			writeCalls++
+			return len(p), nil
+		})
+		err := box.CopyOutStream(context.Background(), "/root/copy-out-pull-contract-missing", writer, nil)
+		if err == nil {
+			t.Fatal("CopyOutStream succeeded for a missing source")
+		}
+		if writeCalls != 0 {
+			t.Fatalf("writer call count = %d, want 0", writeCalls)
+		}
+	})
+}

--- a/sdks/go/copy_test.go
+++ b/sdks/go/copy_test.go
@@ -1,0 +1,60 @@
+package boxlite
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+)
+
+type failingWriter struct{ err error }
+
+func (f failingWriter) Write([]byte) (int, error) { return 0, f.err }
+
+type shortWriter struct{}
+
+func (shortWriter) Write(p []byte) (int, error) { return len(p) - 1, nil }
+
+func TestWriteCopyOutChunkSurfacesWriterError(t *testing.T) {
+	want := errors.New("client gone")
+	if err := writeCopyOutChunk(failingWriter{err: want}, []byte("chunk")); !errors.Is(err, want) {
+		t.Fatalf("writeCopyOutChunk() error = %v, want %v", err, want)
+	}
+}
+
+func TestWriteCopyOutChunkRejectsShortWrite(t *testing.T) {
+	if err := writeCopyOutChunk(shortWriter{}, []byte("chunk")); !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("writeCopyOutChunk() error = %v, want %v", err, io.ErrShortWrite)
+	}
+}
+
+func TestDeliverCopyOutMetaMapsKnownKinds(t *testing.T) {
+	var got []bool
+	onMeta := func(sourceIsDir bool) { got = append(got, sourceIsDir) }
+
+	deliverCopyOutMeta(CopySourceUnknown, onMeta)
+	deliverCopyOutMeta(CopySourceFile, onMeta)
+	deliverCopyOutMeta(CopySourceDir, onMeta)
+
+	if len(got) != 2 || got[0] || !got[1] {
+		t.Fatalf("metadata callbacks = %v, want [false true]", got)
+	}
+}
+
+func TestCopyOutBoundaryError(t *testing.T) {
+	closing := make(chan struct{})
+	if err := copyOutBoundaryError(context.Background(), closing); err != nil {
+		t.Fatalf("open boundary error = %v, want nil", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := copyOutBoundaryError(ctx, closing); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled boundary error = %v, want %v", err, context.Canceled)
+	}
+
+	close(closing)
+	if err := copyOutBoundaryError(context.Background(), closing); !errors.Is(err, ErrRuntimeClosed) {
+		t.Fatalf("closed boundary error = %v, want %v", err, ErrRuntimeClosed)
+	}
+}

--- a/src/boxlite/src/lib.rs
+++ b/src/boxlite/src/lib.rs
@@ -39,6 +39,7 @@ pub use litebox::{
 pub use portal::GuestSession;
 pub use runtime::{AuthHandle, BoxliteRuntime, ImageHandle, Principal};
 
+pub use boxlite_shared::BoxTarStream;
 pub use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 pub use disk::DiskInfo;
 pub use event_listener::{AuditEvent, AuditEventKind, AuditEventListener, EventListener};

--- a/src/boxlite/src/lib.rs
+++ b/src/boxlite/src/lib.rs
@@ -39,7 +39,7 @@ pub use litebox::{
 pub use portal::GuestSession;
 pub use runtime::{AuthHandle, BoxliteRuntime, ImageHandle, Principal};
 
-pub use boxlite_shared::BoxTarStream;
+pub use boxlite_shared::BoxByteStream;
 pub use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 pub use disk::DiskInfo;
 pub use event_listener::{AuditEvent, AuditEventKind, AuditEventListener, EventListener};
@@ -47,8 +47,8 @@ pub use litebox::SnapshotHandle;
 pub use litebox::archive::ArchiveManifest;
 pub use litebox::snapshot_mgr::SnapshotInfo;
 pub use litebox::{
-    AttachOptions, BoxCommand, CopyOptions, ExecResult, ExecStderr, ExecStdin, ExecStdout,
-    Execution, ExecutionId, HealthState, HealthStatus,
+    AttachOptions, BoxCommand, CopyOptions, CopySourceKind, ExecResult, ExecStderr, ExecStdin,
+    ExecStdout, Execution, ExecutionId, HealthState, HealthStatus,
 };
 pub use metrics::{BoxMetrics, RuntimeMetrics};
 pub use runtime::advanced_options::{

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -991,6 +991,85 @@ impl BoxImpl {
         Ok(())
     }
 
+    /// Stream a tar byte stream into the guest at `container_dst`.
+    ///
+    /// `source_is_dir` is the archive shape; `None` when the caller cannot
+    /// tell — the guest then peeks the archive to decide. This is the
+    /// streaming counterpart to [`Self::copy_into`] — no temp tar file.
+    pub(crate) async fn copy_in_tar_stream<S>(
+        self: std::sync::Arc<Self>,
+        tar: S,
+        container_dst: String,
+        source_is_dir: Option<bool>,
+        opts: CopyOptions,
+    ) -> BoxliteResult<()>
+    where
+        S: futures::Stream<Item = std::io::Result<Vec<u8>>> + Send + 'static,
+    {
+        if self.shutdown_token.is_cancelled() {
+            return Err(BoxliteError::Stopped(
+                "Handle invalidated after stop(). Use runtime.get() to get a new handle.".into(),
+            ));
+        }
+        self.ensure_usable_without_rerunning_main("copy into")?;
+        if container_dst.is_empty() {
+            return Err(BoxliteError::Config(
+                "destination path cannot be empty".into(),
+            ));
+        }
+        // Match the path-based copy_into contract: a directory tree with
+        // recursive=false is rejected before anything is streamed.
+        if source_is_dir == Some(true) {
+            opts.validate_for_dir()?;
+        }
+        // Materialise borrowed strings before the first await so the future
+        // never holds `&BoxImpl` across an await point (avoids an HRTB `Send`
+        // bound that trips tokio::spawn).
+        let cid = self.container_id().to_string();
+        let live = self.live_state().await?;
+        let mut files_iface = live.guest_session.files().await?;
+        files_iface
+            .upload_tar_stream(
+                tar,
+                &container_dst,
+                Some(&cid),
+                true,
+                opts.overwrite,
+                source_is_dir,
+            )
+            .await
+    }
+
+    /// Download `container_src` as a tar byte stream plus the archive-shape
+    /// hint. This is the streaming counterpart to [`Self::copy_out`] — no temp
+    /// tar file.
+    pub(crate) async fn copy_out_tar(
+        self: std::sync::Arc<Self>,
+        container_src: String,
+        opts: CopyOptions,
+    ) -> BoxliteResult<(boxlite_shared::BoxTarStream, Option<bool>)> {
+        if self.shutdown_token.is_cancelled() {
+            return Err(BoxliteError::Stopped(
+                "Handle invalidated after stop(). Use runtime.get() to get a new handle.".into(),
+            ));
+        }
+        self.ensure_usable_without_rerunning_main("copy out")?;
+        if container_src.is_empty() {
+            return Err(BoxliteError::Config("source path cannot be empty".into()));
+        }
+        let cid = self.container_id().to_string();
+        let live = self.live_state().await?;
+        let mut files_iface = live.guest_session.files().await?;
+        files_iface
+            .download_tar_stream(
+                &container_src,
+                Some(&cid),
+                opts.include_parent,
+                opts.follow_symlinks,
+            )
+            .await
+    }
+
     // ========================================================================
     // LIVE STATE INITIALIZATION (internal)
     // ========================================================================
@@ -1434,6 +1513,10 @@ impl crate::runtime::backend::BoxBackend for BoxImpl {
 
     fn name(&self) -> Option<&str> {
         self.config.name.as_deref()
+    }
+
+    fn as_any_arc(self: std::sync::Arc<Self>) -> std::sync::Arc<dyn std::any::Any + Send + Sync> {
+        self
     }
 
     async fn info(&self) -> BoxliteResult<BoxInfo> {

--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -25,7 +25,7 @@ use crate::event_listener::EventListener;
 #[cfg(target_os = "linux")]
 use crate::fs::BindMountHandle;
 use crate::litebox::BoxTunnel;
-use crate::litebox::copy::CopyOptions;
+use crate::litebox::copy::{CopyOptions, CopySourceKind};
 use crate::lock::LockGuard;
 use crate::metrics::{BoxMetrics, BoxMetricsStorage};
 use crate::net::NetworkBackend;
@@ -991,16 +991,16 @@ impl BoxImpl {
         Ok(())
     }
 
-    /// Stream a tar byte stream into the guest at `container_dst`.
+    /// Stream opaque transfer bytes into the guest at `container_dst`.
     ///
-    /// `source_is_dir` is the archive shape; `None` when the caller cannot
-    /// tell — the guest then peeks the archive to decide. This is the
-    /// streaming counterpart to [`Self::copy_into`] — no temp tar file.
-    pub(crate) async fn copy_in_tar_stream<S>(
+    /// `source` is the archive shape; [`CopySourceKind::Unknown`] when the
+    /// caller cannot tell — the guest then peeks the archive to decide. This is
+    /// the streaming counterpart to [`Self::copy_into`] — no temp archive file.
+    pub(crate) async fn copy_in_stream<S>(
         self: std::sync::Arc<Self>,
-        tar: S,
+        stream: S,
         container_dst: String,
-        source_is_dir: Option<bool>,
+        source: CopySourceKind,
         opts: CopyOptions,
     ) -> BoxliteResult<()>
     where
@@ -1019,7 +1019,7 @@ impl BoxImpl {
         }
         // Match the path-based copy_into contract: a directory tree with
         // recursive=false is rejected before anything is streamed.
-        if source_is_dir == Some(true) {
+        if source.is_dir() {
             opts.validate_for_dir()?;
         }
         // Materialise borrowed strings before the first await so the future
@@ -1029,25 +1029,24 @@ impl BoxImpl {
         let live = self.live_state().await?;
         let mut files_iface = live.guest_session.files().await?;
         files_iface
-            .upload_tar_stream(
-                tar,
+            .upload_stream(
+                stream,
                 &container_dst,
                 Some(&cid),
                 true,
                 opts.overwrite,
-                source_is_dir,
+                source,
             )
             .await
     }
 
-    /// Download `container_src` as a tar byte stream plus the archive-shape
-    /// hint. This is the streaming counterpart to [`Self::copy_out`] — no temp
-    /// tar file.
-    pub(crate) async fn copy_out_tar(
+    /// Download `container_src` as a byte stream plus its source shape. This is
+    /// the streaming counterpart to [`Self::copy_out`] — no temp archive file.
+    pub(crate) async fn copy_out_stream(
         self: std::sync::Arc<Self>,
         container_src: String,
         opts: CopyOptions,
-    ) -> BoxliteResult<(boxlite_shared::BoxTarStream, Option<bool>)> {
+    ) -> BoxliteResult<(boxlite_shared::BoxByteStream, CopySourceKind)> {
         if self.shutdown_token.is_cancelled() {
             return Err(BoxliteError::Stopped(
                 "Handle invalidated after stop(). Use runtime.get() to get a new handle.".into(),
@@ -1061,7 +1060,7 @@ impl BoxImpl {
         let live = self.live_state().await?;
         let mut files_iface = live.guest_session.files().await?;
         files_iface
-            .download_tar_stream(
+            .download_stream(
                 &container_src,
                 Some(&cid),
                 opts.include_parent,

--- a/src/boxlite/src/litebox/copy.rs
+++ b/src/boxlite/src/litebox/copy.rs
@@ -1,5 +1,43 @@
 use crate::BoxliteError;
 
+/// Shape of a streaming copy's source: a directory tree, a single file, or
+/// unknown.
+///
+/// `Unknown` is the honest answer when the producer cannot tell (a peer that
+/// predates the hint, or a caller streaming bytes it did not pack). The
+/// receiver then peeks the archive to decide the extraction shape, which costs
+/// a staged copy — so pass `File`/`Dir` whenever the shape is known.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CopySourceKind {
+    Unknown,
+    File,
+    Dir,
+}
+
+impl CopySourceKind {
+    /// The wire encoding: proto's `optional bool source_is_dir`.
+    pub fn to_wire(self) -> Option<bool> {
+        match self {
+            Self::Unknown => None,
+            Self::File => Some(false),
+            Self::Dir => Some(true),
+        }
+    }
+
+    /// Decode the wire hint; a peer that omits it reports `Unknown`.
+    pub fn from_wire(source_is_dir: Option<bool>) -> Self {
+        match source_is_dir {
+            None => Self::Unknown,
+            Some(false) => Self::File,
+            Some(true) => Self::Dir,
+        }
+    }
+
+    pub fn is_dir(self) -> bool {
+        matches!(self, Self::Dir)
+    }
+}
+
 /// Options controlling copy behavior.
 #[derive(Debug, Clone)]
 pub struct CopyOptions {
@@ -52,5 +90,35 @@ impl CopyOptions {
             ));
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The guest reads `source_is_dir` to pick the extraction shape, so an
+    /// inverted arm here silently unpacks a directory as a file (or the
+    /// reverse) on every peer — Rust, Go and C alike, since all three encode
+    /// through this one pair. Pin the encoding itself, not just the round trip:
+    /// a round trip survives a consistently inverted mapping.
+    #[test]
+    fn source_kind_encodes_the_guest_protocol_hint() {
+        assert_eq!(CopySourceKind::Unknown.to_wire(), None);
+        assert_eq!(CopySourceKind::File.to_wire(), Some(false));
+        assert_eq!(CopySourceKind::Dir.to_wire(), Some(true));
+
+        assert_eq!(CopySourceKind::from_wire(None), CopySourceKind::Unknown);
+        assert_eq!(CopySourceKind::from_wire(Some(false)), CopySourceKind::File);
+        assert_eq!(CopySourceKind::from_wire(Some(true)), CopySourceKind::Dir);
+    }
+
+    /// Only `Dir` makes the caller validate recursion — an `Unknown` source
+    /// must not be treated as a directory before the guest has peeked.
+    #[test]
+    fn only_dir_reports_a_directory_source() {
+        assert!(CopySourceKind::Dir.is_dir());
+        assert!(!CopySourceKind::File.is_dir());
+        assert!(!CopySourceKind::Unknown.is_dir());
     }
 }

--- a/src/boxlite/src/litebox/mod.rs
+++ b/src/boxlite/src/litebox/mod.rs
@@ -21,7 +21,7 @@ mod state;
 mod watcher;
 
 pub use attach::AttachOptions;
-pub use copy::CopyOptions;
+pub use copy::{CopyOptions, CopySourceKind};
 pub(crate) use crash_report::CrashReport;
 pub use exec::{BoxCommand, ExecResult, ExecStderr, ExecStdin, ExecStdout, Execution, ExecutionId};
 pub(crate) use manager::BoxManager;
@@ -165,20 +165,20 @@ impl LiteBox {
             .await
     }
 
-    /// Stream a tar byte stream into the container at `container_dst`.
+    /// Stream opaque transfer bytes into the container at `container_dst`.
     ///
-    /// `source_is_dir` is the archive shape (directory tree vs single file);
-    /// `None` when the caller cannot tell — the guest then peeks the archive
-    /// to decide. Only the local backend supports this.
+    /// `source` is the archive shape (directory tree vs single file);
+    /// [`CopySourceKind::Unknown`] when the caller cannot tell — the guest then
+    /// peeks the archive to decide. Only the local backend supports this.
     ///
     /// Returns a `BoxFuture` (rather than being an `async fn`) so the future
     /// owns the downcast backend and never borrows `&self` across an await —
     /// which avoids an HRTB `Send` bound on `&LiteBox`.
-    pub fn copy_in_tar_stream<S>(
+    pub fn copy_in_stream<S>(
         &self,
-        tar: S,
+        stream: S,
         container_dst: &str,
-        source_is_dir: Option<bool>,
+        source: copy::CopySourceKind,
         opts: copy::CopyOptions,
     ) -> futures::future::BoxFuture<'static, BoxliteResult<()>>
     where
@@ -194,21 +194,19 @@ impl LiteBox {
             let backend = backend.map_err(|_| {
                 BoxliteError::Unsupported("streaming copy-in requires the local backend".into())
             })?;
-            backend
-                .copy_in_tar_stream(tar, dst, source_is_dir, opts)
-                .await
+            backend.copy_in_stream(stream, dst, source, opts).await
         })
     }
 
-    /// Download `container_src` as a tar byte stream plus the archive-shape
-    /// hint. Only the local backend supports this.
-    pub fn copy_out_tar(
+    /// Download `container_src` as a byte stream plus its source shape. Only
+    /// the local backend supports this.
+    pub fn copy_out_stream(
         &self,
         container_src: &str,
         opts: copy::CopyOptions,
     ) -> futures::future::BoxFuture<
         'static,
-        BoxliteResult<(boxlite_shared::BoxTarStream, Option<bool>)>,
+        BoxliteResult<(boxlite_shared::BoxByteStream, copy::CopySourceKind)>,
     > {
         let backend = self
             .box_backend
@@ -220,7 +218,7 @@ impl LiteBox {
             let backend = backend.map_err(|_| {
                 BoxliteError::Unsupported("streaming copy-out requires the local backend".into())
             })?;
-            backend.copy_out_tar(src, opts).await
+            backend.copy_out_stream(src, opts).await
         })
     }
 

--- a/src/boxlite/src/litebox/mod.rs
+++ b/src/boxlite/src/litebox/mod.rs
@@ -42,7 +42,7 @@ use crate::metrics::BoxMetrics;
 use crate::runtime::backend::{BoxBackend, BoxNetworkBackend, SnapshotBackend};
 use crate::runtime::options::{BoxArchive, CloneOptions, ExportOptions};
 use crate::{BoxID, BoxInfo};
-use boxlite_shared::errors::BoxliteResult;
+use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 pub use config::BoxConfig;
 
 /// LiteBox - Handle to a box.
@@ -163,6 +163,65 @@ impl LiteBox {
         self.box_backend
             .copy_out(container_src.as_ref(), host_dst.as_ref(), opts)
             .await
+    }
+
+    /// Stream a tar byte stream into the container at `container_dst`.
+    ///
+    /// `source_is_dir` is the archive shape (directory tree vs single file);
+    /// `None` when the caller cannot tell — the guest then peeks the archive
+    /// to decide. Only the local backend supports this.
+    ///
+    /// Returns a `BoxFuture` (rather than being an `async fn`) so the future
+    /// owns the downcast backend and never borrows `&self` across an await —
+    /// which avoids an HRTB `Send` bound on `&LiteBox`.
+    pub fn copy_in_tar_stream<S>(
+        &self,
+        tar: S,
+        container_dst: &str,
+        source_is_dir: Option<bool>,
+        opts: copy::CopyOptions,
+    ) -> futures::future::BoxFuture<'static, BoxliteResult<()>>
+    where
+        S: futures::Stream<Item = std::io::Result<Vec<u8>>> + Send + 'static,
+    {
+        let backend = self
+            .box_backend
+            .clone()
+            .as_any_arc()
+            .downcast::<box_impl::BoxImpl>();
+        let dst = container_dst.to_string();
+        Box::pin(async move {
+            let backend = backend.map_err(|_| {
+                BoxliteError::Unsupported("streaming copy-in requires the local backend".into())
+            })?;
+            backend
+                .copy_in_tar_stream(tar, dst, source_is_dir, opts)
+                .await
+        })
+    }
+
+    /// Download `container_src` as a tar byte stream plus the archive-shape
+    /// hint. Only the local backend supports this.
+    pub fn copy_out_tar(
+        &self,
+        container_src: &str,
+        opts: copy::CopyOptions,
+    ) -> futures::future::BoxFuture<
+        'static,
+        BoxliteResult<(boxlite_shared::BoxTarStream, Option<bool>)>,
+    > {
+        let backend = self
+            .box_backend
+            .clone()
+            .as_any_arc()
+            .downcast::<box_impl::BoxImpl>();
+        let src = container_src.to_string();
+        Box::pin(async move {
+            let backend = backend.map_err(|_| {
+                BoxliteError::Unsupported("streaming copy-out requires the local backend".into())
+            })?;
+            backend.copy_out_tar(src, opts).await
+        })
     }
 
     /// Get a network handle for raw tunnel operations.

--- a/src/boxlite/src/portal/interfaces/files.rs
+++ b/src/boxlite/src/portal/interfaces/files.rs
@@ -2,7 +2,10 @@
 //!
 //! Provides tar-based upload/download to the guest container rootfs.
 
-use boxlite_shared::{BoxliteError, BoxliteResult, DownloadRequest, FilesClient, UploadChunk};
+use boxlite_shared::{
+    BoxTarStream, BoxliteError, BoxliteResult, DownloadRequest, FilesClient, UploadChunk,
+};
+use futures::StreamExt;
 use tokio::fs::File;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tonic::transport::Channel;
@@ -54,6 +57,7 @@ impl FilesInterface {
                         data: buf[..n].to_vec(),
                         mkdir_parents,
                         overwrite,
+                        source_is_dir: None,
                     };
                     first = false;
                     chunks.push(chunk);
@@ -131,6 +135,136 @@ impl FilesInterface {
             .map_err(|e| BoxliteError::Storage(format!("Failed to flush tar file: {}", e)))?;
 
         Ok(())
+    }
+
+    /// Upload a tar byte stream to the guest and extract at `dest_path`.
+    ///
+    /// `source_is_dir` is the archive shape (dir tree vs single file); `None`
+    /// when the caller cannot tell — the guest then peeks the tar to decide
+    /// extraction mode. It is attached to the first chunk only.
+    pub async fn upload_tar_stream<S>(
+        &mut self,
+        tar: S,
+        dest_path: &str,
+        container_id: Option<&str>,
+        mkdir_parents: bool,
+        overwrite: bool,
+        source_is_dir: Option<bool>,
+    ) -> BoxliteResult<()>
+    where
+        S: futures::Stream<Item = std::io::Result<Vec<u8>>> + Send + 'static,
+    {
+        let dest = dest_path.to_string();
+        let cid = container_id.unwrap_or_default().to_string();
+
+        // tonic client-streaming yields the message directly (no per-item
+        // `Result`); a mid-stream error is signalled by ending the stream, and
+        // the guest reports the failure in `UploadResponse`. The generator
+        // parks the first source-stream error in a shared slot: the guest may
+        // still report success on the truncated archive it received, and the
+        // caller must not see that as a successful copy.
+        let stream_err: std::sync::Arc<tokio::sync::Mutex<Option<std::io::Error>>> =
+            std::sync::Arc::new(tokio::sync::Mutex::new(None));
+        let stream_err_slot = stream_err.clone();
+        let stream = async_stream::stream! {
+            futures::pin_mut!(tar);
+            let mut first = true;
+            while let Some(item) = tar.next().await {
+                match item {
+                    Ok(data) => {
+                        yield UploadChunk {
+                            dest_path: if first { dest.clone() } else { String::new() },
+                            container_id: cid.clone(),
+                            data,
+                            mkdir_parents,
+                            overwrite,
+                            source_is_dir: if first { source_is_dir } else { None },
+                        };
+                        first = false;
+                    }
+                    Err(e) => {
+                        *stream_err_slot.lock().await = Some(e);
+                        break;
+                    }
+                }
+            }
+        };
+
+        let response = self
+            .client
+            .upload(stream)
+            .await
+            .map_err(map_tonic_err)?
+            .into_inner();
+
+        // Prefer the source-stream failure over the guest's verdict: a pack or
+        // read failure (or an explicit abort) must never surface as a
+        // successful copy of a truncated archive.
+        if let Some(e) = stream_err.lock().await.take() {
+            return Err(BoxliteError::Internal(format!(
+                "tar stream failed during upload: {e}"
+            )));
+        }
+
+        if response.success {
+            Ok(())
+        } else {
+            Err(BoxliteError::Internal(
+                response.error.unwrap_or_else(|| "Upload failed".into()),
+            ))
+        }
+    }
+
+    /// Download a path from the guest as a tar byte stream.
+    ///
+    /// Returns the stream plus the archive-shape hint read from the guest's
+    /// first chunk. `None` means the guest predates the hint (older peer).
+    pub async fn download_tar_stream(
+        &mut self,
+        container_src: &str,
+        container_id: Option<&str>,
+        include_parent: bool,
+        follow_symlinks: bool,
+    ) -> BoxliteResult<(BoxTarStream, Option<bool>)> {
+        let request = DownloadRequest {
+            src_path: container_src.to_string(),
+            container_id: container_id.unwrap_or_default().to_string(),
+            include_parent,
+            follow_symlinks,
+        };
+
+        let mut stream = self
+            .client
+            .download(request)
+            .await
+            .map_err(map_tonic_err)?
+            .into_inner();
+
+        let first = stream.message().await.map_err(map_tonic_err)?;
+        let source_is_dir = first.as_ref().and_then(|c| c.source_is_dir);
+        let mut first_data = first.map(|c| c.data);
+
+        let out = async_stream::stream! {
+            if let Some(data) = first_data.take().filter(|d| !d.is_empty()) {
+                yield Ok(data);
+            }
+            loop {
+                match stream.message().await {
+                    Ok(Some(chunk)) => {
+                        if !chunk.data.is_empty() {
+                            yield Ok(chunk.data);
+                        }
+                    }
+                    Ok(None) => break,
+                    Err(e) => {
+                        yield Err(std::io::Error::other(e));
+                        break;
+                    }
+                }
+            }
+        };
+
+        Ok((Box::pin(out), source_is_dir))
     }
 }
 

--- a/src/boxlite/src/portal/interfaces/files.rs
+++ b/src/boxlite/src/portal/interfaces/files.rs
@@ -2,8 +2,9 @@
 //!
 //! Provides tar-based upload/download to the guest container rootfs.
 
+use crate::litebox::CopySourceKind;
 use boxlite_shared::{
-    BoxTarStream, BoxliteError, BoxliteResult, DownloadRequest, FilesClient, UploadChunk,
+    BoxByteStream, BoxliteError, BoxliteResult, DownloadRequest, FilesClient, UploadChunk,
 };
 use futures::StreamExt;
 use tokio::fs::File;
@@ -137,19 +138,20 @@ impl FilesInterface {
         Ok(())
     }
 
-    /// Upload a tar byte stream to the guest and extract at `dest_path`.
+    /// Upload a byte stream to the guest and extract at `dest_path`.
     ///
-    /// `source_is_dir` is the archive shape (dir tree vs single file); `None`
-    /// when the caller cannot tell — the guest then peeks the tar to decide
-    /// extraction mode. It is attached to the first chunk only.
-    pub async fn upload_tar_stream<S>(
+    /// `source` is the archive shape (dir tree vs single file);
+    /// [`CopySourceKind::Unknown`] when the caller cannot tell — the guest then
+    /// peeks the archive to decide extraction mode. It is attached to the first
+    /// chunk only.
+    pub async fn upload_stream<S>(
         &mut self,
-        tar: S,
+        stream: S,
         dest_path: &str,
         container_id: Option<&str>,
         mkdir_parents: bool,
         overwrite: bool,
-        source_is_dir: Option<bool>,
+        source: CopySourceKind,
     ) -> BoxliteResult<()>
     where
         S: futures::Stream<Item = std::io::Result<Vec<u8>>> + Send + 'static,
@@ -166,10 +168,11 @@ impl FilesInterface {
         let stream_err: std::sync::Arc<tokio::sync::Mutex<Option<std::io::Error>>> =
             std::sync::Arc::new(tokio::sync::Mutex::new(None));
         let stream_err_slot = stream_err.clone();
-        let stream = async_stream::stream! {
-            futures::pin_mut!(tar);
+        let source_is_dir = source.to_wire();
+        let chunks = async_stream::stream! {
+            futures::pin_mut!(stream);
             let mut first = true;
-            while let Some(item) = tar.next().await {
+            while let Some(item) = stream.next().await {
                 match item {
                     Ok(data) => {
                         yield UploadChunk {
@@ -192,7 +195,7 @@ impl FilesInterface {
 
         let response = self
             .client
-            .upload(stream)
+            .upload(chunks)
             .await
             .map_err(map_tonic_err)?
             .into_inner();
@@ -202,7 +205,7 @@ impl FilesInterface {
         // successful copy of a truncated archive.
         if let Some(e) = stream_err.lock().await.take() {
             return Err(BoxliteError::Internal(format!(
-                "tar stream failed during upload: {e}"
+                "source stream failed during upload: {e}"
             )));
         }
 
@@ -215,17 +218,18 @@ impl FilesInterface {
         }
     }
 
-    /// Download a path from the guest as a tar byte stream.
+    /// Download a path from the guest as a byte stream.
     ///
-    /// Returns the stream plus the archive-shape hint read from the guest's
-    /// first chunk. `None` means the guest predates the hint (older peer).
-    pub async fn download_tar_stream(
+    /// Returns the stream plus the source shape read from the guest's first
+    /// chunk. [`CopySourceKind::Unknown`] means the guest predates the hint
+    /// (older peer).
+    pub async fn download_stream(
         &mut self,
         container_src: &str,
         container_id: Option<&str>,
         include_parent: bool,
         follow_symlinks: bool,
-    ) -> BoxliteResult<(BoxTarStream, Option<bool>)> {
+    ) -> BoxliteResult<(BoxByteStream, CopySourceKind)> {
         let request = DownloadRequest {
             src_path: container_src.to_string(),
             container_id: container_id.unwrap_or_default().to_string(),
@@ -241,7 +245,7 @@ impl FilesInterface {
             .into_inner();
 
         let first = stream.message().await.map_err(map_tonic_err)?;
-        let source_is_dir = first.as_ref().and_then(|c| c.source_is_dir);
+        let source = CopySourceKind::from_wire(first.as_ref().and_then(|c| c.source_is_dir));
         let mut first_data = first.map(|c| c.data);
 
         let out = async_stream::stream! {
@@ -264,7 +268,7 @@ impl FilesInterface {
             }
         };
 
-        Ok((Box::pin(out), source_is_dir))
+        Ok((Box::pin(out), source))
     }
 }
 

--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -2,13 +2,16 @@
 
 use std::net::SocketAddr;
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use reqwest::Method;
 use tokio::sync::mpsc;
 
+use boxlite_shared::constants::files::FALLBACK_CAP_BYTES;
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
+use futures::StreamExt;
+use std::io;
 
 use crate::BoxInfo;
 use crate::litebox::copy::CopyOptions;
@@ -125,6 +128,10 @@ impl BoxBackend for RestBox {
 
     fn name(&self) -> Option<&str> {
         self.name.as_deref()
+    }
+
+    fn as_any_arc(self: std::sync::Arc<Self>) -> std::sync::Arc<dyn std::any::Any + Send + Sync> {
+        self
     }
 
     async fn info(&self) -> BoxliteResult<BoxInfo> {
@@ -323,18 +330,30 @@ impl BoxBackend for RestBox {
             ));
         }
 
-        // Create tar archive from host path
-        let tar_bytes = create_tar_from_path(host_src)?;
+        // Stream a tar of the host source straight into the request body.
+        let (source_is_dir, tar) = boxlite_shared::tar::pack_stream(
+            host_src.to_path_buf(),
+            boxlite_shared::tar::PackContext {
+                follow_symlinks: opts.follow_symlinks,
+                include_parent: opts.include_parent,
+            },
+        )
+        .await?;
 
-        // Upload tar to server
+        let body = reqwest::Body::wrap_stream(tar.map(|r| r.map(bytes::Bytes::from)));
+
+        // Upload tar to server, carrying the archive-shape hint.
         let encoded_dst = urlencoding::encode(container_dst);
-        let path = format!("/boxes/{}/files?path={}", box_id, encoded_dst);
+        let path = format!(
+            "/boxes/{}/files?path={}&source_is_dir={}",
+            box_id, encoded_dst, source_is_dir
+        );
         let builder = self
             .client
             .authorized_request(Method::PUT, &path)
             .await?
             .header("Content-Type", "application/x-tar")
-            .body(tar_bytes);
+            .body(body);
 
         let resp = builder.send().await.map_err(transport_error)?;
 
@@ -371,10 +390,64 @@ impl BoxBackend for RestBox {
             return Err(map_http_body(status, &text));
         }
 
-        let tar_bytes = resp.bytes().await.map_err(transport_error)?;
+        // The archive shape is carried on the response header (newer servers);
+        // absence means the peer predates it → capped buffered fallback.
+        let source_is_dir = resp
+            .headers()
+            .get("x-boxlite-source-is-dir")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<bool>().ok());
 
-        // Extract tar to host path
-        extract_tar_to_path(&tar_bytes, host_dst)
+        let Some(source_is_dir) = source_is_dir else {
+            // Legacy peer: without the shape hint we must buffer to detect it.
+            let bytes = read_capped(resp, FALLBACK_CAP_BYTES).await?;
+            return extract_tar_to_path(&bytes, host_dst);
+        };
+        // The header carries the *source* shape; the destination's own
+        // signals — an existing directory, or a trailing slash naming one —
+        // must still win for a single file, matching the legacy
+        // `detect_extraction_mode` and Unix cp semantics.
+        let dest_wants_dir = host_dst.as_os_str().to_string_lossy().ends_with('/');
+        let force_directory = source_is_dir || host_dst.is_dir() || dest_wants_dir;
+
+        // A severed body must stay classified as a transport fault so callers
+        // retry instead of filing a bug. `unpack_stream` flattens the byte
+        // stream's `io::Error` into its own storage message, so park the
+        // classified error in a shared slot and prefer it if the unpack then
+        // fails. A `Mutex` (not `OnceLock` + `Arc::try_unwrap`) because the
+        // forwarding task inside `unpack_stream` may still hold a clone of the
+        // slot when we read it back — we must not depend on Arc drop timing.
+        let transport_fault: Arc<Mutex<Option<BoxliteError>>> = Arc::new(Mutex::new(None));
+        let fault_slot = Arc::clone(&transport_fault);
+        let stream: boxlite_shared::BoxTarStream = Box::pin(resp.bytes_stream().map(move |r| {
+            r.map(|b| b.to_vec()).map_err(|e| {
+                let classified = transport_error(e);
+                let message = classified.to_string();
+                if let Ok(mut slot) = fault_slot.lock() {
+                    *slot = Some(classified);
+                }
+                io::Error::other(message)
+            })
+        }));
+
+        let unpacked = boxlite_shared::tar::unpack_stream(
+            stream,
+            host_dst.to_path_buf(),
+            boxlite_shared::tar::UnpackContext {
+                overwrite: true,
+                mkdir_parents: true,
+                force_directory,
+            },
+        )
+        .await;
+
+        match unpacked {
+            Ok(_) => Ok(()),
+            Err(unpack_err) => {
+                let fault = transport_fault.lock().ok().and_then(|mut s| s.take());
+                Err(fault.unwrap_or(unpack_err))
+            }
+        }
     }
 
     async fn clone_box(
@@ -1062,38 +1135,26 @@ async fn emit_or_fallback(
 // Tar Helpers
 // ============================================================================
 
-/// Create a tar archive from a host file or directory.
-fn create_tar_from_path(host_src: &Path) -> BoxliteResult<Vec<u8>> {
-    let mut archive = tar::Builder::new(Vec::new());
-
-    if host_src.is_dir() {
-        archive.append_dir_all(".", host_src).map_err(|e| {
-            BoxliteError::Internal(format!(
-                "failed to create tar from {}: {}",
-                host_src.display(),
-                e
-            ))
-        })?;
-    } else {
-        let file_name = host_src
-            .file_name()
-            .map(|n| n.to_string_lossy().to_string())
-            .unwrap_or_else(|| "file".to_string());
-        let mut file = std::fs::File::open(host_src).map_err(|e| {
-            BoxliteError::Internal(format!("failed to open {}: {}", host_src.display(), e))
-        })?;
-        archive.append_file(&file_name, &mut file).map_err(|e| {
-            BoxliteError::Internal(format!(
-                "failed to add {} to tar: {}",
-                host_src.display(),
-                e
-            ))
-        })?;
+/// Read a tar response body into memory, enforcing a size cap.
+///
+/// Used only as a fallback when the server predates the `source_is_dir`
+/// hint and therefore cannot stream end-to-end; past the cap we error
+/// instead of buffering unboundedly. Takes the `Response` rather than a
+/// byte stream so a severed body keeps its transport classification.
+async fn read_capped(resp: reqwest::Response, cap: u64) -> BoxliteResult<Vec<u8>> {
+    let mut stream = resp.bytes_stream();
+    let mut out: Vec<u8> = Vec::new();
+    while let Some(item) = stream.next().await {
+        let chunk = item.map_err(transport_error)?;
+        if out.len() as u64 + chunk.len() as u64 > cap {
+            return Err(BoxliteError::Unsupported(format!(
+                "copy_out exceeds {} MiB fallback cap; upgrade the server to stream end-to-end",
+                cap / (1024 * 1024)
+            )));
+        }
+        out.extend_from_slice(&chunk);
     }
-
-    archive
-        .into_inner()
-        .map_err(|e| BoxliteError::Internal(format!("failed to finalize tar archive: {}", e)))
+    Ok(out)
 }
 
 /// Extract a tar archive to a host path.
@@ -1546,6 +1607,179 @@ mod tests {
         assert!(
             matches!(&error, BoxliteError::Network(_)),
             "a severed download must classify as transport, got {error:?}"
+        );
+        server.await.unwrap();
+    }
+
+    /// The streaming path (server sends the shape hint) must preserve the same
+    /// transport-fault classification the buffered fallback gives. Exercises the
+    /// shared fault slot, not just `read_capped`.
+    #[tokio::test]
+    async fn copy_out_streaming_truncation_classifies_as_network() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut head = Vec::new();
+            while !head.ends_with(b"\r\n\r\n") {
+                head.push(socket.read_u8().await.unwrap());
+            }
+            // Streaming peer: carries the shape hint, promises 4 KiB, hangs up.
+            socket
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\n\
+                      Content-Type: application/x-tar\r\n\
+                      X-Boxlite-Source-Is-Dir: false\r\n\
+                      Content-Length: 4096\r\n\
+                      Connection: close\r\n\r\nhi",
+                )
+                .await
+                .unwrap();
+        });
+
+        let rest_box = rest_box_for(port, "box1");
+        let host_dst = std::env::temp_dir().join("boxlite-copy-out-stream-truncated");
+
+        let error = rest_box
+            .copy_out("/tmp/archive", &host_dst, CopyOptions::default())
+            .await
+            .expect_err("a truncated streaming download must fail");
+
+        assert!(
+            matches!(&error, BoxliteError::Network(_)),
+            "a severed streaming download must classify as transport, got {error:?}"
+        );
+        server.await.unwrap();
+    }
+
+    /// Streaming copy_out must fold the destination's directory-ness back into
+    /// the archive shape: a single-file source whose destination is an existing
+    /// directory lands *inside* it (Unix cp semantics), not at the directory
+    /// path — mirroring `detect_extraction_mode` in the legacy path.
+    #[tokio::test]
+    async fn copy_out_places_single_file_inside_existing_directory() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        // A single-file tar: one regular entry "file.txt".
+        let mut tar_bytes = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut tar_bytes);
+            let content = b"inside-dir\n";
+            let mut header = tar::Header::new_gnu();
+            header.set_size(content.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, "file.txt", &content[..])
+                .unwrap();
+            builder.finish().unwrap();
+        }
+
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut head = Vec::new();
+            while !head.ends_with(b"\r\n\r\n") {
+                head.push(socket.read_u8().await.unwrap());
+            }
+            socket
+                .write_all(
+                    format!(
+                        "HTTP/1.1 200 OK\r\n\
+                         Content-Type: application/x-tar\r\n\
+                         X-Boxlite-Source-Is-Dir: false\r\n\
+                         Content-Length: {}\r\n\
+                         Connection: close\r\n\r\n",
+                        tar_bytes.len()
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+            socket.write_all(&tar_bytes).await.unwrap();
+        });
+
+        let rest_box = rest_box_for(port, "box1");
+        let dir = tempfile::tempdir().unwrap();
+
+        rest_box
+            .copy_out("/tmp/file.txt", dir.path(), CopyOptions::default())
+            .await
+            .expect("copy_out into existing directory");
+
+        let landed = dir.path().join("file.txt");
+        assert_eq!(
+            std::fs::read_to_string(&landed).unwrap(),
+            "inside-dir\n",
+            "single file must land inside the destination directory"
+        );
+        server.await.unwrap();
+    }
+
+    /// A destination with a trailing slash names a directory even when it
+    /// does not exist yet: a single-file source must land *inside* it (the
+    /// legacy `detect_extraction_mode` trailing-slash rule), not fail to
+    /// unpack at the directory-designated path.
+    #[tokio::test]
+    async fn copy_out_trailing_slash_forces_directory_mode() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        // A single-file tar: one regular entry "file.txt".
+        let mut tar_bytes = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut tar_bytes);
+            let content = b"trailing-slash\n";
+            let mut header = tar::Header::new_gnu();
+            header.set_size(content.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, "file.txt", &content[..])
+                .unwrap();
+            builder.finish().unwrap();
+        }
+
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut head = Vec::new();
+            while !head.ends_with(b"\r\n\r\n") {
+                head.push(socket.read_u8().await.unwrap());
+            }
+            socket
+                .write_all(
+                    format!(
+                        "HTTP/1.1 200 OK\r\n\
+                         Content-Type: application/x-tar\r\n\
+                         X-Boxlite-Source-Is-Dir: false\r\n\
+                         Content-Length: {}\r\n\
+                         Connection: close\r\n\r\n",
+                        tar_bytes.len()
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+            socket.write_all(&tar_bytes).await.unwrap();
+        });
+
+        let rest_box = rest_box_for(port, "box1");
+        let dir = tempfile::tempdir().unwrap();
+
+        // The trailing slash makes this a directory even though it does not
+        // exist yet (mkdir_parents creates it).
+        let dest_with_slash =
+            std::path::PathBuf::from(format!("{}/", dir.path().join("newdir").display()));
+        rest_box
+            .copy_out("/tmp/file.txt", &dest_with_slash, CopyOptions::default())
+            .await
+            .expect("copy_out with trailing-slash destination");
+
+        let landed = dir.path().join("newdir").join("file.txt");
+        assert_eq!(
+            std::fs::read_to_string(&landed).unwrap(),
+            "trailing-slash\n",
+            "single file must land inside the trailing-slash directory"
         );
         server.await.unwrap();
     }

--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -419,7 +419,7 @@ impl BoxBackend for RestBox {
         // slot when we read it back — we must not depend on Arc drop timing.
         let transport_fault: Arc<Mutex<Option<BoxliteError>>> = Arc::new(Mutex::new(None));
         let fault_slot = Arc::clone(&transport_fault);
-        let stream: boxlite_shared::BoxTarStream = Box::pin(resp.bytes_stream().map(move |r| {
+        let stream: boxlite_shared::BoxByteStream = Box::pin(resp.bytes_stream().map(move |r| {
             r.map(|b| b.to_vec()).map_err(|e| {
                 let classified = transport_error(e);
                 let message = classified.to_string();

--- a/src/boxlite/src/runtime/backend.rs
+++ b/src/boxlite/src/runtime/backend.rs
@@ -1,7 +1,9 @@
 //! Runtime backend trait — internal abstraction for local vs REST execution.
 
+use std::any::Any;
 use std::net::SocketAddr;
 use std::path::Path;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 
@@ -68,7 +70,12 @@ pub(crate) trait RuntimeBackend: Send + Sync {
 /// Local backend is implemented directly by `BoxImpl`.
 /// REST backend delegates to HTTP API calls.
 #[async_trait]
-pub(crate) trait BoxBackend: Send + Sync {
+pub(crate) trait BoxBackend: Send + Sync + Any {
+    /// Owned downcast helper (`Arc` upcast), so callers can move the local
+    /// backend out of the trait object without borrowing `&self` across an
+    /// `await`.
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn Any + Send + Sync>;
+
     fn id(&self) -> &BoxID;
 
     fn name(&self) -> Option<&str>;

--- a/src/boxlite/tests/copy.rs
+++ b/src/boxlite/tests/copy.rs
@@ -11,7 +11,7 @@ mod common;
 
 use boxlite::BoxliteRuntime;
 use boxlite::runtime::options::BoxliteOptions;
-use boxlite::{BoxCommand, CopyOptions, LiteBox};
+use boxlite::{BoxCommand, CopyOptions, CopySourceKind, LiteBox};
 use std::path::Path;
 use tempfile::TempDir;
 use tokio_stream::StreamExt;
@@ -67,9 +67,14 @@ async fn streaming_single_file_into_existing_dir(bx: &LiteBox, tmp: &Path) {
     assert!(!source_is_dir);
 
     // `/root` already exists as a directory; the file must go inside it.
-    bx.copy_in_tar_stream(tar, "/root", Some(source_is_dir), CopyOptions::default())
-        .await
-        .expect("copy_in_tar_stream into existing directory");
+    bx.copy_in_stream(
+        tar,
+        "/root",
+        CopySourceKind::from_wire(Some(source_is_dir)),
+        CopyOptions::default(),
+    )
+    .await
+    .expect("copy_in_stream into existing directory");
 
     let out = exec_stdout(
         bx,
@@ -79,8 +84,8 @@ async fn streaming_single_file_into_existing_dir(bx: &LiteBox, tmp: &Path) {
     assert_eq!(out, "landed inside\n");
 }
 
-/// Exercise the streaming entry points (`copy_in_tar_stream` / `copy_out_tar`)
-/// end-to-end: pack a host file into a tar stream, stream it into the guest,
+/// Exercise the streaming entry points (`copy_in_stream` / `copy_out_stream`)
+/// end-to-end: pack a host file into a byte stream, stream it into the guest,
 /// then stream it back out and unpack it — with no temp-file staging.
 async fn streaming_roundtrip(bx: &LiteBox, tmp: &Path) {
     let host_src = tmp.join("stream-src.txt");
@@ -100,23 +105,27 @@ async fn streaming_roundtrip(bx: &LiteBox, tmp: &Path) {
         "single file must report source_is_dir=false"
     );
 
-    bx.copy_in_tar_stream(
+    bx.copy_in_stream(
         tar,
         "/root/stream-src.txt",
-        Some(source_is_dir),
+        CopySourceKind::from_wire(Some(source_is_dir)),
         CopyOptions::default(),
     )
     .await
-    .expect("copy_in_tar_stream");
+    .expect("copy_in_stream");
 
     let out = exec_stdout(bx, BoxCommand::new("cat").args(["/root/stream-src.txt"])).await;
     assert_eq!(out, "streaming hello");
 
     let (tar, hint) = bx
-        .copy_out_tar("/root/stream-src.txt", CopyOptions::default())
+        .copy_out_stream("/root/stream-src.txt", CopyOptions::default())
         .await
-        .expect("copy_out_tar");
-    assert_eq!(hint, Some(false), "guest must report source_is_dir=false");
+        .expect("copy_out_stream");
+    assert_eq!(
+        hint,
+        CopySourceKind::File,
+        "guest must report a single-file source"
+    );
 
     let dest = tmp.join("stream-dest.txt");
     let report = boxlite_shared::tar::unpack_stream(
@@ -155,16 +164,21 @@ async fn streaming_hintless_single_file(bx: &LiteBox, tmp: &Path) {
     .await
     .expect("pack_stream");
 
-    bx.copy_in_tar_stream(tar, "/root/hintless-file.txt", None, CopyOptions::default())
-        .await
-        .expect("hintless copy_in_tar_stream");
+    bx.copy_in_stream(
+        tar,
+        "/root/hintless-file.txt",
+        CopySourceKind::Unknown,
+        CopyOptions::default(),
+    )
+    .await
+    .expect("hintless copy_in_stream");
 
     let out = exec_stdout(bx, BoxCommand::new("cat").args(["/root/hintless-file.txt"])).await;
     assert_eq!(out, "hintless single\n");
 }
 
 /// A directory tree streamed WITHOUT a hint must unpack as a tree. A
-/// regression that treated `None` as `Some(false)` would force file mode and
+/// regression that treated `Unknown` as `File` would force file mode and
 /// fail to unpack the directory — the behavior this test pins.
 async fn streaming_hintless_directory(bx: &LiteBox, tmp: &Path) {
     let host_dir = tmp.join("hintless-src-dir");
@@ -183,9 +197,14 @@ async fn streaming_hintless_directory(bx: &LiteBox, tmp: &Path) {
     .expect("pack_stream");
 
     // Fresh dest, no trailing slash — only the guest's peek can decide.
-    bx.copy_in_tar_stream(tar, "/root/hintless-dir", None, CopyOptions::default())
-        .await
-        .expect("hintless directory copy_in_tar_stream");
+    bx.copy_in_stream(
+        tar,
+        "/root/hintless-dir",
+        CopySourceKind::Unknown,
+        CopyOptions::default(),
+    )
+    .await
+    .expect("hintless directory copy_in_stream");
 
     let out = exec_stdout(
         bx,
@@ -218,13 +237,13 @@ async fn streaming_stream_error_after_data_fails(bx: &LiteBox, tmp: &Path) {
         items.push(item);
     }
     items.push(Err(std::io::Error::other("injected stream failure")));
-    let poisoned: boxlite_shared::BoxTarStream = Box::pin(tokio_stream::iter(items));
+    let poisoned: boxlite_shared::BoxByteStream = Box::pin(tokio_stream::iter(items));
 
     let result = bx
-        .copy_in_tar_stream(
+        .copy_in_stream(
             poisoned,
             "/root/stream-err.txt",
-            Some(source_is_dir),
+            CopySourceKind::from_wire(Some(source_is_dir)),
             CopyOptions::default(),
         )
         .await;
@@ -253,10 +272,10 @@ async fn streaming_dir_rejects_non_recursive(bx: &LiteBox, tmp: &Path) {
     assert!(source_is_dir);
 
     let result = bx
-        .copy_in_tar_stream(
+        .copy_in_stream(
             tar,
             "/root/nonrec",
-            Some(source_is_dir),
+            CopySourceKind::from_wire(Some(source_is_dir)),
             CopyOptions::default().non_recursive(),
         )
         .await;
@@ -272,11 +291,16 @@ async fn streaming_dir_rejects_non_recursive(bx: &LiteBox, tmp: &Path) {
 /// crate's `TempUploadGuard` unit tests — the container cannot see the
 /// agent's own /tmp.)
 async fn streaming_hintless_corrupt_archive_fails(bx: &LiteBox, _tmp: &Path) {
-    let tar: boxlite_shared::BoxTarStream =
+    let tar: boxlite_shared::BoxByteStream =
         Box::pin(tokio_stream::iter(vec![Ok(b"not a tar archive".to_vec())]));
 
     let result = bx
-        .copy_in_tar_stream(tar, "/root/hintless-fail.txt", None, CopyOptions::default())
+        .copy_in_stream(
+            tar,
+            "/root/hintless-fail.txt",
+            CopySourceKind::Unknown,
+            CopyOptions::default(),
+        )
         .await;
     assert!(result.is_err(), "corrupt archive must fail the copy");
 }
@@ -305,10 +329,10 @@ async fn streaming_payload_under_mount_is_refused(bx: &LiteBox, tmp: &Path) {
             .unwrap();
         builder.finish().unwrap();
     }
-    let poisoned: boxlite_shared::BoxTarStream = Box::pin(tokio_stream::iter(vec![Ok(tar_bytes)]));
+    let poisoned: boxlite_shared::BoxByteStream = Box::pin(tokio_stream::iter(vec![Ok(tar_bytes)]));
 
     let err = bx
-        .copy_in_tar_stream(poisoned, "/", Some(true), CopyOptions::default())
+        .copy_in_stream(poisoned, "/", CopySourceKind::Dir, CopyOptions::default())
         .await
         .expect_err("a payload under a mount must be refused, not silently shadowed");
 

--- a/src/boxlite/tests/copy.rs
+++ b/src/boxlite/tests/copy.rs
@@ -48,6 +48,277 @@ async fn exec_exit_code(bx: &LiteBox, cmd: BoxCommand) -> i32 {
 // SINGLE TEST ENTRY POINT — one VM, all cases
 // ============================================================================
 
+/// A single file streamed into an *existing* directory must land inside it
+/// (Unix cp semantics), not try to overwrite the directory path. This is the
+/// destination-side signal that the streaming path used to drop.
+async fn streaming_single_file_into_existing_dir(bx: &LiteBox, tmp: &Path) {
+    let host_src = tmp.join("stream-into-dir.txt");
+    std::fs::write(&host_src, b"landed inside\n").unwrap();
+
+    let (source_is_dir, tar) = boxlite_shared::tar::pack_stream(
+        host_src.clone(),
+        boxlite_shared::tar::PackContext {
+            follow_symlinks: false,
+            include_parent: false,
+        },
+    )
+    .await
+    .expect("pack_stream");
+    assert!(!source_is_dir);
+
+    // `/root` already exists as a directory; the file must go inside it.
+    bx.copy_in_tar_stream(tar, "/root", Some(source_is_dir), CopyOptions::default())
+        .await
+        .expect("copy_in_tar_stream into existing directory");
+
+    let out = exec_stdout(
+        bx,
+        BoxCommand::new("cat").args(["/root/stream-into-dir.txt"]),
+    )
+    .await;
+    assert_eq!(out, "landed inside\n");
+}
+
+/// Exercise the streaming entry points (`copy_in_tar_stream` / `copy_out_tar`)
+/// end-to-end: pack a host file into a tar stream, stream it into the guest,
+/// then stream it back out and unpack it — with no temp-file staging.
+async fn streaming_roundtrip(bx: &LiteBox, tmp: &Path) {
+    let host_src = tmp.join("stream-src.txt");
+    std::fs::write(&host_src, b"streaming hello").unwrap();
+
+    let (source_is_dir, tar) = boxlite_shared::tar::pack_stream(
+        host_src.clone(),
+        boxlite_shared::tar::PackContext {
+            follow_symlinks: false,
+            include_parent: false,
+        },
+    )
+    .await
+    .expect("pack_stream");
+    assert!(
+        !source_is_dir,
+        "single file must report source_is_dir=false"
+    );
+
+    bx.copy_in_tar_stream(
+        tar,
+        "/root/stream-src.txt",
+        Some(source_is_dir),
+        CopyOptions::default(),
+    )
+    .await
+    .expect("copy_in_tar_stream");
+
+    let out = exec_stdout(bx, BoxCommand::new("cat").args(["/root/stream-src.txt"])).await;
+    assert_eq!(out, "streaming hello");
+
+    let (tar, hint) = bx
+        .copy_out_tar("/root/stream-src.txt", CopyOptions::default())
+        .await
+        .expect("copy_out_tar");
+    assert_eq!(hint, Some(false), "guest must report source_is_dir=false");
+
+    let dest = tmp.join("stream-dest.txt");
+    let report = boxlite_shared::tar::unpack_stream(
+        tar,
+        dest.clone(),
+        boxlite_shared::tar::UnpackContext {
+            overwrite: true,
+            mkdir_parents: true,
+            force_directory: false,
+        },
+    )
+    .await
+    .expect("unpack_stream");
+    assert_eq!(std::fs::read_to_string(&dest).unwrap(), "streaming hello");
+    assert_eq!(
+        report.entry_paths,
+        vec![std::path::PathBuf::from("stream-src.txt")]
+    );
+}
+
+/// A single-file tar streamed WITHOUT a shape hint must land as that exact
+/// file — the guest's hintless path spools the archive and peeks it to decide
+/// (the pre-hint behavior). This is what an old-client upload looks like
+/// after the runner relays the body with hint=Unknown.
+async fn streaming_hintless_single_file(bx: &LiteBox, tmp: &Path) {
+    let host_src = tmp.join("hintless-src.txt");
+    std::fs::write(&host_src, b"hintless single\n").unwrap();
+
+    let (_, tar) = boxlite_shared::tar::pack_stream(
+        host_src.clone(),
+        boxlite_shared::tar::PackContext {
+            follow_symlinks: false,
+            include_parent: false,
+        },
+    )
+    .await
+    .expect("pack_stream");
+
+    bx.copy_in_tar_stream(tar, "/root/hintless-file.txt", None, CopyOptions::default())
+        .await
+        .expect("hintless copy_in_tar_stream");
+
+    let out = exec_stdout(bx, BoxCommand::new("cat").args(["/root/hintless-file.txt"])).await;
+    assert_eq!(out, "hintless single\n");
+}
+
+/// A directory tree streamed WITHOUT a hint must unpack as a tree. A
+/// regression that treated `None` as `Some(false)` would force file mode and
+/// fail to unpack the directory — the behavior this test pins.
+async fn streaming_hintless_directory(bx: &LiteBox, tmp: &Path) {
+    let host_dir = tmp.join("hintless-src-dir");
+    std::fs::create_dir_all(host_dir.join("sub")).unwrap();
+    std::fs::write(host_dir.join("a.txt"), b"hintless dir a\n").unwrap();
+    std::fs::write(host_dir.join("sub").join("b.txt"), b"hintless dir b\n").unwrap();
+
+    let (_, tar) = boxlite_shared::tar::pack_stream(
+        host_dir.clone(),
+        boxlite_shared::tar::PackContext {
+            follow_symlinks: false,
+            include_parent: true,
+        },
+    )
+    .await
+    .expect("pack_stream");
+
+    // Fresh dest, no trailing slash — only the guest's peek can decide.
+    bx.copy_in_tar_stream(tar, "/root/hintless-dir", None, CopyOptions::default())
+        .await
+        .expect("hintless directory copy_in_tar_stream");
+
+    let out = exec_stdout(
+        bx,
+        BoxCommand::new("cat").args(["/root/hintless-dir/hintless-src-dir/a.txt"]),
+    )
+    .await;
+    assert_eq!(out, "hintless dir a\n");
+}
+
+/// A tar stream that fails AFTER delivering a complete archive must not
+/// surface as a successful copy: the guest extracts the complete prefix and
+/// reports success, so the host-side upload has to prefer the source-stream
+/// error over the guest's verdict.
+async fn streaming_stream_error_after_data_fails(bx: &LiteBox, tmp: &Path) {
+    let host_src = tmp.join("stream-err-after-data.txt");
+    std::fs::write(&host_src, b"complete archive\n").unwrap();
+
+    let (source_is_dir, mut tar) = boxlite_shared::tar::pack_stream(
+        host_src.clone(),
+        boxlite_shared::tar::PackContext {
+            follow_symlinks: false,
+            include_parent: false,
+        },
+    )
+    .await
+    .expect("pack_stream");
+
+    let mut items: Vec<std::io::Result<Vec<u8>>> = Vec::new();
+    while let Some(item) = tar.next().await {
+        items.push(item);
+    }
+    items.push(Err(std::io::Error::other("injected stream failure")));
+    let poisoned: boxlite_shared::BoxTarStream = Box::pin(tokio_stream::iter(items));
+
+    let result = bx
+        .copy_in_tar_stream(
+            poisoned,
+            "/root/stream-err.txt",
+            Some(source_is_dir),
+            CopyOptions::default(),
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "a stream error after a complete archive must fail the copy"
+    );
+}
+
+/// Streaming a directory with recursive=false must be rejected before any
+/// data flows, matching the path-based copy_into contract.
+async fn streaming_dir_rejects_non_recursive(bx: &LiteBox, tmp: &Path) {
+    let host_dir = tmp.join("nonrec-dir");
+    std::fs::create_dir_all(host_dir.join("sub")).unwrap();
+    std::fs::write(host_dir.join("a.txt"), b"x").unwrap();
+
+    let (source_is_dir, tar) = boxlite_shared::tar::pack_stream(
+        host_dir.clone(),
+        boxlite_shared::tar::PackContext {
+            follow_symlinks: false,
+            include_parent: false,
+        },
+    )
+    .await
+    .expect("pack_stream");
+    assert!(source_is_dir);
+
+    let result = bx
+        .copy_in_tar_stream(
+            tar,
+            "/root/nonrec",
+            Some(source_is_dir),
+            CopyOptions::default().non_recursive(),
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "streaming a directory with recursive=false must be rejected"
+    );
+}
+
+/// A failed hintless upload surfaces as an error through the streaming path.
+/// The streamed bytes are not a tar archive, so the guest's peek/extract
+/// fails after spooling. (The spool cleanup itself is asserted by the guest
+/// crate's `TempUploadGuard` unit tests — the container cannot see the
+/// agent's own /tmp.)
+async fn streaming_hintless_corrupt_archive_fails(bx: &LiteBox, _tmp: &Path) {
+    let tar: boxlite_shared::BoxTarStream =
+        Box::pin(tokio_stream::iter(vec![Ok(b"not a tar archive".to_vec())]));
+
+    let result = bx
+        .copy_in_tar_stream(tar, "/root/hintless-fail.txt", None, CopyOptions::default())
+        .await;
+    assert!(result.is_err(), "corrupt archive must fail the copy");
+}
+
+/// A hinted (streaming) upload whose archive names an entry under a mount
+/// must be refused — post-hoc for the stream (it cannot be pre-scanned
+/// without spooling), but the failure must surface instead of silently
+/// writing beneath the mount.
+async fn streaming_payload_under_mount_is_refused(bx: &LiteBox, tmp: &Path) {
+    let host_src = tmp.join("stream-mount-payload.txt");
+    std::fs::write(&host_src, "PAYLOAD-STREAM-MOUNT\n").unwrap();
+
+    // The entry lands under the guest's /tmp tmpfs mount: destination root
+    // is reachable, only the payload entry is shadowed — exactly the case
+    // the staged arm refuses via entry_paths pre-scan.
+    let mut tar_bytes = Vec::new();
+    {
+        let mut builder = tar::Builder::new(&mut tar_bytes);
+        let content = std::fs::read(&host_src).unwrap();
+        let mut header = tar::Header::new_gnu();
+        header.set_size(content.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "tmp/stream-mount-payload.txt", &content[..])
+            .unwrap();
+        builder.finish().unwrap();
+    }
+    let poisoned: boxlite_shared::BoxTarStream = Box::pin(tokio_stream::iter(vec![Ok(tar_bytes)]));
+
+    let err = bx
+        .copy_in_tar_stream(poisoned, "/", Some(true), CopyOptions::default())
+        .await
+        .expect_err("a payload under a mount must be refused, not silently shadowed");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("'/tmp' mount"),
+        "refusal should name the mount that blocks it, got: {msg}"
+    );
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn copy_integration() {
     let home = boxlite_test_utils::home::PerTestBoxHome::new();
@@ -90,6 +361,15 @@ async fn copy_integration() {
     copy_in_beside_a_file_mount_is_allowed(&bx, tmp.path()).await;
     copy_in_landing_on_a_file_mount_is_refused(&bx, tmp.path()).await;
     copy_out_of_a_dir_containing_a_mount_is_refused(&bx, tmp.path()).await;
+    streaming_roundtrip(&bx, tmp.path()).await;
+    streaming_single_file_into_existing_dir(&bx, tmp.path()).await;
+
+    streaming_hintless_single_file(&bx, tmp.path()).await;
+    streaming_payload_under_mount_is_refused(&bx, tmp.path()).await;
+    streaming_hintless_directory(&bx, tmp.path()).await;
+    streaming_hintless_corrupt_archive_fails(&bx, tmp.path()).await;
+    streaming_stream_error_after_data_fails(&bx, tmp.path()).await;
+    streaming_dir_rejects_non_recursive(&bx, tmp.path()).await;
 
     let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }

--- a/src/boxlite/tests/copy_ownership.rs
+++ b/src/boxlite/tests/copy_ownership.rs
@@ -156,3 +156,93 @@ async fn copy_in_hands_files_to_the_box_user() {
     let _ = runtime.remove(bx.id().as_str(), true).await;
     let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
 }
+
+/// The streaming (hinted) copy-in arm must hand created files to the box
+/// user exactly like the staged arm does — the extraction recording is the
+/// list that decides what changes owner.
+#[tokio::test(flavor = "multi_thread")]
+async fn streaming_copy_in_hands_files_to_the_box_user() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::new();
+    let runtime = boxlite::BoxliteRuntime::new(boxlite::runtime::options::BoxliteOptions {
+        home_dir: home.path.clone(),
+        image_registries: common::test_registries(),
+    })
+    .expect("create runtime");
+
+    let opts = BoxOptions {
+        rootfs: RootfsSpec::Image("alpine:latest".into()),
+        auto_delete: Some(0),
+        user: Some(format!("{BOX_UID}:{BOX_GID}")),
+        ..Default::default()
+    };
+    let bx = runtime.create(opts, None).await.expect("create box");
+    bx.start().await.expect("start box");
+
+    let tmp = TempDir::new_in("/tmp").unwrap();
+    let src = tmp.path().join("stream-payload.txt");
+    std::fs::write(&src, "PAYLOAD-STREAM-OWNED\n").unwrap();
+    let mut perms = std::fs::metadata(&src).unwrap().permissions();
+    {
+        use std::os::unix::fs::PermissionsExt;
+        perms.set_mode(0o600);
+    }
+    std::fs::set_permissions(&src, perms).unwrap();
+
+    let (source_is_dir, tar) = boxlite_shared::tar::pack_stream(
+        src.clone(),
+        boxlite_shared::tar::PackContext {
+            follow_symlinks: false,
+            include_parent: false,
+        },
+    )
+    .await
+    .expect("pack_stream");
+    assert!(!source_is_dir);
+
+    bx.copy_in_tar_stream(
+        tar,
+        "/srv/probe/stream-payload.txt",
+        Some(source_is_dir),
+        CopyOptions::default(),
+    )
+    .await
+    .expect("streaming copy_in failed");
+
+    let file_owner = exec_stdout(
+        &bx,
+        BoxCommand::new("stat").args(["-c", "%u:%g", "/srv/probe/stream-payload.txt"]),
+    )
+    .await;
+    assert_eq!(
+        file_owner.trim(),
+        format!("{BOX_UID}:{BOX_GID}"),
+        "streamed file must belong to the box user"
+    );
+
+    // mkdir_parents conjured /srv/probe — the staged arm hands it over, and
+    // the streamed arm must match, or the workload cannot replace its file.
+    let dir_owner = exec_stdout(
+        &bx,
+        BoxCommand::new("stat").args(["-c", "%u:%g", "/srv/probe"]),
+    )
+    .await;
+    assert_eq!(
+        dir_owner.trim(),
+        format!("{BOX_UID}:{BOX_GID}"),
+        "directories created for the streamed copy must belong to the box user too"
+    );
+
+    let content = exec_stdout(
+        &bx,
+        BoxCommand::new("cat").args(["/srv/probe/stream-payload.txt"]),
+    )
+    .await;
+    assert_eq!(
+        content, "PAYLOAD-STREAM-OWNED\n",
+        "box user must be able to read it"
+    );
+
+    let _ = bx.stop().await;
+    let _ = runtime.remove(bx.id().as_str(), true).await;
+    let _ = runtime.shutdown(Some(common::TEST_SHUTDOWN_TIMEOUT)).await;
+}

--- a/src/boxlite/tests/copy_ownership.rs
+++ b/src/boxlite/tests/copy_ownership.rs
@@ -14,7 +14,7 @@
 mod common;
 
 use boxlite::runtime::options::{BoxOptions, RootfsSpec};
-use boxlite::{BoxCommand, CopyOptions};
+use boxlite::{BoxCommand, CopyOptions, CopySourceKind};
 use tempfile::TempDir;
 use tokio_stream::StreamExt;
 
@@ -199,10 +199,10 @@ async fn streaming_copy_in_hands_files_to_the_box_user() {
     .expect("pack_stream");
     assert!(!source_is_dir);
 
-    bx.copy_in_tar_stream(
+    bx.copy_in_stream(
         tar,
         "/srv/probe/stream-payload.txt",
-        Some(source_is_dir),
+        CopySourceKind::from_wire(Some(source_is_dir)),
         CopyOptions::default(),
     )
     .await

--- a/src/guest/src/service/files.rs
+++ b/src/guest/src/service/files.rs
@@ -6,7 +6,7 @@
 
 use crate::service::server::GuestServer;
 use boxlite_shared::{
-    files_server::Files, BoxTarStream, DownloadChunk, DownloadRequest, UploadChunk, UploadResponse,
+    files_server::Files, BoxByteStream, DownloadChunk, DownloadRequest, UploadChunk, UploadResponse,
 };
 use futures::StreamExt;
 use nix::fcntl::OFlag;
@@ -485,7 +485,7 @@ impl Files for GuestServer {
             Some(source_is_dir) => {
                 let force_directory =
                     source_is_dir || dest_path.ends_with('/') || dest_root.is_dir();
-                let tar_stream: BoxTarStream = Box::pin(async_stream::stream! {
+                let tar_stream: BoxByteStream = Box::pin(async_stream::stream! {
                     if !first_data.is_empty() {
                         yield Ok(first_data);
                     }

--- a/src/guest/src/service/files.rs
+++ b/src/guest/src/service/files.rs
@@ -6,21 +6,21 @@
 
 use crate::service::server::GuestServer;
 use boxlite_shared::{
-    files_server::Files, DownloadChunk, DownloadRequest, UploadChunk, UploadResponse,
+    files_server::Files, BoxTarStream, DownloadChunk, DownloadRequest, UploadChunk, UploadResponse,
 };
+use futures::StreamExt;
 use nix::fcntl::OFlag;
 use std::collections::HashSet;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::fs::File;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::AsyncWriteExt;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status, Streaming};
 use tracing::info;
 
-const CHUNK_SIZE: usize = 1 << 20; // 1 MiB
 const MAX_UPLOAD_BYTES: u64 = 512 * 1024 * 1024; // 512 MiB safety cap
 
 /// A staged upload, deleted whenever it goes out of scope.
@@ -171,6 +171,20 @@ struct DestBefore {
 }
 
 impl DestBefore {
+    /// The streamed-arm variant: all facts are captured while they still
+    /// describe the tree before extraction creates each path.
+    fn recorded(
+        created_dirs: Vec<PathBuf>,
+        dest_existed: bool,
+        existing_dirs: HashSet<PathBuf>,
+    ) -> Self {
+        Self {
+            created_dirs,
+            dest_existed,
+            existing_dirs,
+        }
+    }
+
     /// Sample off the async worker: one `stat` per archive entry, and the
     /// caller chooses how many entries there are — the same reason
     /// [`boxlite_shared::tar::entry_paths`] runs on a blocking thread.
@@ -458,90 +472,175 @@ impl Files for GuestServer {
         // Overwrite / mkdir flags
         let mkdir_parents = first.mkdir_parents;
         let overwrite = first.overwrite;
+        let source_is_dir = first.source_is_dir;
+        let first_data = first.data;
 
-        // Temp file to hold tar stream. `StagedTar` owns the deletion, because
-        // every step from here to the end can leave through a `?`.
-        let staged = StagedTar::new(
-            std::env::temp_dir().join(format!("boxlite-upload-{}.tar", uuid::Uuid::new_v4())),
-        );
-        let mut file = File::create(staged.path())
-            .await
-            .map_err(|e| Status::internal(format!("failed to create temp file: {}", e)))?;
+        match source_is_dir {
+            // Streaming path: unpack directly from the byte stream. The hint
+            // carries the *source* shape, but the destination can still force
+            // directory mode — same as `detect_extraction_mode` in the legacy
+            // path. Fold the destination-side signals back in here so
+            // "single file → existing directory" keeps landing inside it
+            // (Unix cp semantics), not overwriting the directory path.
+            Some(source_is_dir) => {
+                let force_directory =
+                    source_is_dir || dest_path.ends_with('/') || dest_root.is_dir();
+                let tar_stream: BoxTarStream = Box::pin(async_stream::stream! {
+                    if !first_data.is_empty() {
+                        yield Ok(first_data);
+                    }
+                    loop {
+                        match stream.message().await {
+                            Ok(Some(chunk)) => {
+                                if !chunk.data.is_empty() {
+                                    yield Ok(chunk.data);
+                                }
+                            }
+                            Ok(None) => break,
+                            Err(e) => {
+                                yield Err(std::io::Error::other(e));
+                                break;
+                            }
+                        }
+                    }
+                });
 
-        // write first data chunk if present
-        let mut total: u64 = 0;
-        if !first.data.is_empty() {
-            total += first.data.len() as u64;
-            if total > MAX_UPLOAD_BYTES {
-                return Err(Status::resource_exhausted("upload too large"));
+                // The two pre-extraction facts the streamed path can still
+                // sample — whether the destination existed, and which
+                // ancestors mkdir_parents still has to conjure. Both must be
+                // captured BEFORE extraction: afterwards the ancestors exist
+                // and are indistinguishable from ones the image shipped.
+                let dest_existed = dest_root.exists();
+                let created_dirs = missing_ancestors(&dest_root);
+                let report = boxlite_shared::tar::unpack_stream(
+                    tar_stream,
+                    dest_root.clone(),
+                    boxlite_shared::tar::UnpackContext {
+                        overwrite,
+                        mkdir_parents,
+                        force_directory,
+                    },
+                )
+                .await
+                .map_err(|e| Status::internal(e.to_string()))?;
+                let boxlite_shared::tar::UnpackReport {
+                    entry_paths,
+                    preexisting_dirs,
+                } = report;
+                let existing_dirs = preexisting_dirs
+                    .into_iter()
+                    .map(|rel| dest_root.join(rel))
+                    .collect();
+                let entry_paths: Arc<[PathBuf]> = entry_paths.into();
+
+                // The stream cannot be pre-scanned without spooling, so the
+                // mount-shadow refusal runs after extraction: weaker than the
+                // hintless arm's refuse-before (a refused copy may have
+                // partially landed), but the failure surfaces instead of a
+                // silent write beneath the mount.
+                dest.refuse_shadowed_payload(&entry_paths)?;
+
+                // Hand the recorded paths to the box user, plus the
+                // ancestors captured above — the recording names what the
+                // archive made, the pre-sampled ancestors name what
+                // mkdir_parents made.
+                self.chown_to_container_user(
+                    &container_id,
+                    dest_root.clone(),
+                    Arc::clone(&entry_paths),
+                    DestBefore::recorded(created_dirs, dest_existed, existing_dirs),
+                )
+                .await;
             }
-            file.write_all(&first.data)
-                .await
-                .map_err(|e| Status::internal(format!("failed to write temp file: {}", e)))?;
-        }
+            // Legacy fallback for older hosts/runners that omit the hint:
+            // buffer to a size-capped temp file and detect the shape by peeking.
+            None => {
+                // Temp file to hold the tar stream. `StagedTar` owns the
+                // deletion, because every step from here to the end can leave
+                // through a `?`. Created only here — the hinted arm streams
+                // straight into extraction and never stages.
+                let staged = StagedTar::new(
+                    std::env::temp_dir()
+                        .join(format!("boxlite-upload-{}.tar", uuid::Uuid::new_v4())),
+                );
+                let mut file = File::create(staged.path())
+                    .await
+                    .map_err(|e| Status::internal(format!("failed to create temp file: {}", e)))?;
 
-        // stream remaining chunks
-        while let Some(chunk) = stream.message().await? {
-            let len = chunk.data.len() as u64;
-            total += len;
-            if total > MAX_UPLOAD_BYTES {
-                return Err(Status::resource_exhausted("upload too large"));
+                let mut total: u64 = 0;
+                if !first_data.is_empty() {
+                    total += first_data.len() as u64;
+                    if total > MAX_UPLOAD_BYTES {
+                        return Err(Status::resource_exhausted("upload too large"));
+                    }
+                    file.write_all(&first_data).await.map_err(|e| {
+                        Status::internal(format!("failed to write temp file: {}", e))
+                    })?;
+                }
+
+                while let Some(chunk) = stream.message().await? {
+                    let len = chunk.data.len() as u64;
+                    total += len;
+                    if total > MAX_UPLOAD_BYTES {
+                        return Err(Status::resource_exhausted("upload too large"));
+                    }
+                    file.write_all(&chunk.data).await.map_err(|e| {
+                        Status::internal(format!("failed to write temp file: {}", e))
+                    })?;
+                }
+
+                file.flush()
+                    .await
+                    .map_err(|e| Status::internal(format!("failed to flush temp file: {}", e)))?;
+
+                // Names the archive carries, read once: the mount check below
+                // and the ownership hand-off afterwards must agree on what
+                // this copy wrote. Shared rather than cloned — an archive may
+                // carry a great many names.
+                let entry_paths: Arc<[PathBuf]> =
+                    boxlite_shared::tar::entry_paths(staged.path().to_path_buf())
+                        .await
+                        .map_err(|e| Status::internal(e.to_string()))?
+                        .into();
+
+                // The root cleared the mount check, but individual entries may
+                // still land under one. Refuse before touching the rootfs — a
+                // partially applied copy is worse than a refused one.
+                dest.refuse_shadowed_payload(&entry_paths)?;
+
+                // What is not there yet — unpack is about to create it, and it
+                // needs the same owner as the payload. Must be sampled *before*
+                // extraction, since afterwards there is no way to tell what we
+                // made from what the image already shipped.
+                let before =
+                    DestBefore::sample(dest_root.clone(), Arc::clone(&entry_paths)).await?;
+
+                // dest_path may have a trailing '/' indicating directory mode.
+                let force_directory = dest_path.ends_with('/');
+                boxlite_shared::tar::unpack(
+                    staged.path().to_path_buf(),
+                    dest_root.clone(),
+                    boxlite_shared::tar::UnpackContext {
+                        overwrite,
+                        mkdir_parents,
+                        force_directory,
+                    },
+                )
+                .await
+                .map_err(|e| Status::internal(e.to_string()))?;
+
+                // Hand the payload to the user the box actually runs as. tar
+                // preserves neither owner (it extracts as this process, root)
+                // nor any notion of who will read the file, so without this
+                // every copy_in lands root-owned and a non-root workload
+                // cannot open it.
+                self.chown_to_container_user(&container_id, dest_root.clone(), entry_paths, before)
+                    .await;
             }
-            file.write_all(&chunk.data)
-                .await
-                .map_err(|e| Status::internal(format!("failed to write temp file: {}", e)))?;
         }
-
-        file.flush()
-            .await
-            .map_err(|e| Status::internal(format!("failed to flush temp file: {}", e)))?;
-
-        // Names the archive carries, read once: the mount check below and the
-        // ownership hand-off afterwards must agree on what this copy wrote.
-        // Shared rather than cloned — an archive may carry a great many names.
-        let entry_paths: Arc<[PathBuf]> =
-            boxlite_shared::tar::entry_paths(staged.path().to_path_buf())
-                .await
-                .map_err(|e| Status::internal(e.to_string()))?
-                .into();
-
-        // The root cleared the mount check, but individual entries may still
-        // land under one. Refuse before touching the rootfs — a partially
-        // applied copy is worse than a refused one.
-        dest.refuse_shadowed_payload(&entry_paths)?;
-
-        // What is not there yet — unpack is about to create it, and it needs
-        // the same owner as the payload. Must be sampled *before* extraction,
-        // since afterwards there is no way to tell what we made from what the
-        // image already shipped.
-        let before = DestBefore::sample(dest_root.clone(), Arc::clone(&entry_paths)).await?;
-
-        // Extract tar using shared logic
-        // The original dest_path may have trailing '/' indicating directory mode,
-        // but the resolved rootfs path won't. Use force_directory in that case.
-        let force_directory = dest_path.ends_with('/');
-        boxlite_shared::tar::unpack(
-            staged.path().to_path_buf(),
-            dest_root.clone(),
-            boxlite_shared::tar::UnpackContext {
-                overwrite,
-                mkdir_parents,
-                force_directory,
-            },
-        )
-        .await
-        .map_err(|e| Status::internal(e.to_string()))?;
-
-        // Hand the payload to the user the box actually runs as. tar preserves
-        // neither owner (it extracts as this process, root) nor any notion of
-        // who will read the file, so without this every copy_in lands
-        // root-owned and a non-root workload cannot open it.
-        self.chown_to_container_user(&container_id, dest_root.clone(), entry_paths, before)
-            .await;
 
         info!(
             dest = %dest_root.display(),
-            bytes = total,
             container_id = %container_id,
             "upload completed"
         );
@@ -577,19 +676,13 @@ impl Files for GuestServer {
             src.refuse_shadowed_subtree()?;
         }
 
-        // Build tar into temp file. `StagedTar` owns the deletion: a failed
-        // pack leaves through a `?` and the streaming task below moves it in so
-        // the file outlives this call exactly as long as it is being read.
-        let staged = StagedTar::new(
-            std::env::temp_dir().join(format!("boxlite-download-{}.tar", uuid::Uuid::new_v4())),
-        );
-
         let include_parent = req.include_parent;
         let follow_symlinks = req.follow_symlinks;
 
-        boxlite_shared::tar::pack(
+        // Stream the tar directly from disk (no temp file); the first chunk
+        // carries the source_is_dir shape hint.
+        let (source_is_dir, tar_stream) = boxlite_shared::tar::pack_stream(
             src_path,
-            staged.path().to_path_buf(),
             boxlite_shared::tar::PackContext {
                 follow_symlinks,
                 include_parent,
@@ -598,43 +691,24 @@ impl Files for GuestServer {
         .await
         .map_err(|e| Status::internal(e.to_string()))?;
 
-        // Stream file contents
         let (tx, rx) = mpsc::channel::<Result<DownloadChunk, Status>>(4);
         tokio::spawn(async move {
-            let mut file = match File::open(staged.path()).await {
-                Ok(f) => f,
-                Err(e) => {
-                    let _ = tx
-                        .send(Err(Status::internal(format!(
-                            "open temp tar failed: {}",
-                            e
-                        ))))
-                        .await;
-                    return;
-                }
-            };
-            let mut buf = vec![0u8; CHUNK_SIZE];
-            loop {
-                match file.read(&mut buf).await {
-                    Ok(0) => break,
-                    Ok(n) => {
-                        if tx
-                            .send(Ok(DownloadChunk {
-                                data: buf[..n].to_vec(),
-                            }))
-                            .await
-                            .is_err()
-                        {
+            let mut first = true;
+            let mut stream = tar_stream;
+            while let Some(item) = stream.next().await {
+                match item {
+                    Ok(data) => {
+                        let chunk = DownloadChunk {
+                            data,
+                            source_is_dir: if first { Some(source_is_dir) } else { None },
+                        };
+                        first = false;
+                        if tx.send(Ok(chunk)).await.is_err() {
                             break;
                         }
                     }
                     Err(e) => {
-                        let _ = tx
-                            .send(Err(Status::internal(format!(
-                                "read temp tar failed: {}",
-                                e
-                            ))))
-                            .await;
+                        let _ = tx.send(Err(Status::internal(e.to_string()))).await;
                         break;
                     }
                 }
@@ -1059,4 +1133,33 @@ mod tests {
         assert_eq!(to_container_path("tmp/x").unwrap(), PathBuf::from("/tmp/x"));
         assert!(to_container_path("/a/../b").is_err());
     }
+}
+
+/// The spool tar must be removed on drop — covering every error path of
+/// the hintless upload arm, not just the success path. The guest agent's
+/// /tmp is not visible to container processes, so this is asserted here
+/// rather than from the copy integration tests.
+#[test]
+fn staged_tar_removes_file_on_drop() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path: std::path::PathBuf = dir.path().join("spool.tar");
+    std::fs::write(&path, b"partial tar").unwrap();
+
+    {
+        let _guard = StagedTar::new(path.clone());
+        assert!(path.exists(), "guard must not remove the file while alive");
+    }
+
+    assert!(!path.exists(), "guard must remove the file on drop");
+}
+
+/// Dropping a guard whose file was already removed (or never created) is
+/// harmless — the error-path cleanup must not panic.
+#[test]
+fn staged_tar_tolerates_missing_file() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path: std::path::PathBuf = dir.path().join("never-created.tar");
+
+    let _guard = StagedTar::new(path);
+    // Dropping happens at end of scope; no panic is the assertion.
 }

--- a/src/shared/Cargo.toml
+++ b/src/shared/Cargo.toml
@@ -13,7 +13,9 @@ serde_json = "1.0"
 thiserror = "2.0"
 prost = "0.13"
 tonic = "0.12"
-tokio = { version = "1", features = ["io-util", "rt"] }
+tokio = { version = "1", features = ["io-util", "rt", "sync"] }
+tokio-stream = "0.1"
+futures = "0.3"
 tar = "0.4"
 
 [build-dependencies]

--- a/src/shared/proto/boxlite/v1/service.proto
+++ b/src/shared/proto/boxlite/v1/service.proto
@@ -577,6 +577,10 @@ message UploadChunk {
   bool mkdir_parents = 4;
   // If true, overwrite existing files (default: true)
   bool overwrite = 5;
+  // Whether the source is a directory (true) or a single file (false).
+  // Set only on the first chunk; unset = unknown (older peer), which makes the
+  // receiver fall back to legacy shape detection.
+  optional bool source_is_dir = 6;
 }
 
 message UploadResponse {
@@ -602,4 +606,8 @@ message DownloadRequest {
 message DownloadChunk {
   // Raw tar archive bytes
   bytes data = 1;
+  // Whether the source is a directory (true) or a single file (false).
+  // Set only on the first chunk; unset = unknown (older peer), which makes the
+  // receiver fall back to legacy shape detection.
+  optional bool source_is_dir = 2;
 }

--- a/src/shared/src/constants.rs
+++ b/src/shared/src/constants.rs
@@ -54,3 +54,21 @@ pub mod mount_tags {
     /// Tag for shared container directory (contains overlayfs/ and rootfs/)
     pub const SHARED: &str = "BoxLiteShared";
 }
+
+/// File-transfer constants shared between host, guest, and runner.
+pub mod files {
+    /// Upper bound for the size-capped *fallback* path used when a peer is too
+    /// old to stream end-to-end. Transfers that must be buffered to disk/memory
+    /// (because the peer omits the `source_is_dir` shape hint) are rejected past
+    /// this size instead of buffering unboundedly. Matches the guest's legacy
+    /// `MAX_UPLOAD_BYTES`.
+    pub const FALLBACK_CAP_BYTES: u64 = 512 * 1024 * 1024;
+
+    /// In-flight chunk count for the bounded channel that bridges blocking tar
+    /// I/O with the async stream (backpressure window ≈ `PIPE_CHUNK_SIZE` ×
+    /// this).
+    pub const PIPE_CHUNKS: usize = 4;
+
+    /// Chunk size emitted by the stream pack side (1 MiB).
+    pub const PIPE_CHUNK_SIZE: usize = 1 << 20;
+}

--- a/src/shared/src/constants.rs
+++ b/src/shared/src/constants.rs
@@ -64,11 +64,11 @@ pub mod files {
     /// `MAX_UPLOAD_BYTES`.
     pub const FALLBACK_CAP_BYTES: u64 = 512 * 1024 * 1024;
 
-    /// In-flight chunk count for the bounded channel that bridges blocking tar
-    /// I/O with the async stream (backpressure window ≈ `PIPE_CHUNK_SIZE` ×
-    /// this).
-    pub const PIPE_CHUNKS: usize = 4;
+    /// In-flight chunk count for the bounded channel that bridges blocking
+    /// archive I/O with the async stream (backpressure window ≈
+    /// `COPY_CHUNK_SIZE` × this).
+    pub const COPY_CHUNKS_IN_FLIGHT: usize = 4;
 
     /// Chunk size emitted by the stream pack side (1 MiB).
-    pub const PIPE_CHUNK_SIZE: usize = 1 << 20;
+    pub const COPY_CHUNK_SIZE: usize = 1 << 20;
 }

--- a/src/shared/src/lib.rs
+++ b/src/shared/src/lib.rs
@@ -33,6 +33,7 @@ pub mod generated {
 }
 
 pub use errors::{BoxliteError, BoxliteResult};
+pub use tar::BoxTarStream;
 pub use transport::BoxTransport;
 
 // Container service

--- a/src/shared/src/lib.rs
+++ b/src/shared/src/lib.rs
@@ -20,6 +20,13 @@
 /// declines it.
 pub const GIT_COMMIT: Option<&str> = option_env!("BOXLITE_GIT_COMMIT");
 
+/// A stream of byte chunks carrying a terminal `Err` item on producer failure.
+///
+/// The transfer wire format (today: tar) is deliberately absent from the name —
+/// callers move opaque bytes and never inspect them.
+pub type BoxByteStream =
+    std::pin::Pin<Box<dyn futures::Stream<Item = std::io::Result<Vec<u8>>> + Send + 'static>>;
+
 pub mod constants;
 pub mod errors;
 pub mod layout;
@@ -33,7 +40,6 @@ pub mod generated {
 }
 
 pub use errors::{BoxliteError, BoxliteResult};
-pub use tar::BoxTarStream;
 pub use transport::BoxTransport;
 
 // Container service

--- a/src/shared/src/tar.rs
+++ b/src/shared/src/tar.rs
@@ -3,9 +3,18 @@
 //! Both host (boxlite) and guest agent share this module to avoid
 //! duplicating tar building/extraction logic.
 
+use crate::constants::files::{PIPE_CHUNKS, PIPE_CHUNK_SIZE};
 use crate::{BoxliteError, BoxliteResult};
+use futures::{Stream, StreamExt};
 use std::collections::HashSet;
+use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+
+/// A stream of raw tar bytes carrying a terminal `Err` item on pack failure.
+pub type BoxTarStream = Pin<Box<dyn Stream<Item = io::Result<Vec<u8>>> + Send + 'static>>;
 
 // ── Pack ──────────────────────────────────────────────────────────
 
@@ -22,20 +31,23 @@ pub struct PackContext {
 ///
 /// Runs blocking I/O on a dedicated thread via `spawn_blocking`.
 pub async fn pack(src: PathBuf, tar_path: PathBuf, opts: PackContext) -> BoxliteResult<()> {
-    tokio::task::spawn_blocking(move || pack_blocking(&src, &tar_path, &opts))
-        .await
-        .map_err(|e| BoxliteError::Storage(format!("pack task join error: {}", e)))?
+    tokio::task::spawn_blocking(move || {
+        let tar_file = std::fs::File::create(&tar_path).map_err(|e| {
+            BoxliteError::Storage(format!(
+                "failed to create tar {}: {}",
+                tar_path.display(),
+                e
+            ))
+        })?;
+        pack_blocking(&src, tar_file, &opts)
+    })
+    .await
+    .map_err(|e| BoxliteError::Storage(format!("pack task join error: {}", e)))?
 }
 
-fn pack_blocking(src: &Path, tar_path: &Path, opts: &PackContext) -> BoxliteResult<()> {
-    let tar_file = std::fs::File::create(tar_path).map_err(|e| {
-        BoxliteError::Storage(format!(
-            "failed to create tar {}: {}",
-            tar_path.display(),
-            e
-        ))
-    })?;
-    let mut builder = tar::Builder::new(tar_file);
+/// Pack `src` into `writer` (generic over `std::io::Write`).
+fn pack_blocking<W: Write>(src: &Path, writer: W, opts: &PackContext) -> BoxliteResult<()> {
+    let mut builder = tar::Builder::new(writer);
     builder.follow_symlinks(opts.follow_symlinks);
 
     if src.is_dir() {
@@ -80,7 +92,115 @@ fn pack_blocking(src: &Path, tar_path: &Path, opts: &PackContext) -> BoxliteResu
 
     builder
         .finish()
-        .map_err(|e| BoxliteError::Storage(format!("failed to finish tar: {}", e)))
+        .map_err(|e| BoxliteError::Storage(format!("failed to finish tar: {}", e)))?;
+
+    // `finish` writes the trailer but not the writer's own pending buffer
+    // (PipeWriter coalesces the final sub-chunk-size bytes). Flush it here
+    // so a dropped consumer surfaces as an error instead of silently
+    // truncating the stream.
+    let mut inner = builder
+        .into_inner()
+        .map_err(|e| BoxliteError::Storage(format!("failed to finish tar: {}", e)))?;
+    inner
+        .flush()
+        .map_err(|e| BoxliteError::Storage(format!("failed to flush tar stream: {}", e)))
+}
+
+// ── Stream pack ──────────────────────────────────────────────────
+
+/// Blocking `Write` adapter feeding a bounded channel. Coalesces small writes
+/// into full `PIPE_CHUNK_SIZE` messages; `blocking_send` provides backpressure
+/// (a slow consumer throttles the pack thread) and surfaces `BrokenPipe` when
+/// the consumer drops the stream.
+struct PipeWriter {
+    tx: mpsc::Sender<io::Result<Vec<u8>>>,
+    pending: Vec<u8>,
+}
+
+impl PipeWriter {
+    fn send_chunk(&self, chunk: Vec<u8>) -> io::Result<()> {
+        self.tx
+            .blocking_send(Ok(chunk))
+            .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "tar stream consumer dropped"))
+    }
+
+    fn flush_pending(&mut self) -> io::Result<()> {
+        if self.pending.is_empty() {
+            return Ok(());
+        }
+        let chunk = std::mem::take(&mut self.pending);
+        self.send_chunk(chunk)
+    }
+}
+
+impl Write for PipeWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        let write_len = (PIPE_CHUNK_SIZE - self.pending.len()).min(buf.len());
+        self.pending.extend_from_slice(&buf[..write_len]);
+        if self.pending.len() == PIPE_CHUNK_SIZE {
+            let chunk = std::mem::take(&mut self.pending);
+            self.send_chunk(chunk)?;
+            self.pending = Vec::with_capacity(PIPE_CHUNK_SIZE);
+        }
+        Ok(write_len)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.flush_pending()
+    }
+}
+
+impl Drop for PipeWriter {
+    fn drop(&mut self) {
+        let _ = self.flush_pending();
+    }
+}
+
+/// Stream `src` into a tar byte stream.
+///
+/// Returns the source shape (`source_is_dir = src.is_dir()`) alongside the
+/// stream. The pack runs on a `spawn_blocking` thread; a pack failure surfaces
+/// as a terminal `Err` item on the stream.
+pub async fn pack_stream(src: PathBuf, opts: PackContext) -> BoxliteResult<(bool, BoxTarStream)> {
+    let source_is_dir = src.is_dir();
+    if !src.exists() {
+        return Err(BoxliteError::NotFound(format!(
+            "source path {} does not exist",
+            src.display()
+        )));
+    }
+    let (tx, rx) = mpsc::channel::<io::Result<Vec<u8>>>(PIPE_CHUNKS);
+    let writer = PipeWriter {
+        tx: tx.clone(),
+        pending: Vec::with_capacity(PIPE_CHUNK_SIZE),
+    };
+    let task_tx = tx;
+    tokio::task::spawn_blocking(move || {
+        let outcome = pack_task_body(&src, writer, &opts);
+        // Report a failure as a terminal stream error through the original
+        // sender, then drop it to signal EOF.
+        if let Err(e) = outcome {
+            let _ = task_tx.blocking_send(Err(io::Error::other(e)));
+        }
+    });
+    Ok((source_is_dir, Box::pin(ReceiverStream::new(rx))))
+}
+
+/// Body of the pack task: runs [`pack_blocking`] under `catch_unwind` so a
+/// panicking pack surfaces as an error (per the stream contract) instead of
+/// ending the stream on a clean EOF that consumers would read as a truncated
+/// archive.
+fn pack_task_body<W: Write>(src: &Path, writer: W, opts: &PackContext) -> BoxliteResult<()> {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        pack_blocking(src, writer, opts)
+    })) {
+        Ok(outcome) => outcome,
+        Err(_) => Err(BoxliteError::Internal("tar pack task panicked".into())),
+    }
 }
 
 // ── Unpack ────────────────────────────────────────────────────────
@@ -113,6 +233,18 @@ pub struct UnpackContext {
     pub force_directory: bool,
 }
 
+/// Paths observed while unpacking a one-shot tar stream.
+#[derive(Debug, Default)]
+pub struct UnpackReport {
+    /// Extracted paths relative to the destination, including implied directories.
+    pub entry_paths: Vec<PathBuf>,
+    /// Entry directories that existed before streamed extraction reached them.
+    ///
+    /// These paths are relative to the destination and are only collected when
+    /// extracting into a directory.
+    pub preexisting_dirs: Vec<PathBuf>,
+}
+
 /// Unpack a tar archive to `dest`.
 ///
 /// Automatically detects whether to extract as a single file (FileToFile)
@@ -132,7 +264,26 @@ fn unpack_blocking(tar_path: &Path, dest: &Path, opts: &UnpackContext) -> Boxlit
     } else {
         detect_extraction_mode(dest, tar_path)?
     };
+    let tar_file = std::fs::File::open(tar_path).map_err(|e| {
+        BoxliteError::Storage(format!("failed to open tar {}: {}", tar_path.display(), e))
+    })?;
+    extract_from_reader(tar_file, dest, opts, mode, None)
+}
 
+/// Extract a tar archive read from `reader` to `dest` using the given `mode`.
+fn extract_from_reader<R: Read>(
+    reader: R,
+    dest: &Path,
+    opts: &UnpackContext,
+    mode: ExtractionMode,
+    mut report: Option<&mut UnpackReport>,
+) -> BoxliteResult<()> {
+    let mut seen = HashSet::new();
+    let mut record = |path: &Path, existing_root: Option<&Path>| {
+        if let Some(report) = report.as_deref_mut() {
+            record_paths(report, &mut seen, existing_root, path);
+        }
+    };
     match mode {
         ExtractionMode::FileToFile => {
             if let Some(parent) = dest.parent() {
@@ -157,10 +308,7 @@ fn unpack_blocking(tar_path: &Path, dest: &Path, opts: &UnpackContext) -> Boxlit
                     dest.display()
                 )));
             }
-            let tar_file = std::fs::File::open(tar_path).map_err(|e| {
-                BoxliteError::Storage(format!("failed to open tar {}: {}", tar_path.display(), e))
-            })?;
-            let mut archive = tar::Archive::new(tar_file);
+            let mut archive = tar::Archive::new(reader);
             let mut entries = archive
                 .entries()
                 .map_err(|e| BoxliteError::Storage(format!("failed to read tar entries: {}", e)))?;
@@ -168,6 +316,9 @@ fn unpack_blocking(tar_path: &Path, dest: &Path, opts: &UnpackContext) -> Boxlit
                 let mut entry = entry.map_err(|e| {
                     BoxliteError::Storage(format!("failed to read tar entry: {}", e))
                 })?;
+                if let Ok(path) = entry.path() {
+                    record(path.as_ref(), None);
+                }
                 entry.unpack(dest).map_err(|e| {
                     BoxliteError::Storage(format!(
                         "failed to unpack file to {}: {}",
@@ -201,13 +352,69 @@ fn unpack_blocking(tar_path: &Path, dest: &Path, opts: &UnpackContext) -> Boxlit
                     dest.display()
                 )));
             }
-            let tar_file = std::fs::File::open(tar_path).map_err(|e| {
-                BoxliteError::Storage(format!("failed to open tar {}: {}", tar_path.display(), e))
-            })?;
-            let mut archive = tar::Archive::new(tar_file);
-            archive.unpack(dest).map_err(|e| {
-                BoxliteError::Storage(format!("failed to extract archive: {}", with_causes(&e)))
-            })
+            let mut archive = tar::Archive::new(reader);
+            // The same pass tar::Archive::unpack would run, with one
+            // addition: every extracted name is recorded (sanitized, with
+            // implied directories) so callers can hand the created paths to
+            // the box user and refuse entries the mounts shadow — without
+            // consuming the one-shot stream twice. Directory entries are
+            // delayed and sorted the way tar-rs does it (permissions).
+            let mut directories = Vec::new();
+            for entry in archive
+                .entries()
+                .map_err(|e| BoxliteError::Storage(format!("failed to read tar entries: {}", e)))?
+            {
+                let mut file = entry.map_err(|e| {
+                    BoxliteError::Storage(format!("failed to read tar entry: {}", e))
+                })?;
+                if let Ok(path) = file.path() {
+                    record(path.as_ref(), Some(dest));
+                }
+                if file.header().entry_type() == tar::EntryType::Directory {
+                    directories.push(file);
+                } else {
+                    file.unpack_in(dest).map_err(|e| {
+                        BoxliteError::Storage(format!(
+                            "failed to extract archive: {}",
+                            with_causes(&e)
+                        ))
+                    })?;
+                }
+            }
+            directories.sort_by(|a, b| b.path_bytes().cmp(&a.path_bytes()));
+            for mut dir in directories {
+                dir.unpack_in(dest).map_err(|e| {
+                    BoxliteError::Storage(format!("failed to extract archive: {}", with_causes(&e)))
+                })?;
+            }
+            Ok(())
+        }
+    }
+}
+
+/// Record `path` — sanitized, plus every directory its name implies,
+/// outermost first — in `report`, deduplicated through `seen`. Mirrors
+/// [`entry_paths_blocking`] so the streamed extraction reports exactly the
+/// same path shape the staged path's pre-scan does. When `existing_root` is
+/// present, directories that predate their first archive occurrence are also
+/// recorded before extraction can create or replace them.
+fn record_paths(
+    report: &mut UnpackReport,
+    seen: &mut HashSet<PathBuf>,
+    existing_root: Option<&Path>,
+    path: &Path,
+) {
+    let Some(sanitized) = sanitize_entry_path(path) else {
+        return;
+    };
+    for step in implied_dirs_then_self(&sanitized) {
+        if seen.insert(step.clone()) {
+            if let Some(root) = existing_root {
+                if root.join(&step).is_dir() {
+                    report.preexisting_dirs.push(step.clone());
+                }
+            }
+            report.entry_paths.push(step);
         }
     }
 }
@@ -306,6 +513,90 @@ fn sanitize_entry_path(path: &Path) -> Option<PathBuf> {
         }
     }
     (!out.as_os_str().is_empty()).then_some(out)
+}
+
+// ── Stream unpack ────────────────────────────────────────────────
+
+/// Blocking `Read` adapter draining a bounded channel, used to feed a
+/// `tar::Archive` from an async byte stream.
+struct PipeReader {
+    rx: mpsc::Receiver<io::Result<Vec<u8>>>,
+    pending: Option<(Vec<u8>, usize)>,
+}
+
+impl Read for PipeReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        loop {
+            if let Some((data, pos)) = &mut self.pending {
+                let remaining = &data[*pos..];
+                let n = remaining.len().min(buf.len());
+                buf[..n].copy_from_slice(&remaining[..n]);
+                *pos += n;
+                if *pos == data.len() {
+                    self.pending = None;
+                }
+                return Ok(n);
+            }
+            match self.rx.blocking_recv() {
+                Some(Ok(data)) => {
+                    if data.is_empty() {
+                        continue;
+                    }
+                    self.pending = Some((data, 0));
+                }
+                Some(Err(e)) => return Err(e),
+                None => return Ok(0),
+            }
+        }
+    }
+}
+
+/// Unpack a tar byte stream to `dest`.
+///
+/// Unlike the file-based [`unpack`], there is no archive peek — the extraction
+/// shape is taken authoritatively from `opts.force_directory` (`true` →
+/// directory, `false` → single file). Callers must resolve that from the peer's
+/// `source_is_dir` hint; a missing hint must fall back to the file-based
+/// [`unpack`] path, never call here with a guessed bool.
+///
+/// Returns the extracted paths relative to `dest` (sanitized, implied
+/// directories included) and which of those directories already existed, so
+/// the caller can hand only newly created paths to the box user and refuse
+/// entries the mounts shadow.
+pub async fn unpack_stream(
+    mut stream: BoxTarStream,
+    dest: PathBuf,
+    opts: UnpackContext,
+) -> BoxliteResult<UnpackReport> {
+    let (tx, rx) = mpsc::channel::<io::Result<Vec<u8>>>(PIPE_CHUNKS);
+    let forward = tokio::spawn(async move {
+        while let Some(item) = stream.next().await {
+            if tx.send(item).await.is_err() {
+                break;
+            }
+        }
+    });
+    let mut reader = PipeReader { rx, pending: None };
+    let unpack = tokio::task::spawn_blocking(move || {
+        let mode = if opts.force_directory {
+            ExtractionMode::IntoDirectory
+        } else {
+            ExtractionMode::FileToFile
+        };
+        let mut report = UnpackReport::default();
+        extract_from_reader(&mut reader, &dest, &opts, mode, Some(&mut report))?;
+        // Extraction can finish before the byte stream ends: FileToFile stops
+        // after one entry, and tar-rs stops at the archive end marker. Drain
+        // the raw stream so a terminal producer error cannot become success.
+        io::copy(&mut reader, &mut io::sink())
+            .map_err(|e| BoxliteError::Storage(format!("failed to drain tar stream: {}", e)))?;
+        Ok(report)
+    });
+    let result = unpack.await;
+    // Abort the forwarder before mapping the join result, so a panicked
+    // unpack task can't leak a forwarder that keeps draining the stream.
+    forward.abort();
+    result.map_err(|e| BoxliteError::Storage(format!("unpack task join error: {}", e)))?
 }
 
 // ── Private ───────────────────────────────────────────────────────
@@ -1293,5 +1584,181 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(std::fs::read_to_string(&dest).unwrap(), "spaces\n");
+    }
+
+    // ── streaming pack/unpack round-trips ────────────────────────
+
+    // ── streaming failure-path machinery ──────────────────────────────
+
+    /// A writer that panics on its first write. Subsequent writes succeed so
+    /// the drop-time `Builder::finish` (tar::Builder::Drop calls finish, which
+    /// writes the trailer) cannot double-panic during the unwind.
+    struct PanicWriter(bool);
+    impl Write for PanicWriter {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            if self.0 {
+                self.0 = false;
+                panic!("injected pack panic")
+            }
+            Ok(0)
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn pack_task_body_surfaces_panic_as_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("p.txt");
+        std::fs::write(&src, b"x").unwrap();
+
+        let result = pack_task_body(
+            &src,
+            PanicWriter(true),
+            &PackContext {
+                follow_symlinks: true,
+                include_parent: false,
+            },
+        );
+        assert!(
+            matches!(result, Err(BoxliteError::Internal(_))),
+            "a panicking pack must surface as Internal, got {result:?}"
+        );
+    }
+
+    /// PipeWriter must deliver sub-chunk pending bytes on flush — the final
+    /// partial chunk of a small archive rides on this, not on Drop. Plain
+    /// (non-runtime) thread: `blocking_send` panics inside a tokio runtime.
+    #[test]
+    fn pipe_writer_flush_delivers_pending_bytes() {
+        let (tx, mut rx) = mpsc::channel(4);
+        let mut writer = PipeWriter {
+            tx,
+            pending: Vec::with_capacity(PIPE_CHUNK_SIZE),
+        };
+        writer.write_all(b"tail bytes").unwrap();
+        writer.flush().unwrap();
+        drop(writer);
+
+        let chunk = rx
+            .blocking_recv()
+            .expect("flush must deliver the chunk")
+            .unwrap();
+        assert_eq!(chunk, b"tail bytes");
+        assert!(
+            rx.blocking_recv().is_none(),
+            "dropped sender must signal EOF"
+        );
+    }
+
+    /// A consumer that dropped the stream must surface as BrokenPipe from
+    /// flush — the pack task then reports a terminal Err instead of silently
+    /// truncating. Small writes stay buffered, so the failure only shows at
+    /// flush time (which is exactly what pack_blocking's explicit flush
+    /// after finish exists to observe).
+    #[test]
+    fn pipe_writer_reports_broken_pipe_on_dropped_consumer() {
+        let (tx, rx) = mpsc::channel(4);
+        drop(rx); // consumer gone before any send
+        let mut writer = PipeWriter {
+            tx,
+            pending: Vec::with_capacity(PIPE_CHUNK_SIZE),
+        };
+        writer.write_all(b"lost bytes").unwrap(); // buffered, no send yet
+        let err = writer.flush().unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
+    }
+
+    #[tokio::test]
+    async fn stream_pack_reports_source_is_dir() {
+        let tmp = TempDir::new().unwrap();
+
+        let file = tmp.path().join("f.txt");
+        std::fs::write(&file, b"x").unwrap();
+        let (is_dir, _stream) = pack_stream(file, default_pack()).await.unwrap();
+        assert!(!is_dir);
+
+        let dir = tmp.path().join("d");
+        std::fs::create_dir(&dir).unwrap();
+        std::fs::write(dir.join("f.txt"), b"x").unwrap();
+        let (is_dir, _stream) = pack_stream(dir, default_pack()).await.unwrap();
+        assert!(is_dir);
+    }
+
+    #[tokio::test]
+    async fn stream_pack_nonexistent_source_errors() {
+        let tmp = TempDir::new().unwrap();
+        let result = pack_stream(tmp.path().join("does-not-exist"), default_pack()).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn stream_roundtrip_single_file() {
+        let tmp = TempDir::new().unwrap();
+        let src = tmp.path().join("hello.txt");
+        std::fs::write(&src, b"streaming hello").unwrap();
+
+        let (source_is_dir, stream) = pack_stream(
+            src,
+            PackContext {
+                follow_symlinks: true,
+                include_parent: false,
+            },
+        )
+        .await
+        .unwrap();
+        assert!(!source_is_dir);
+
+        let dest = tmp.path().join("dest.txt");
+        let report = unpack_stream(stream, dest.clone(), uc(true, true, false))
+            .await
+            .unwrap();
+        assert_eq!(std::fs::read_to_string(&dest).unwrap(), "streaming hello");
+        assert_eq!(
+            report.entry_paths,
+            vec![PathBuf::from("hello.txt")],
+            "streamed extraction must report the entry it created"
+        );
+    }
+
+    #[tokio::test]
+    async fn stream_roundtrip_dir_tree() {
+        let tmp = TempDir::new().unwrap();
+        let src_dir = tmp.path().join("s");
+        std::fs::create_dir_all(src_dir.join("sub")).unwrap();
+        std::fs::write(src_dir.join("a.txt"), "aaa").unwrap();
+        std::fs::write(src_dir.join("sub").join("b.txt"), "bbb").unwrap();
+
+        let (source_is_dir, stream) = pack_stream(
+            src_dir,
+            PackContext {
+                follow_symlinks: true,
+                include_parent: true,
+            },
+        )
+        .await
+        .unwrap();
+        assert!(source_is_dir);
+
+        let dest = tmp.path().join("out");
+        let report = unpack_stream(stream, dest.clone(), uc(true, true, true))
+            .await
+            .unwrap();
+        assert_eq!(
+            std::fs::read_to_string(dest.join("s").join("a.txt")).unwrap(),
+            "aaa"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dest.join("s").join("sub").join("b.txt")).unwrap(),
+            "bbb"
+        );
+        for expected in ["s", "s/a.txt", "s/sub", "s/sub/b.txt"] {
+            assert!(
+                report.entry_paths.contains(&PathBuf::from(expected)),
+                "created paths missing {expected}: {:?}",
+                report.entry_paths
+            );
+        }
     }
 }

--- a/src/shared/src/tar.rs
+++ b/src/shared/src/tar.rs
@@ -3,18 +3,14 @@
 //! Both host (boxlite) and guest agent share this module to avoid
 //! duplicating tar building/extraction logic.
 
-use crate::constants::files::{PIPE_CHUNKS, PIPE_CHUNK_SIZE};
-use crate::{BoxliteError, BoxliteResult};
-use futures::{Stream, StreamExt};
+use crate::constants::files::{COPY_CHUNKS_IN_FLIGHT, COPY_CHUNK_SIZE};
+use crate::{BoxByteStream, BoxliteError, BoxliteResult};
+use futures::StreamExt;
 use std::collections::HashSet;
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
-use std::pin::Pin;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
-
-/// A stream of raw tar bytes carrying a terminal `Err` item on pack failure.
-pub type BoxTarStream = Pin<Box<dyn Stream<Item = io::Result<Vec<u8>>> + Send + 'static>>;
 
 // ── Pack ──────────────────────────────────────────────────────────
 
@@ -109,7 +105,7 @@ fn pack_blocking<W: Write>(src: &Path, writer: W, opts: &PackContext) -> Boxlite
 // ── Stream pack ──────────────────────────────────────────────────
 
 /// Blocking `Write` adapter feeding a bounded channel. Coalesces small writes
-/// into full `PIPE_CHUNK_SIZE` messages; `blocking_send` provides backpressure
+/// into full `COPY_CHUNK_SIZE` messages; `blocking_send` provides backpressure
 /// (a slow consumer throttles the pack thread) and surfaces `BrokenPipe` when
 /// the consumer drops the stream.
 struct PipeWriter {
@@ -139,12 +135,12 @@ impl Write for PipeWriter {
             return Ok(0);
         }
 
-        let write_len = (PIPE_CHUNK_SIZE - self.pending.len()).min(buf.len());
+        let write_len = (COPY_CHUNK_SIZE - self.pending.len()).min(buf.len());
         self.pending.extend_from_slice(&buf[..write_len]);
-        if self.pending.len() == PIPE_CHUNK_SIZE {
+        if self.pending.len() == COPY_CHUNK_SIZE {
             let chunk = std::mem::take(&mut self.pending);
             self.send_chunk(chunk)?;
-            self.pending = Vec::with_capacity(PIPE_CHUNK_SIZE);
+            self.pending = Vec::with_capacity(COPY_CHUNK_SIZE);
         }
         Ok(write_len)
     }
@@ -165,7 +161,7 @@ impl Drop for PipeWriter {
 /// Returns the source shape (`source_is_dir = src.is_dir()`) alongside the
 /// stream. The pack runs on a `spawn_blocking` thread; a pack failure surfaces
 /// as a terminal `Err` item on the stream.
-pub async fn pack_stream(src: PathBuf, opts: PackContext) -> BoxliteResult<(bool, BoxTarStream)> {
+pub async fn pack_stream(src: PathBuf, opts: PackContext) -> BoxliteResult<(bool, BoxByteStream)> {
     let source_is_dir = src.is_dir();
     if !src.exists() {
         return Err(BoxliteError::NotFound(format!(
@@ -173,10 +169,10 @@ pub async fn pack_stream(src: PathBuf, opts: PackContext) -> BoxliteResult<(bool
             src.display()
         )));
     }
-    let (tx, rx) = mpsc::channel::<io::Result<Vec<u8>>>(PIPE_CHUNKS);
+    let (tx, rx) = mpsc::channel::<io::Result<Vec<u8>>>(COPY_CHUNKS_IN_FLIGHT);
     let writer = PipeWriter {
         tx: tx.clone(),
-        pending: Vec::with_capacity(PIPE_CHUNK_SIZE),
+        pending: Vec::with_capacity(COPY_CHUNK_SIZE),
     };
     let task_tx = tx;
     tokio::task::spawn_blocking(move || {
@@ -564,11 +560,11 @@ impl Read for PipeReader {
 /// the caller can hand only newly created paths to the box user and refuse
 /// entries the mounts shadow.
 pub async fn unpack_stream(
-    mut stream: BoxTarStream,
+    mut stream: BoxByteStream,
     dest: PathBuf,
     opts: UnpackContext,
 ) -> BoxliteResult<UnpackReport> {
-    let (tx, rx) = mpsc::channel::<io::Result<Vec<u8>>>(PIPE_CHUNKS);
+    let (tx, rx) = mpsc::channel::<io::Result<Vec<u8>>>(COPY_CHUNKS_IN_FLIGHT);
     let forward = tokio::spawn(async move {
         while let Some(item) = stream.next().await {
             if tx.send(item).await.is_err() {
@@ -1635,7 +1631,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(4);
         let mut writer = PipeWriter {
             tx,
-            pending: Vec::with_capacity(PIPE_CHUNK_SIZE),
+            pending: Vec::with_capacity(COPY_CHUNK_SIZE),
         };
         writer.write_all(b"tail bytes").unwrap();
         writer.flush().unwrap();
@@ -1663,7 +1659,7 @@ mod tests {
         drop(rx); // consumer gone before any send
         let mut writer = PipeWriter {
             tx,
-            pending: Vec::with_capacity(PIPE_CHUNK_SIZE),
+            pending: Vec::with_capacity(COPY_CHUNK_SIZE),
         };
         writer.write_all(b"lost bytes").unwrap(); // buffered, no send yet
         let err = writer.flush().unwrap_err();


### PR DESCRIPTION
## Summary

Stream file copies end to end across REST, the API proxy, runner, Go SDK,
C ABI, Rust core, gRPC, and guest instead of repeatedly staging complete tar
archives. Preserve older-peer compatibility while making archive shape,
backpressure, cancellation, and mid-stream failures explicit.

## Call graph

Before

```text
Copy in
  copy_into              (RestBox · src/boxlite/src/rest/litebox.rs:272) — builds a complete tar in memory
    └─ BoxliteFileUpload (Gin handler · apps/runner/pkg/api/controllers/boxlite_files.go:14) — unpacks into runner staging
       └─ CopyInto       (Go Box · sdks/go/copy.go:21) — submits a staged host path
          └─ boxlite_copy_into (C ABI · sdks/c/src/copy.rs:15) — crosses into Rust
             └─ upload_tar (FilesInterface · src/boxlite/src/portal/interfaces/files.rs:26) — buffers chunks before RPC
                └─ upload (GuestServer · src/guest/src/service/files.rs:431) — stages, scans, and unpacks a temp tar

Copy out
  copy_out               (RestBox · src/boxlite/src/rest/litebox.rs:322) — buffers the complete HTTP response
    └─ BoxliteFileDownload (Gin handler · apps/runner/pkg/api/controllers/boxlite_files.go:135) — stages and re-tars on runner
       └─ CopyOut        (Go Box · sdks/go/copy.go:56) — writes to a host path
          └─ boxlite_copy_out (C ABI · sdks/c/src/copy.rs:27) — crosses into Rust
             └─ download_tar (FilesInterface · src/boxlite/src/portal/interfaces/files.rs:90) — writes a temp tar
                └─ download (GuestServer · src/guest/src/service/files.rs:557) — packs fully before streaming
```

After

```text
Copy in
  copy_into              (RestBox · src/boxlite/src/rest/litebox.rs:279) — streams a bounded tar request
    └─ pack_stream       (shared tar · src/shared/src/tar.rs:164) — applies bounded producer backpressure
       └─ BoxliteFileUpload (Gin handler · apps/runner/pkg/api/controllers/boxlite_files.go:14) — relays body and source shape
          └─ CopyInStream (Go Box · sdks/go/copy.go:227) — pushes reader chunks with cancellation
             └─ boxlite_copy_in_start/write/close/abort (C ABI · sdks/c/src/copy.rs:411) — owns stream lifecycle
                └─ upload_stream     (FilesInterface · src/boxlite/src/portal/interfaces/files.rs:147) — preserves source errors over gRPC
                   └─ unpack_stream (shared tar · src/shared/src/tar.rs:562) — extracts directly in the guest

Copy out
  copy_out               (RestBox · src/boxlite/src/rest/litebox.rs:341) — consumes body stream and shape header
    └─ proxyToRunner     (BoxliteProxyController · apps/api/src/boxlite-rest/boxlite-proxy.controller.ts:237) — preserves source shape
       └─ BoxliteFileDownload (Gin handler · apps/runner/pkg/api/controllers/boxlite_files.go:40) — streams or aborts a truncated response
          └─ CopyOutStream (Go Box · sdks/go/copy.go:142) — pull loop applies writer backpressure
             └─ boxlite_copy_out_start/read (C ABI · sdks/c/src/copy.rs:289) — exposes pull-based reads
                └─ download_stream   (FilesInterface · src/boxlite/src/portal/interfaces/files.rs:226) — relays guest chunks
                   └─ pack_stream (shared tar · src/shared/src/tar.rs:164) — produces a bounded guest tar stream
```

## Changes

- Add bounded `pack_stream` and `unpack_stream` paths with explicit panic,
  flush, consumer-drop, and stream-error propagation.
- Carry optional `source_is_dir` metadata through HTTP and gRPC so new peers
  stream directly while old peers retain a capped compatibility path.
- Add push-based C/Go copy-in and pull-based copy-out APIs with cancellation,
  runtime-close, invalid-reader, short-write, and backpressure handling.
- Relay request and response bodies through the runner, preserve runtime error
  classes, and abort already-started responses when a tar stream truncates.
- Preserve directory placement, recursive copy, mount refusal, and non-root
  ownership semantics, with coverage across core, SDK, runner, and REST paths.

## How to verify

```bash
make fmt:check:rust
make fmt:check:go
make test:unit:rust FILTER=copy
make test:unit:ffi FILTER=copy
make test:unit:go FILTER=Copy
make test:apps
```

## Risks / rollout

- Hintless old-peer uploads use the compatibility staging path capped at
  512 MiB.
- A streaming upload cannot pre-scan a one-shot body; mount-shadow validation
  occurs after extraction and a rejected upload can leave partial output.
- A copy-out failure after response headers are sent intentionally closes the
  connection so clients cannot mistake a truncated tar for success.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added streaming file uploads and downloads without temporary staging.
  * Added Go and C SDK APIs for streaming copy operations.
  * Added source-type indicators for files, directories, and unknown inputs.
  * Improved archive handling for single-file and directory transfers.
* **Bug Fixes**
  * Improved handling of interrupted transfers, truncated streams, and transfer failures.
  * Preserved download metadata and compatibility with older peers.
* **Documentation**
  * Updated the C SDK migration guide with the new source-type API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
