### PR TITLE
test(e2e): fix stale exec-on-stopped-box assertion (POL-422)

### DIFF
--- a/apps/e2e/cases/test_execution_shutdown.py
+++ b/apps/e2e/cases/test_execution_shutdown.py
@@ -1,8 +1,9 @@
 """E2E port of `src/boxlite/tests/execution_shutdown.rs`.
 
 Verifies the behaviour of exec and box state during/after box.stop():
-pending exec.wait() should resolve, new exec attempts on a stopped
-box should be cleanly rejected (not 5xx).
+pending exec.wait() should resolve, and a new exec attempt against a
+stopped box auto-starts it (intended behaviour, see PR #861) rather
+than being rejected.
 """
 from __future__ import annotations
 
@@ -38,21 +39,32 @@ async def test_wait_resolves_after_box_stop(rt, image):
 
 
 @pytest.mark.asyncio
-async def test_exec_on_stopped_box_is_typed_error(rt, image):
-    """Trying to exec on a stopped box must return a typed client
-    error (not 5xx). Catches API/runner mapping regressions."""
+async def test_exec_on_stopped_box_auto_starts_it(rt, image):
+    """exec on a stopped box auto-starts it (see PR #861) — the exec
+    itself must succeed, and the box's reported status must converge
+    to running rather than staying stuck at stopped."""
     box = await rt.create(boxlite.BoxOptions(image=image, auto_remove=False))
     try:
         await box.stop()
-        # Now try to exec — should fail with a clean client error
-        with pytest.raises(Exception) as exc_info:
-            ex = await box.exec("sh", ["-c", "echo nope"], None)
-            await drain(ex)
-            await ex.wait()
-        msg = str(exc_info.value)
-        assert "500" not in msg and "Internal" not in msg, (
-            f"exec on stopped box returned 5xx: {msg!r}"
-        )
+
+        ex = await box.exec("sh", ["-c", "echo woke"], None)
+        out, _ = await drain(ex)
+        rc = await asyncio.wait_for(ex.wait(), timeout=30)
+        assert rc.exit_code == 0, f"exec on stopped box failed: rc={rc.exit_code}"
+        assert "woke" in out, f"exec on stopped box produced no output: {out!r}"
+
+        # The auto-start is async on the server side; poll until the
+        # reported status converges instead of asserting immediately.
+        for _ in range(10):
+            info = await rt.get(box.id)
+            if info is not None and str(info.status).lower() == "running":
+                break
+            await asyncio.sleep(1)
+        else:
+            pytest.fail(
+                f"box status did not converge to running after exec "
+                f"auto-started it: last status={info.status if info else None!r}"
+            )
     finally:
         try:
             await rt.remove(box.id, force=True)

--- a/apps/e2e/cases/test_execution_shutdown.py
+++ b/apps/e2e/cases/test_execution_shutdown.py
@@ -55,15 +55,18 @@ async def test_exec_on_stopped_box_auto_starts_it(rt, image):
 
         # The auto-start is async on the server side; poll until the
         # reported status converges instead of asserting immediately.
+        # `rt.get()` returns a `Box` handle (no `status`); the metadata
+        # snapshot with status lives on `BoxInfo.state.status` via
+        # `rt.get_info()`.
         for _ in range(10):
-            info = await rt.get(box.id)
-            if info is not None and str(info.status).lower() == "running":
+            info = await rt.get_info(box.id)
+            if info is not None and str(info.state.status).lower() == "running":
                 break
             await asyncio.sleep(1)
         else:
             pytest.fail(
                 f"box status did not converge to running after exec "
-                f"auto-started it: last status={info.status if info else None!r}"
+                f"auto-started it: last status={info.state.status if info else None!r}"
             )
     finally:
         try:


### PR DESCRIPTION
## Summary

`test_exec_on_stopped_box_is_typed_error` asserted that `exec()` on a stopped box must raise. That contract changed with #861 (merged 2026-06-26): exec on a stopped box is intended to auto-start it. The test was never updated and has been failing in every dev E2E run since.

## Call graph

Before
```
test_exec_on_stopped_box_is_typed_error
  box.stop()
  pytest.raises(Exception): box.exec(...)  ← BUG: asserts pre-#861 contract
```

After
```
test_exec_on_stopped_box_auto_starts_it
  box.stop()
  box.exec(...) → exit_code == 0, output present
  poll rt.get(box.id).status until "running"
```

## Test plan

- [x] `python3 -m ast` syntax check
- [ ] Run against dev (`make test:e2e` with dev profile) — not run here, no dev API key in this environment; residual risk until CI runs it

Fixes POL-422

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pending execution waits now resolve correctly when a box shuts down.
  * Executing a command on a stopped box now automatically starts the box and completes successfully.
  * Box status is updated to reflect the running state after execution begins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->