### PR TITLE
feat(cli): enforce command-specific option contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ curl -s -X POST http://localhost:8100/v1/boxes \
   -d '{"image": "alpine:latest"}'
 ```
 
-Every CLI command also works against a running server with `--url`: `boxlite --url http://localhost:8100 list`.
+REST-capable CLI commands also work against a running server with `--url`:
+`boxlite --url http://localhost:8100 list`.
 
 </details>
 

--- a/docs/reference/cli/README.md
+++ b/docs/reference/cli/README.md
@@ -17,6 +17,7 @@ For a quick start, see [`src/cli/README.md`](../../../src/cli/README.md).
   - [`boxlite auth login`](#boxlite-auth-login)
   - [`boxlite auth logout`](#boxlite-auth-logout)
   - [`boxlite auth status`](#boxlite-auth-status)
+  - [`boxlite auth whoami`](#boxlite-auth-whoami)
   - [`boxlite run`](#boxlite-run)
   - [`boxlite exec`](#boxlite-exec)
   - [`boxlite create`](#boxlite-create)
@@ -118,20 +119,29 @@ sh ./install.sh
 
 ## Global Options
 
-These flags can appear before *or* after the subcommand and apply to every command.
+Place these options before the top-level command or after the complete command
+path. A parent command accepts only options shared by all children; for example,
+use `boxlite auth status --url URL` or `boxlite --url URL auth status`, not
+`boxlite auth --url URL status`. Help lists only options meaningful to that
+backend, and executing invocations reject unsupported options. Clap's `--help`
+and `--version` display actions remain terminal.
 
-| Flag | Type | Default | Env Var | Description |
-|------|------|---------|---------|-------------|
-| `--debug` | bool | `false` | `RUST_LOG` (lower precedence than the flag) | Enable debug output. Precedence: `--debug` > `RUST_LOG` env > default (`warn` on stderr, `info` in file when enabled). |
-| `--home PATH` | path | `~/.boxlite` | `BOXLITE_HOME` | BoxLite runtime data directory |
-| `--registry REGISTRY` | string (repeatable) | `[]` | — | Image registry hostname; prepended to the registries from `--config` |
-| `--config PATH` | path | none | — | JSON config file (see [Configuration File](#configuration-file)) |
-| `--url URL` | string | none | `BOXLITE_REST_URL` | Connect to a remote BoxLite REST API server instead of the local runtime |
+| Flag | Scope | Env Var | Description |
+|------|-------|---------|-------------|
+| `--debug` | all commands except `completion` | `RUST_LOG` (lower precedence) | Enable debug output. |
+| `--home PATH` | local runtime + credentials | `BOXLITE_HOME` | Absolute runtime data directory and credential-store root. |
+| `--registry REGISTRY` | `run`, `create`, `pull`, `serve` | — | Image registry hostname; repeatable and prepended to config. |
+| `--config PATH` | local-capable commands | — | JSON runtime config (see [Configuration File](#configuration-file)). |
+| `--url URL` | REST-capable commands | `BOXLITE_REST_URL` | Select a REST API server. |
+| `--profile NAME` | REST-capable commands + `auth` | `BOXLITE_PROFILE` | Profile in `<BOXLITE_HOME>/credentials.toml`; default `default`. |
+| `--path-prefix VALUE` | REST box/volume commands | `BOXLITE_REST_PATH_PREFIX` | Override the profile's routing path segment. |
 
 **Precedence** (from `src/cli/src/cli.rs`):
 
-1. `--url` short-circuits to the REST runtime — no local hypervisor is touched. `--home`, `--registry`, and `--config` are ignored.
-2. Otherwise, `--config` is loaded as the base options, then `--home` overrides `home_dir`, and `--registry` flags are prepended to `image_registries`.
+1. On dual-backend commands, `--url` selects REST; local runtime config is then unused.
+2. Otherwise, `--config` is the base, `--home` overrides `home_dir`, and
+   `--registry` values are prepended to `image_registries`.
+3. `serve`, `pull`, `images`, `info`, and `logs` always use the embedded local runtime.
 
 ---
 
@@ -139,10 +149,26 @@ These flags can appear before *or* after the subcommand and apply to every comma
 
 | Variable | Read by | Description |
 |----------|---------|-------------|
-| `BOXLITE_HOME` | `--home` | Runtime data directory; equivalent to `--home` |
+| `BOXLITE_HOME` | `--home` | Runtime data and credential directory; equivalent to `--home` |
 | `BOXLITE_REST_URL` | `--url` | REST server endpoint; equivalent to `--url` |
 | `BOXLITE_API_KEY` | REST runtime | Long-lived API key sent as `Authorization: Bearer`. Overrides any stored credentials. |
+| `BOXLITE_PROFILE` | `--profile` | Credential profile; default `default` |
+| `BOXLITE_REST_PATH_PREFIX` | `--path-prefix` | REST routing path segment; overrides the selected profile's value |
+| `BOXLITE_SECURITY` | `run`, `create` | Sandbox preset; equivalent to `--security` |
+| `BOXLITE_SERVE_API_KEY` | `serve` | Expected bearer key; equivalent to `serve --api-key` |
+| `OIDC_ISSUER` | `auth login` | OIDC issuer fallback after an explicit flag and server discovery |
+| `OIDC_CLIENT_ID` | `auth login` | OIDC client-id fallback after an explicit flag and server discovery |
+| `OIDC_AUDIENCE` | `auth login` | OIDC audience fallback after an explicit flag and server discovery |
+| `BOXLITE_LOG_FILE` | logging | Explicit JSON log-file path for any command; a bare filename is relative to the current directory. `serve` otherwise logs to `<BOXLITE_HOME>/logs/serve.log`. |
+| `BOXLITE_EXPERIMENTAL` | `run`, `create` | Comma-separated RC features: `custom-kernel`, `nested-virtualization` |
+| `BOXLITE_RECONNECT_GRACE` | `serve` | Reconnect grace before SIGHUP; default `5m` |
+| `BOXLITE_SHUTDOWN_GRACE` | `serve` | Grace between shutdown escalation stages; default `30s` |
+| `BOXLITE_MAX_SESSION_LIFETIME` | `serve` | Session hard cap; default `24h` |
+| `SSH_CONNECTION` | `auth login` | Headless detection; choosing Browser from the TTY picker falls back to device flow when set |
 | `RUST_LOG` | tracing | Log level/filter (`error`, `warn`, `info`, `debug`, `trace`; or per-module e.g. `boxlite=debug`) |
+
+The three `serve` duration variables accept bare seconds or `Ns`, `Nm`, and
+`Nh`. Invalid values log a warning and use the documented default.
 
 ---
 
@@ -161,7 +187,10 @@ echo "$KEY" | boxlite auth login --api-key-stdin --url https://<your-server>
 BOXLITE_API_KEY=$KEY BOXLITE_REST_URL=https://<your-server> boxlite list
 ```
 
-Credentials are stored at `~/.boxlite/credentials.toml` (perms `0600`). See [`boxlite auth login`](#boxlite-auth-login), [`boxlite auth logout`](#boxlite-auth-logout), and [`boxlite auth status`](#boxlite-auth-status) for the full command surface.
+Credentials are stored at `<BOXLITE_HOME>/credentials.toml` (default
+`~/.boxlite/credentials.toml`, perms `0600`). See [`boxlite auth login`](#boxlite-auth-login),
+[`boxlite auth logout`](#boxlite-auth-logout), [`boxlite auth status`](#boxlite-auth-status),
+and [`boxlite auth whoami`](#boxlite-auth-whoami) for the full command surface.
 
 ---
 
@@ -171,16 +200,22 @@ Credentials are stored at `~/.boxlite/credentials.toml` (perms `0600`). See [`bo
 
 **Synopsis:** `boxlite auth login [OPTIONS]`
 
-Log in to a BoxLite REST server using a dashboard-issued opaque API key.
-Long-lived, org-scoped. Credentials are stored at
-`~/.boxlite/credentials.toml` (perms `0600`).
+Log in with a long-lived API key, browser OIDC, or device-code OIDC.
+Credentials are stored at `<BOXLITE_HOME>/credentials.toml` (default
+`~/.boxlite/credentials.toml`, perms `0600`).
 
 **Options:**
 
 | Flag | Description |
 |------|-------------|
-| `--url URL` | Server URL (default: `http://localhost:8100`, matching `boxlite serve`) |
-| `--api-key-stdin` | Read the API key from stdin (one line). The flag takes no value, so the secret never appears on argv. |
+| `--url URL` | Server URL. Precedence: flag, `BOXLITE_REST_URL`, selected profile URL, then `http://localhost:8100`. |
+| `--method <api-key\|browser\|device>` | Select the login flow explicitly. |
+| `--api-key-stdin` | Read the API key from stdin (one line); selects `api-key` and conflicts with explicit browser/device methods. |
+| `--no-browser` | Use device-code login when no method is explicit; conflicts with API-key stdin and explicit `api-key`/`browser` methods. |
+| `--issuer URL` | Browser/device only: override the OIDC issuer discovered from the server. |
+| `--client-id ID` | Browser/device only: override the discovered OIDC client ID. |
+| `--audience VALUE` | Browser/device only: override the discovered OIDC audience. |
+| `--callback-port PORT` | Browser only: callback port, `1..=65535` (default `5555`). |
 
 **Examples:**
 
@@ -198,7 +233,8 @@ echo "$KEY" | boxlite auth login --api-key-stdin --url https://<your-server>
 
 **Synopsis:** `boxlite auth logout [OPTIONS]`
 
-Delete the stored credentials file at `~/.boxlite/credentials.toml`. Prompts for confirmation unless `--yes` is given. Prints `Logged out` on success, or `Not logged in` if no file exists.
+Delete the selected profile from `<BOXLITE_HOME>/credentials.toml`. The file is
+removed when its final profile is deleted. Prompts unless `--yes` is given.
 
 **Options:**
 
@@ -210,23 +246,47 @@ Delete the stored credentials file at `~/.boxlite/credentials.toml`. Prompts for
 
 ### `boxlite auth status`
 
-**Synopsis:** `boxlite auth status`
+**Synopsis:** `boxlite auth status [--url URL] [--profile NAME]`
 
 Print the current authentication state without revealing the secret. Reports
 the logged-in URL and the source (stored file vs env var). If neither the
-file nor env vars are present, prints `Not logged in.`
+file nor env vars are present, prints
+``Not logged in (profile `NAME`).`` An explicit `--url`
+overrides the stored URL in the report. With only `BOXLITE_API_KEY` set, the
+auth probe reports the local `serve` default, `http://localhost:8100`.
 
 **Example output:**
 
 ```
 Logged in to:    http://localhost:8100
-Credential:      API key (from ~/.boxlite/credentials.toml)
+Credential:      API key (from <BOXLITE_HOME>/credentials.toml [default])
 ```
 
 When the env var override is active:
 
 ```
 Credential:      API key (from BOXLITE_API_KEY env var)
+```
+
+---
+
+### `boxlite auth whoami`
+
+**Synopsis:** `boxlite auth whoami [--url URL] [--profile NAME]`
+
+Call `GET /v1/me` with the active credential and print the server-resolved
+principal, path prefix, scopes, and server URL. An explicit `--url` overrides
+the selected profile's URL. OIDC credentials refresh when near expiry.
+
+**Example output:**
+
+```
+Logged in as:    dev@acme.test
+Name:            Dev McAcme
+Principal:       auth0|abc123 (user)
+Path prefix:     acme
+Server:          https://api.boxlite.ai/api
+Scopes:          box:read, box:write, box:exec
 ```
 
 ---
@@ -247,16 +307,19 @@ The box's lifetime is that command's lifetime. When it exits, the box stops and
 takes the command's exit code; `boxlite ps` shows it stopped and
 `boxlite inspect -f '{{.State.ExitCode}}'` gives the code.
 
-**Options:** Uses [`ProcessFlags`](#processflags) + [`CapabilityFlags`](#capabilityflags) + [`ResourceFlags`](#resourceflags) + [`PublishFlags`](#publishflags) + [`VolumeFlags`](#volumeflags) + [`ManagementFlags`](#managementflags), plus:
+**Options:** Uses [`ProcessFlags`](#processflags) + [`CapabilityFlags`](#capabilityflags) + [`ResourceFlags`](#resourceflags) + [`PublishFlags`](#publishflags) + [`VolumeFlags`](#volumeflags) + [`NetworkFlags`](#networkflags) + [`ManagementFlags`](#managementflags), plus:
 
 | Flag | Short | Description |
 |------|-------|-------------|
 | `--rootfs PATH` | — | Use a prepared rootfs path instead of pulling/resolving an image |
+| `--entrypoint EXEC` | — | Override the image entrypoint |
+| `--detach` | `-d` | Run in the background and print the box ID |
+| `--rm` | — | Remove the box when it stops; conflicts with lifecycle deadlines and is ignored with `--detach` |
 
 **Exit behavior:**
 
 - Default (foreground): streams stdout/stderr to the terminal, exits with the box command's exit code. If the command was killed by signal *N*, exits with `128 + N` (Unix convention, see [Exit Codes](#exit-codes)).
-- `-d`/`--detach`: prints the box ID to stdout and exits `0` immediately; `auto_remove` is force-disabled in this mode so the box outlives the CLI process.
+- `-d`/`--detach`: prints the box ID to stdout and exits `0` immediately; remove-on-stop is force-disabled in this mode so the box outlives the CLI process.
 - `--tty` with non-TTY stdin: fails with `the input device is not a TTY.`
 
 **Examples:**
@@ -277,7 +340,10 @@ boxlite run --rootfs /path/to/rootfs /bin/sh
 
 **Synopsis:** `boxlite exec [OPTIONS] BOX -- COMMAND [ARGS...]`
 
-Run a command in a *running* box. The `--` separator is required (`src/cli/src/commands/exec.rs:22`, `last = true`).
+Run a command in a box. A safely resumable stopped box starts implicitly; a
+job box whose start would run or re-run its user-selected main command is
+refused, so start it deliberately with `boxlite start` first. The `--`
+separator is required (`src/cli/src/commands/exec.rs:22`, `last = true`).
 
 **Options:** Uses [`ProcessFlags`](#processflags), plus:
 
@@ -320,10 +386,11 @@ implicitly, because starting it runs that command. Start it deliberately with
 | Flag | Short | Description |
 |------|-------|-------------|
 | `--rootfs PATH` | — | Use a prepared rootfs path instead of pulling/resolving an image |
-| `--env KEY=VALUE` | `-e` | Set environment variables (repeatable) |
+| `--env KEY[=VALUE]` | `-e` | Set environment variables; a bare key inherits its host value (repeatable) |
 | `--workdir PATH` | `-w` | Working directory inside the box |
+| `--entrypoint EXEC` | — | Replace the image entrypoint with one executable |
 
-Also uses [`CapabilityFlags`](#capabilityflags) + [`ResourceFlags`](#resourceflags) + [`PublishFlags`](#publishflags) + [`VolumeFlags`](#volumeflags) + [`ManagementFlags`](#managementflags).
+Also uses [`CapabilityFlags`](#capabilityflags) + [`ResourceFlags`](#resourceflags) + [`PublishFlags`](#publishflags) + [`VolumeFlags`](#volumeflags) + [`NetworkFlags`](#networkflags) + [`ManagementFlags`](#managementflags).
 
 > Note: `create` accepts `--env` and `--workdir` directly rather than via `ProcessFlags` (no `-i`/`-t`/`-u` here, since no command is being executed).
 
@@ -351,8 +418,8 @@ List boxes.
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--all` | `-a` | `false` | Show all boxes (default: only active) |
-| `--quiet` | `-q` | `false` | Print only IDs |
-| `--format FMT` | — | `table` | Output format (see [Output Formats](#output-formats)) |
+| `--quiet` | `-q` | `false` | Print only IDs; conflicts with `--format` |
+| `--format FMT` | — | `table` | Output format; conflicts with `--quiet` (see [Output Formats](#output-formats)) |
 
 **Examples:**
 
@@ -444,9 +511,8 @@ List cached images.
 
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
-| `--all` | `-a` | `false` | Show all images (default: hide intermediates) |
-| `--quiet` | `-q` | `false` | Print only image IDs |
-| `--format FMT` | — | `table` | Output format (see [Output Formats](#output-formats)) |
+| `--quiet` | `-q` | `false` | Print only image IDs; conflicts with `--format` |
+| `--format FMT` | — | `table` | Output format; conflicts with `--quiet` (see [Output Formats](#output-formats)) |
 
 ---
 
@@ -489,11 +555,14 @@ Copy files/folders between host and box. Exactly one of `SRC` or `DST` must be a
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--follow-symlinks` | `false` | Resolve and copy the symlink target rather than the link itself |
-| `--no-overwrite` | `false` | Skip files that already exist at the destination |
-| `--include-parent` | `true` | Include the source's parent directory when copying out (docker-cp semantics) |
+| `--follow-symlinks` | `false` | Resolve symlink targets (embedded local runtime only) |
+| `--no-overwrite` | `false` | Refuse to overwrite destination files (embedded local runtime only) |
+| `--no-include-parent` | `false` | Copy directory contents without their parent (embedded local runtime only) |
 
-If the box is stopped at copy time, it's started temporarily and stopped again afterwards.
+If a stopped box is safe to resume, it is started temporarily and restored to
+stopped state after the copy succeeds or fails. A job box whose start would run
+or re-run its user-selected main command is refused; start it deliberately
+before copying.
 
 Paths at or under a mount inside the box are refused in both directions — `/tmp`,
 `/dev/shm`, volumes, and the `/etc/hosts`, `/etc/hostname`, `/etc/resolv.conf` binds.
@@ -514,7 +583,7 @@ owned by the box's exec user.
 ```bash
 boxlite cp ./script.py mybox:/work/script.py        # host -> box
 boxlite cp mybox:/var/log/app.log ./app.log         # box -> host
-boxlite cp --no-overwrite ./data/ mybox:/data/      # idempotent sync
+boxlite cp --no-overwrite ./data/ mybox:/data/      # local runtime only
 ```
 
 ---
@@ -571,9 +640,9 @@ Display resource usage statistics for a box.
 
 **Synopsis:** `boxlite network tunnel BOX GUEST_PORT [--listen ADDRESS]`
 
-Print the public URL for a box service port. Requires a remote REST profile
-(`--url` or `--profile`); local boxes have no public ingress. With `--listen`,
-bind a local listener and open one tunnel per accepted connection instead:
+Without `--listen`, print the public URL supplied by a remote REST service;
+local boxes have no public URL. With `--listen`, bind a local listener and
+forward it to either a local or remote box instead:
 
 ```bash
 boxlite network tunnel mybox 3000 --listen 8080
@@ -599,14 +668,20 @@ Run a long-running REST API server. The server holds a single `BoxliteRuntime` a
 
 | Flag | Default | Description |
 |------|---------|-------------|
+| `--debug` | `false` | Enable debug output |
 | `--port N` | `8100` | TCP port to listen on |
+| `--home PATH` | `~/.boxlite` | Absolute runtime data directory; env `BOXLITE_HOME` |
 | `--host ADDR` | `0.0.0.0` | Bind address |
+| `--api-key KEY` | unset | Require this exact `Authorization: Bearer` value (constant-time match) on every route except `GET /v1/config`; env `BOXLITE_SERVE_API_KEY`. Unset is permissive. |
+| `--registry REGISTRY` | none | Image registry; repeatable and prepended to config |
+| `--config PATH` | none | JSON runtime configuration file |
 
 **Examples:**
 
 ```bash
 boxlite serve
 boxlite serve --host 127.0.0.1 --port 9000
+BOXLITE_SERVE_API_KEY="$KEY" boxlite serve --host 127.0.0.1
 ```
 
 ---
@@ -623,9 +698,9 @@ local runtime has no volume backend, so every subcommand returns
 | Subcommand | Synopsis | Notes |
 |---|---|---|
 | `create` | `boxlite volume create [--name NAME]` | Prints the new id |
-| `ls` (`list`) | `boxlite volume ls [-q] [--format FORMAT]` | Columns: ID, NAME, CREATED, SIZE |
-| `get` (`inspect`) | `boxlite volume get ID [--format FORMAT]` | By id |
-| `rm` (`delete`) | `boxlite volume rm ID... [--force]` | By id |
+| `ls` (`list`) | `boxlite volume ls [-q \| --format FORMAT]` | `table`, `json`, or `yaml` (default `table`); quiet and format conflict |
+| `get` (`inspect`) | `boxlite volume get ID [--format FORMAT]` | `table`, `json`, or `yaml` (default `table`); by id |
+| `rm` (`delete`) | `boxlite volume rm ID... [--force]` | By id; `--force` ignores missing volumes |
 
 **`--name`** is mountable in place of the id, so a box can ask for the volume it
 wants without knowing the id:
@@ -675,13 +750,16 @@ Used by `run` and `exec` (defined in `src/cli/src/cli.rs`).
 
 | Flag | Short | Description |
 |------|-------|-------------|
-| `--interactive` | `-i` | Keep STDIN open even if not attached |
+| `--interactive` | `-i` | Keep STDIN open even if not attached; conflicts with `--detach` |
 | `--tty` | `-t` | Allocate a pseudo-TTY (stdout and stderr are merged in TTY mode) |
-| `--env KEY=VALUE` | `-e` | Set environment variables (repeatable; if value omitted, inherits from host) |
+| `--env KEY[=VALUE]` | `-e` | Set environment variables (repeatable; a bare key inherits from the host) |
 | `--workdir PATH` | `-w` | Working directory inside the box |
 | `--user NAME[:GROUP]` | `-u` | Run as `name`/`uid`[:`group`/`gid`] |
 
-`--tty` implies `--interactive` when stdin is a TTY. `--tty` without a TTY-attached stdin is a hard error.
+For `run`, `--tty` always requires TTY-attached stdin, including with
+`--detach`. Foreground `exec --tty` has the same requirement and implies
+interactive input; detached `exec --tty` skips the stdin check and attaches no
+stdin.
 
 ### `CapabilityFlags`
 
@@ -726,18 +804,29 @@ Used by `run` and `create` (defined in `src/cli/src/cli.rs`).
 |------|-------|-------------|
 | `--volume VOLUME` | `-v` | Mount a volume; repeatable (see [Volume Mount Syntax](#volume-mount-syntax)) |
 
+### `NetworkFlags`
+
+Used by `run` and `create` (defined in `src/cli/src/cli.rs`).
+
+| Flag | Description |
+|------|-------------|
+| `--network <enabled\|disabled>` | Outbound mode; default `enabled`. Disabled mode creates no network interface. |
+| `--allow-net HOST` | Restrict TCP/UDP egress to exact hosts, `*.example.com`, IPs, or CIDRs; repeatable, implies enabled networking, and is incompatible with `--network disabled`. Hostname-only rules deny UDP unless an IP/CIDR is also allowed. |
+| `--inbound <enabled\|disabled>` | Inbound mode; default `enabled` (services exposed by the box are reachable). |
+
 ### `ManagementFlags`
 
 Used by `run` and `create` (defined in `src/cli/src/cli.rs`).
+`--detach` and `--rm` belong only to `run`; `create` is always detached and
+does not expose remove-on-stop.
 
 | Flag | Short | Description |
 |------|-------|-------------|
 | `--name NAME` | — | Assign a name to the box |
-| `--detach` | `-d` | Run in the background; print box ID and return |
-| `--rm` | — | Remove the box when it stops; conflicts with `--auto-stop` and `--auto-delete` |
 | `--auto-stop DURATION` | — | Stop the box after this much inactivity; `0` disables |
 | `--auto-delete DURATION` | — | Delete the box this long after it stops; `0` disables |
-| `--no-auto-resume` | — | Refuse operations that would implicitly wake a stopped box |
+| `--no-auto-resume` | — | Ask a REST server to refuse implicit resume after a box has run; first boot is unaffected, and the embedded runtime records but does not enforce it |
+| `--security <enable\|disable>` | — | Sandbox security for the embedded runtime (env `BOXLITE_SECURITY`, default `enable`); REST servers own this policy and do not accept a client override |
 
 `DURATION` is seconds when bare, or a suffixed value: `30s`, `15m`, `2h`, `7d`.
 
@@ -827,18 +916,20 @@ Image `EXPOSE` declarations remain metadata and do not open host listeners.
 
 ## Output Formats
 
-The `--format` flag is shared across `list`, `images`, `inspect`, `stats`, and `info`. Valid values come from `OutputFormat::from_str` at `src/cli/src/formatter.rs:26`:
+The `--format` flag is shared across `list`, `images`, `inspect`, `stats`,
+`info`, `volume ls`, and `volume get`. Valid values come from
+`OutputFormat::from_str` at `src/cli/src/formatter.rs:26`:
 
 | Format | Available on | Description |
 |--------|--------------|-------------|
-| `table` | `list`, `images`, `stats` | Human-readable columnar layout (default) |
-| `json` | `list`, `images`, `stats`, `inspect`, `info` | Pretty-printed JSON (`serde_json::to_string_pretty`) |
-| `yaml` | `list`, `images`, `stats`, `inspect`, `info` | YAML (`serde_yaml::to_string`) |
+| `table` | `list`, `images`, `stats`, `volume ls`, `volume get` | Human-readable columnar layout |
+| `json` | `list`, `images`, `stats`, `inspect`, `info`, `volume ls`, `volume get` | Pretty-printed JSON (`serde_json::to_string_pretty`) |
+| `yaml` | `list`, `images`, `stats`, `inspect`, `info`, `volume ls`, `volume get` | YAML (`serde_yaml::to_string`) |
 | Go template | `inspect` only | Any `gtmpl` template, e.g. `'{{.State.Status}}'`; `{{json .Field}}` serializes a nested value |
 
 Defaults:
 
-- `list`, `images`, `stats`: `table`
+- `list`, `images`, `stats`, `volume ls`, `volume get`: `table`
 - `inspect`: `json`
 - `info`: `yaml`
 

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -19,7 +19,7 @@ The BoxLite CLI (`boxlite`) lets you create, run, and manage BoxLite boxes from 
 - **Create** — Create a box from an image or prepared rootfs without running; supports `-p` and `-v`
 - **Lifecycle** — Start, stop, restart, remove boxes
 - **Inspect** — Show detailed box info (JSON, YAML, or Go template)
-- **Exec** — Run commands inside a running box
+- **Exec** — Run commands in a running or safely resumable box
 - **Images** — Pull and list OCI images
 - **Copy** — Copy files between host and box (`boxlite cp`)
 - **Output formats** — Table, JSON, or YAML for list/images
@@ -152,7 +152,8 @@ echo "$KEY" | boxlite --profile local auth login --url http://localhost:8100 --a
 BOXLITE_API_KEY=$KEY BOXLITE_REST_URL=https://<your-server> boxlite list
 ```
 
-Credentials are stored at `~/.boxlite/credentials.toml` (perms `0600`). OIDC
+Credentials are stored at `<BOXLITE_HOME>/credentials.toml` (default
+`~/.boxlite/credentials.toml`, perms `0600`). OIDC
 sessions auto-refresh on use when within 5 minutes of expiry; if the refresh
 token is rejected (`invalid_grant`) the CLI prompts you to re-run `auth login`.
 
@@ -164,22 +165,28 @@ token is rejected (`invalid_grant`) the CLI prompts you to re-run `auth login`.
 
 ### Global flags
 
-Available for all commands:
+Place these options before the top-level command or after the complete command
+path. A parent command accepts only options shared by all of its children, so
+write `boxlite auth status --url URL` (or `boxlite --url URL auth status`), not
+`boxlite auth --url URL status`. Each command's help shows only options it can
+use. Executing invocations reject unsupported options; Clap's `--help` and
+`--version` display actions remain terminal.
 
-| Flag | Description |
-|------|-------------|
-| `--debug` | Enable debug output. Precedence: `--debug` > `RUST_LOG` env > default (`warn`). |
-| `--home PATH` | BoxLite home directory (default: `~/.boxlite`). Overridden by `BOXLITE_HOME` |
-| `--registry REGISTRY` | Image registry (repeatable; prepended to config) |
-| `--config PATH` | JSON config file path (e.g. for `image_registries`) |
-| `--url URL` | Connect to a remote BoxLite REST server instead of the local runtime. Env: `BOXLITE_REST_URL`. |
-| `--profile NAME` | Named credential profile in `~/.boxlite/credentials.toml`. Lets one machine hold separate logins (e.g. `local` for `boxlite serve`, `cloud` for a remote control plane). Default `default`. Env: `BOXLITE_PROFILE`. |
-| `--path-prefix VALUE` | Routing-slot value for the URL path (`/v1/<prefix>/boxes/...`). Opaque — the server decides what it means (organization, workspace, catalog, …). Captured automatically at `auth login` time from `Principal.path_prefix`. This flag overrides the stored profile's value for credentials with scope over multiple routing values. Unset / empty → URL skips the segment (`/v1/boxes/...`), the canonical shape for single-tenant deployments like `boxlite serve`. Env: `BOXLITE_REST_PATH_PREFIX`. |
+| Flag | Scope | Description |
+|------|-------|-------------|
+| `--debug` | all commands except `completion` | Enable debug output. Precedence: `--debug` > `RUST_LOG` env > default (`warn`). |
+| `--home PATH` | local runtime + credentials | Absolute BoxLite home directory (default: `~/.boxlite`). `BOXLITE_HOME` is the env spelling. |
+| `--registry REGISTRY` | `run`, `create`, `pull`, `serve` | Image registry (repeatable; prepended to config). |
+| `--config PATH` | local-capable commands | JSON config file path (e.g. for `home_dir` and `image_registries`). |
+| `--url URL` | REST-capable commands | Connect to a remote BoxLite REST server instead of the local runtime. Env: `BOXLITE_REST_URL`. |
+| `--profile NAME` | REST-capable commands + `auth` | Named credential profile in `<BOXLITE_HOME>/credentials.toml`. Default `default`. Env: `BOXLITE_PROFILE`. |
+| `--path-prefix VALUE` | REST box/volume commands | Routing-slot value for `/v1/<prefix>/...`; overrides the selected profile. Env: `BOXLITE_REST_PATH_PREFIX`. |
 
 ### `boxlite auth login`
 
 Log in to a BoxLite REST server. Supports three flows that all save to
-`~/.boxlite/credentials.toml` (perms `0600`):
+`<BOXLITE_HOME>/credentials.toml` (default `~/.boxlite/credentials.toml`,
+perms `0600`):
 
 - **API key** — paste or stdin. Long-lived, org-scoped. Good for CI, SDK
   integrations, `boxlite serve` setups.
@@ -204,23 +211,24 @@ non-interactive exchanges. An SSH user should finish verification through the
 BoxLite dashboard in a separate browser, then retry the device login.
 
 When `--method` is unset, the CLI infers it: piped stdin → `api-key` (CI-safe),
-TTY → interactive picker, `$SSH_CONNECTION` set → silent fallback to `device`.
+while a TTY opens the interactive picker. If Browser is selected from that
+picker in a detected headless/SSH environment, the CLI falls back to `device`.
 
 **Usage:** `boxlite auth login [OPTIONS]`
 
 | Option | Description |
 |--------|-------------|
-| `--url URL` | Server URL (default: `http://localhost:8100`, matching `boxlite serve`). For cloud control planes include the `/api` prefix, e.g. `https://api.example.com/api`. |
+| `--url URL` | Server URL (precedence: flag, `BOXLITE_REST_URL`, selected profile URL, then `http://localhost:8100`). For cloud control planes include the `/api` prefix. |
 | `--method <api-key\|browser\|device>` | Explicit flow choice. Overrides inference. |
-| `--api-key-stdin` | Read the API key from stdin (one line). The flag takes no value, so the secret never appears on argv. Implies `--method api-key`. |
-| `--no-browser` | Skip the browser; use device code instead. Implies `--method device`. |
+| `--api-key-stdin` | Read the API key from stdin (one line). The flag takes no value, so the secret never appears on argv. Selects API-key login and conflicts with explicit browser/device methods. |
+| `--no-browser` | Use device code when no method is explicit; conflicts with API-key stdin and explicit API-key/browser methods. |
 | `--callback-port <PORT>` | Local port for the browser-flow callback (default `5555`). **Must match an entry in the IdP's allow-list byte-for-byte** — a different port produces "Callback URL mismatch" exactly like no entry at all. |
 | `--issuer URL` | OIDC issuer URL. Overrides what `GET /api/config` returns. Useful for self-hosted Dex tenants where the discovery is wrong. |
 | `--client-id ID` | OIDC client_id. Overrides `/api/config`. |
 | `--audience VAL` | OIDC audience. Auth0 requires it; Dex tolerates `None`. |
 
-Global flags also apply — most importantly `--profile NAME` to log in to a
-specific credential profile (default `default`).
+`--profile NAME` selects the credential profile (default `default`), and
+`--home PATH` selects the credential-store root.
 
 **Examples:**
 
@@ -250,7 +258,8 @@ URL goes under the `boxlite` static client's `redirectURIs`, plus
 
 ### `boxlite auth logout`
 
-Remove stored credentials at `~/.boxlite/credentials.toml`. Prompts for confirmation unless `--yes` is given.
+Remove the selected profile from `<BOXLITE_HOME>/credentials.toml` (default
+`~/.boxlite/credentials.toml`). Prompts for confirmation unless `--yes` is given.
 
 **Usage:** `boxlite auth logout [OPTIONS]`
 
@@ -265,20 +274,20 @@ Print the current authentication state: the logged-in URL, the source
 OIDC sessions the access token's expiry. Offline — no network calls,
 no secret material printed.
 
-**Usage:** `boxlite auth status [--profile NAME]`
+**Usage:** `boxlite auth status [--url URL] [--profile NAME]`
 
 **Example output (API key):**
 
 ```
 Logged in to:    http://localhost:8100
-Credential:      API key (from ~/.boxlite/credentials.toml [local])
+Credential:      API key (from <BOXLITE_HOME>/credentials.toml [local])
 ```
 
 **Example output (OIDC session):**
 
 ```
 Logged in to:    https://api.boxlite.ai/api
-Credential:      OIDC bearer token (from ~/.boxlite/credentials.toml [cloud])
+Credential:      OIDC bearer token (from <BOXLITE_HOME>/credentials.toml [cloud])
 Expires:         2026-05-21T15:42:00+00:00
 ```
 
@@ -287,10 +296,10 @@ Expires:         2026-05-21T15:42:00+00:00
 Confirm the active credential's identity by making one authenticated
 request to `GET /v1/me`. Unlike `auth status` (offline, only reports where
 the credential came from), `whoami` shows the server-resolved principal,
-organization, and scopes. Triggers a silent OIDC refresh if the access
+path prefix, and scopes. Triggers a silent OIDC refresh if the access
 token is within 5 minutes of expiry.
 
-**Usage:** `boxlite auth whoami [--profile NAME]`
+**Usage:** `boxlite auth whoami [--url URL] [--profile NAME]`
 
 **Example output:**
 
@@ -298,7 +307,7 @@ token is within 5 minutes of expiry.
 Logged in as:    dev@acme.test
 Name:            Dev McAcme
 Principal:       auth0|abc123 (user)
-Organization:    acme
+Path prefix:     acme
 Server:          https://api.boxlite.ai/api
 Scopes:          box:read, box:write, box:exec, image:read, snapshot:read
 ```
@@ -323,22 +332,29 @@ silently restarting it, because restarting would run the command a second time.
 | Option | Short | Description |
 |--------|-------|-------------|
 | `--rootfs PATH` | | Use a prepared rootfs path instead of pulling/resolving an image |
-| `--interactive` | `-i` | Keep STDIN open |
-| `--tty` | `-t` | Allocate a pseudo-TTY |
-| `--env KEY=VALUE` | `-e` | Set environment variables (repeatable) |
+| `--interactive` | `-i` | Keep STDIN open; conflicts with `--detach` |
+| `--tty` | `-t` | Allocate a pseudo-TTY; requires TTY-attached stdin, even with `--detach` |
+| `--env KEY[=VALUE]` | `-e` | Set environment variables; a bare key inherits its host value (repeatable) |
 | `--workdir PATH` | `-w` | Working directory in the box |
+| `--user NAME[:GROUP]` | `-u` | Run as a name/uid and optional group/gid |
+| `--entrypoint EXEC` | | Override the image entrypoint |
 | `--publish PORT` | `-p` | Publish a TCP box port locally (`80` = automatic host port, `8080:80` = fixed) |
 | `--volume VOLUME` | `-v` | Mount a volume: `name:/box` for a managed volume, `./path:/box` for a host bind, `/box` for anonymous |
 | `--cpus N` | | CPU limit |
 | `--memory MiB` | | Memory limit (MiB) |
+| `--disk-size GB` | | Sparse rootfs disk size; smaller values than the base image are ignored |
 | `--cap-add CAPABILITY` | | Add a Linux capability (repeatable; accepts `CAP_` prefix or `ALL`) |
 | `--cap-drop CAPABILITY` | | Drop a Linux capability (repeatable; accepts `CAP_` prefix or `ALL`) |
+| `--network <enabled\|disabled>` | | Outbound network mode (default `enabled`) |
+| `--allow-net HOST` | | Restrict egress to an exact host, wildcard domain, IP, or CIDR; repeatable and implies enabled networking |
+| `--inbound <enabled\|disabled>` | | Inbound network mode (default `enabled`) |
 | `--name NAME` | | Name the box |
 | `--detach` | `-d` | Run in background, print box ID |
-| `--rm` | | Remove the box when it exits |
+| `--rm` | | Remove the box when it stops; conflicts with lifecycle deadlines and is ignored with `--detach` |
 | `--auto-stop DURATION` | | Stop the box after this much inactivity; `0` disables |
 | `--auto-delete DURATION` | | Delete the box this long after it stops; `0` disables |
-| `--no-auto-resume` | | Refuse operations that would implicitly wake a stopped box |
+| `--no-auto-resume` | | Ask a REST server to refuse implicit resume after a box has run; first boot is unaffected, and the embedded runtime records but does not enforce it |
+| `--security <enable\|disable>` | | Embedded-runtime sandbox security (default `enable`; env `BOXLITE_SECURITY`); REST servers own this policy |
 
 `-p` is explicit local publication. Remote REST profiles reject it and direct
 the caller to `boxlite network tunnel`.
@@ -379,16 +395,23 @@ default, and `exec` still starts it on demand.
 |--------|-------|-------------|
 | `--rootfs PATH` | | Use a prepared rootfs path instead of pulling/resolving an image |
 | `--name NAME` | | Name the box |
-| `--env KEY=VALUE` | `-e` | Environment variables |
+| `--env KEY[=VALUE]` | `-e` | Environment variables; a bare key inherits its host value |
 | `--workdir PATH` | `-w` | Working directory |
+| `--entrypoint EXEC` | | Override the image entrypoint |
 | `--publish PORT` | `-p` | Publish a TCP box port locally (`80` = automatic host port, `8080:80` = fixed) |
 | `--volume VOLUME` | `-v` | Mount a volume: `name:/box` for a managed volume, `./path:/box` for a host bind, `/box` for anonymous |
 | `--cpus N` | | CPU limit |
 | `--memory MiB` | | Memory limit (MiB) |
+| `--disk-size GB` | | Sparse rootfs disk size; smaller values than the base image are ignored |
 | `--cap-add CAPABILITY` | | Add a Linux capability (repeatable; accepts `CAP_` prefix or `ALL`) |
 | `--cap-drop CAPABILITY` | | Drop a Linux capability (repeatable; accepts `CAP_` prefix or `ALL`) |
-| `--detach` | `-d` | (create always “detaches”) |
-| `--rm` | | Auto-remove when stopped |
+| `--network <enabled\|disabled>` | | Outbound network mode (default `enabled`) |
+| `--allow-net HOST` | | Restrict egress to an exact host, wildcard domain, IP, or CIDR; repeatable and implies enabled networking |
+| `--inbound <enabled\|disabled>` | | Inbound network mode (default `enabled`) |
+| `--auto-stop DURATION` | | Stop the box after this much inactivity; `0` disables; requires a REST server |
+| `--auto-delete DURATION` | | Delete the box this long after it stops; `0` disables; requires a REST server |
+| `--no-auto-resume` | | Ask a REST server to refuse implicit resume after a box has run; first boot is unaffected, and the embedded runtime records but does not enforce it |
+| `--security <enable\|disable>` | | Embedded-runtime sandbox security (default `enable`; env `BOXLITE_SECURITY`); REST servers own this policy |
 
 `-p` is explicit local publication. Remote REST profiles reject it and direct
 the caller to `boxlite network tunnel`.
@@ -406,22 +429,25 @@ boxlite start openclaw
 
 ### `boxlite exec`
 
-Run a command in a running box.
+Run a command in a box. A safely resumable stopped box starts implicitly; a
+job box whose start would run or re-run its user-selected main command is
+refused, so start that box deliberately with `boxlite start` first.
 
-**Usage:** `boxlite exec [OPTIONS] BOX COMMAND [ARGS]...`
+**Usage:** `boxlite exec [OPTIONS] BOX -- COMMAND [ARGS]...`
 
 | Option | Short | Description |
 |--------|-------|-------------|
-| `--interactive` | `-i` | Keep STDIN open |
-| `--tty` | `-t` | Allocate a TTY |
-| `--env KEY=VALUE` | `-e` | Environment variables |
+| `--interactive` | `-i` | Keep STDIN open; conflicts with `--detach` |
+| `--tty` | `-t` | Allocate a TTY; foreground mode requires TTY-attached stdin, while detached mode attaches no stdin |
+| `--env KEY[=VALUE]` | `-e` | Environment variables; a bare key inherits its host value |
 | `--workdir PATH` | `-w` | Working directory |
+| `--user NAME[:GROUP]` | `-u` | Run as a name/uid and optional group/gid |
 | `--detach` | `-d` | Run in background (don’t wait) |
 
 **Example:**
 
 ```bash
-boxlite exec -it mybox /bin/sh
+boxlite exec -it mybox -- /bin/sh
 ```
 
 ### `boxlite list` (alias: `ls`, `ps`)
@@ -433,8 +459,8 @@ List boxes.
 | Option | Short | Description |
 |--------|-------|-------------|
 | `--all` | `-a` | Show all boxes (default: running only) |
-| `--quiet` | `-q` | Show only IDs |
-| `--format FMT` | | Output format: `table`, `json`, `yaml` (default: `table`) |
+| `--quiet` | `-q` | Show only IDs; conflicts with `--format` |
+| `--format FMT` | | Output format: `table`, `json`, `yaml`; conflicts with `--quiet` (default: `table`) |
 
 ### `boxlite start`
 
@@ -503,9 +529,8 @@ List cached images.
 
 | Option | Short | Description |
 |--------|-------|-------------|
-| `--all` | `-a` | Show all images (including intermediate) |
-| `--quiet` | `-q` | Show only image IDs |
-| `--format FMT` | | Output format: `table`, `json`, `yaml` |
+| `--quiet` | `-q` | Show only image IDs; conflicts with `--format` |
+| `--format FMT` | | Output format: `table`, `json`, `yaml`; conflicts with `--quiet` |
 
 ### `boxlite cp`
 
@@ -517,9 +542,9 @@ Copy files or directories between host and box.
 
 | Option | Description |
 |--------|-------------|
-| `--follow-symlinks` | Follow symlinks when copying |
-| `--no-overwrite` | Do not overwrite existing files |
-| `--include-parent` | Include parent directory when copying from box (default: true) |
+| `--follow-symlinks` | Follow symlinks when copying (local runtime only) |
+| `--no-overwrite` | Do not overwrite existing files (local runtime only) |
+| `--no-include-parent` | Copy directory contents without their parent (local runtime only) |
 
 **Examples:**
 
@@ -583,8 +608,20 @@ Then reload your shell or source the file.
 
 | Variable | Description |
 |----------|-------------|
-| `BOXLITE_HOME` | Runtime home directory (default: `~/.boxlite`). Overridden by `--home`. |
+| `BOXLITE_HOME` | Runtime and credential home directory (default: `~/.boxlite`). Overridden by `--home`. |
+| `BOXLITE_REST_URL` | REST server endpoint; equivalent to `--url`. |
 | `BOXLITE_API_KEY` | Long-lived API key sent as `Authorization: Bearer`. Overrides any stored credentials. |
+| `BOXLITE_PROFILE` | Credential profile; equivalent to `--profile` (default `default`). |
+| `BOXLITE_REST_PATH_PREFIX` | REST routing path segment; equivalent to `--path-prefix`. |
+| `BOXLITE_SECURITY` | `run`/`create` sandbox preset; equivalent to `--security`. |
+| `BOXLITE_SERVE_API_KEY` | Expected bearer key for `serve`; equivalent to `serve --api-key`. |
+| `OIDC_ISSUER`, `OIDC_CLIENT_ID`, `OIDC_AUDIENCE` | OIDC login fallbacks after flags and server discovery. |
+| `BOXLITE_LOG_FILE` | Explicit JSON log-file path for any command; `serve` otherwise defaults to `<BOXLITE_HOME>/logs/serve.log`. |
+| `BOXLITE_EXPERIMENTAL` | Comma-separated RC features: `custom-kernel`, `nested-virtualization`. |
+| `BOXLITE_RECONNECT_GRACE` | `serve` reconnect grace (default `5m`). |
+| `BOXLITE_SHUTDOWN_GRACE` | `serve` shutdown-stage grace (default `30s`). |
+| `BOXLITE_MAX_SESSION_LIFETIME` | `serve` session hard cap (default `24h`). |
+| `SSH_CONNECTION` | `auth login` headless detection; choosing Browser from the TTY picker falls back to device flow when set. |
 | `RUST_LOG` | Log level: `trace`, `debug`, `info`, `warn`, `error`. Use `RUST_LOG=debug` for troubleshooting. |
 
 ## Configuration file

--- a/src/cli/src/cli.rs
+++ b/src/cli/src/cli.rs
@@ -2,6 +2,7 @@
 //! This module contains all CLI-related code including the main CLI structure,
 //! subcommands, and flag definitions.
 
+use anyhow::Context;
 use boxlite::experimental::custom_kernel::{KernelFormat, KernelOptions, configure};
 use boxlite::experimental::{
     EXPERIMENTAL_FEATURES_ENV, ExperimentalFeature, ExperimentalFeatures, RuntimeBuilder,
@@ -13,8 +14,13 @@ use boxlite::{
     BoxCommand, BoxOptions, BoxliteOptions, BoxliteRestOptions, BoxliteRuntime,
     ContainerCapabilities, ImageRegistry, NetworkSpec,
 };
-use clap::{Args, Command, Parser, Subcommand, ValueEnum};
+use clap::error::ErrorKind;
+use clap::parser::ValueSource;
+use clap::{
+    Arg, ArgMatches, Args, Command, CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum,
+};
 use clap_complete::shells::{Bash, Fish, Zsh};
+use std::ffi::OsString;
 use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
 
@@ -28,11 +34,19 @@ pub fn apply_env_vars_with_lookup<F>(env: &[String], opts: &mut BoxOptions, look
 where
     F: Fn(&str) -> Option<String>,
 {
+    opts.env.extend(resolve_env_vars_with_lookup(env, lookup));
+}
+
+fn resolve_env_vars_with_lookup<F>(env: &[String], lookup: F) -> Vec<(String, String)>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let mut resolved = Vec::with_capacity(env.len());
     for env_str in env {
         if let Some((k, v)) = env_str.split_once('=') {
-            opts.env.push((k.to_string(), v.to_string()));
+            resolved.push((k.to_string(), v.to_string()));
         } else if let Some(val) = lookup(env_str) {
-            opts.env.push((env_str.to_string(), val));
+            resolved.push((env_str.to_string(), val));
         } else {
             tracing::warn!(
                 "Environment variable '{}' not found on host, skipping",
@@ -40,6 +54,7 @@ where
             );
         }
     }
+    resolved
 }
 
 // ============================================================================
@@ -54,6 +69,497 @@ pub struct Cli {
 
     #[command(subcommand)]
     pub command: Commands,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum GlobalOption {
+    Debug,
+    Home,
+    Registry,
+    Config,
+    Url,
+    Profile,
+    PathPrefix,
+}
+
+impl GlobalOption {
+    const ALL: &'static [Self] = &[
+        Self::Debug,
+        Self::Home,
+        Self::Registry,
+        Self::Config,
+        Self::Url,
+        Self::Profile,
+        Self::PathPrefix,
+    ];
+
+    const fn id(self) -> &'static str {
+        match self {
+            Self::Debug => "debug",
+            Self::Home => "home",
+            Self::Registry => "registry",
+            Self::Config => "config",
+            Self::Url => "url",
+            Self::Profile => "profile",
+            Self::PathPrefix => "path_prefix",
+        }
+    }
+
+    const fn long(self) -> &'static str {
+        match self {
+            Self::PathPrefix => "path-prefix",
+            _ => self.id(),
+        }
+    }
+
+    const fn propagates_value(self) -> bool {
+        !matches!(self, Self::Registry)
+    }
+
+    fn clear(self, global: &mut GlobalFlags) {
+        match self {
+            Self::Debug => global.debug = false,
+            Self::Home => global.home = None,
+            Self::Registry => global.registry.clear(),
+            Self::Config => global.config = None,
+            Self::Url => global.url = None,
+            Self::Profile => global.profile = None,
+            Self::PathPrefix => global.path_prefix = None,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct CommandScope {
+    name: &'static str,
+    globals: &'static [GlobalOption],
+    children: &'static [CommandScope],
+}
+
+impl CommandScope {
+    fn allows(&self, option: GlobalOption) -> bool {
+        self.globals.contains(&option)
+    }
+}
+
+const ALL_GLOBALS: &[GlobalOption] = GlobalOption::ALL;
+const BOX_GLOBALS: &[GlobalOption] = &[
+    GlobalOption::Debug,
+    GlobalOption::Home,
+    GlobalOption::Config,
+    GlobalOption::Url,
+    GlobalOption::Profile,
+    GlobalOption::PathPrefix,
+];
+const LOCAL_IMAGE_GLOBALS: &[GlobalOption] = &[
+    GlobalOption::Debug,
+    GlobalOption::Home,
+    GlobalOption::Registry,
+    GlobalOption::Config,
+];
+const LOCAL_GLOBALS: &[GlobalOption] = &[
+    GlobalOption::Debug,
+    GlobalOption::Home,
+    GlobalOption::Config,
+];
+const AUTH_GLOBALS: &[GlobalOption] = &[
+    GlobalOption::Debug,
+    GlobalOption::Home,
+    GlobalOption::Profile,
+];
+const AUTH_URL_GLOBALS: &[GlobalOption] = &[
+    GlobalOption::Debug,
+    GlobalOption::Home,
+    GlobalOption::Url,
+    GlobalOption::Profile,
+];
+const VOLUME_GLOBALS: &[GlobalOption] = &[
+    GlobalOption::Debug,
+    GlobalOption::Home,
+    GlobalOption::Url,
+    GlobalOption::Profile,
+    GlobalOption::PathPrefix,
+];
+
+const AUTH_SCOPES: &[CommandScope] = &[
+    CommandScope {
+        name: "login",
+        globals: AUTH_URL_GLOBALS,
+        children: &[],
+    },
+    CommandScope {
+        name: "logout",
+        globals: AUTH_GLOBALS,
+        children: &[],
+    },
+    CommandScope {
+        name: "status",
+        globals: AUTH_URL_GLOBALS,
+        children: &[],
+    },
+    CommandScope {
+        name: "whoami",
+        globals: AUTH_URL_GLOBALS,
+        children: &[],
+    },
+];
+const NETWORK_SCOPES: &[CommandScope] = &[CommandScope {
+    name: "tunnel",
+    globals: BOX_GLOBALS,
+    children: &[],
+}];
+const VOLUME_SCOPES: &[CommandScope] = &[
+    CommandScope {
+        name: "create",
+        globals: VOLUME_GLOBALS,
+        children: &[],
+    },
+    CommandScope {
+        name: "ls",
+        globals: VOLUME_GLOBALS,
+        children: &[],
+    },
+    CommandScope {
+        name: "get",
+        globals: VOLUME_GLOBALS,
+        children: &[],
+    },
+    CommandScope {
+        name: "rm",
+        globals: VOLUME_GLOBALS,
+        children: &[],
+    },
+];
+const COMMAND_SCOPES: &[CommandScope] = &[
+    CommandScope {
+        name: "run",
+        globals: ALL_GLOBALS,
+        children: &[],
+    },
+    CommandScope {
+        name: "exec",
+        globals: BOX_GLOBALS,
+        children: &[],
+    },
+    CommandScope {
+        name: "create",
+        globals: ALL_GLOBALS,
+        children: &[],
+    },
+    CommandScope {
+        name: "list",
+        globals: BOX_GLOBALS,
+        children: &[],
+    },
+    CommandScope {
+        name: "rm",
+        globals: BOX_GLOBALS,
+        children: &[],
+    },
+    CommandScope {
+        name: "start",
+        globals: BOX_GLOBALS,
+        children: &[],
+    },
+    CommandScope {
+        name: "stop",
+        globals: BOX_GLOBALS,
+        children: &[],
+    },
+    CommandScope {
+        name: "restart",
+        globals: BOX_GLOBALS,
+        children: &[],
+    },
+    CommandScope {
+        name: "pull",
+        globals: LOCAL_IMAGE_GLOBALS,
+        children: &[],
+    },
+    CommandScope {
+        name: "images",
+        globals: LOCAL_GLOBALS,
+        children: &[],
+    },
+    CommandScope {
+        name: "inspect",
+        globals: BOX_GLOBALS,
+        children: &[],
+    },
+    CommandScope {
+        name: "cp",
+        globals: BOX_GLOBALS,
+        children: &[],
+    },
+    CommandScope {
+        name: "info",
+        globals: LOCAL_GLOBALS,
+        children: &[],
+    },
+    CommandScope {
+        name: "logs",
+        globals: LOCAL_GLOBALS,
+        children: &[],
+    },
+    CommandScope {
+        name: "stats",
+        globals: BOX_GLOBALS,
+        children: &[],
+    },
+    CommandScope {
+        name: "network",
+        globals: BOX_GLOBALS,
+        children: NETWORK_SCOPES,
+    },
+    CommandScope {
+        name: "serve",
+        globals: LOCAL_IMAGE_GLOBALS,
+        children: &[],
+    },
+    CommandScope {
+        name: "auth",
+        globals: AUTH_GLOBALS,
+        children: AUTH_SCOPES,
+    },
+    CommandScope {
+        name: "volume",
+        globals: VOLUME_GLOBALS,
+        children: VOLUME_SCOPES,
+    },
+    CommandScope {
+        name: "completion",
+        globals: &[],
+        children: &[],
+    },
+];
+
+/// Build one command tree for runtime parsing, help, and completion.
+///
+/// Root copies preserve `boxlite --option command` compatibility but are not
+/// global. Each command receives only the positive set it owns, so Clap itself
+/// rejects an irrelevant option written after the command and renders the same
+/// scope in help. Environment bindings live on those scoped copies so an
+/// irrelevant ambient value is never parsed. Singular values use Clap's
+/// documented propagation back to the root `GlobalFlags`; repeatable values
+/// are folded explicitly because propagation selects one level's `MatchedArg`
+/// rather than appending values from independently defined levels.
+pub fn command() -> Command {
+    let command = Cli::command();
+    let global_args = command
+        .get_arguments()
+        .filter(|argument| argument.is_global_set())
+        .cloned()
+        .collect::<Vec<_>>();
+    let command = command.mut_args(|argument| {
+        if argument.is_global_set() {
+            argument.global(false).env(None::<&'static str>)
+        } else {
+            argument
+        }
+    });
+    apply_command_scopes(command, COMMAND_SCOPES, &global_args)
+}
+
+fn apply_command_scopes(
+    command: Command,
+    scopes: &'static [CommandScope],
+    global_args: &[Arg],
+) -> Command {
+    for subcommand in command.get_subcommands() {
+        assert!(
+            scopes
+                .iter()
+                .any(|scope| scope.name == subcommand.get_name()),
+            "missing global-option scope for `boxlite {}`",
+            subcommand.get_name()
+        );
+    }
+    for scope in scopes {
+        assert!(
+            command
+                .get_subcommands()
+                .any(|subcommand| subcommand.get_name() == scope.name),
+            "global-option scope references missing command `{}`",
+            scope.name
+        );
+    }
+
+    command.mut_subcommands(|subcommand| {
+        let scope = scopes
+            .iter()
+            .find(|scope| scope.name == subcommand.get_name())
+            .expect("command scope checked above");
+        let local_ids = subcommand
+            .get_arguments()
+            .map(|argument| argument.get_id().clone())
+            .collect::<Vec<_>>();
+        let scoped_args = global_args
+            .iter()
+            .filter(|argument| {
+                scope
+                    .globals
+                    .iter()
+                    .any(|option| option.id() == argument.get_id().as_str())
+            })
+            .filter(|argument| !local_ids.contains(argument.get_id()))
+            .cloned()
+            .map(|argument| {
+                let option = GlobalOption::ALL
+                    .iter()
+                    .copied()
+                    .find(|option| option.id() == argument.get_id().as_str())
+                    .expect("scoped argument must be a declared global option");
+                argument.global(option.propagates_value())
+            });
+        apply_command_scopes(subcommand.args(scoped_args), scope.children, global_args)
+    })
+}
+
+/// Parse through [`command`] so the runtime parser and rendered help use the
+/// same command-capability policy.
+pub fn parse() -> Cli {
+    try_parse_from(std::env::args_os()).unwrap_or_else(|error| error.exit())
+}
+
+pub(crate) fn try_parse_from<I, T>(args: I) -> Result<Cli, clap::Error>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString> + Clone,
+{
+    let mut parser = command();
+    let mut matches = parser.clone().try_get_matches_from(args)?;
+    let command_path = selected_command_path(&matches);
+    let scope = command_scope(&command_path).expect("parsed command must have a declared scope");
+
+    if let Some(option) = GlobalOption::ALL.iter().copied().find(|option| {
+        !scope.allows(*option)
+            && matches.value_source(option.id()) == Some(ValueSource::CommandLine)
+    }) {
+        return Err(irrelevant_global_error(&mut parser, &command_path, option));
+    }
+
+    if let Some(home) = matches.get_one::<PathBuf>("home")
+        && scope.allows(GlobalOption::Home)
+        && !home.is_absolute()
+    {
+        return Err(parser.error(
+            ErrorKind::ValueValidation,
+            format!(
+                "BoxLite home must be an absolute path, got: {}",
+                home.display()
+            ),
+        ));
+    }
+
+    for id in ["url", "profile", "path_prefix", "config"] {
+        if scope.globals.iter().any(|option| option.id() == id)
+            && matches.value_source(id) == Some(ValueSource::CommandLine)
+            && matches.get_one::<String>(id).is_some_and(String::is_empty)
+        {
+            let option = id.replace('_', "-");
+            return Err(parser.error(
+                ErrorKind::ValueValidation,
+                format!("--{option} cannot be empty"),
+            ));
+        }
+    }
+    let registry_values = command_line_values_along_selected_path(&matches, "registry");
+    if scope.allows(GlobalOption::Registry) && registry_values.iter().any(String::is_empty) {
+        return Err(parser.error(ErrorKind::ValueValidation, "--registry cannot be empty"));
+    }
+
+    let mut cli = Cli::from_arg_matches_mut(&mut matches)?;
+    if scope.allows(GlobalOption::Registry) {
+        cli.global.registry = registry_values;
+    }
+    clear_irrelevant_environment_globals(&mut cli.global, scope);
+    merge_root_login_url(&mut cli);
+    normalize_empty_urls(&mut cli);
+    Ok(cli)
+}
+
+fn command_line_values_along_selected_path(matches: &ArgMatches, id: &str) -> Vec<String> {
+    let mut values = Vec::new();
+    let mut current = matches;
+    loop {
+        if let Ok(Some(level_values)) = current.try_get_many::<String>(id) {
+            values.extend(level_values.cloned());
+        }
+        let Some((_, child)) = current.subcommand() else {
+            break;
+        };
+        current = child;
+    }
+    values
+}
+
+fn selected_command_path(matches: &ArgMatches) -> Vec<&str> {
+    let mut path = Vec::new();
+    let mut current = matches;
+    while let Some((name, child)) = current.subcommand() {
+        path.push(name);
+        current = child;
+    }
+    path
+}
+
+fn command_scope(path: &[&str]) -> Option<&'static CommandScope> {
+    let mut scopes = COMMAND_SCOPES;
+    let mut selected = None;
+    for name in path {
+        let scope = scopes.iter().find(|scope| scope.name == *name)?;
+        selected = Some(scope);
+        scopes = scope.children;
+    }
+    selected
+}
+
+fn irrelevant_global_error(
+    parser: &mut Command,
+    command_path: &[&str],
+    option: GlobalOption,
+) -> clap::Error {
+    parser.error(
+        ErrorKind::UnknownArgument,
+        format!(
+            "--{} is not valid for `boxlite {}`",
+            option.long(),
+            command_path.join(" ")
+        ),
+    )
+}
+
+/// Irrelevant values supplied by ambient environment variables are ignored:
+/// they are not command options and must not make an unrelated command fail.
+fn clear_irrelevant_environment_globals(global: &mut GlobalFlags, scope: &CommandScope) {
+    for option in GlobalOption::ALL {
+        if !scope.allows(*option) {
+            option.clear(global);
+        }
+    }
+}
+
+fn merge_root_login_url(cli: &mut Cli) {
+    if let Commands::Auth(crate::commands::auth::AuthArgs {
+        command: crate::commands::auth::AuthCommand::Login(login),
+    }) = &mut cli.command
+        && login.url.is_none()
+    {
+        login.url.clone_from(&cli.global.url);
+    }
+}
+
+fn normalize_empty_urls(cli: &mut Cli) {
+    if cli.global.url.as_deref() == Some("") {
+        cli.global.url = None;
+    }
+    if let Commands::Auth(crate::commands::auth::AuthArgs {
+        command: crate::commands::auth::AuthCommand::Login(login),
+    }) = &mut cli.command
+        && login.url.as_deref() == Some("")
+    {
+        login.url = None;
+    }
 }
 
 #[derive(Subcommand, Debug)]
@@ -112,7 +618,7 @@ pub enum Commands {
     /// Authenticate with a remote BoxLite server
     Auth(crate::commands::auth::AuthArgs),
 
-    /// Manage named local volumes
+    /// Manage named volumes on a REST server
     Volume(crate::commands::volume::VolumeArgs),
 
     /// Generate shell completion script (hidden from help)
@@ -137,11 +643,8 @@ pub struct CompletionArgs {
 }
 
 /// Writes a completion script for the given shell to `out`.
-pub fn generate_completion(shell: &Shell, cmd: &mut Command, name: &str, out: &mut dyn Write) {
-    // clap_complete's AOT generators enumerate hidden arguments. Generate
-    // from a projection of the affected commands so RC flags remain
-    // parseable without becoming a discovery surface.
-    let mut cmd = completion_projection(cmd);
+pub fn generate_completion(shell: &Shell, name: &str, out: &mut dyn Write) {
+    let mut cmd = completion_command();
     match shell {
         Shell::Bash => clap_complete::generate(Bash, &mut cmd, name, out),
         Shell::Zsh => clap_complete::generate(Zsh, &mut cmd, name, out),
@@ -149,8 +652,11 @@ pub fn generate_completion(shell: &Shell, cmd: &mut Command, name: &str, out: &m
     }
 }
 
-fn completion_projection(cmd: &Command) -> Command {
-    cmd.clone()
+fn completion_command() -> Command {
+    // clap_complete's AOT generators enumerate hidden arguments. Runtime,
+    // help, and scoped globals already share `command()`; this final projection
+    // removes only experimental arguments from completion discovery.
+    command()
         .mut_subcommand("run", without_hidden_arguments)
         .mut_subcommand("create", without_hidden_arguments)
 }
@@ -204,7 +710,7 @@ pub struct GlobalFlags {
     #[arg(long, global = true)]
     pub debug: bool,
 
-    /// BoxLite home directory
+    /// Absolute BoxLite runtime and credential home directory
     #[arg(long, global = true, env = "BOXLITE_HOME")]
     pub home: Option<std::path::PathBuf>,
 
@@ -223,14 +729,13 @@ pub struct GlobalFlags {
     #[arg(long, global = true, env = "BOXLITE_REST_URL")]
     pub url: Option<String>,
 
-    /// Named credential profile in `~/.boxlite/credentials.toml`. Lets one
-    /// machine hold separate logins for, e.g., a local `boxlite serve` and a
-    /// remote control plane. Defaults to `default` if neither flag nor env
-    /// is set.
+    /// Named profile in `<BOXLITE_HOME>/credentials.toml`. Lets one machine
+    /// hold separate remote logins. Defaults to `default` if neither flag nor
+    /// env is set.
     #[arg(long, global = true, env = "BOXLITE_PROFILE")]
     pub profile: Option<String>,
 
-    /// Routing-slot value for the URL path (`/v1/<prefix>/boxes/...`).
+    /// Routing-slot value for the URL path (`/v1/<prefix>/...`).
     /// Opaque — the server decides what this means (org id, workspace,
     /// catalog, …); the value typically comes from the `auth login`
     /// flow capturing `Principal.path_prefix`. This flag overrides
@@ -247,6 +752,10 @@ pub struct GlobalFlags {
 }
 
 impl GlobalFlags {
+    pub(crate) fn credential_store(&self) -> crate::credentials::CredentialStore {
+        crate::credentials::CredentialStore::new(self.home.clone())
+    }
+
     /// Resolve which credential profile to read/write. Order: explicit
     /// `--profile` flag (which clap also fills from `BOXLITE_PROFILE`) > the
     /// hard-coded `default` name. Keeping this in one helper means a future
@@ -305,18 +814,14 @@ impl GlobalFlags {
     /// about which backend a command is aimed at. It re-reads the credential
     /// file rather than threading the resolution through; the cost is one extra
     /// read on the two commands that ask.
-    pub fn targets_rest(&self) -> bool {
-        let stored = crate::credentials::load_named(&self.resolved_profile())
-            .ok()
-            .flatten();
+    pub fn targets_rest(&self) -> anyhow::Result<bool> {
+        let stored = self.load_selected_profile()?;
         let env_api_key = std::env::var("BOXLITE_API_KEY").ok();
-        self.resolve_rest_options(stored, env_api_key).is_some()
+        Ok(self.resolve_rest_options(stored, env_api_key).is_some())
     }
 
     pub fn create_runtime(&self) -> anyhow::Result<BoxliteRuntime> {
-        let stored = crate::credentials::load_named(&self.resolved_profile())
-            .ok()
-            .flatten();
+        let stored = self.load_selected_profile()?;
         // Clap reads BOXLITE_REST_URL into `self.url`; BOXLITE_API_KEY is the
         // one credential env we still consult directly here.
         let env_api_key = std::env::var("BOXLITE_API_KEY").ok();
@@ -329,6 +834,13 @@ impl GlobalFlags {
                 self.create_runtime_with_options(options)
             }
         }
+    }
+
+    fn load_selected_profile(&self) -> anyhow::Result<Option<crate::credentials::Profile>> {
+        let profile = self.resolved_profile();
+        self.credential_store()
+            .load_named(&profile)
+            .with_context(|| format!("loading credential profile `{profile}`"))
     }
 
     /// Build REST connection options from the selected credential profile and
@@ -349,7 +861,7 @@ impl GlobalFlags {
     /// Building the options bare in that branch (instead of starting from the
     /// profile) was the cause of the prefix-less `/v1/boxes` 404 against a
     /// multi-tenant server.
-    fn resolve_rest_options(
+    pub(crate) fn resolve_rest_options(
         &self,
         stored: Option<crate::credentials::Profile>,
         env_api_key: Option<String>,
@@ -395,7 +907,7 @@ impl GlobalFlags {
 #[derive(Args, Debug, Clone)]
 pub struct ProcessFlags {
     /// Keep STDIN open even if not attached
-    #[arg(short, long)]
+    #[arg(short, long, conflicts_with = "detach")]
     pub interactive: bool,
 
     /// Allocate a pseudo-TTY (stdout and stderr are merged in TTY mode)
@@ -413,13 +925,6 @@ pub struct ProcessFlags {
     /// User to run the command as (format: <name|uid>[:<group|gid>])
     #[arg(short = 'u', long = "user")]
     pub user: Option<String>,
-
-    /// Override the image entrypoint with a single executable, mirroring
-    /// `docker run --entrypoint`. Any trailing COMMAND replaces the image's
-    /// CMD and is appended to it, and the result runs as the container's
-    /// init.
-    #[arg(long = "entrypoint", value_name = "EXEC")]
-    pub entrypoint: Option<String>,
 }
 
 impl ProcessFlags {
@@ -435,9 +940,6 @@ impl ProcessFlags {
     {
         opts.working_dir = self.workdir.clone();
         apply_env_vars_with_lookup(&self.env, opts, lookup);
-        if let Some(ref exec) = self.entrypoint {
-            opts.entrypoint = Some(vec![exec.clone()]);
-        }
         if let Some(ref user) = self.user {
             opts.user = Some(user.clone());
         }
@@ -459,12 +961,8 @@ impl ProcessFlags {
 
     /// Configures a BoxCommand with process flags (env, workdir, tty)
     pub fn configure_command(&self, mut cmd: BoxCommand) -> BoxCommand {
-        for env_str in &self.env {
-            if let Some((k, v)) = env_str.split_once('=') {
-                cmd = cmd.env(k, v);
-            } else if let Ok(val) = std::env::var(env_str) {
-                cmd = cmd.env(env_str, val);
-            }
+        for (key, value) in resolve_env_vars_with_lookup(&self.env, |key| std::env::var(key).ok()) {
+            cmd = cmd.env(key, value);
         }
 
         if let Some(ref w) = self.workdir {
@@ -909,20 +1407,6 @@ pub struct ManagementFlags {
     #[arg(long)]
     pub name: Option<String>,
 
-    /// Run the box in the background (detach)
-    #[arg(short = 'd', long)]
-    pub detach: bool,
-
-    /// Automatically remove the box when it exits
-    ///
-    /// Conflicts with both deadlines. `--rm` is carried on the wire as the
-    /// shortest possible `auto_delete`, and the contract requires
-    /// `auto_delete > auto_stop`, so `--rm --auto-stop N` fails server-side for
-    /// every N the caller would write it for, naming a field they never set.
-    /// Rejecting the pair here says so in the caller's own vocabulary.
-    #[arg(long, conflicts_with_all = ["auto_delete", "auto_stop"])]
-    pub rm: bool,
-
     /// Stop the box after this much inactivity; `0` disables.
     ///
     /// Seconds when bare, or a suffixed duration: `30s`, `15m`, `2h`, `7d`.
@@ -935,8 +1419,6 @@ pub struct ManagementFlags {
     /// Delete the box this long after it stops; `0` disables.
     ///
     /// Same grammar and the same server requirement as `--auto-stop`.
-    /// Conflicts with `--rm`, which deletes as soon as the box stops rather
-    /// than after a delay.
     #[arg(long = "auto-delete", value_name = "DURATION", value_parser = parse_duration_seconds)]
     pub auto_delete: Option<u32>,
 
@@ -991,8 +1473,8 @@ impl ManagementFlags {
             if seconds.is_some_and(|seconds| seconds > 0) {
                 anyhow::bail!(
                     "{flag} needs a server to enforce it — point at one with --url \
-                     (or a configured profile). Use --rm to delete the box as soon \
-                     as it stops on the local runtime."
+                     (or a configured profile). Use `boxlite run --rm` when \
+                     immediate local cleanup is required."
                 );
             }
         }
@@ -1000,10 +1482,10 @@ impl ManagementFlags {
     }
 
     pub fn apply_to(&self, opts: &mut BoxOptions) -> anyhow::Result<()> {
-        opts.detach = self.detach;
-        // `--rm` is the CLI spelling of "delete when stopped"; the CLI
-        // default (like `docker run`) is to keep the box.
-        opts.auto_delete = Some(if self.rm { 1 } else { 0 });
+        // The CLI default (like `docker run`) is to keep the box. `run --rm`
+        // overrides this sentinel at its command boundary; `create` does not
+        // expose remove-on-stop because it always creates a detached box.
+        opts.auto_delete = Some(0);
 
         // An explicit deadline replaces that sentinel. It has to be written
         // after it, not before: the line above is unconditional, so setting
@@ -1036,8 +1518,363 @@ impl ManagementFlags {
 mod tests {
     use super::*;
     use boxlite::runtime::options::NetworkSpec;
-    use clap::CommandFactory;
     use std::fs;
+
+    fn parse_projected(args: &[&str]) -> Cli {
+        try_parse_from(args).expect("parse")
+    }
+
+    #[test]
+    fn command_tree_owns_after_command_scope_rejection() {
+        for args in [
+            &["boxlite", "serve", "--url", "https://irrelevant.test"][..],
+            &["boxlite", "ls", "--registry", "registry.example.test"][..],
+            &[
+                "boxlite",
+                "auth",
+                "logout",
+                "--url",
+                "https://irrelevant.test",
+            ][..],
+            &[
+                "boxlite",
+                "volume",
+                "list",
+                "--config",
+                "/tmp/irrelevant.json",
+            ][..],
+            &["boxlite", "completion", "bash", "--debug"][..],
+        ] {
+            let error = command()
+                .try_get_matches_from(args)
+                .expect_err("the command tree must reject an out-of-scope option");
+            assert_eq!(error.kind(), ErrorKind::UnknownArgument, "{args:?}");
+        }
+    }
+
+    #[test]
+    fn scoped_command_tree_is_valid_and_preserves_root_and_leaf_flag_positions() {
+        command().debug_assert();
+
+        for args in [
+            ["boxlite", "--url", "https://example.test", "run", "alpine"],
+            ["boxlite", "run", "--url", "https://example.test", "alpine"],
+        ] {
+            let cli = parse_projected(&args);
+            assert_eq!(cli.global.url.as_deref(), Some("https://example.test"));
+            assert!(matches!(cli.command, Commands::Run(_)));
+        }
+
+        for args in [
+            &["boxlite", "run", "--path-prefix", "", "alpine"][..],
+            &["boxlite", "run", "--profile", "", "alpine"][..],
+            &["boxlite", "run", "--registry", "", "alpine"][..],
+            &["boxlite", "run", "--config", "", "alpine"][..],
+        ] {
+            let error = try_parse_from(args).expect_err("empty global value must be rejected");
+            assert_eq!(error.kind(), ErrorKind::ValueValidation, "{args:?}");
+        }
+
+        for args in [
+            ["boxlite", "--url", "https://example.test", "auth", "login"],
+            ["boxlite", "auth", "login", "--url", "https://example.test"],
+        ] {
+            let cli = parse_projected(&args);
+            let Commands::Auth(auth) = cli.command else {
+                panic!("expected auth");
+            };
+            let crate::commands::auth::AuthCommand::Login(login) = auth.command else {
+                panic!("expected login");
+            };
+            assert_eq!(login.url.as_deref(), Some("https://example.test"));
+        }
+
+        for args in [
+            &["boxlite", "--url", "https://example.test", "auth", "status"][..],
+            &["boxlite", "auth", "status", "--url", "https://example.test"][..],
+        ] {
+            let cli = parse_projected(args);
+            assert_eq!(cli.global.url.as_deref(), Some("https://example.test"));
+        }
+
+        let error = try_parse_from(["boxlite", "auth", "--url", "https://example.test", "status"])
+            .expect_err("leaf-only --url must follow the auth leaf");
+        assert_eq!(error.kind(), ErrorKind::UnknownArgument);
+    }
+
+    #[test]
+    fn root_and_leaf_repeatable_global_values_are_both_preserved() {
+        let cli = parse_projected(&[
+            "boxlite",
+            "--registry",
+            "root.example.test",
+            "run",
+            "--registry",
+            "leaf.example.test",
+            "alpine",
+        ]);
+
+        assert_eq!(
+            cli.global.registry,
+            ["root.example.test", "leaf.example.test"]
+        );
+    }
+
+    #[test]
+    fn auth_login_rejects_an_explicit_empty_leaf_url() {
+        let error = try_parse_from(["boxlite", "auth", "login", "--url", ""])
+            .expect_err("an explicit empty URL must not fall through to another target");
+
+        assert_eq!(error.kind(), ErrorKind::InvalidValue);
+    }
+
+    fn global_option_tokens(id: &str) -> Vec<&'static str> {
+        match id {
+            "debug" => vec!["--debug"],
+            "home" => vec!["--home", "/tmp/boxlite-strict-options"],
+            "registry" => vec!["--registry", "registry.example.test"],
+            "config" => vec!["--config", "/tmp/boxlite-config.json"],
+            "url" => vec!["--url", "https://example.test"],
+            "profile" => vec!["--profile", "test-profile"],
+            "path_prefix" => vec!["--path-prefix", "tenant"],
+            other => panic!("missing command-line spelling for {other}"),
+        }
+    }
+
+    const REGISTRY: &[&str] = &["registry"];
+    const LOCAL_WITHOUT_REGISTRY: &[&str] = &["registry", "url", "profile", "path_prefix"];
+    const LOCAL_WITH_REGISTRY: &[&str] = &["url", "profile", "path_prefix"];
+    const AUTH_WITH_URL: &[&str] = &["registry", "config", "path_prefix"];
+    const AUTH_WITHOUT_URL: &[&str] = &["registry", "config", "url", "path_prefix"];
+    const VOLUME: &[&str] = &["registry", "config"];
+    const ALL_GLOBALS: &[&str] = &[
+        "debug",
+        "home",
+        "registry",
+        "config",
+        "url",
+        "profile",
+        "path_prefix",
+    ];
+    const IRRELEVANT_GLOBAL_CASES: &[(&[&str], usize, &[&str])] = &[
+        (&["boxlite", "exec", "box", "--", "true"], 1, REGISTRY),
+        (&["boxlite", "list"], 1, REGISTRY),
+        (&["boxlite", "ls"], 1, REGISTRY),
+        (&["boxlite", "ps"], 1, REGISTRY),
+        (&["boxlite", "rm", "box"], 1, REGISTRY),
+        (&["boxlite", "start", "box"], 1, REGISTRY),
+        (&["boxlite", "stop", "box"], 1, REGISTRY),
+        (&["boxlite", "restart", "box"], 1, REGISTRY),
+        (&["boxlite", "inspect", "box"], 1, REGISTRY),
+        (&["boxlite", "cp", "box:/src", "/tmp/dst"], 1, REGISTRY),
+        (&["boxlite", "stats", "box"], 1, REGISTRY),
+        (
+            &["boxlite", "network", "tunnel", "box", "3000"],
+            2,
+            REGISTRY,
+        ),
+        (&["boxlite", "images"], 1, LOCAL_WITHOUT_REGISTRY),
+        (&["boxlite", "info"], 1, LOCAL_WITHOUT_REGISTRY),
+        (&["boxlite", "logs", "box"], 1, LOCAL_WITHOUT_REGISTRY),
+        (&["boxlite", "pull", "alpine"], 1, LOCAL_WITH_REGISTRY),
+        (&["boxlite", "serve"], 1, LOCAL_WITH_REGISTRY),
+        (&["boxlite", "auth", "login"], 2, AUTH_WITH_URL),
+        (&["boxlite", "auth", "status"], 2, AUTH_WITH_URL),
+        (&["boxlite", "auth", "whoami"], 2, AUTH_WITH_URL),
+        (&["boxlite", "auth", "logout"], 2, AUTH_WITHOUT_URL),
+        (&["boxlite", "volume", "create"], 2, VOLUME),
+        (&["boxlite", "volume", "ls"], 2, VOLUME),
+        (&["boxlite", "volume", "list"], 2, VOLUME),
+        (&["boxlite", "volume", "get", "volume"], 2, VOLUME),
+        (&["boxlite", "volume", "inspect", "volume"], 2, VOLUME),
+        (&["boxlite", "volume", "rm", "volume"], 2, VOLUME),
+        (&["boxlite", "volume", "delete", "volume"], 2, VOLUME),
+        (&["boxlite", "completion", "bash"], 1, ALL_GLOBALS),
+    ];
+
+    fn assert_irrelevant_global_rejected(base: &[&str], command_depth: usize, id: &str) {
+        let tokens = global_option_tokens(id);
+        let mut positions = vec![1, command_depth + 1];
+        if command_depth > 1 {
+            positions.push(2);
+        }
+        positions.push(
+            base.iter()
+                .position(|token| *token == "--")
+                .unwrap_or(base.len()),
+        );
+        positions.sort_unstable();
+        positions.dedup();
+
+        for position in positions {
+            let mut args = base.to_vec();
+            args.splice(position..position, tokens.iter().copied());
+            let error = try_parse_from(&args).expect_err("irrelevant option must be rejected");
+            assert_eq!(error.kind(), ErrorKind::UnknownArgument, "{args:?}");
+            assert!(
+                error.to_string().contains(tokens[0]),
+                "error must identify {}: {error}",
+                tokens[0]
+            );
+        }
+    }
+
+    #[test]
+    fn every_command_path_rejects_irrelevant_global_options() {
+        for (base, command_depth, hidden) in IRRELEVANT_GLOBAL_CASES {
+            for id in *hidden {
+                assert_irrelevant_global_rejected(base, *command_depth, id);
+            }
+        }
+    }
+
+    #[test]
+    fn command_tree_rejects_irrelevant_options_encountered_before_help() {
+        for args in [
+            &[
+                "boxlite",
+                "exec",
+                "--registry",
+                "registry.example.test",
+                "--help",
+            ][..],
+            &[
+                "boxlite",
+                "auth",
+                "logout",
+                "--url=https://irrelevant.test",
+                "--help",
+            ][..],
+            &[
+                "boxlite",
+                "volume",
+                "list",
+                "--config",
+                "/tmp/irrelevant.json",
+                "--help",
+            ][..],
+            &["boxlite", "completion", "--debug", "bash", "--help"][..],
+        ] {
+            let error = try_parse_from(args).expect_err("irrelevant option precedes help");
+            assert_eq!(error.kind(), ErrorKind::UnknownArgument, "{args:?}");
+        }
+    }
+
+    #[test]
+    fn display_actions_remain_terminal() {
+        for args in [
+            &[
+                "boxlite",
+                "--help",
+                "serve",
+                "--url",
+                "https://example.test",
+            ][..],
+            &[
+                "boxlite",
+                "-h",
+                "completion",
+                "--url",
+                "https://example.test",
+            ][..],
+            &[
+                "boxlite",
+                "serve",
+                "--help",
+                "--url",
+                "https://example.test",
+            ][..],
+            &[
+                "boxlite",
+                "auth",
+                "logout",
+                "--help",
+                "--url",
+                "https://example.test",
+            ][..],
+            &[
+                "boxlite",
+                "--registry",
+                "registry.example.test",
+                "exec",
+                "--help",
+            ][..],
+            &["boxlite", "--url", "https://example.test", "help", "serve"][..],
+        ] {
+            let error = try_parse_from(args).expect_err("help exits through clap");
+            assert_eq!(error.kind(), ErrorKind::DisplayHelp, "{args:?}");
+        }
+
+        let error = try_parse_from([
+            "boxlite",
+            "--registry",
+            "registry.example.test",
+            "--version",
+        ])
+        .expect_err("version exits through clap");
+        assert_eq!(error.kind(), ErrorKind::DisplayVersion);
+    }
+
+    #[test]
+    fn completion_uses_the_same_global_capability_matrix() {
+        let mut completion = completion_command();
+        completion.build();
+
+        let serve = completion
+            .get_subcommands()
+            .find(|subcommand| subcommand.get_name() == "serve")
+            .unwrap();
+        assert!(!serve.get_arguments().any(|arg| arg.get_id() == "url"));
+
+        let run = completion
+            .get_subcommands()
+            .find(|subcommand| subcommand.get_name() == "run")
+            .unwrap();
+        assert!(run.get_arguments().any(|arg| arg.get_id() == "url"));
+    }
+
+    #[test]
+    fn parser_rejects_options_that_cannot_affect_the_command() {
+        for args in [
+            &[
+                "boxlite",
+                "exec",
+                "--entrypoint",
+                "/bin/sh",
+                "box",
+                "--",
+                "true",
+            ][..],
+            &["boxlite", "create", "--detach", "alpine"][..],
+            &["boxlite", "create", "--rm", "alpine"][..],
+            &["boxlite", "images", "--all"][..],
+            &["boxlite", "run", "-i", "-d", "alpine"][..],
+            &["boxlite", "exec", "-i", "-d", "box", "--", "true"][..],
+            &["boxlite", "rm", "--all", "box"][..],
+            &["boxlite", "inspect", "--latest", "box"][..],
+            &["boxlite", "auth", "login", "--callback-port", "0"][..],
+            &["boxlite", "list", "--quiet", "--format", "json"][..],
+            &["boxlite", "images", "--quiet", "--format", "json"][..],
+            &["boxlite", "volume", "ls", "--quiet", "--format", "json"][..],
+            &["boxlite", "serve", "--api-key", ""][..],
+        ] {
+            assert!(Cli::try_parse_from(args).is_err(), "accepted {args:?}");
+        }
+
+        let cli = Cli::try_parse_from(["boxlite", "run", "--entrypoint", "/bin/sh", "alpine"])
+            .expect("run owns --entrypoint");
+        let Commands::Run(run) = cli.command else {
+            panic!("expected run");
+        };
+        assert_eq!(run.entrypoint.as_deref(), Some("/bin/sh"));
+
+        let cli = Cli::try_parse_from(["boxlite", "cp", "--no-include-parent", "box:/src", "/dst"])
+            .expect("inverse parent option parses");
+        let Commands::Cp(cp) = cli.command else {
+            panic!("expected cp");
+        };
+        assert!(cp.no_include_parent);
+    }
     use std::path::PathBuf;
     use tempfile::TempDir;
 
@@ -1300,8 +2137,6 @@ mod tests {
             auto_delete: None,
             no_auto_resume: false,
             name: None,
-            detach: false,
-            rm: false,
             security: None,
         };
 
@@ -1348,7 +2183,7 @@ mod tests {
     fn experimental_flags_are_hidden_from_completions() {
         for shell in [Shell::Bash, Shell::Zsh, Shell::Fish] {
             let mut output = Vec::new();
-            generate_completion(&shell, &mut Cli::command(), "boxlite", &mut output);
+            generate_completion(&shell, "boxlite", &mut output);
             let completion = String::from_utf8(output).unwrap();
 
             for name in [
@@ -1524,27 +2359,14 @@ mod tests {
         assert!(err.to_string().contains("network mode"));
     }
 
-    fn process_flags_with_entrypoint(entrypoint: Option<&str>) -> ProcessFlags {
+    fn process_flags() -> ProcessFlags {
         ProcessFlags {
             interactive: false,
             tty: false,
             env: Vec::new(),
             workdir: None,
             user: None,
-            entrypoint: entrypoint.map(str::to_string),
         }
-    }
-
-    #[test]
-    fn test_process_flags_entrypoint_override() {
-        // --entrypoint <EXEC> reaches BoxOptions.entrypoint as a single-token
-        // argv, which container_rootfs applies as config.entrypoint.
-        let mut opts = BoxOptions::default();
-        process_flags_with_entrypoint(Some("/bin/bash"))
-            .apply_to(&mut opts)
-            .expect("entrypoint apply");
-
-        assert_eq!(opts.entrypoint, Some(vec!["/bin/bash".to_string()]));
     }
 
     /// `-t` has to reach `BoxOptions.tty`, because the terminal now belongs to
@@ -1557,23 +2379,11 @@ mod tests {
         let mut opts = BoxOptions::default();
         assert!(!opts.tty, "a box is not a terminal by default");
 
-        let mut flags = process_flags_with_entrypoint(None);
+        let mut flags = process_flags();
         flags.tty = true;
         flags.apply_to(&mut opts).expect("tty apply");
 
         assert!(opts.tty, "-t must make the main command a terminal");
-    }
-
-    #[test]
-    fn test_process_flags_entrypoint_default_none() {
-        // No --entrypoint leaves BoxOptions.entrypoint None so the image's
-        // own entrypoint is used unchanged.
-        let mut opts = BoxOptions::default();
-        process_flags_with_entrypoint(None)
-            .apply_to(&mut opts)
-            .expect("no-op apply");
-
-        assert_eq!(opts.entrypoint, None);
     }
 
     #[test]
@@ -1976,8 +2786,6 @@ mod tests {
     ) -> ManagementFlags {
         ManagementFlags {
             name: None,
-            detach: false,
-            rm: false,
             security: None,
             nested_virtualization: false,
             auto_stop,
@@ -2120,8 +2928,6 @@ mod tests {
     fn management_security_preset_applies_to_box_options() {
         let flags = ManagementFlags {
             name: None,
-            detach: false,
-            rm: false,
             security: Some("disable".to_string()),
             nested_virtualization: false,
             auto_stop: None,
@@ -2141,8 +2947,6 @@ mod tests {
     fn management_security_preset_absent_leaves_default() {
         let flags = ManagementFlags {
             name: None,
-            detach: false,
-            rm: false,
             security: None,
             nested_virtualization: false,
             auto_stop: None,
@@ -2164,8 +2968,6 @@ mod tests {
     fn management_security_preset_typo_surfaces_anyhow_error() {
         let flags = ManagementFlags {
             name: None,
-            detach: false,
-            rm: false,
             security: Some("ultra".to_string()),
             nested_virtualization: false,
             auto_stop: None,

--- a/src/cli/src/commands/auth/api_key.rs
+++ b/src/cli/src/commands/auth/api_key.rs
@@ -11,7 +11,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use boxlite::{BoxliteError, BoxliteRuntime, Principal};
 use secrecy::SecretString;
 
-use crate::credentials::{self, Profile};
+use crate::credentials::{self, CredentialStore, Profile};
 use crate::defaults::LOCAL_SERVE_URL;
 
 const URL_ENV: &str = "BOXLITE_REST_URL";
@@ -21,8 +21,13 @@ const URL_ENV: &str = "BOXLITE_REST_URL";
 /// - `url_flag`: explicit `--url`, if any.
 /// - `api_key_stdin`: when `true`, read the key from stdin (single line).
 ///   When `false`, prompt with `rpassword` for an interactive paste.
-/// - `profile_name`: which profile in `~/.boxlite/credentials.toml` to write.
-pub async fn run(url_flag: Option<&str>, api_key_stdin: bool, profile_name: &str) -> Result<()> {
+/// - `profile_name`: which profile in `<BOXLITE_HOME>/credentials.toml` to write.
+pub async fn run(
+    url_flag: Option<&str>,
+    api_key_stdin: bool,
+    profile_name: &str,
+    store: &CredentialStore,
+) -> Result<()> {
     let url = resolve_url(url_flag, api_key_stdin)?;
 
     let api_key = if api_key_stdin {
@@ -45,7 +50,9 @@ pub async fn run(url_flag: Option<&str>, api_key_stdin: bool, profile_name: &str
     if let Some(p) = identity.as_ref() {
         profile.path_prefix = p.path_prefix.clone();
     }
-    credentials::save_named(profile_name, &profile).context("saving credentials")?;
+    store
+        .save_named(profile_name, &profile)
+        .context("saving credentials")?;
 
     // Don't log profile.url — CodeQL flags the success line as cleartext
     // logging of sensitive info (the profile carries the api_key). The
@@ -58,10 +65,7 @@ pub async fn run(url_flag: Option<&str>, api_key_stdin: bool, profile_name: &str
                 Some(path_prefix) => {
                     println!("Logged in as {} (path prefix: {})", who, path_prefix)
                 }
-                None => println!(
-                    "Logged in as {} (no path prefix; use --path-prefix or BOXLITE_REST_PATH_PREFIX for multi-tenant servers)",
-                    who
-                ),
+                None => println!("Logged in as {} (the server returned no path prefix)", who),
             }
         }
         None => println!("Logged in (API key)"),

--- a/src/cli/src/commands/auth/login.rs
+++ b/src/cli/src/commands/auth/login.rs
@@ -15,21 +15,25 @@
 
 use std::io::IsTerminal;
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result, anyhow, bail};
 use clap::{Args, ValueEnum};
 use dialoguer::{Select, theme::ColorfulTheme};
 
 use super::api_key;
 use super::oidc::{self, DiscoveryOverrides, OidcConfig, OidcTokens, discovery};
-use crate::credentials::{self, Profile};
+use crate::credentials::{self, CredentialStore, Profile};
 use crate::defaults::LOCAL_SERVE_URL;
 
 const URL_ENV: &str = "BOXLITE_REST_URL";
 
 #[derive(Args, Debug, Clone)]
 pub struct LoginArgs {
-    /// Server URL. Defaults to `LOCAL_SERVE_URL` (matching `boxlite serve`).
-    #[arg(long)]
+    /// Server URL. Defaults to `BOXLITE_REST_URL`, the selected profile's URL,
+    /// then `LOCAL_SERVE_URL` (matching `boxlite serve`).
+    #[arg(
+        long,
+        value_parser = clap::builder::NonEmptyStringValueParser::new()
+    )]
     pub url: Option<String>,
 
     /// Read a long-lived API key from stdin (one line). The flag takes no
@@ -66,7 +70,7 @@ pub struct LoginArgs {
     /// Must match an entry in the IdP's allow-list **byte-for-byte** — a
     /// different port produces the same "callback URL mismatch" failure
     /// as no entry at all. Defaults to 5555.
-    #[arg(long)]
+    #[arg(long, value_parser = clap::value_parser!(u16).range(1..))]
     pub callback_port: Option<u16>,
 }
 
@@ -81,19 +85,25 @@ pub enum Method {
     Device,
 }
 
-pub async fn run(args: LoginArgs, profile_name: &str) -> Result<()> {
+pub async fn run(args: LoginArgs, profile_name: &str, store: &CredentialStore) -> Result<()> {
     let method = resolve_method(&args)?;
-    let url = resolve_target(&args)?;
+    let stored_url = store.load_named(profile_name)?.map(|profile| profile.url);
+    let url = resolve_target(&args, stored_url.as_deref())?;
 
     match method {
-        Method::ApiKey => api_key::run(Some(&url), args.api_key_stdin, profile_name).await,
-        Method::Browser => run_browser(&args, &url, profile_name).await,
-        Method::Device => run_device(&args, &url, profile_name).await,
+        Method::ApiKey => api_key::run(Some(&url), args.api_key_stdin, profile_name, store).await,
+        Method::Browser => run_browser(&args, &url, profile_name, store).await,
+        Method::Device => run_device(&args, &url, profile_name, store).await,
     }
 }
 
 /// Browser-based OIDC login.
-async fn run_browser(args: &LoginArgs, url: &str, profile_name: &str) -> Result<()> {
+async fn run_browser(
+    args: &LoginArgs,
+    url: &str,
+    profile_name: &str,
+    store: &CredentialStore,
+) -> Result<()> {
     let http = discovery::http_client()?;
     let overrides = overrides_from_args(args);
     let cfg = discovery::resolve_config(url, &overrides, &http).await?;
@@ -101,16 +111,21 @@ async fn run_browser(args: &LoginArgs, url: &str, profile_name: &str) -> Result<
         .callback_port
         .unwrap_or(oidc::auth_code::DEFAULT_CALLBACK_PORT);
     let tokens = oidc::auth_code::run(&cfg, &http, port).await?;
-    persist_oidc(url, profile_name, &cfg, tokens).await
+    persist_oidc(url, profile_name, &cfg, tokens, store).await
 }
 
 /// Device-code OIDC login.
-async fn run_device(args: &LoginArgs, url: &str, profile_name: &str) -> Result<()> {
+async fn run_device(
+    args: &LoginArgs,
+    url: &str,
+    profile_name: &str,
+    store: &CredentialStore,
+) -> Result<()> {
     let http = discovery::http_client()?;
     let overrides = overrides_from_args(args);
     let cfg = discovery::resolve_config(url, &overrides, &http).await?;
     let tokens = oidc::device_code::run(&cfg, &http).await?;
-    persist_oidc(url, profile_name, &cfg, tokens).await
+    persist_oidc(url, profile_name, &cfg, tokens, store).await
 }
 
 /// Common tail: write tokens into a Profile, save under `profile_name`,
@@ -121,6 +136,7 @@ async fn persist_oidc(
     profile_name: &str,
     cfg: &OidcConfig,
     tokens: OidcTokens,
+    store: &CredentialStore,
 ) -> Result<()> {
     // Confirm against `/v1/me` BEFORE saving — same contract as the API-key
     // flow. A working access token that the server rejects is the kind of
@@ -137,15 +153,14 @@ async fn persist_oidc(
     // `None` means the deployment doesn't use a routing slot;
     // URL builder skips the segment (`/v1/boxes/...`).
     profile.path_prefix = principal.path_prefix.clone();
-    credentials::save_named(profile_name, &profile).context("saving credentials")?;
+    store
+        .save_named(profile_name, &profile)
+        .context("saving credentials")?;
 
     let who = principal.email.as_deref().unwrap_or(principal.sub.as_str());
     match principal.path_prefix.as_deref() {
         Some(path_prefix) => println!("Logged in as {} (path prefix: {})", who, path_prefix),
-        None => println!(
-            "Logged in as {} (no path prefix; use --path-prefix or BOXLITE_REST_PATH_PREFIX for multi-tenant servers)",
-            who
-        ),
+        None => println!("Logged in as {} (the server returned no path prefix)", who),
     }
     Ok(())
 }
@@ -179,26 +194,49 @@ fn overrides_from_args(args: &LoginArgs) -> DiscoveryOverrides {
 /// we read the environment: a non-TTY stdin → `api-key` (CI), `--no-browser`
 /// → `device`, otherwise prompt the user with a `dialoguer::Select`.
 fn resolve_method(args: &LoginArgs) -> Result<Method> {
-    if args.api_key_stdin {
-        return Ok(Method::ApiKey);
-    }
-    if let Some(m) = args.method {
+    let method = if args.api_key_stdin {
+        Method::ApiKey
+    } else if let Some(m) = args.method {
         // Honor the explicit choice even on a TTY.
-        return Ok(if args.no_browser && m == Method::Browser {
-            Method::Device
-        } else {
-            m
-        });
-    }
-    if args.no_browser {
-        return Ok(Method::Device);
-    }
-    if !std::io::stdin().is_terminal() {
+        m
+    } else if args.no_browser {
+        Method::Device
+    } else if !std::io::stdin().is_terminal() {
         // Piped stdin: keep `echo $KEY | boxlite auth login --api-key-stdin`
         // working when callers forget the flag — never block on a prompt.
-        return Ok(Method::ApiKey);
+        Method::ApiKey
+    } else {
+        prompt_method()?
+    };
+    validate_method_options(args, method)?;
+    Ok(method)
+}
+
+fn validate_method_options(args: &LoginArgs, method: Method) -> Result<()> {
+    if args.api_key_stdin && args.method.is_some_and(|method| method != Method::ApiKey) {
+        bail!("--api-key-stdin cannot be combined with a non-api-key --method");
     }
-    prompt_method()
+    if args.no_browser && args.method == Some(Method::Browser) {
+        bail!("--no-browser cannot be combined with --method browser");
+    }
+    if method == Method::ApiKey {
+        if args.no_browser {
+            bail!("--no-browser cannot be used with --method api-key");
+        }
+        for (flag, is_set) in [
+            ("--issuer", args.issuer.is_some()),
+            ("--client-id", args.client_id.is_some()),
+            ("--audience", args.audience.is_some()),
+        ] {
+            if is_set {
+                bail!("{flag} applies only to browser or device login");
+            }
+        }
+    }
+    if method != Method::Browser && args.callback_port.is_some() {
+        bail!("--callback-port applies only to browser login");
+    }
+    Ok(())
 }
 
 /// Interactive picker for the three flows. Lives behind a TTY check so
@@ -254,14 +292,19 @@ fn prompt_method() -> Result<Method> {
 //     `--url http://localhost:8100` because the URL clearly belongs to a
 //     different profile.
 // =============================================================================
-fn resolve_target(args: &LoginArgs) -> Result<String> {
+fn resolve_target(args: &LoginArgs, stored_url: Option<&str>) -> Result<String> {
     if let Some(url) = args.url.as_deref() {
         return Ok(url.to_string());
     }
-    if let Ok(env_url) = std::env::var(URL_ENV)
-        && !env_url.is_empty()
-    {
-        return Ok(env_url);
+    match std::env::var(URL_ENV) {
+        Ok(env_url) if !env_url.is_empty() => return Ok(env_url),
+        Ok(_) | Err(std::env::VarError::NotPresent) => {}
+        Err(std::env::VarError::NotUnicode(_)) => {
+            bail!("{URL_ENV} must contain valid UTF-8")
+        }
+    }
+    if let Some(stored_url) = stored_url.filter(|url| !url.is_empty()) {
+        return Ok(stored_url.to_string());
     }
     Ok(LOCAL_SERVE_URL.to_string())
 }
@@ -296,15 +339,14 @@ fn should_use_device_flow() -> bool {
 mod tests {
     use super::*;
 
-    /// `--api-key-stdin` forces api-key even if the user also passed
-    /// `--method browser` (which the rest of the surface would otherwise
-    /// accept). Stops a careless CI script from silently switching flows.
+    /// `--api-key-stdin` selects the API-key flow when no redundant method is
+    /// supplied. Contradictory explicit methods are rejected separately.
     #[test]
-    fn api_key_stdin_forces_api_key_method() {
+    fn api_key_stdin_selects_api_key_method() {
         let args = LoginArgs {
             url: None,
             api_key_stdin: true,
-            method: Some(Method::Browser),
+            method: None,
             no_browser: false,
             issuer: None,
             client_id: None,
@@ -314,11 +356,10 @@ mod tests {
         assert_eq!(resolve_method(&args).unwrap(), Method::ApiKey);
     }
 
-    /// `--no-browser` + `--method browser` → device. The flag combination
-    /// is contradictory; this is the only one we silently resolve rather
-    /// than reject — `--no-browser` is the more specific intent.
+    /// An explicit browser method contradicts `--no-browser`; neither flag is
+    /// silently allowed to override the other.
     #[test]
-    fn no_browser_overrides_browser_method() {
+    fn no_browser_rejects_browser_method() {
         let args = LoginArgs {
             url: None,
             api_key_stdin: false,
@@ -329,7 +370,67 @@ mod tests {
             audience: None,
             callback_port: None,
         };
-        assert_eq!(resolve_method(&args).unwrap(), Method::Device);
+        assert!(resolve_method(&args).is_err());
+    }
+
+    #[test]
+    fn login_rejects_options_the_selected_method_cannot_use() {
+        let cases = [
+            LoginArgs {
+                url: None,
+                api_key_stdin: false,
+                method: Some(Method::ApiKey),
+                no_browser: true,
+                issuer: None,
+                client_id: None,
+                audience: None,
+                callback_port: None,
+            },
+            LoginArgs {
+                url: None,
+                api_key_stdin: false,
+                method: Some(Method::ApiKey),
+                no_browser: false,
+                issuer: Some("https://issuer.example.test".to_string()),
+                client_id: None,
+                audience: None,
+                callback_port: None,
+            },
+            LoginArgs {
+                url: None,
+                api_key_stdin: false,
+                method: Some(Method::Device),
+                no_browser: false,
+                issuer: None,
+                client_id: None,
+                audience: None,
+                callback_port: Some(5555),
+            },
+            LoginArgs {
+                url: None,
+                api_key_stdin: true,
+                method: Some(Method::Device),
+                no_browser: false,
+                issuer: None,
+                client_id: None,
+                audience: None,
+                callback_port: None,
+            },
+            LoginArgs {
+                url: None,
+                api_key_stdin: true,
+                method: Some(Method::Browser),
+                no_browser: false,
+                issuer: None,
+                client_id: None,
+                audience: None,
+                callback_port: None,
+            },
+        ];
+
+        for args in cases {
+            assert!(resolve_method(&args).is_err(), "accepted {args:?}");
+        }
     }
 
     /// Today's `resolve_target` falls back to the local serve URL — locks
@@ -354,6 +455,25 @@ mod tests {
             audience: None,
             callback_port: None,
         };
-        assert_eq!(resolve_target(&args).unwrap(), LOCAL_SERVE_URL);
+        assert_eq!(resolve_target(&args, None).unwrap(), LOCAL_SERVE_URL);
+    }
+
+    #[test]
+    fn resolve_target_reuses_the_selected_profiles_url() {
+        let args = LoginArgs {
+            url: None,
+            api_key_stdin: true,
+            method: None,
+            no_browser: false,
+            issuer: None,
+            client_id: None,
+            audience: None,
+            callback_port: None,
+        };
+
+        assert_eq!(
+            resolve_target(&args, Some("https://cloud.example.test")).unwrap(),
+            "https://cloud.example.test"
+        );
     }
 }

--- a/src/cli/src/commands/auth/logout.rs
+++ b/src/cli/src/commands/auth/logout.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 use anyhow::{Context, Result};
 use clap::Args;
 
-use crate::credentials;
+use crate::credentials::CredentialStore;
 
 #[derive(Args, Debug, Clone)]
 pub struct LogoutArgs {
@@ -14,11 +14,11 @@ pub struct LogoutArgs {
     pub yes: bool,
 }
 
-pub async fn run(args: LogoutArgs, profile_name: &str) -> Result<()> {
-    let path = credentials::path().context("resolving credentials path")?;
-    let exists = credentials::load_named(profile_name)
-        .ok()
-        .flatten()
+pub async fn run(args: LogoutArgs, profile_name: &str, store: &CredentialStore) -> Result<()> {
+    let path = store.path().context("resolving credentials path")?;
+    let exists = store
+        .load_named(profile_name)
+        .context("loading stored credentials")?
         .is_some();
     if !exists {
         println!("Not logged in (profile `{}`).", profile_name);
@@ -43,7 +43,7 @@ pub async fn run(args: LogoutArgs, profile_name: &str) -> Result<()> {
         }
     }
 
-    let removed = credentials::delete_named(profile_name)?;
+    let removed = store.delete_named(profile_name)?;
     if removed {
         println!("Logged out (profile `{}`)", profile_name);
     } else {

--- a/src/cli/src/commands/auth/mod.rs
+++ b/src/cli/src/commands/auth/mod.rs
@@ -35,10 +35,11 @@ pub enum AuthCommand {
 
 pub async fn run(args: AuthArgs, global: &GlobalFlags) -> anyhow::Result<()> {
     let profile = global.resolved_profile();
+    let store = global.credential_store();
     match args.command {
-        AuthCommand::Login(a) => login::run(a, &profile).await,
-        AuthCommand::Logout(a) => logout::run(a, &profile).await,
-        AuthCommand::Status => status::run(&profile),
-        AuthCommand::Whoami => whoami::run(&profile).await,
+        AuthCommand::Login(a) => login::run(a, &profile, &store).await,
+        AuthCommand::Logout(a) => logout::run(a, &profile, &store).await,
+        AuthCommand::Status => status::run(global, &store),
+        AuthCommand::Whoami => whoami::run(global, &store).await,
     }
 }

--- a/src/cli/src/commands/auth/status.rs
+++ b/src/cli/src/commands/auth/status.rs
@@ -3,11 +3,11 @@
 
 use anyhow::{Context, Result};
 
-use crate::credentials::{self, AuthMethod};
+use crate::cli::GlobalFlags;
+use crate::credentials::{AuthMethod, CredentialStore};
 use crate::defaults::LOCAL_SERVE_URL;
 
 const API_KEY_ENV: &str = "BOXLITE_API_KEY";
-const URL_ENV: &str = "BOXLITE_REST_URL";
 
 enum Source {
     /// `BOXLITE_API_KEY` set in the environment.
@@ -26,8 +26,9 @@ struct Identity {
     expires_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
-pub fn run(profile_name: &str) -> Result<()> {
-    let identity = match resolve_identity(profile_name)? {
+pub fn run(global: &GlobalFlags, store: &CredentialStore) -> Result<()> {
+    let profile_name = global.resolved_profile();
+    let identity = match resolve_identity(global, store)? {
         Some(id) => id,
         None => {
             println!("Not logged in (profile `{}`).", profile_name);
@@ -55,9 +56,12 @@ pub fn run(profile_name: &str) -> Result<()> {
     Ok(())
 }
 
-/// Resolve the active credential source. Env vars win over the file (matches
-/// the runtime precedence used by `from_env()`).
-fn resolve_identity(profile_name: &str) -> Result<Option<Identity>> {
+/// Resolve the active credential source. Env vars win over the file. An API
+/// key without a configured URL targets the zero-config local `serve`
+/// endpoint for this auth probe; ordinary box commands still default to the
+/// embedded runtime until a REST URL is configured.
+fn resolve_identity(global: &GlobalFlags, store: &CredentialStore) -> Result<Option<Identity>> {
+    let profile_name = global.resolved_profile();
     // Both `auth whoami` and the runtime in `cli.rs` skip the env path when
     // `BOXLITE_API_KEY` is set-but-empty (`!key.is_empty()`). `auth status`
     // used to short-circuit on a bare `is_ok()` check, so an empty value
@@ -67,7 +71,13 @@ fn resolve_identity(profile_name: &str) -> Result<Option<Identity>> {
     if let Ok(api_key) = std::env::var(API_KEY_ENV)
         && !api_key.is_empty()
     {
-        let url = std::env::var(URL_ENV).unwrap_or_else(|_| LOCAL_SERVE_URL.to_string());
+        let stored_url = store.load_named(&profile_name)?.map(|profile| profile.url);
+        let url = global
+            .url
+            .clone()
+            .filter(|url| !url.is_empty())
+            .or(stored_url)
+            .unwrap_or_else(|| LOCAL_SERVE_URL.to_string());
         return Ok(Some(Identity {
             url,
             source: Source::EnvApiKey,
@@ -76,13 +86,19 @@ fn resolve_identity(profile_name: &str) -> Result<Option<Identity>> {
         }));
     }
 
-    let profile = credentials::load_named(profile_name).context("loading stored credentials")?;
+    let profile = store
+        .load_named(&profile_name)
+        .context("loading stored credentials")?;
     let Some(profile) = profile else {
         return Ok(None);
     };
-    let path = credentials::path().context("resolving credentials path")?;
+    let path = store.path().context("resolving credentials path")?;
     Ok(Some(Identity {
-        url: profile.url,
+        url: global
+            .url
+            .clone()
+            .filter(|url| !url.is_empty())
+            .unwrap_or(profile.url),
         source: Source::File {
             path_display: path.display().to_string(),
         },

--- a/src/cli/src/commands/auth/whoami.rs
+++ b/src/cli/src/commands/auth/whoami.rs
@@ -9,15 +9,16 @@ use anyhow::{Context, Result, anyhow};
 use boxlite::{BoxliteError, BoxliteRestOptions, BoxliteRuntime};
 use secrecy::SecretString;
 
+use crate::cli::GlobalFlags;
 use crate::commands::auth::oidc::discovery;
-use crate::credentials::{self, Profile};
+use crate::credentials::{CredentialStore, Profile};
 use crate::defaults::LOCAL_SERVE_URL;
 
 const API_KEY_ENV: &str = "BOXLITE_API_KEY";
-const URL_ENV: &str = "BOXLITE_REST_URL";
 
-pub async fn run(profile_name: &str) -> Result<()> {
-    let Some(opts) = resolve_options(profile_name).await? else {
+pub async fn run(global: &GlobalFlags, store: &CredentialStore) -> Result<()> {
+    let profile_name = global.resolved_profile();
+    let Some(opts) = resolve_options(global, store).await? else {
         println!("Not logged in (profile `{}`).", profile_name);
         return Ok(());
     };
@@ -67,26 +68,40 @@ pub async fn run(profile_name: &str) -> Result<()> {
 
 /// Active credential, ready to attach to a REST runtime.
 ///
-/// `$BOXLITE_API_KEY` (+ `$BOXLITE_REST_URL`) wins over the stored profile,
-/// matching the runtime precedence used elsewhere
-/// (`GlobalFlags::create_runtime`, `auth status`). The env path returns a
-/// fresh `BoxliteRestOptions` directly; the file path goes through
-/// [`credentials::load_active`], which is also where OIDC tokens get
+/// `$BOXLITE_API_KEY` (+ `$BOXLITE_REST_URL`) wins over the stored profile.
+/// An API key without a URL targets the zero-config local `serve` endpoint
+/// for this auth probe; ordinary box commands still default to the embedded
+/// runtime. The env path returns fresh `BoxliteRestOptions`; the file path goes through
+/// [`CredentialStore::load_active`], which is also where OIDC tokens get
 /// refreshed when they are about to expire.
-async fn resolve_options(profile_name: &str) -> Result<Option<BoxliteRestOptions>> {
+async fn resolve_options(
+    global: &GlobalFlags,
+    store: &CredentialStore,
+) -> Result<Option<BoxliteRestOptions>> {
+    let profile_name = global.resolved_profile();
     if let Ok(api_key) = std::env::var(API_KEY_ENV)
         && !api_key.is_empty()
     {
-        let url = std::env::var(URL_ENV).unwrap_or_else(|_| LOCAL_SERVE_URL.to_string());
+        let stored = store.load_named(&profile_name)?;
+        if let Some(options) = global.resolve_rest_options(stored, Some(api_key.clone())) {
+            return Ok(Some(options));
+        }
         let profile = Profile {
-            url,
+            url: LOCAL_SERVE_URL.to_string(),
             api_key: Some(SecretString::from(api_key)),
             ..Profile::default()
         };
-        return Ok(Some(credentials::into_rest_options(profile)));
+        return Ok(Some(crate::credentials::into_rest_options(profile)));
     }
     let http = discovery::http_client()?;
-    credentials::load_active(profile_name, &http)
+    let mut options = store
+        .load_active(&profile_name, &http)
         .await
-        .context("loading stored credentials")
+        .context("loading stored credentials")?;
+    if let Some(options) = options.as_mut()
+        && let Some(url) = global.url.as_ref().filter(|url| !url.is_empty())
+    {
+        options.url = url.clone();
+    }
+    Ok(options)
 }

--- a/src/cli/src/commands/cp.rs
+++ b/src/cli/src/commands/cp.rs
@@ -6,17 +6,17 @@ use std::path::PathBuf;
 
 #[derive(Args, Debug)]
 pub struct CpArgs {
-    /// Copy symlinks by following their targets
+    /// Copy symlinks by following their targets (local runtime only)
     #[arg(long, default_value_t = false)]
     pub follow_symlinks: bool,
 
-    /// Do not overwrite existing files
+    /// Do not overwrite existing files (local runtime only)
     #[arg(long, default_value_t = false)]
     pub no_overwrite: bool,
 
-    /// Include parent directory when copying from box (docker cp semantics)
-    #[arg(long, default_value_t = true)]
-    pub include_parent: bool,
+    /// Copy directory contents without their parent directory (local runtime only)
+    #[arg(long)]
+    pub no_include_parent: bool,
 
     /// Source path (host path or BOX:PATH)
     #[arg(index = 1)]
@@ -31,11 +31,12 @@ pub async fn execute(args: CpArgs, global: &GlobalFlags) -> Result<()> {
     let rt = global.create_runtime()?;
 
     let direction = parse_direction(&args.src, &args.dst)?;
+    args.require_supported_backend(global.targets_rest()?)?;
 
     let opts = CopyOptions {
         follow_symlinks: args.follow_symlinks,
         overwrite: !args.no_overwrite,
-        include_parent: args.include_parent,
+        include_parent: !args.no_include_parent,
         ..Default::default()
     };
 
@@ -93,6 +94,19 @@ pub async fn execute(args: CpArgs, global: &GlobalFlags) -> Result<()> {
             stopped?;
             Ok(())
         }
+    }
+}
+
+impl CpArgs {
+    fn require_supported_backend(&self, targets_rest: bool) -> Result<()> {
+        if targets_rest && (self.follow_symlinks || self.no_overwrite || self.no_include_parent) {
+            anyhow::bail!(
+                "--follow-symlinks, --no-overwrite, and --no-include-parent are supported only \
+                 by the embedded local runtime; the REST copy protocol does not carry these \
+                 options"
+            );
+        }
+        Ok(())
     }
 }
 
@@ -161,6 +175,33 @@ async fn require_box(rt: &boxlite::BoxliteRuntime, name: &str) -> Result<LiteBox
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn args() -> CpArgs {
+        CpArgs {
+            follow_symlinks: false,
+            no_overwrite: false,
+            no_include_parent: false,
+            src: "box:/src".to_string(),
+            dst: "/dst".to_string(),
+        }
+    }
+
+    #[test]
+    fn rest_copy_rejects_every_option_the_protocol_would_discard() {
+        assert!(args().require_supported_backend(true).is_ok());
+
+        let mut follow = args();
+        follow.follow_symlinks = true;
+        assert!(follow.require_supported_backend(true).is_err());
+
+        let mut overwrite = args();
+        overwrite.no_overwrite = true;
+        assert!(overwrite.require_supported_backend(true).is_err());
+
+        let mut parent = args();
+        parent.no_include_parent = true;
+        assert!(parent.require_supported_backend(true).is_err());
+    }
 
     #[test]
     fn parse_host_to_box() {

--- a/src/cli/src/commands/create.rs
+++ b/src/cli/src/commands/create.rs
@@ -71,7 +71,7 @@ impl CreateArgs {
         self.boot.require_enabled(global.experimental_features())?;
         self.management
             .require_enabled(global.experimental_features())?;
-        self.management.require_sweeper(global.targets_rest())?;
+        self.management.require_sweeper(global.targets_rest()?)?;
         let mut options = BoxOptions::default();
         self.resource.apply_to(&mut options);
         self.capability.apply_to(&mut options);
@@ -88,16 +88,9 @@ impl CreateArgs {
         // non-detached created box is killed by the exiting `start` CLI (its
         // watchdog + the runtime's drop-time auto-stop) before its main command
         // records an exit code — the box then reports 0 instead of its real
-        // code. Detached boxes have no foreground watcher, so auto-remove cannot
-        // apply — the same rule `run -d` enforces (remove-on-stop with detach is
-        // rejected at sanitize).
+        // code. Remove-on-stop belongs to `run`; create exposes only deferred
+        // lifecycle deadlines, which a server can enforce after this CLI exits.
         options.detach = true;
-        // Clears the `--rm` encoding, which cannot apply to a box that is
-        // always detached — but must not clobber an explicit `--auto-delete`,
-        // which is a deferred deadline rather than remove-on-stop.
-        if self.management.auto_delete.is_none() {
-            options.auto_delete = Some(0);
-        }
         options.working_dir = self.workdir.clone();
         if let Some(ref exec) = self.entrypoint {
             options.entrypoint = Some(vec![exec.clone()]);
@@ -126,10 +119,9 @@ mod tests {
     use crate::cli::{Cli, Commands};
     use clap::Parser;
 
-    /// `create` always detaches and clears the `--rm` encoding afterwards, so
-    /// an explicit deadline is exactly what that line can clobber. This is the
-    /// consuming boundary — `ManagementFlags::apply_to` gets the order right on
-    /// its own and still could not have caught a later overwrite here.
+    /// `ManagementFlags::apply_to` writes the keep-on-stop sentinel before an
+    /// optional deadline. `create` then sets detach without changing lifecycle
+    /// policy, so the explicit deadline must survive this consuming boundary.
     #[test]
     fn an_explicit_delete_deadline_survives_creates_detach_default() {
         let cli = Cli::try_parse_from([
@@ -155,7 +147,7 @@ mod tests {
     }
 
     #[test]
-    fn create_without_a_deadline_keeps_the_rm_encoding() {
+    fn create_without_a_deadline_disables_remove_on_stop() {
         let opts = {
             let cli = Cli::try_parse_from(["boxlite", "create", "alpine:latest"])
                 .expect("create should parse");

--- a/src/cli/src/commands/images.rs
+++ b/src/cli/src/commands/images.rs
@@ -8,12 +8,8 @@ use tabled::Tabled;
 /// List images
 #[derive(Args, Debug)]
 pub struct ImagesArgs {
-    /// Show all images (default hides intermediate images)
-    #[arg(short = 'a', long)]
-    pub all: bool,
-
     /// Only show image IDs
-    #[arg(short, long)]
+    #[arg(short, long, conflicts_with = "format")]
     pub quiet: bool,
 
     /// Output format (table, json, yaml)
@@ -54,7 +50,8 @@ impl From<&ImageInfo> for ImagePresenter {
 }
 
 pub async fn execute(args: ImagesArgs, global: &GlobalFlags) -> anyhow::Result<()> {
-    let rt = global.create_runtime()?;
+    let options = global.resolve_runtime_options()?;
+    let rt = global.create_runtime_with_options(options)?;
     let image_handle = rt.images()?;
     let images = image_handle.list().await?;
 

--- a/src/cli/src/commands/inspect.rs
+++ b/src/cli/src/commands/inspect.rs
@@ -10,7 +10,12 @@ use serde::Serialize;
 #[derive(Args, Debug)]
 pub struct InspectArgs {
     /// Box ID(s) or name(s). At least one box or --latest is required.
-    #[arg(value_name = "BOX", required = false, num_args = 0..)]
+    #[arg(
+        value_name = "BOX",
+        required_unless_present = "latest",
+        num_args = 1..,
+        conflicts_with = "latest"
+    )]
     pub boxes: Vec<String>,
 
     /// Inspect the most recently created box (cannot be used with BOX)

--- a/src/cli/src/commands/list.rs
+++ b/src/cli/src/commands/list.rs
@@ -13,7 +13,7 @@ pub struct ListArgs {
     pub all: bool,
 
     /// Only show IDs
-    #[arg(short, long)]
+    #[arg(short, long, conflicts_with = "format")]
     pub quiet: bool,
 
     /// Output format (table, json, yaml)

--- a/src/cli/src/commands/pull.rs
+++ b/src/cli/src/commands/pull.rs
@@ -14,7 +14,8 @@ pub struct PullArgs {
 }
 
 pub async fn execute(args: PullArgs, global: &GlobalFlags) -> Result<()> {
-    let runtime = global.create_runtime()?;
+    let options = global.resolve_runtime_options()?;
+    let runtime = global.create_runtime_with_options(options)?;
     let images = runtime.images()?;
 
     let image = images.pull(&args.image).await?;

--- a/src/cli/src/commands/rm.rs
+++ b/src/cli/src/commands/rm.rs
@@ -11,7 +11,7 @@ pub struct RmArgs {
     pub all: bool,
 
     /// Name or ID of the box(es) to remove
-    #[arg(required_unless_present = "all", num_args = 1..)]
+    #[arg(required_unless_present = "all", num_args = 1.., conflicts_with = "all")]
     pub targets: Vec<String>,
 }
 

--- a/src/cli/src/commands/run.rs
+++ b/src/cli/src/commands/run.rs
@@ -31,6 +31,20 @@ pub struct RunArgs {
     #[command(flatten)]
     pub management: ManagementFlags,
 
+    /// Run the box in the background (detach)
+    #[arg(short = 'd', long)]
+    pub detach: bool,
+
+    /// Automatically remove the box when it exits. Conflicts with lifecycle
+    /// deadlines; ignored with `--detach` so the box outlives this CLI.
+    #[arg(long, conflicts_with_all = ["auto_delete", "auto_stop"])]
+    pub rm: bool,
+
+    /// Override the image entrypoint with a single executable. Any trailing
+    /// COMMAND replaces the image CMD and is appended to the entrypoint.
+    #[arg(long = "entrypoint", value_name = "EXEC")]
+    pub entrypoint: Option<String>,
+
     /// Path to an already prepared rootfs
     #[arg(long = "rootfs", value_name = "PATH")]
     pub rootfs: Option<String>,
@@ -55,7 +69,7 @@ pub async fn execute(args: RunArgs, global: &GlobalFlags) -> anyhow::Result<i32>
     args.boot.require_enabled(global.experimental_features())?;
     args.management
         .require_enabled(global.experimental_features())?;
-    args.management.require_sweeper(global.targets_rest())?;
+    args.management.require_sweeper(global.targets_rest()?)?;
     let (rootfs, command_args) = args.rootfs_and_command()?;
     let command_args = command_args.to_vec();
     let mut runner = BoxRunner::new(args, global)?;
@@ -89,11 +103,19 @@ fn build_options(
     args.network.apply_to(&mut options)?;
     args.process.apply_to(&mut options)?;
 
+    options.detach = args.detach;
+    if args.rm {
+        options.auto_delete = Some(1);
+    }
+    if let Some(ref exec) = args.entrypoint {
+        options.entrypoint = Some(vec![exec.clone()]);
+    }
+
     // Detached boxes keep manual lifecycle control: detach silently overrides
     // `--rm` (historical CLI behaviour). An explicit `--auto-delete` is a
     // deferred deadline, not remove-on-stop, so it survives detaching — that
     // pairing is the point of the flag.
-    if args.management.detach && args.management.auto_delete.is_none() {
+    if args.detach && args.management.auto_delete.is_none() {
         options.auto_delete = Some(0);
     }
 
@@ -127,7 +149,7 @@ impl BoxRunner {
 
         // Detach mode: start it and get out of the way. Nobody is reading the
         // output, so there is nothing to be attached for.
-        if self.args.management.detach {
+        if self.args.detach {
             litebox.start().await?;
             println!("{}", litebox.id());
             return Ok(0);

--- a/src/cli/src/commands/serve/README.md
+++ b/src/cli/src/commands/serve/README.md
@@ -27,7 +27,9 @@ let rt = BoxliteRuntime::rest(BoxliteRestOptions::new("http://localhost:8100"))?
 ```
 execute(ServeArgs, GlobalFlags)
   │
-  ├─ GlobalFlags::create_runtime()          — build local BoxliteRuntime
+  ├─ GlobalFlags::resolve_runtime_options() — resolve local runtime settings
+  ├─ GlobalFlags::create_runtime_with_options()
+  │                                          — build local BoxliteRuntime
   │
   ├─ Arc::new(AppState { runtime, boxes, executions,
   │                      api_key, lifecycle, last_activity })

--- a/src/cli/src/commands/serve/mod.rs
+++ b/src/cli/src/commands/serve/mod.rs
@@ -35,6 +35,14 @@ use crate::defaults::{LOCAL_SERVE_HOST, LOCAL_SERVE_PORT};
 
 use self::types::{BoxResponse, CreateBoxRequest, ErrorBody, ErrorDetail, ExecRequest};
 
+fn parse_api_key(raw: &str) -> Result<String, String> {
+    if raw.is_empty() {
+        Err("API key must not be empty".to_string())
+    } else {
+        Ok(raw.to_string())
+    }
+}
+
 // ============================================================================
 // CLI Args
 // ============================================================================
@@ -53,7 +61,12 @@ pub struct ServeArgs {
     /// `GET /v1/config` requires `Authorization: Bearer <this>` (constant-time
     /// match) and returns 401 otherwise. Unset = permissive (accepts any/no
     /// bearer) — the zero-config local-dev default.
-    #[arg(long, env = "BOXLITE_SERVE_API_KEY")]
+    #[arg(
+        long,
+        env = "BOXLITE_SERVE_API_KEY",
+        hide_env_values = true,
+        value_parser = parse_api_key
+    )]
     pub api_key: Option<String>,
 }
 
@@ -1871,7 +1884,11 @@ fn build_router(state: Arc<AppState>) -> Router {
 // ============================================================================
 
 pub async fn execute(args: ServeArgs, global: &GlobalFlags) -> anyhow::Result<()> {
-    let runtime = global.create_runtime()?;
+    // A server owns an embedded runtime. Client connection settings must not
+    // turn it into a proxy merely because a credential profile or REST URL is
+    // present in the environment.
+    let options = global.resolve_runtime_options()?;
+    let runtime = global.create_runtime_with_options(options)?;
 
     let state = Arc::new(AppState {
         runtime,
@@ -1887,8 +1904,8 @@ pub async fn execute(args: ServeArgs, global: &GlobalFlags) -> anyhow::Result<()
     tokio::spawn(reaper_loop(Arc::clone(&state)));
 
     let app = build_router(state.clone());
-    let addr = format!("{}:{}", args.host, args.port);
-    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    let listener = tokio::net::TcpListener::bind((args.host.as_str(), args.port)).await?;
+    let addr = listener.local_addr()?;
 
     tracing::info!("boxlite serve listening on {}", addr);
     eprintln!("BoxLite REST API server listening on http://{addr}");

--- a/src/cli/src/commands/volume/ls.rs
+++ b/src/cli/src/commands/volume/ls.rs
@@ -11,7 +11,7 @@ use tabled::Tabled;
 #[derive(Args, Debug)]
 pub struct LsArgs {
     /// Only show volume ids.
-    #[arg(short, long)]
+    #[arg(short, long, conflicts_with = "format")]
     pub quiet: bool,
 
     /// Output format (table, json, yaml).

--- a/src/cli/src/credentials.rs
+++ b/src/cli/src/credentials.rs
@@ -130,6 +130,111 @@ struct CredentialsFile {
 /// the string.
 pub const DEFAULT_PROFILE: &str = "default";
 
+/// Credential file access rooted at the effective BoxLite home directory.
+///
+/// Keeping the path and all reads/writes together prevents `--home` from
+/// selecting one runtime directory while authentication silently reads a
+/// different credential file.
+#[derive(Debug, Clone, Default)]
+pub struct CredentialStore {
+    home: Option<PathBuf>,
+}
+
+impl CredentialStore {
+    pub fn new(home: Option<PathBuf>) -> Self {
+        Self { home }
+    }
+
+    pub fn path(&self) -> Result<PathBuf> {
+        if let Some(home) = &self.home {
+            return Ok(home.join("credentials.toml"));
+        }
+        if let Some(env_home) = std::env::var_os("BOXLITE_HOME") {
+            let env_home = PathBuf::from(env_home);
+            if env_home.is_absolute() {
+                return Ok(env_home.join("credentials.toml"));
+            }
+        }
+        let home = dirs::home_dir()
+            .ok_or_else(|| anyhow!("could not determine home directory for $HOME"))?;
+        Ok(home.join(".boxlite").join("credentials.toml"))
+    }
+
+    pub fn load_named(&self, name: &str) -> Result<Option<Profile>> {
+        let file_path = self.path()?;
+        if !file_path.exists() {
+            return Ok(None);
+        }
+        let raw = fs::read_to_string(&file_path)
+            .with_context(|| format!("reading credentials file {}", file_path.display()))?;
+        let parsed: CredentialsFile = toml::from_str(&raw)
+            .with_context(|| format!("parsing credentials file {}", file_path.display()))?;
+        Ok(parsed.profiles.get(name).cloned())
+    }
+
+    pub fn save_named(&self, name: &str, profile: &Profile) -> Result<()> {
+        let file_path = self.path()?;
+        let parent = file_path
+            .parent()
+            .ok_or_else(|| anyhow!("credentials path has no parent: {}", file_path.display()))?;
+        create_secure_dir(parent)?;
+
+        let mut existing: CredentialsFile = if file_path.exists() {
+            let raw = fs::read_to_string(&file_path)
+                .with_context(|| format!("reading credentials file {}", file_path.display()))?;
+            toml::from_str(&raw)
+                .with_context(|| format!("parsing credentials file {}", file_path.display()))?
+        } else {
+            CredentialsFile::default()
+        };
+        existing.profiles.insert(name.to_string(), profile.clone());
+
+        let serialized =
+            toml::to_string_pretty(&existing).context("serializing credentials to TOML")?;
+        write_secure(&file_path, serialized.as_bytes())?;
+        Ok(())
+    }
+
+    pub fn delete_named(&self, name: &str) -> Result<bool> {
+        let file_path = self.path()?;
+        if !file_path.exists() {
+            return Ok(false);
+        }
+        let raw = fs::read_to_string(&file_path)
+            .with_context(|| format!("reading credentials file {}", file_path.display()))?;
+        let mut parsed: CredentialsFile = toml::from_str(&raw)
+            .with_context(|| format!("parsing credentials file {}", file_path.display()))?;
+        if parsed.profiles.remove(name).is_none() {
+            return Ok(false);
+        }
+        if parsed.profiles.is_empty() {
+            fs::remove_file(&file_path).with_context(|| {
+                format!("removing empty credentials file {}", file_path.display())
+            })?;
+            return Ok(true);
+        }
+        let serialized =
+            toml::to_string_pretty(&parsed).context("serializing credentials to TOML")?;
+        write_secure(&file_path, serialized.as_bytes())?;
+        Ok(true)
+    }
+
+    pub async fn load_active(
+        &self,
+        name: &str,
+        http: &reqwest::Client,
+    ) -> Result<Option<BoxliteRestOptions>> {
+        let Some(mut profile) = self.load_named(name)? else {
+            return Ok(None);
+        };
+        if crate::commands::auth::oidc::refresh::refresh_needed(&profile) {
+            crate::commands::auth::oidc::refresh::refresh(&mut profile, http).await?;
+            self.save_named(name, &profile)?;
+        }
+        Ok(Some(into_rest_options(profile)))
+    }
+}
+
 /// Absolute path to the credentials file.
 ///
 /// Resolution order: `$BOXLITE_HOME/credentials.toml` →
@@ -137,61 +242,27 @@ pub const DEFAULT_PROFILE: &str = "default";
 /// convention of consolidating per-tool state under a single dotdir, and
 /// keeps the credentials co-located with the rest of `$BOXLITE_HOME`
 /// (images, runtime state) so `--home PATH` users have one place to look.
+#[cfg(test)]
 pub fn path() -> Result<PathBuf> {
-    if let Some(env_home) = std::env::var_os("BOXLITE_HOME") {
-        let env_home = PathBuf::from(env_home);
-        if env_home.is_absolute() {
-            return Ok(env_home.join("credentials.toml"));
-        }
-    }
-    let home =
-        dirs::home_dir().ok_or_else(|| anyhow!("could not determine home directory for $HOME"))?;
-    Ok(home.join(".boxlite").join("credentials.toml"))
+    CredentialStore::default().path()
 }
 
 /// Load the named profile from the credentials file. `Ok(None)` when either
 /// the file is absent or the requested profile is not in it; parse errors
 /// propagate so a corrupted file surfaces instead of being silently treated
 /// as "no credentials".
+#[cfg(test)]
 pub fn load_named(name: &str) -> Result<Option<Profile>> {
-    let file_path = path()?;
-    if !file_path.exists() {
-        return Ok(None);
-    }
-    let raw = fs::read_to_string(&file_path)
-        .with_context(|| format!("reading credentials file {}", file_path.display()))?;
-    let parsed: CredentialsFile = toml::from_str(&raw)
-        .with_context(|| format!("parsing credentials file {}", file_path.display()))?;
-    Ok(parsed.profiles.get(name).cloned())
+    CredentialStore::default().load_named(name)
 }
 
 /// Save `profile` under `name`, replacing any existing profile with that
 /// name and preserving every other profile in the file. On Unix, the file
 /// is created with mode `0o600` and the parent dir with `0o700`. On
 /// non-Unix platforms the file is local-only — no perms set.
+#[cfg(test)]
 pub fn save_named(name: &str, profile: &Profile) -> Result<()> {
-    let file_path = path()?;
-    let parent = file_path
-        .parent()
-        .ok_or_else(|| anyhow!("credentials path has no parent: {}", file_path.display()))?;
-    create_secure_dir(parent)?;
-
-    let mut existing: CredentialsFile = if file_path.exists() {
-        let raw = fs::read_to_string(&file_path)
-            .with_context(|| format!("reading credentials file {}", file_path.display()))?;
-        // Tolerate an empty file but not malformed TOML — corrupt state
-        // should surface, not be silently overwritten.
-        toml::from_str(&raw)
-            .with_context(|| format!("parsing credentials file {}", file_path.display()))?
-    } else {
-        CredentialsFile::default()
-    };
-    existing.profiles.insert(name.to_string(), profile.clone());
-
-    let serialized =
-        toml::to_string_pretty(&existing).context("serializing credentials to TOML")?;
-    write_secure(&file_path, serialized.as_bytes())?;
-    Ok(())
+    CredentialStore::default().save_named(name, profile)
 }
 
 /// Remove the named profile from the credentials file, leaving the rest
@@ -199,50 +270,9 @@ pub fn save_named(name: &str, profile: &Profile) -> Result<()> {
 /// `Ok(false)` if either the file or the profile was absent. If removing
 /// the last profile leaves the file empty, the file itself is deleted so
 /// `auth status` reports "Not logged in" instead of finding an empty stub.
+#[cfg(test)]
 pub fn delete_named(name: &str) -> Result<bool> {
-    let file_path = path()?;
-    if !file_path.exists() {
-        return Ok(false);
-    }
-    let raw = fs::read_to_string(&file_path)
-        .with_context(|| format!("reading credentials file {}", file_path.display()))?;
-    let mut parsed: CredentialsFile = toml::from_str(&raw)
-        .with_context(|| format!("parsing credentials file {}", file_path.display()))?;
-    if parsed.profiles.remove(name).is_none() {
-        return Ok(false);
-    }
-    if parsed.profiles.is_empty() {
-        // No profiles left — collapse the file so the absence is visible to
-        // `path().exists()` and to humans `ls`-ing the dotdir.
-        fs::remove_file(&file_path)
-            .with_context(|| format!("removing empty credentials file {}", file_path.display()))?;
-        return Ok(true);
-    }
-    let serialized = toml::to_string_pretty(&parsed).context("serializing credentials to TOML")?;
-    write_secure(&file_path, serialized.as_bytes())?;
-    Ok(true)
-}
-
-/// Load `name`, refresh its OIDC tokens if they're within five minutes of
-/// expiry, persist any refreshed material, and return the
-/// `BoxliteRestOptions` to use for an authenticated REST call.
-///
-/// This is the chokepoint every authenticated command flows through —
-/// keep the network round-trip + on-disk update in one place so callers
-/// never see a fresh-from-disk Profile that is already stale.
-///
-/// `Ok(None)` means "no profile by that name" (use the unauthenticated
-/// runtime / env vars instead). `Err` is reserved for actual problems
-/// (corrupt file, broken IdP) that should surface to the user.
-pub async fn load_active(name: &str, http: &reqwest::Client) -> Result<Option<BoxliteRestOptions>> {
-    let Some(mut profile) = load_named(name)? else {
-        return Ok(None);
-    };
-    if crate::commands::auth::oidc::refresh::refresh_needed(&profile) {
-        crate::commands::auth::oidc::refresh::refresh(&mut profile, http).await?;
-        save_named(name, &profile)?;
-    }
-    Ok(Some(into_rest_options(profile)))
+    CredentialStore::default().delete_named(name)
 }
 
 /// Convert a stored `Profile` into `BoxliteRestOptions`.
@@ -384,6 +414,22 @@ mod tests {
             api_key: None,
             path_prefix: Some("acme".to_string()),
         }
+    }
+
+    #[test]
+    fn explicit_home_scopes_every_credential_operation() {
+        let temp = TempDir::new().expect("temp home");
+        let store = CredentialStore::new(Some(temp.path().to_path_buf()));
+        let profile = sample_api_key_profile();
+
+        assert_eq!(store.path().unwrap(), temp.path().join("credentials.toml"));
+        store.save_named("cloud", &profile).expect("save");
+        let loaded = store
+            .load_named("cloud")
+            .expect("load")
+            .expect("profile exists");
+        assert_profiles_equal(&loaded, &profile);
+        assert!(store.delete_named("cloud").expect("delete"));
     }
 
     /// `SecretString` intentionally does not implement `PartialEq` (to keep

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -12,8 +12,6 @@ use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::OnceLock;
 
-use clap::CommandFactory;
-use clap::Parser;
 use cli::Cli;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{EnvFilter, Layer, fmt, layer::SubscriberExt, util::SubscriberInitExt};
@@ -21,12 +19,11 @@ use tracing_subscriber::{EnvFilter, Layer, fmt, layer::SubscriberExt, util::Subs
 static FILE_LOG_GUARD: OnceLock<WorkerGuard> = OnceLock::new();
 
 fn main() {
-    let mut cli = Cli::parse();
+    let mut cli = cli::parse();
 
     // Handle shell completion before starting tokio or tracing
     if let cli::Commands::Completion(args) = &cli.command {
-        let mut cmd = Cli::command();
-        cli::generate_completion(&args.shell, &mut cmd, "boxlite", &mut std::io::stdout());
+        cli::generate_completion(&args.shell, "boxlite", &mut std::io::stdout());
         process::exit(0);
     }
 
@@ -75,16 +72,10 @@ async fn run_cli(cli: Cli) -> i32 {
 
     // For `boxlite serve`, the daemon's logs must land under the *resolved*
     // home_dir (config file + --home + BOXLITE_HOME), not just the --home flag.
-    // Other subcommands resolve options later inside their handlers.
-    //
-    // The `.ok()` here is intentionally best-effort: this resolution is only
-    // consulted for the log directory. In local mode the serve handler calls
-    // `create_runtime()` which re-runs `resolve_runtime_options()` and
-    // surfaces config errors to the user. In REST mode (`--url` /
-    // `BOXLITE_API_KEY` set) the resolver is *not* re-invoked, so a malformed
-    // config file is silently ignored here; `boxlite serve` is overwhelmingly
-    // a local-daemon operation, so we accept that narrow gap rather than
-    // duplicating the resolver call here.
+    // Other subcommands resolve options later inside their handlers. The
+    // `.ok()` here is intentionally best-effort because this first resolution
+    // only selects the log directory; the serve handler resolves again and
+    // surfaces any malformed config as the command error.
     let serve_mode = matches!(cli.command, cli::Commands::Serve(_));
     let serve_home_dir = if serve_mode {
         cli.global

--- a/src/cli/tests/auth.rs
+++ b/src/cli/tests/auth.rs
@@ -102,6 +102,14 @@ fn creds_path(home: &TempDir) -> std::path::PathBuf {
     home.path().join("credentials.toml")
 }
 
+fn write_api_key_profile(home: &TempDir, url: &str) {
+    std::fs::write(
+        creds_path(home),
+        format!("[profiles.default]\nurl = {url:?}\napi_key = \"k_test\"\n"),
+    )
+    .unwrap();
+}
+
 #[test]
 fn login_success_prints_identity_and_saves() {
     let stub = Stub::start(|_m, path| match path {
@@ -218,6 +226,63 @@ fn status_is_offline_and_reports_source() {
         .stdout(predicate::str::contains("Not logged in"));
 }
 
+#[test]
+fn status_applies_an_explicit_url_to_a_stored_profile() {
+    let home = TempDir::new().unwrap();
+    write_api_key_profile(&home, "https://stored.example.test");
+
+    auth_cmd(&home)
+        .args(["auth", "status", "--url", "https://override.example.test"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Logged in to:    https://override.example.test",
+        ));
+}
+
+#[test]
+fn whoami_applies_an_explicit_url_to_a_stored_profile() {
+    let stub = Stub::start(|_m, path| match path {
+        "/v1/me" => (200, PRINCIPAL_JSON.to_string()),
+        _ => (404, NOT_FOUND_JSON.to_string()),
+    });
+    let home = TempDir::new().unwrap();
+    write_api_key_profile(&home, "http://127.0.0.1:1");
+
+    auth_cmd(&home)
+        .args(["auth", "whoami", "--url", &stub.url()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "Server:          {}",
+            stub.url()
+        )));
+}
+
+#[test]
+fn malformed_credentials_never_fall_back_to_the_local_runtime() {
+    let home = TempDir::new().unwrap();
+    std::fs::write(creds_path(&home), "[profiles.default\n").unwrap();
+
+    auth_cmd(&home)
+        .args(["list"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("parsing credentials file"));
+}
+
+#[test]
+fn logout_reports_a_malformed_credential_store() {
+    let home = TempDir::new().unwrap();
+    std::fs::write(creds_path(&home), "[profiles.default\n").unwrap();
+
+    auth_cmd(&home)
+        .args(["auth", "logout", "--yes"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("parsing credentials file"));
+}
+
 /// Regression: `BOXLITE_API_KEY=""` (an empty-but-set env var, easy to
 /// produce from `export BOXLITE_API_KEY=$VAR_THAT_IS_UNSET`) used to make
 /// `auth status` report "Logged in (env)" while every actual authenticated
@@ -235,4 +300,36 @@ fn status_treats_empty_env_api_key_as_not_logged_in() {
         .assert()
         .success()
         .stdout(predicate::str::contains("Not logged in"));
+}
+
+#[test]
+fn status_treats_an_empty_url_environment_value_as_unset() {
+    let home = TempDir::new().unwrap();
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("boxlite"));
+    cmd.env("BOXLITE_HOME", home.path())
+        .env("BOXLITE_API_KEY", "k_test")
+        .env("BOXLITE_REST_URL", "")
+        .timeout(Duration::from_secs(30));
+    cmd.args(["auth", "status"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Logged in to:    http://localhost:8100",
+        ));
+}
+
+#[test]
+fn relative_home_environment_value_is_rejected_for_auth_too() {
+    let working = TempDir::new().unwrap();
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("boxlite"));
+    cmd.current_dir(working.path())
+        .env("BOXLITE_HOME", "relative-home")
+        .env_remove("BOXLITE_API_KEY")
+        .env_remove("BOXLITE_REST_URL")
+        .timeout(Duration::from_secs(30));
+    cmd.args(["auth", "status"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("must be an absolute path"));
 }

--- a/src/cli/tests/common/mod.rs
+++ b/src/cli/tests/common/mod.rs
@@ -7,15 +7,22 @@ use std::fs;
 use std::path::PathBuf;
 use std::time::Duration;
 
-fn apply_registries(cmd: &mut Command) {
-    for reg in TEST_REGISTRIES {
-        cmd.arg("--registry").arg(reg);
-    }
+fn write_registry_config(home: &std::path::Path) -> PathBuf {
+    let path = home.join("test-runtime-config.json");
+    let registries = TEST_REGISTRIES
+        .iter()
+        .map(|host| serde_json::json!({ "host": host, "search": true }))
+        .collect::<Vec<_>>();
+    let config = serde_json::to_vec(&serde_json::json!({ "image_registries": registries }))
+        .expect("serialize test runtime config");
+    fs::write(&path, config).expect("write test runtime config");
+    path
 }
 
 pub struct TestContext {
     pub cmd: Command,
     pub home: PathBuf,
+    registry_config: Option<PathBuf>,
     _home: PerTestBoxHome,
 }
 
@@ -26,7 +33,9 @@ impl TestContext {
         let mut cmd = Command::new(bin_path);
         cmd.timeout(Duration::from_secs(60));
         cmd.arg("--home").arg(&self.home);
-        apply_registries(&mut cmd);
+        if let Some(config) = &self.registry_config {
+            cmd.arg("--config").arg(config);
+        }
         cmd
     }
 
@@ -90,6 +99,7 @@ pub fn boxlite_bare() -> TestContext {
     TestContext {
         cmd,
         home,
+        registry_config: None,
         _home: home_dir,
     }
 }
@@ -101,11 +111,13 @@ pub fn boxlite() -> TestContext {
     let mut cmd = Command::new(bin_path);
     cmd.timeout(Duration::from_secs(60));
     cmd.arg("--home").arg(&home);
-    apply_registries(&mut cmd);
+    let registry_config = write_registry_config(&home);
+    cmd.arg("--config").arg(&registry_config);
 
     TestContext {
         cmd,
         home,
+        registry_config: Some(registry_config),
         _home: home_dir,
     }
 }

--- a/src/cli/tests/exec.rs
+++ b/src/cli/tests/exec.rs
@@ -134,6 +134,27 @@ fn test_exec_env_override() {
 }
 
 #[test]
+fn test_exec_warns_when_inherited_host_env_is_missing() {
+    const MISSING: &str = "BOXLITE_TEST_MISSING_EXEC_ENV_33A6";
+    let mut ctx = common::boxlite();
+
+    ctx.cmd.args(["run", "-d", "alpine:latest", "sleep", "300"]);
+    let output = ctx.cmd.assert().success().get_output().clone();
+    let box_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+    ctx.new_cmd()
+        .env_remove(MISSING)
+        .args(["exec", "-e", MISSING, &box_id, "--", "true"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(format!(
+            "Environment variable '{MISSING}' not found on host, skipping"
+        )));
+
+    cleanup(&ctx, &box_id);
+}
+
+#[test]
 fn test_exec_inherits_box_workdir() {
     let mut ctx = common::boxlite();
 

--- a/src/cli/tests/help.rs
+++ b/src/cli/tests/help.rs
@@ -1,0 +1,354 @@
+use assert_cmd::Command;
+use predicates::prelude::PredicateBooleanExt;
+
+const GLOBAL_OPTIONS: &[&str] = &[
+    "--debug",
+    "--home",
+    "--registry",
+    "--config",
+    "--url",
+    "--profile",
+    "--path-prefix",
+];
+
+fn help_for(path: &[&str], help_flag: &str) -> String {
+    let output = Command::new(assert_cmd::cargo::cargo_bin!("boxlite"))
+        .args(path)
+        .arg(help_flag)
+        .assert()
+        .success();
+    std::str::from_utf8(&output.get_output().stdout)
+        .unwrap()
+        .to_owned()
+}
+
+fn declares_option(help: &str, option: &str) -> bool {
+    help.lines().any(|line| {
+        let declaration = line.trim_start();
+        declaration.starts_with('-')
+            && declaration
+                .split_ascii_whitespace()
+                .any(|token| token.trim_end_matches(',') == option)
+    })
+}
+
+#[test]
+fn command_help_only_advertises_meaningful_global_options() {
+    let cases: &[(&[&str], &[&str])] = &[
+        (&["run"], GLOBAL_OPTIONS),
+        (
+            &["exec"],
+            &[
+                "--debug",
+                "--home",
+                "--config",
+                "--url",
+                "--profile",
+                "--path-prefix",
+            ],
+        ),
+        (&["create"], GLOBAL_OPTIONS),
+        (
+            &["list"],
+            &[
+                "--debug",
+                "--home",
+                "--config",
+                "--url",
+                "--profile",
+                "--path-prefix",
+            ],
+        ),
+        (
+            &["ls"],
+            &[
+                "--debug",
+                "--home",
+                "--config",
+                "--url",
+                "--profile",
+                "--path-prefix",
+            ],
+        ),
+        (
+            &["ps"],
+            &[
+                "--debug",
+                "--home",
+                "--config",
+                "--url",
+                "--profile",
+                "--path-prefix",
+            ],
+        ),
+        (
+            &["rm"],
+            &[
+                "--debug",
+                "--home",
+                "--config",
+                "--url",
+                "--profile",
+                "--path-prefix",
+            ],
+        ),
+        (
+            &["start"],
+            &[
+                "--debug",
+                "--home",
+                "--config",
+                "--url",
+                "--profile",
+                "--path-prefix",
+            ],
+        ),
+        (
+            &["stop"],
+            &[
+                "--debug",
+                "--home",
+                "--config",
+                "--url",
+                "--profile",
+                "--path-prefix",
+            ],
+        ),
+        (
+            &["restart"],
+            &[
+                "--debug",
+                "--home",
+                "--config",
+                "--url",
+                "--profile",
+                "--path-prefix",
+            ],
+        ),
+        (&["pull"], &["--debug", "--home", "--registry", "--config"]),
+        (&["images"], &["--debug", "--home", "--config"]),
+        (
+            &["inspect"],
+            &[
+                "--debug",
+                "--home",
+                "--config",
+                "--url",
+                "--profile",
+                "--path-prefix",
+            ],
+        ),
+        (
+            &["cp"],
+            &[
+                "--debug",
+                "--home",
+                "--config",
+                "--url",
+                "--profile",
+                "--path-prefix",
+            ],
+        ),
+        (&["info"], &["--debug", "--home", "--config"]),
+        (&["logs"], &["--debug", "--home", "--config"]),
+        (
+            &["stats"],
+            &[
+                "--debug",
+                "--home",
+                "--config",
+                "--url",
+                "--profile",
+                "--path-prefix",
+            ],
+        ),
+        (
+            &["network"],
+            &[
+                "--debug",
+                "--home",
+                "--config",
+                "--url",
+                "--profile",
+                "--path-prefix",
+            ],
+        ),
+        (
+            &["network", "tunnel"],
+            &[
+                "--debug",
+                "--home",
+                "--config",
+                "--url",
+                "--profile",
+                "--path-prefix",
+            ],
+        ),
+        (&["serve"], &["--debug", "--home", "--registry", "--config"]),
+        (&["auth"], &["--debug", "--home", "--profile"]),
+        (
+            &["auth", "login"],
+            &["--debug", "--home", "--url", "--profile"],
+        ),
+        (&["auth", "logout"], &["--debug", "--home", "--profile"]),
+        (
+            &["auth", "status"],
+            &["--debug", "--home", "--url", "--profile"],
+        ),
+        (
+            &["auth", "whoami"],
+            &["--debug", "--home", "--url", "--profile"],
+        ),
+        (
+            &["volume"],
+            &["--debug", "--home", "--url", "--profile", "--path-prefix"],
+        ),
+        (
+            &["volume", "create"],
+            &["--debug", "--home", "--url", "--profile", "--path-prefix"],
+        ),
+        (
+            &["volume", "ls"],
+            &["--debug", "--home", "--url", "--profile", "--path-prefix"],
+        ),
+        (
+            &["volume", "list"],
+            &["--debug", "--home", "--url", "--profile", "--path-prefix"],
+        ),
+        (
+            &["volume", "get"],
+            &["--debug", "--home", "--url", "--profile", "--path-prefix"],
+        ),
+        (
+            &["volume", "inspect"],
+            &["--debug", "--home", "--url", "--profile", "--path-prefix"],
+        ),
+        (
+            &["volume", "rm"],
+            &["--debug", "--home", "--url", "--profile", "--path-prefix"],
+        ),
+        (
+            &["volume", "delete"],
+            &["--debug", "--home", "--url", "--profile", "--path-prefix"],
+        ),
+        (&["completion"], &[]),
+    ];
+
+    for help_flag in ["-h", "--help"] {
+        for (path, visible) in cases {
+            let help = help_for(path, help_flag);
+            for option in GLOBAL_OPTIONS {
+                assert_eq!(
+                    declares_option(&help, option),
+                    visible.contains(option),
+                    "{option} visibility is wrong in `boxlite {} {help_flag}`:\n{help}",
+                    path.join(" ")
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn command_specific_help_has_no_noop_options() {
+    let cases: &[(&[&str], &[&str])] = &[
+        (&["exec"], &["--entrypoint"]),
+        (&["create"], &["--detach", "--rm"]),
+        (&["images"], &["--all"]),
+        (&["cp"], &["--include-parent"]),
+    ];
+
+    for (path, absent) in cases {
+        let help = help_for(path, "--help");
+        for option in *absent {
+            assert!(
+                !declares_option(&help, option),
+                "{option} is a no-op but appears in `boxlite {} --help`:\n{help}",
+                path.join(" ")
+            );
+        }
+    }
+
+    let cp_help = help_for(&["cp"], "--help");
+    assert!(
+        declares_option(&cp_help, "--no-include-parent"),
+        "{cp_help}"
+    );
+}
+
+#[test]
+fn serve_help_never_reveals_the_api_key_environment_value() {
+    const SENTINEL: &str = "boxlite-help-must-mask-this-secret";
+
+    Command::new(assert_cmd::cargo::cargo_bin!("boxlite"))
+        .env("BOXLITE_SERVE_API_KEY", SENTINEL)
+        .args(["serve", "--help"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains(SENTINEL).not())
+        .stderr(predicates::str::contains(SENTINEL).not());
+}
+
+#[test]
+fn irrelevant_global_options_are_rejected_wherever_they_are_written() {
+    for (args, diagnostic) in [
+        (
+            ["--url", "https://ignored.test", "completion", "bash"],
+            "--url is not valid for `boxlite completion`",
+        ),
+        (
+            ["completion", "bash", "--url", "https://ignored.test"],
+            "unexpected argument '--url'",
+        ),
+    ] {
+        Command::new(assert_cmd::cargo::cargo_bin!("boxlite"))
+            .args(args)
+            .assert()
+            .failure()
+            .stderr(predicates::str::contains(diagnostic));
+    }
+}
+
+#[test]
+fn irrelevant_global_environment_values_do_not_break_a_command() {
+    Command::new(assert_cmd::cargo::cargo_bin!("boxlite"))
+        .env("BOXLITE_HOME", "relative-but-unused")
+        .args(["completion", "bash"])
+        .assert()
+        .success();
+}
+
+#[cfg(unix)]
+#[test]
+fn irrelevant_non_utf8_global_environment_values_do_not_break_a_command() {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+
+    Command::new(assert_cmd::cargo::cargo_bin!("boxlite"))
+        .env(
+            "BOXLITE_REST_URL",
+            OsString::from_vec(vec![b'h', b't', b't', b'p', 0xff]),
+        )
+        .args(["completion", "bash"])
+        .assert()
+        .success();
+}
+
+#[cfg(unix)]
+#[test]
+fn auth_login_rejects_a_non_utf8_url_environment_value() {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+
+    Command::new(assert_cmd::cargo::cargo_bin!("boxlite"))
+        .env(
+            "BOXLITE_REST_URL",
+            OsString::from_vec(vec![b'h', b't', b't', b'p', 0xff]),
+        )
+        .args(["auth", "login", "--api-key-stdin"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "BOXLITE_REST_URL must contain valid UTF-8",
+        ));
+}

--- a/src/cli/tests/images.rs
+++ b/src/cli/tests/images.rs
@@ -1,3 +1,4 @@
+use assert_cmd::Command;
 use predicates::prelude::*;
 
 mod common;
@@ -79,4 +80,17 @@ fn test_images_yaml_format() {
     assert!(stdout.contains("Tag:") || stdout.trim() == "[]");
     assert!(stdout.contains("ID:") || stdout.trim() == "[]");
     assert!(stdout.contains("CreatedAt:") || stdout.trim() == "[]");
+}
+
+#[test]
+fn images_ignores_an_ambient_rest_url_and_stays_local() {
+    let home = tempfile::tempdir().unwrap();
+    Command::new(assert_cmd::cargo::cargo_bin!("boxlite"))
+        .env("BOXLITE_HOME", home.path())
+        .env("BOXLITE_REST_URL", "http://127.0.0.1:1")
+        .env_remove("BOXLITE_API_KEY")
+        .args(["images", "--format", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::eq("[]\n"));
 }

--- a/src/cli/tests/inspect.rs
+++ b/src/cli/tests/inspect.rs
@@ -13,7 +13,9 @@ fn test_inspect_no_args() {
         .args(["inspect"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("no names or ids specified"));
+        .stderr(predicate::str::contains(
+            "required arguments were not provided",
+        ));
 }
 
 #[test]
@@ -509,8 +511,8 @@ fn test_inspect_latest_and_ref_fail() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("cannot be used together"),
-        "stderr should say --latest and arguments cannot be used together; got: {}",
+        stderr.contains("--latest") && stderr.contains("cannot be used with"),
+        "stderr should say --latest cannot be used with box arguments; got: {}",
         stderr
     );
 }


### PR DESCRIPTION
## Summary

Align CLI help, parsing, completions, runtime selection, and documentation with the options each command actually supports. Irrelevant globals and unsupported combinations are now hidden or rejected instead of advertised or silently ignored.

## Call graph

Before
  main       (fn · src/cli/src/main.rs:21) — parse and dispatch
    ├─ parse (Cli · src/cli/src/cli.rs:66) — propagate every global option to every descendant ← BUG: commands advertise and accept options they cannot use
    └─ run_cli (fn · src/cli/src/main.rs:57) — dispatch values containing irrelevant configuration

After
  main                    (fn · src/cli/src/main.rs:21) — parse and dispatch
    ├─ parse               (fn · src/cli/src/cli.rs:420) — enter the scoped parser
    │  └─ try_parse_from   (fn · src/cli/src/cli.rs:424) — validate selected-command values
    │     └─ command       (fn · src/cli/src/cli.rs:346) — build one command tree
    │        └─ apply_command_scopes (fn · src/cli/src/cli.rs:363) — attach only positively owned options
    ├─ generate_completion (fn · src/cli/src/cli.rs:646) — generate scoped completions
    │  └─ completion_command (fn · src/cli/src/cli.rs:655) — reuse the runtime command tree
    └─ run_cli             (fn · src/cli/src/main.rs:57) — dispatch normalized arguments

## Changes

- Define a declarative capability matrix for every top-level and nested command.
- Use the same scoped Clap tree for runtime parsing, help, and shell completion.
- Preserve root-before-command and leaf-after-command option placement while rejecting unsupported flags, empty values, and conflicting combinations.
- Keep local-only commands on the embedded runtime despite ambient REST credentials.
- Move flags to their owning workflows, validate REST copy limitations, and root credential access in the effective BoxLite home.
- Align authentication methods, profiles, lifecycle flags, output conflicts, and command documentation with implemented semantics.
- Cover command paths, aliases, environment inputs, no-op flags, and conflicts with regression tests.

## How to verify

- `make test:integration:cli SETUP_DONE=1`
- `make fmt:check`
- `make lint`
- `git diff --check`

The CLI integration suite reports 462 passed and 1 skipped.

## Risks / rollout

Previously accepted no-op or contradictory combinations now fail. Leaf-specific options must appear before the top-level command or after the complete command path. `cp --include-parent` becomes the default behavior with `--no-include-parent` as its inverse, and authentication now honors the effective credential home and selected profile URL.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added credential profiles with browser/device-code login, `auth whoami`, configurable credential homes, and profile selection.
  - Added networking, security, entrypoint, detach, and automatic-removal options for box creation and execution.
  - Added server configuration options and expanded environment-variable support.
  - Added path-prefix support and improved command-specific help and shell completions.

- **Bug Fixes**
  - Improved validation for conflicting or unsupported options.
  - Preserved explicit auto-delete deadlines and improved credential and URL error handling.
  - Clarified CLI documentation for supported server commands and runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->