### PR TITLE
fix(api): create rollover periods from current box attribution

### DIFF
--- a/apps/api/src/usage/entities/box-usage-period.entity.ts
+++ b/apps/api/src/usage/entities/box-usage-period.entity.ts
@@ -47,18 +47,4 @@ export class BoxUsagePeriod {
 
   @Column()
   region: string
-
-  public static fromUsagePeriod(usagePeriod: BoxUsagePeriod) {
-    const usagePeriodEntity = new BoxUsagePeriod()
-    usagePeriodEntity.boxId = usagePeriod.boxId
-    usagePeriodEntity.organizationId = usagePeriod.organizationId
-    usagePeriodEntity.startAt = usagePeriod.startAt
-    usagePeriodEntity.endAt = usagePeriod.endAt
-    usagePeriodEntity.cpu = usagePeriod.cpu
-    usagePeriodEntity.gpu = usagePeriod.gpu
-    usagePeriodEntity.mem = usagePeriod.mem
-    usagePeriodEntity.disk = usagePeriod.disk
-    usagePeriodEntity.region = usagePeriod.region
-    return usagePeriodEntity
-  }
 }

--- a/apps/api/src/usage/services/usage.service.integration.spec.ts
+++ b/apps/api/src/usage/services/usage.service.integration.spec.ts
@@ -181,7 +181,8 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
     )
 
   const isBlockedBy = async (blockerPid: number): Promise<boolean> => {
-    for (let attempt = 0; attempt < 100; attempt += 1) {
+    const deadline = Date.now() + 5_000
+    while (Date.now() < deadline) {
       const [{ blocked }] = await dataSource.query(
         `SELECT EXISTS (
            SELECT 1
@@ -193,7 +194,7 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
       if (blocked) {
         return true
       }
-      await new Promise<void>((resolve) => setImmediate(resolve))
+      await new Promise<void>((resolve) => setTimeout(resolve, 25))
     }
     return false
   }
@@ -494,7 +495,7 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
     expect(await periods.findOneByOrFail({ boxId: box.id, endAt: IsNull() })).toEqual(
       expect.objectContaining({ organizationId: currentOrganizationId, ...currentShape }),
     )
-  })
+  }, 10_000)
 
   it('rollover keeps the old period open when creating the replacement fails', async () => {
     await insertBox({ state: BoxState.STARTED })

--- a/apps/api/src/usage/services/usage.service.integration.spec.ts
+++ b/apps/api/src/usage/services/usage.service.integration.spec.ts
@@ -171,6 +171,33 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
       { find: async () => [] } as any,
     )
 
+  const serviceForPersistedBox = (exportEnabled = false) =>
+    new UsageService(
+      periods,
+      new RedisLockProvider(redis),
+      dataSource.getRepository(Box) as any,
+      outboxService(exportEnabled),
+      { find: async () => [] } as any,
+    )
+
+  const isBlockedBy = async (blockerPid: number): Promise<boolean> => {
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const [{ blocked }] = await dataSource.query(
+        `SELECT EXISTS (
+           SELECT 1
+           FROM pg_stat_activity
+           WHERE $1 = ANY(pg_blocking_pids(pid))
+         ) AS blocked`,
+        [blockerPid],
+      )
+      if (blocked) {
+        return true
+      }
+      await new Promise<void>((resolve) => setImmediate(resolve))
+    }
+    return false
+  }
+
   const quoted = TABLES.map((table) => `"${table}"`).join(', ')
   // CASCADE because box_last_activity references box.
   const truncateTables = () => dataSource.query(`TRUNCATE ${quoted} CASCADE`)
@@ -344,9 +371,10 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
   })
 
   it('rolls a day-old period over, carrying the resources of a running box', async () => {
+    await insertBox({ state: BoxState.STARTED })
     await openPeriod({ startAt: new Date(Date.now() - DAY_MS - 60_000) })
 
-    await serviceForBoxState(BoxState.STARTED).closeAndReopenUsagePeriods()
+    await serviceForPersistedBox().closeAndReopenUsagePeriods()
 
     const [closed, reopened] = await periods.find({ order: { startAt: 'ASC' } })
     expect(closed.endAt).toBeInstanceOf(Date)
@@ -356,9 +384,10 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
   it('stops charging compute when it rolls over a period whose box is already stopped', async () => {
     // a box that reached STOPPED without passing through STOPPING keeps a
     // full-resource period open; the roll-over must not re-bill its cpu forever
+    await insertBox({ state: BoxState.STOPPED })
     await openPeriod({ startAt: new Date(Date.now() - DAY_MS - 60_000) })
 
-    await serviceForBoxState(BoxState.STOPPED).closeAndReopenUsagePeriods()
+    await serviceForPersistedBox().closeAndReopenUsagePeriods()
 
     const [, reopened] = await periods.find({ order: { startAt: 'ASC' } })
     expect(reopened).toEqual(expect.objectContaining({ endAt: null, cpu: 0, gpu: 0, mem: 0, disk: 10 }))
@@ -384,9 +413,10 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
   })
 
   it('starts the reopened period exactly where the closed one ended, with the same attribution', async () => {
+    await insertBox({ state: BoxState.STOPPING })
     await openPeriod({ startAt: new Date(Date.now() - DAY_MS - 60_000) })
 
-    await serviceForBoxState(BoxState.STOPPING).closeAndReopenUsagePeriods()
+    await serviceForPersistedBox().closeAndReopenUsagePeriods()
 
     const [closed, reopened] = await periods.find({ order: { startAt: 'ASC' } })
     // no gap and no overlap: an inherited startAt would bill the elapsed day twice
@@ -396,17 +426,96 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
     )
   })
 
+  it('rollover keeps historical attribution and opens from the current Box attribution', async () => {
+    const previousOrganizationId = '7f33c512-a431-4a21-9efc-ff6924f9724c'
+    const currentOrganizationId = '8746db21-0d5b-4f0d-b26d-5a385ba6ecf2'
+    const currentShape = { region: 'eu', cpu: 6, gpu: 2, mem: 12, disk: 80 }
+    await insertBox({
+      state: BoxState.STARTED,
+      organizationId: currentOrganizationId,
+      ...currentShape,
+    })
+    const historical = await openPeriod({
+      organizationId: previousOrganizationId,
+      region: 'us',
+      cpu: 1,
+      gpu: 0,
+      mem: 2,
+      disk: 5,
+      startAt: new Date(Date.now() - DAY_MS - 60_000),
+    })
+
+    await serviceForPersistedBox().closeAndReopenUsagePeriods()
+
+    const closed = await periods.findOneByOrFail({ id: historical.id })
+    const reopened = await periods.findOneByOrFail({ boxId: box.id, endAt: IsNull() })
+    expect(closed).toEqual(
+      expect.objectContaining({ organizationId: previousOrganizationId, region: 'us', cpu: 1, disk: 5 }),
+    )
+    expect(reopened).toEqual(
+      expect.objectContaining({ organizationId: currentOrganizationId, ...currentShape, endAt: null }),
+    )
+    expect(reopened.startAt).toEqual(closed.endAt)
+  })
+
+  it('rollover waits for a concurrent Box update and uses the committed attribution', async () => {
+    const previousOrganizationId = '7f33c512-a431-4a21-9efc-ff6924f9724c'
+    const currentOrganizationId = '8746db21-0d5b-4f0d-b26d-5a385ba6ecf2'
+    const currentShape = { region: 'eu', cpu: 6, gpu: 2, mem: 12, disk: 80 }
+    await insertBox({ state: BoxState.STARTED, organizationId: previousOrganizationId })
+    await openPeriod({
+      organizationId: previousOrganizationId,
+      startAt: new Date(Date.now() - DAY_MS - 60_000),
+    })
+
+    const writer = dataSource.createQueryRunner()
+    await writer.connect()
+    await writer.startTransaction()
+    let rollover: Promise<void> | undefined
+    try {
+      const [{ pid }] = await writer.query(`SELECT pg_backend_pid()::int AS pid`)
+      await writer.manager.update(Box, { id: box.id }, { organizationId: currentOrganizationId, ...currentShape })
+
+      rollover = serviceForPersistedBox().closeAndReopenUsagePeriods()
+      expect(await isBlockedBy(pid)).toBe(true)
+
+      await writer.commitTransaction()
+      await rollover
+    } finally {
+      if (writer.isTransactionActive) {
+        await writer.rollbackTransaction()
+      }
+      if (rollover) {
+        await Promise.allSettled([rollover])
+      }
+      await writer.release()
+    }
+
+    expect(await periods.findOneByOrFail({ boxId: box.id, endAt: IsNull() })).toEqual(
+      expect.objectContaining({ organizationId: currentOrganizationId, ...currentShape }),
+    )
+  })
+
+  it('rollover keeps the old period open when creating the replacement fails', async () => {
+    await insertBox({ state: BoxState.STARTED })
+    const historical = await openPeriod({ startAt: new Date(Date.now() - DAY_MS - 60_000) })
+    const service = serviceForPersistedBox()
+    const creationError = new Error('injected usage-period creation failure')
+    const createUsagePeriod = jest.spyOn(service as any, 'createUsagePeriod').mockRejectedValueOnce(creationError)
+
+    try {
+      await service.closeAndReopenUsagePeriods()
+    } finally {
+      createUsagePeriod.mockRestore()
+    }
+
+    expect(await periods.find()).toEqual([expect.objectContaining({ id: historical.id, endAt: null })])
+  })
+
   it('closes without reopening when the box row no longer exists', async () => {
     await openPeriod({ startAt: new Date(Date.now() - DAY_MS - 60_000) })
-    const serviceWithoutBox = new UsageService(
-      periods,
-      new RedisLockProvider(redis),
-      { findOne: async () => null } as any,
-      outboxService(),
-      { find: async () => [] } as any,
-    )
 
-    await serviceWithoutBox.closeAndReopenUsagePeriods()
+    await serviceForPersistedBox().closeAndReopenUsagePeriods()
 
     // a missing box must not throw inside the transaction — that would roll the
     // close back and leave the period accruing forever
@@ -416,9 +525,10 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
   })
 
   it('does not reopen a period for a box that is already gone', async () => {
+    await insertBox({ state: BoxState.DESTROYED })
     await openPeriod({ startAt: new Date(Date.now() - DAY_MS - 60_000) })
 
-    await serviceForBoxState(BoxState.DESTROYED).closeAndReopenUsagePeriods()
+    await serviceForPersistedBox().closeAndReopenUsagePeriods()
 
     const remaining = await periods.find()
     expect(remaining).toHaveLength(1)
@@ -574,8 +684,10 @@ describeIfDatabase('UsageService (integration, real Postgres + Redis)', () => {
   // it would paper over a roll-over that carried the wrong figures forward, and
   // the ledger would still churn out a wrong period every single day.
   describe('the daily roll-over on its own', () => {
-    const rollOver = (state: BoxState, boxOverrides: Partial<typeof box> = {}) =>
-      serviceForBoxState(state, false, boxOverrides).closeAndReopenUsagePeriods()
+    const rollOver = async (state: BoxState, boxOverrides: Partial<typeof box> = {}) => {
+      await insertBox({ state, ...boxOverrides })
+      await serviceForPersistedBox().closeAndReopenUsagePeriods()
+    }
 
     it('carries the resources the box has now, not the ones the closing period held', async () => {
       await openPeriod({ cpu: 0, gpu: 0, mem: 0, startAt: new Date(Date.now() - DAY_MS - 60_000) })

--- a/apps/api/src/usage/services/usage.service.spec.ts
+++ b/apps/api/src/usage/services/usage.service.spec.ts
@@ -50,6 +50,7 @@ const makeService = (stored: BoxUsagePeriod[] = []) => {
   }
   const transactionalEntityManager = {
     find: jest.fn().mockResolvedValue([]),
+    findOne: jest.fn(),
     delete: jest.fn().mockResolvedValue(undefined),
     save: jest.fn().mockImplementation(async (value) => value),
   }
@@ -91,6 +92,7 @@ const makeService = (stored: BoxUsagePeriod[] = []) => {
     usageExportOutboxService,
     lease,
     transactionalEntityManager,
+    boxRepository,
   }
 }
 
@@ -336,6 +338,84 @@ describe('UsageService.handleBoxDesiredStateUpdate', () => {
     )
 
     expect(lease.release).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('UsageService.closeAndReopenUsagePeriods', () => {
+  const previousPeriod = () =>
+    Object.assign(new BoxUsagePeriod(), {
+      id: 'period-1',
+      boxId: box.id,
+      organizationId: 'org-previous',
+      region: 'us',
+      startAt: new Date(Date.now() - 25 * 60 * 60 * 1000),
+      endAt: null,
+      cpu: 1,
+      gpu: 0,
+      mem: 2,
+      disk: 5,
+    })
+
+  const currentBox = {
+    ...box,
+    organizationId: 'org-current',
+    region: 'eu',
+    state: BoxState.STARTED,
+    cpu: 6,
+    gpu: 2,
+    mem: 12,
+    disk: 80,
+  } as Box
+
+  it('rollover locks the current Box before the eligible open period and uses current attribution', async () => {
+    const previous = previousPeriod()
+    const { service, usagePeriodRepository, transactionalEntityManager, boxRepository } = makeService()
+    usagePeriodRepository.find.mockResolvedValue([previous])
+    boxRepository.findOne.mockResolvedValue(currentBox)
+    transactionalEntityManager.findOne.mockResolvedValueOnce(currentBox).mockResolvedValueOnce(previous)
+
+    await service.closeAndReopenUsagePeriods()
+
+    expect(transactionalEntityManager.findOne).toHaveBeenNthCalledWith(1, Box, {
+      where: { id: box.id },
+      lock: { mode: 'pessimistic_write' },
+      loadEagerRelations: false,
+    })
+    expect(transactionalEntityManager.findOne).toHaveBeenNthCalledWith(2, BoxUsagePeriod, {
+      where: { id: previous.id, boxId: box.id, endAt: expect.anything() },
+      lock: { mode: 'pessimistic_write' },
+    })
+    expect(boxRepository.findOne).not.toHaveBeenCalled()
+
+    const [closed, opened] = transactionalEntityManager.save.mock.calls.map(([period]) => period)
+    expect(closed).toBe(previous)
+    expect(closed.endAt).toBeInstanceOf(Date)
+    expect(opened.startAt).toEqual(closed.endAt)
+    expect(opened).toEqual(
+      expect.objectContaining({
+        boxId: box.id,
+        organizationId: currentBox.organizationId,
+        region: currentBox.region,
+        cpu: currentBox.cpu,
+        gpu: currentBox.gpu,
+        mem: currentBox.mem,
+        disk: currentBox.disk,
+        endAt: null,
+      }),
+    )
+  })
+
+  it('rollover skips a candidate that is no longer open when its transaction begins', async () => {
+    const previous = previousPeriod()
+    const { service, usagePeriodRepository, transactionalEntityManager, boxRepository } = makeService()
+    usagePeriodRepository.find.mockResolvedValue([previous])
+    boxRepository.findOne.mockResolvedValue(currentBox)
+    transactionalEntityManager.findOne.mockResolvedValueOnce(currentBox).mockResolvedValueOnce(null)
+
+    await service.closeAndReopenUsagePeriods()
+
+    expect(transactionalEntityManager.save).not.toHaveBeenCalled()
+    expect(previous.endAt).toBeNull()
   })
 })
 

--- a/apps/api/src/usage/services/usage.service.spec.ts
+++ b/apps/api/src/usage/services/usage.service.spec.ts
@@ -50,9 +50,14 @@ const makeService = (stored: BoxUsagePeriod[] = []) => {
   }
   const transactionalEntityManager = {
     find: jest.fn().mockResolvedValue([]),
-    findOne: jest.fn(),
+    findOne: jest.fn(
+      async (_entity, { where }: any): Promise<any> =>
+        stored.find((period) =>
+          Object.entries(where).every(([column, condition]) => satisfies((period as any)[column], condition)),
+        ),
+    ),
     delete: jest.fn().mockResolvedValue(undefined),
-    save: jest.fn().mockImplementation(async (value) => value),
+    save: jest.fn().mockImplementation(async (value) => usagePeriodRepository.save(value)),
   }
   const usagePeriodRepository = {
     findOne: jest.fn(async ({ where }: any) =>
@@ -166,6 +171,19 @@ describe('UsageService.handleBoxStateUpdate', () => {
     expect(closed).toBe(stale)
     expect(stale.endAt).toBeInstanceOf(Date)
     expect(opened).toEqual(expect.objectContaining({ cpu: 2, endAt: null }))
+  })
+
+  it('switches stopped billing to started billing atomically at one timestamp', async () => {
+    const stopped = openPeriod(0)
+    const { service, usagePeriodRepository, transactionalEntityManager } = makeService([stopped])
+    transactionalEntityManager.findOne.mockResolvedValue(stopped)
+
+    await service.handleBoxStateUpdate(new BoxStateUpdatedEvent(box, BoxState.STOPPED, BoxState.STARTED))
+
+    expect(usagePeriodRepository.manager.transaction).toHaveBeenCalledTimes(1)
+    const [closed, opened] = transactionalEntityManager.save.mock.calls.map(([period]) => period)
+    expect(closed).toBe(stopped)
+    expect(opened.startAt).toEqual(closed.endAt)
   })
 
   it('never closes a period belonging to a different box', async () => {

--- a/apps/api/src/usage/services/usage.service.ts
+++ b/apps/api/src/usage/services/usage.service.ts
@@ -189,10 +189,11 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
     box: Pick<Box, 'id' | 'organizationId' | 'region'>,
     shape: UsagePeriodShape,
     entityManager?: EntityManager,
+    startAt = new Date(),
   ) {
     const usagePeriod = new BoxUsagePeriod()
     usagePeriod.boxId = box.id
-    usagePeriod.startAt = new Date()
+    usagePeriod.startAt = startAt
     usagePeriod.endAt = null
     usagePeriod.cpu = shape.cpu
     usagePeriod.gpu = shape.gpu
@@ -256,36 +257,33 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
           await this.withLease(
             boxLease,
             async (boxSignal) => {
-              const box = await this.boxRepository.findOne({
-                where: {
-                  id: usagePeriod.boxId,
-                },
-              })
-
               await this.boxUsagePeriodRepository.manager.transaction(async (transactionalEntityManager) => {
                 boxSignal.throwIfAborted()
-                // Close usage period
-                const closeTime = new Date()
-                usagePeriod.endAt = closeTime
-                await transactionalEntityManager.save(usagePeriod)
+                // Keep current attribution stable through the rollover, and use
+                // one Box -> usage-period lock order for competing writers.
+                const box = await transactionalEntityManager.findOne(Box, {
+                  where: { id: usagePeriod.boxId },
+                  lock: { mode: 'pessimistic_write' },
+                  loadEagerRelations: false,
+                })
+                boxSignal.throwIfAborted()
 
-                // Roll over with the resources the box calls for *now*, not the ones
-                // the closing period happened to carry. Copying the old figures kept
-                // any drift alive forever: a period left charging no cpu for a running
-                // box was re-copied every day, and a disk resize that landed while the
-                // box was stopped never reached the ledger at all. A box that is gone
-                // or terminal yields no shape and so is not reopened, which is what
-                // stops a deleted box from accruing.
+                const currentUsagePeriod = await transactionalEntityManager.findOne(BoxUsagePeriod, {
+                  where: { id: usagePeriod.id, boxId: usagePeriod.boxId, endAt: IsNull() },
+                  lock: { mode: 'pessimistic_write' },
+                })
+                boxSignal.throwIfAborted()
+                if (!currentUsagePeriod) {
+                  return
+                }
+
+                const closeTime = new Date()
+                currentUsagePeriod.endAt = closeTime
+                await transactionalEntityManager.save(currentUsagePeriod)
+
                 const expected = expectedOpenPeriod(box)
-                if (expected !== null) {
-                  const newUsagePeriod = BoxUsagePeriod.fromUsagePeriod(usagePeriod)
-                  newUsagePeriod.startAt = closeTime
-                  newUsagePeriod.endAt = null
-                  newUsagePeriod.cpu = expected.cpu
-                  newUsagePeriod.gpu = expected.gpu
-                  newUsagePeriod.mem = expected.mem
-                  newUsagePeriod.disk = expected.disk
-                  await transactionalEntityManager.save(newUsagePeriod)
+                if (box && expected !== null) {
+                  await this.createUsagePeriod(box, expected, transactionalEntityManager, closeTime)
                 }
                 boxSignal.throwIfAborted()
               })

--- a/apps/api/src/usage/services/usage.service.ts
+++ b/apps/api/src/usage/services/usage.service.ts
@@ -128,9 +128,13 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
         signal.throwIfAborted()
         switch (event.newState) {
           case BoxState.STARTED: {
-            await this.closeUsagePeriod(event.box.id)
-            signal.throwIfAborted()
-            await this.openUsagePeriodFor(event.box, event.newState)
+            await this.boxUsagePeriodRepository.manager.transaction(async (transactionalEntityManager) => {
+              const transitionAt = new Date()
+              await this.closeUsagePeriod(event.box.id, transactionalEntityManager, transitionAt)
+              signal.throwIfAborted()
+              await this.openUsagePeriodFor(event.box, event.newState, transactionalEntityManager, transitionAt)
+              signal.throwIfAborted()
+            })
             break
           }
           // Billing stops charging compute the moment a stop is requested.
@@ -174,7 +178,7 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
    * (terminal) or whose state is still in flight gets none — the caller has
    * already closed whatever was open.
    */
-  private async openUsagePeriodFor(box: Box, state: BoxState) {
+  private async openUsagePeriodFor(box: Box, state: BoxState, entityManager?: EntityManager, startAt?: Date) {
     // The event's newState is the authority on where the box landed; the entity
     // it carries is a snapshot, and a synthetic transition may have been built
     // with a state of its own (see the warm-pool claim in box.service.ts).
@@ -182,7 +186,7 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
     if (expected === null) {
       return
     }
-    await this.createUsagePeriod(box, expected)
+    await this.createUsagePeriod(box, expected, entityManager, startAt)
   }
 
   private async createUsagePeriod(
@@ -205,17 +209,15 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
     await (entityManager ? entityManager.save(usagePeriod) : this.boxUsagePeriodRepository.save(usagePeriod))
   }
 
-  private async closeUsagePeriod(boxId: string) {
-    const lastUsagePeriod = await this.boxUsagePeriodRepository.findOne({
-      where: {
-        boxId,
-        endAt: IsNull(),
-      },
-    })
+  private async closeUsagePeriod(boxId: string, entityManager?: EntityManager, endAt = new Date()) {
+    const where = { boxId, endAt: IsNull() }
+    const lastUsagePeriod = entityManager
+      ? await entityManager.findOne(BoxUsagePeriod, { where })
+      : await this.boxUsagePeriodRepository.findOne({ where })
 
     if (lastUsagePeriod) {
-      lastUsagePeriod.endAt = new Date()
-      await this.boxUsagePeriodRepository.save(lastUsagePeriod)
+      lastUsagePeriod.endAt = endAt
+      await (entityManager ? entityManager.save(lastUsagePeriod) : this.boxUsagePeriodRepository.save(lastUsagePeriod))
     }
   }
 


### PR DESCRIPTION
## Summary

Create 24-hour rollover periods from the locked current Box instead of cloning historical attribution. Use one transaction and boundary timestamp for `STOPPED` → `STARTED` cutovers so creating the replacement cannot leave a billing gap.

## Call graph

Before

```text
closeAndReopenUsagePeriods (UsageService · apps/api/src/usage/services/usage.service.ts:225) — rolls periods older than 24 hours
├─ findOne (BoxRepository · apps/api/src/usage/services/usage.service.ts:259) — reads the Box before the period transaction ← BUG: a concurrent update can stale this snapshot
└─ transaction (EntityManager · apps/api/src/usage/services/usage.service.ts:265) — closes the historical period
   └─ fromUsagePeriod (BoxUsagePeriod · apps/api/src/usage/entities/box-usage-period.entity.ts:51) — clones organization and region ← BUG: the replacement keeps historical attribution

handleBoxStateUpdate (UsageService · apps/api/src/usage/services/usage.service.ts:122) — handles STARTED
├─ closeUsagePeriod (UsageService · apps/api/src/usage/services/usage.service.ts:207) — commits the close at its own timestamp ← BUG: a later insert failure leaves no open period
└─ openUsagePeriodFor (UsageService · apps/api/src/usage/services/usage.service.ts:177) — commits the replacement at a later timestamp ← BUG: successful transitions can contain a gap
```

After

```text
closeAndReopenUsagePeriods (UsageService · apps/api/src/usage/services/usage.service.ts:228) — rolls periods older than 24 hours
└─ transaction (EntityManager · apps/api/src/usage/services/usage.service.ts:262) — owns the complete rollover
   ├─ findOne (EntityManager<Box> · apps/api/src/usage/services/usage.service.ts:266) — locks the current Box attribution first
   ├─ findOne (EntityManager<BoxUsagePeriod> · apps/api/src/usage/services/usage.service.ts:273) — locks and revalidates the eligible open period
   └─ createUsagePeriod (UsageService · apps/api/src/usage/services/usage.service.ts:192) — opens from the locked Box at the close timestamp

handleBoxStateUpdate (UsageService · apps/api/src/usage/services/usage.service.ts:122) — handles STARTED
└─ transaction (EntityManager · apps/api/src/usage/services/usage.service.ts:131) — owns the complete state cutover
   ├─ closeUsagePeriod (UsageService · apps/api/src/usage/services/usage.service.ts:212) — closes at `transitionAt`
   └─ openUsagePeriodFor (UsageService · apps/api/src/usage/services/usage.service.ts:181) — opens in the same transaction at `transitionAt`
      └─ createUsagePeriod (UsageService · apps/api/src/usage/services/usage.service.ts:192) — writes the event Box attribution and resources
```

**Key:** both cutovers close and open atomically at one timestamp; the rollover additionally locks the current Box before deriving the replacement.

Fixes #1207
Refs POL-175
Related: #1387

## Changes

- Lock the current Box and the still-open rollover candidate in `Box` → `BoxUsagePeriod` order, then recheck eligibility inside the transaction.
- Preserve the closed period's historical attribution while creating its replacement from the locked Box's organization, region, and resources.
- Let the existing period helpers accept a transaction manager and explicit boundary timestamp, and use them atomically for `STARTED` events.
- Remove the clone helper that could copy stale attribution.
- Cover current attribution, exact boundaries, concurrent Box updates, replacement-insert rollback, stale candidates, and `STOPPED` → `STARTED` continuity.

## How to verify

- `make test:apps FILTER='UsageService'`
- `yarn jest --config api/jest.config.ts --runInBand --runTestsByPath api/src/usage/services/usage.service.spec.ts` — 28/28 passed.
- Focused rollover integration cases against PostgreSQL and Redis — 5/5 passed.
- `yarn tsc -p api/tsconfig.app.json --noEmit && yarn tsc -p api/tsconfig.spec.json --noEmit` — passed.
- `make lint:apps` — passed with 0 errors and 42 existing warnings.
- `yarn prettier --check api/src/usage/services/usage.service.ts api/src/usage/services/usage.service.spec.ts --config ../.prettierrc` — passed.

## Risks / rollout

- No schema, API, export-format, or historical-backfill changes are included.
- Rollover now holds one Box row and one usage-period row under write locks for the duration of a short transaction.
- `STARTED` remains an in-process event. A completely lost event is repaired by reconcile from the repair time and is not backfilled; `STOPPING` and `STOPPED` paths are unchanged.
- Warm-pool sentinel periods remain excluded from daily rollover. Atomic warm-pool ownership transfer is handled separately in #1387, whose usage-service changes overlap this branch.
- The aggregate `make build:apps` check was blocked before TypeScript compilation by the local Nx `Failed to start plugin worker` error; direct API app and spec type checks passed.
- The aggregate `make fmt:check` check reports 150 pre-existing generated-client files; both changed files pass the repository Prettier configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved usage-period rollover accuracy by using the latest box configuration when creating replacement periods.
  - Ensured billing state transitions close and reopen periods atomically at a consistent timestamp.
  - Added safeguards for concurrent updates and stale or missing usage periods.
  - Preserved existing periods when replacement creation fails.
  - Improved consistency when usage periods change during concurrent billing operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->