### PR TITLE
fix(rest): trust HTTP status over a manufactured code for codeless error bodies

### DIFF
--- a/src/boxlite/src/rest/error.rs
+++ b/src/boxlite/src/rest/error.rs
@@ -23,7 +23,18 @@ pub(crate) fn map_http_body(status: StatusCode, text: &str) -> BoxliteError {
     if let Ok(err_resp) = serde_json::from_str::<ErrorResponse>(text) {
         map_http_error(status, &err_resp.error)
     } else if let Ok(err_resp) = serde_json::from_str::<FlatErrorResponse>(text) {
-        map_http_error(status, &err_resp.into_error_model())
+        if err_resp.code.is_some() {
+            // A real machine code was given — dispatch on it as usual.
+            map_http_error(status, &err_resp.into_error_model())
+        } else {
+            // No machine code: this shape also matches a framework
+            // exception's default body (e.g. Nest's `NotFoundException`
+            // bypassing the API's own envelope), which carries no `code`
+            // field to dispatch on. Guessing "internal" here would bury
+            // the HTTP status the framework already committed to — trust
+            // it instead, the same as a body that fails to parse at all.
+            map_http_status(status, &err_resp.message)
+        }
     } else {
         map_http_status(status, text)
     }
@@ -268,5 +279,26 @@ mod tests {
     fn bare_404_is_not_found() {
         let err = map_http_status(StatusCode::NOT_FOUND, "");
         assert!(matches!(err, BoxliteError::NotFound(_)));
+    }
+
+    /// A guard/framework exception (e.g. Nest's `NotFoundException`)
+    /// bypasses the API's structured envelope and serializes through
+    /// Nest's default filter: `{statusCode, error, message}`, no `code`
+    /// field. `FlatErrorResponse` still parses this (unknown fields are
+    /// ignored, `code` is `Option`), so it must not be treated as a
+    /// same-confidence "no code was given" signal as a body that never
+    /// had a `code` field to begin with — the HTTP status is still
+    /// authoritative and must win over a manufactured "internal" guess.
+    /// Regression for POL-306: `get_or_create` against a fresh name
+    /// raised `Internal` instead of returning `None` from the `get`
+    /// probe, so it never reached the create fallback.
+    #[test]
+    fn nest_default_404_without_code_is_not_found() {
+        let text = r#"{"path":"/api/v1/x/boxes/missing","timestamp":"2026-08-31T00:00:00.000Z","statusCode":404,"error":"Not Found","message":"Box with ID or name missing not found"}"#;
+        let err = map_http_body(StatusCode::NOT_FOUND, text);
+        assert!(
+            matches!(err, BoxliteError::NotFound(_)),
+            "expected NotFound for a codeless 404 body, got {err:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary
`get_or_create`'s create fallback never ran for a fresh name. `RestRuntime::get`
only treats `BoxliteError::NotFound` as "not found", but a framework exception's
default body (Nest's `NotFoundException` bypassing the API's own envelope —
`{statusCode, error, message}`, no `code` field) still parses as
`FlatErrorResponse`, whose `into_error_model()` defaulted a missing `code` to
`"internal"` — discarding the real HTTP status the framework had already
committed to.

## Call graph

```text
Before
  map_http_body                  (rest/error.rs:22)
    └─ FlatErrorResponse          (rest/types.rs:26)
         └─ into_error_model      (rest/types.rs:32) ← BUG: missing code defaults to "internal"
              └─ map_http_error   (rest/error.rs:38) -> BoxliteError::Internal
                   └─ RestRuntime::get (rest/runtime.rs:247) propagates Err instead of Ok(None)
                        └─ RestRuntime::get_or_create (rest/runtime.rs:229) never reaches the create fallback

After
  map_http_body                  (rest/error.rs:22)
    └─ FlatErrorResponse.code.is_some() branch
         ├─ Some(_) -> into_error_model -> map_http_error (unchanged)
         └─ None    -> map_http_status(status, message)   -> BoxliteError::NotFound
              └─ RestRuntime::get returns Ok(None)
                   └─ RestRuntime::get_or_create reaches create(), as documented
```

## Verification
- Added `nest_default_404_without_code_is_not_found` (fails before the fix with
  `Internal("Box with ID or name ... not found")`, passes after).
- Verified live against `api.dev.boxlite.ai` with a temporary pure-Rust probe
  (bypassing the Python bindings entirely): `get()` on a fresh name now
  returns `Ok(None)` instead of `Err(Internal(..))`.
- `cargo fmt --check`, `cargo clippy --features rest -D warnings`, and the full
  `rest::` unit suite pass with no regressions (one pre-existing, unrelated
  flaky test — `ws_watchdog_fires_when_idle` — reproduces identically on
  unmodified `main`).

## How to verify
- `cargo test -p boxlite --lib --features rest rest::error::`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP error handling for responses without a machine-readable error code.
  * Status-only responses now correctly map to the corresponding HTTP error, such as `NotFound`, instead of being treated as internal errors.
  * Added coverage for codeless 404 error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->