### PR TITLE
feat(api): enforce subscription limits on hosted box creation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -422,6 +422,12 @@ jobs:
         with: # Native workspace dependencies are submodules.
           submodules: "recursive"
           persist-credentials: ${{ false }}
+      - name: Checkout Commerce contract provider
+        uses: actions/checkout@v5
+        with:
+          repository: boxlite-ai/boxlite-commerce
+          path: .contract/boxlite-commerce
+          persist-credentials: ${{ false }}
       - name: Enable Corepack
         run: "corepack enable"
       - uses: actions/setup-node@v4
@@ -431,7 +437,12 @@ jobs:
           cache-dependency-path: "apps/yarn.lock"
       - name: Install app dependencies
         run: "yarn install --immutable"
+      - name: Install Commerce contract dependencies
+        working-directory: .contract/boxlite-commerce
+        run: "npm ci --ignore-scripts --no-audit --no-fund"
       - name: Run API unit tests
+        env:
+          BOXLITE_COMMERCE_REPOSITORY: ${{ github.workspace }}/.contract/boxlite-commerce
         run: "yarn nx run api:test"
 
   # End API test job.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -422,11 +422,19 @@ jobs:
         with: # Native workspace dependencies are submodules.
           submodules: "recursive"
           persist-credentials: ${{ false }}
+      # Fork and Dependabot pull_request runs cannot read repository secrets.
+      # The merge_group run still enforces this contract before merge.
       - name: Checkout Commerce contract provider
+        id: commerce_checkout
+        if: >-
+          github.event_name != 'pull_request' ||
+          (github.event.pull_request.head.repo.full_name == github.repository &&
+          github.actor != 'dependabot[bot]')
         uses: actions/checkout@v5
         with:
           repository: boxlite-ai/boxlite-commerce
           path: .contract/boxlite-commerce
+          token: ${{ secrets.GH_PAT }}
           persist-credentials: ${{ false }}
       - name: Enable Corepack
         run: "corepack enable"
@@ -438,11 +446,12 @@ jobs:
       - name: Install app dependencies
         run: "yarn install --immutable"
       - name: Install Commerce contract dependencies
+        if: steps.commerce_checkout.outcome == 'success'
         working-directory: .contract/boxlite-commerce
         run: "npm ci --ignore-scripts --no-audit --no-fund"
       - name: Run API unit tests
         env:
-          BOXLITE_COMMERCE_REPOSITORY: ${{ github.workspace }}/.contract/boxlite-commerce
+          BOXLITE_COMMERCE_REPOSITORY: ${{ steps.commerce_checkout.outcome == 'success' && format('{0}/.contract/boxlite-commerce', github.workspace) || '' }}
         run: "yarn nx run api:test"
 
   # End API test job.

--- a/apps/API.md
+++ b/apps/API.md
@@ -689,12 +689,11 @@ that widen [organization suspend/unsuspend](#control-plane-api) exist for
 Commerce, which does not currently call them.
 
 Admission applies the plan value to the organization's non-finalized Box total.
-`STOPPED` Boxes and `UNKNOWN` Boxes with `pending=true` count, while `ERROR`,
-settled `UNKNOWN`, `DESTROYING`, `DESTROYED`, `ARCHIVING`, and `ARCHIVED` do
-not. The two admission reads have a cross-repository contract test that runs
-the current Commerce controllers and passes their responses through the
-BoxLite consumer. The remaining billing client is hand-written rather than
-generated, so neither side detects its
+`STOPPED` and `UNKNOWN` Boxes count, while `ERROR`, `DESTROYING`, `DESTROYED`,
+`ARCHIVING`, and `ARCHIVED` do not. The two admission reads have a
+cross-repository contract test that runs the current Commerce controllers and
+passes their responses through the BoxLite consumer. The remaining billing
+client is hand-written rather than generated, so neither side detects its
 divergence. Five of its 20 routes — the billing-email group — have no
 implementation in Commerce, of which only `email/verify` has a live caller here
 ([`EmailVerify.tsx`](./dashboard/src/pages/EmailVerify.tsx)); Commerce in turn

--- a/apps/API.md
+++ b/apps/API.md
@@ -667,8 +667,13 @@ The Billing API, Box admission, and Usage export rows are the same Commerce
 service reached three ways, on URLs that normally differ by path rather than
 host. The browser API and Box admission reads live under `/api/billing`, which
 `BILLING_API_URL` already includes; admission authenticates with the shared
-service token. The internal usage routes are served off the bare origin. The API
-itself requires `USAGE_EXPORT_URL` whenever export is on and never derives it
+service token. The API validates that URL and token presence at startup. A
+request-time transport or 5xx failure is logged and temporarily leaves creation
+unlimited without caching the fallback; rejected credentials and malformed
+successful responses still return 503. Successful per-organization resolutions
+are cached in Redis for 30 seconds. The internal usage routes are served off the
+bare origin. The API itself requires `USAGE_EXPORT_URL` whenever export is on
+and never derives it
 ([`configuration.ts`](./api/src/config/configuration.ts)); it is the SST stack
 that supplies a default of `BILLING_API_URL`'s origin
 ([`api.ts`](./infra/stack/api.ts)), so a deployment outside that stack must set
@@ -682,8 +687,13 @@ plane using the caller's own token. The `billing` API role and `BILLING_API_KEY`
 that widen [organization suspend/unsuspend](#control-plane-api) exist for
 Commerce, which does not currently call them.
 
-Because the billing client is hand-written rather than generated, neither side
-detects divergence. Five of its 20 routes — the billing-email group — have no
+Admission applies the plan value to the organization's non-finalized Box total:
+`STOPPED` Boxes count, while `ERROR`, `UNKNOWN`, `DESTROYING`, `DESTROYED`,
+`ARCHIVING`, and `ARCHIVED` do not. The two admission reads have a
+cross-repository contract test that runs the current Commerce controllers and
+passes their responses through the BoxLite consumer. The remaining billing
+client is hand-written rather than generated, so neither side detects its
+divergence. Five of its 20 routes — the billing-email group — have no
 implementation in Commerce, of which only `email/verify` has a live caller here
 ([`EmailVerify.tsx`](./dashboard/src/pages/EmailVerify.tsx)); Commerce in turn
 serves card default/delete, `plan/pay-open-charge`, and a credit admission API

--- a/apps/API.md
+++ b/apps/API.md
@@ -688,12 +688,13 @@ plane using the caller's own token. The `billing` API role and `BILLING_API_KEY`
 that widen [organization suspend/unsuspend](#control-plane-api) exist for
 Commerce, which does not currently call them.
 
-Admission applies the plan value to the organization's non-finalized Box total:
-`STOPPED` Boxes count, while `ERROR`, `UNKNOWN`, `DESTROYING`, `DESTROYED`,
-`ARCHIVING`, and `ARCHIVED` do not. The two admission reads have a
-cross-repository contract test that runs the current Commerce controllers and
-passes their responses through the BoxLite consumer. The remaining billing
-client is hand-written rather than generated, so neither side detects its
+Admission applies the plan value to the organization's non-finalized Box total.
+`STOPPED` Boxes and `UNKNOWN` Boxes with `pending=true` count, while `ERROR`,
+settled `UNKNOWN`, `DESTROYING`, `DESTROYED`, `ARCHIVING`, and `ARCHIVED` do
+not. The two admission reads have a cross-repository contract test that runs
+the current Commerce controllers and passes their responses through the
+BoxLite consumer. The remaining billing client is hand-written rather than
+generated, so neither side detects its
 divergence. Five of its 20 routes — the billing-email group — have no
 implementation in Commerce, of which only `email/verify` has a live caller here
 ([`EmailVerify.tsx`](./dashboard/src/pages/EmailVerify.tsx)); Commerce in turn

--- a/apps/API.md
+++ b/apps/API.md
@@ -645,12 +645,13 @@ their base URL from `GET /api/config` and disable the corresponding UI when it
 is unset; the same document carries PostHog's key and host to the browser.
 
 <details>
-<summary><b>External interfaces</b> · 3 APIs, 2 SaaS integrations</summary>
+<summary><b>External interfaces</b> · 4 APIs, 2 SaaS integrations</summary>
 
 | Interface     | Client                                                                                 | Base URL source                  | What it covers                                                                                                                                                                                             |
 | ------------- | -------------------------------------------------------------------------------------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Analytics API | [`libs/analytics-api-client`](./libs/analytics-api-client/), generated                 | `analyticsApiUrl`                | 8 routes: per-box and organization usage, aggregates, and charts, plus box logs, metrics, and traces.                                                                                                      |
 | Billing API   | [`billingApiClient.ts`](./dashboard/src/billing-api/billingApiClient.ts), hand-written | `billingApiUrl`                  | 20 routes: wallet and top-ups, plans, payment methods, invoices, usage series and prices, coupons, billing emails, portal and checkout URLs.                                                               |
+| Box admission | [`commerce-box-limit.service.ts`](./api/src/boxlite-rest/commerce-box-limit.service.ts) | `billingApiUrl`                  | 2 server-side reads on Commerce: `GET /plan` and `GET /organization/{organizationId}/plan`, bearer `USAGE_EXPORT_TOKEN`, used by hosted CREATE BOX.                                                        |
 | Usage export  | [`api/src/usage/services`](./api/src/usage/services/), hand-written                    | `usageExport.url`                | 2 routes on the same Commerce service, server-side: `POST /internal/usage-events` and `POST /internal/allocation-snapshot`, bearer `USAGE_EXPORT_TOKEN`, which must equal Commerce's `USAGE_INGEST_TOKEN`. |
 | PostHog       | `posthog-js` in the dashboard; `posthog-node` in the API                               | `posthog.apiKey`, `posthog.host` | Browser product analytics; server-side `api_*` operation events from the global metrics interceptor, two `groupIdentify` calls, and feature-flag evaluation.                                               |
 | Pylon         | [`App.tsx`](./dashboard/src/App.tsx) widget, production builds only                    | `pylonAppId`                     | Outbound support-chat widget; it registers no route here.                                                                                                                                                  |
@@ -662,12 +663,12 @@ routes, and the dashboard's box telemetry views call the analytics client only �
 they disable themselves when `analyticsApiUrl` is unset rather than falling back.
 Nothing in this directory registers the analytics or billing paths.
 
-The Billing API and Usage export rows are the same Commerce service reached two
-ways, on URLs that normally differ by path rather than host: the browser API
-lives under `/api/billing`, which `BILLING_API_URL` already includes, while the
-internal routes are served off the bare origin because they authenticate a
-service rather than a user. The API itself requires `USAGE_EXPORT_URL` whenever
-export is on and never derives it
+The Billing API, Box admission, and Usage export rows are the same Commerce
+service reached three ways, on URLs that normally differ by path rather than
+host. The browser API and Box admission reads live under `/api/billing`, which
+`BILLING_API_URL` already includes; admission authenticates with the shared
+service token. The internal usage routes are served off the bare origin. The API
+itself requires `USAGE_EXPORT_URL` whenever export is on and never derives it
 ([`configuration.ts`](./api/src/config/configuration.ts)); it is the SST stack
 that supplies a default of `BILLING_API_URL`'s origin
 ([`api.ts`](./infra/stack/api.ts)), so a deployment outside that stack must set

--- a/apps/API.md
+++ b/apps/API.md
@@ -667,12 +667,13 @@ The Billing API, Box admission, and Usage export rows are the same Commerce
 service reached three ways, on URLs that normally differ by path rather than
 host. The browser API and Box admission reads live under `/api/billing`, which
 `BILLING_API_URL` already includes; admission authenticates with the shared
-service token. The API validates that URL and token presence at startup. A
-request-time transport or 5xx failure is logged and temporarily leaves creation
-unlimited without caching the fallback; rejected credentials and malformed
-successful responses still return 503. Successful per-organization resolutions
-are cached in Redis for 30 seconds. The internal usage routes are served off the
-bare origin. The API itself requires `USAGE_EXPORT_URL` whenever export is on
+service token. When `BILLING_API_URL` is configured, the API validates that URL
+and the shared token at startup. A request-time transport or 5xx failure is
+logged and temporarily leaves creation unlimited without caching the fallback;
+rejected credentials and malformed successful responses still return 503.
+Successful per-organization resolutions are cached in Redis for 30 seconds. The
+internal usage routes are served off the bare origin. The API itself requires
+`USAGE_EXPORT_URL` whenever export is on
 and never derives it
 ([`configuration.ts`](./api/src/config/configuration.ts)); it is the SST stack
 that supplies a default of `BILLING_API_URL`'s origin

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -81,9 +81,11 @@ PYLON_APP_ID=
 
 BILLING_API_URL=
 # Hosted CREATE BOX requests read the public catalog and organization plan from
-# this URL. Those reads use USAGE_EXPORT_TOKEN even when export is disabled; a
-# missing or rejected token makes CREATE fail closed with HTTP 503. Leaving the
-# URL empty keeps creation limits disabled for local/private deployments.
+# this URL. The URL and presence of USAGE_EXPORT_TOKEN are validated at startup,
+# even when export is disabled. A rejected token or malformed Commerce response
+# returns HTTP 503; a transport or 5xx outage logs a warning and temporarily
+# disables the limit without caching that fallback. Leaving the URL empty keeps
+# creation limits disabled for local/private deployments.
 
 # Export of finalized usage periods to the Commerce service. Separate from
 # BILLING_API_URL: pointing the dashboard at a billing service and shipping usage

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -80,6 +80,10 @@ PROXY_TOOLBOX_BASE_URL=http://proxy.localhost:4000
 PYLON_APP_ID=
 
 BILLING_API_URL=
+# Hosted CREATE BOX requests read the public catalog and organization plan from
+# this URL. Those reads use USAGE_EXPORT_TOKEN even when export is disabled; a
+# missing or rejected token makes CREATE fail closed with HTTP 503. Leaving the
+# URL empty keeps creation limits disabled for local/private deployments.
 
 # Export of finalized usage periods to the Commerce service. Separate from
 # BILLING_API_URL: pointing the dashboard at a billing service and shipping usage
@@ -92,7 +96,8 @@ BILLING_API_URL=
 # delivery must behave and are checked only while USAGE_EXPORT_ENABLED is true,
 # so a stage may leave a placeholder destination here without failing to boot:
 #   USAGE_EXPORT_URL   required, and an absolute http(s) URL
-#   USAGE_EXPORT_TOKEN required
+#   USAGE_EXPORT_TOKEN required for export, and for CREATE admission whenever
+#                      BILLING_API_URL is set
 #   USAGE_EXPORT_TIMEOUT_MS below the window a claimed batch stays hidden for —
 #     at or above it, rows can be re-claimed while their request is in flight
 USAGE_EXPORT_ENABLED=false

--- a/apps/api/scripts/probe-commerce-box-limit-contract.cjs
+++ b/apps/api/scripts/probe-commerce-box-limit-contract.cjs
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+const { resolve } = require('node:path')
+
+async function main() {
+  const { PlansController } = require(resolve('src/plans/api/plans.controller.ts'))
+  const { SubscriptionsController } = require(resolve('src/subscriptions/api/subscriptions.controller.ts'))
+  const plans = [
+    {
+      id: 'starter',
+      name: 'Starter',
+      priceMonthlyCents: 1_000,
+      includedQuotaCents: 1_000,
+      concurrencyLimit: 2,
+      selfServe: true,
+      rank: 0,
+    },
+    {
+      id: 'pro',
+      name: 'Pro',
+      priceMonthlyCents: 5_000,
+      includedQuotaCents: 5_000,
+      concurrencyLimit: 8,
+      selfServe: true,
+      rank: 1,
+    },
+  ]
+  const catalog = await new PlansController({ catalog: async () => plans }).listPlans()
+  const noSubscription = await new SubscriptionsController({ current: async () => null }).getOrganizationPlan('org-1')
+
+  process.stdout.write(JSON.stringify({ catalog, noSubscription }))
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`)
+  process.exitCode = 1
+})

--- a/apps/api/src/box/errors/box-creation-limit.error.ts
+++ b/apps/api/src/box/errors/box-creation-limit.error.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { HttpException, HttpStatus } from '@nestjs/common'
+
+export const BOX_CREATION_LIMIT_EXCEEDED_CODE = 'resource_exhausted'
+export const BOX_CREATION_ADMISSION_UNAVAILABLE_CODE = 'upstream_unavailable'
+
+export class BoxCreationLimitExceededError extends HttpException {
+  constructor(currentCount: number, limit: number) {
+    super(
+      {
+        message: `Organization box creation limit reached: ${currentCount} of ${limit} boxes are already counted`,
+        code: BOX_CREATION_LIMIT_EXCEEDED_CODE,
+      },
+      HttpStatus.TOO_MANY_REQUESTS,
+    )
+    this.name = 'BoxCreationLimitExceededError'
+  }
+}
+
+export class BoxCreationAdmissionUnavailableError extends HttpException {
+  constructor(message = 'Box creation admission is temporarily unavailable') {
+    super({ message, code: BOX_CREATION_ADMISSION_UNAVAILABLE_CODE }, HttpStatus.SERVICE_UNAVAILABLE)
+    this.name = 'BoxCreationAdmissionUnavailableError'
+  }
+}

--- a/apps/api/src/box/errors/box-creation-limit.error.ts
+++ b/apps/api/src/box/errors/box-creation-limit.error.ts
@@ -22,7 +22,10 @@ export class BoxCreationLimitExceededError extends HttpException {
 }
 
 export class BoxCreationAdmissionUnavailableError extends HttpException {
-  constructor(message = 'Box creation admission is temporarily unavailable') {
+  constructor(
+    message = 'Box creation admission is temporarily unavailable',
+    readonly retryAfterSeconds?: number,
+  ) {
     super({ message, code: BOX_CREATION_ADMISSION_UNAVAILABLE_CODE }, HttpStatus.SERVICE_UNAVAILABLE)
     this.name = 'BoxCreationAdmissionUnavailableError'
   }

--- a/apps/api/src/box/repositories/box.repository.creation-limit.integration.spec.ts
+++ b/apps/api/src/box/repositories/box.repository.creation-limit.integration.spec.ts
@@ -164,7 +164,7 @@ describeIfDatabase('BoxRepository creation admission (integration, real Postgres
   it.each(Object.values(BoxState))('applies the creation-count policy to state %s', async (state) => {
     const existing = newBox(`existing-${state}`)
     existing.state = state
-    await repository.insert(existing)
+    await boxes.insert(existing)
 
     const creating = repository.insert(newBox(`candidate-${state}`), 1)
     if (excludedStates.has(state)) {

--- a/apps/api/src/box/repositories/box.repository.creation-limit.integration.spec.ts
+++ b/apps/api/src/box/repositories/box.repository.creation-limit.integration.spec.ts
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { randomUUID } from 'node:crypto'
+import { DataSource, EntityManager, Repository } from 'typeorm'
+import { CustomNamingStrategy } from '../../common/utils/naming-strategy.util'
+import { BOX_WARM_POOL_UNASSIGNED_ORGANIZATION } from '../constants/box.constants'
+import { Box } from '../entities/box.entity'
+import { BoxLastActivity } from '../entities/box-last-activity.entity'
+import { BoxState } from '../enums/box-state.enum'
+import { BoxCreationLimitExceededError } from '../errors/box-creation-limit.error'
+import { BoxRepository } from './box.repository'
+
+const describeIfDatabase = process.env.DB_HOST ? describe : describe.skip
+const schemaName = `box_creation_limit_${process.pid}_${randomUUID().replaceAll('-', '')}`
+const organizationId = '00000000-0000-4000-8000-0000000000aa'
+
+const excludedStates = new Set([
+  BoxState.ERROR,
+  BoxState.DESTROYING,
+  BoxState.DESTROYED,
+  BoxState.ARCHIVING,
+  BoxState.ARCHIVED,
+])
+
+function newBox(name: string, owner = organizationId): Box {
+  const box = new Box('us', name)
+  box.organizationId = owner
+  box.osUser = 'boxlite'
+  box.labels = {}
+  box.pending = true
+  return box
+}
+
+function installInitialCountBarrier(dataSource: DataSource): jest.SpyInstance {
+  const transaction = dataSource.transaction.bind(dataSource)
+  let initialCountCalls = 0
+  let releaseBarrier!: () => void
+  const barrier = new Promise<void>((resolve) => (releaseBarrier = resolve))
+
+  return jest.spyOn(dataSource, 'transaction').mockImplementation(async (...args: unknown[]) => {
+    if (args[0] !== 'SERIALIZABLE' || typeof args[1] !== 'function') {
+      return transaction(args[0] as (entityManager: EntityManager) => Promise<unknown>)
+    }
+
+    const callback = args[1] as (entityManager: EntityManager) => Promise<unknown>
+    return transaction('SERIALIZABLE', async (entityManager) => {
+      const count = entityManager.count.bind(entityManager)
+      entityManager.count = async (...countArgs: Parameters<EntityManager['count']>) => {
+        const result = await count(...countArgs)
+        initialCountCalls++
+        if (initialCountCalls <= 2) {
+          if (initialCountCalls === 2) {
+            releaseBarrier()
+          }
+          await barrier
+        }
+        return result
+      }
+      return callback(entityManager)
+    })
+  })
+}
+
+function expectOneSuccessAndOneLimitFailure(results: PromiseSettledResult<unknown>[]): void {
+  expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1)
+  const failures = results.filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+  expect(failures).toHaveLength(1)
+  expect(failures[0].reason).toBeInstanceOf(BoxCreationLimitExceededError)
+}
+
+describeIfDatabase('BoxRepository creation admission (integration, real Postgres)', () => {
+  let dataSource: DataSource
+  let boxes: Repository<Box>
+  let repository: BoxRepository
+  let ownsSchema = false
+
+  beforeAll(async () => {
+    dataSource = await new DataSource({
+      type: 'postgres',
+      host: process.env.DB_HOST,
+      port: Number(process.env.DB_PORT || 5432),
+      username: process.env.DB_USERNAME,
+      password: process.env.DB_PASSWORD,
+      database: process.env.DB_DATABASE,
+      schema: schemaName,
+      entities: [Box, BoxLastActivity],
+      namingStrategy: new CustomNamingStrategy(),
+      entitySkipConstructor: true,
+      synchronize: false,
+      extra: { options: `-c search_path=${schemaName},public` },
+    }).initialize()
+
+    await dataSource.query(`CREATE SCHEMA "${schemaName}"`)
+    ownsSchema = true
+    await dataSource.synchronize()
+    boxes = dataSource.getRepository(Box)
+    repository = new BoxRepository(
+      dataSource,
+      { emit: jest.fn() } as never,
+      { invalidate: jest.fn(), invalidateOrgId: jest.fn() } as never,
+    )
+  })
+
+  afterAll(async () => {
+    if (!dataSource?.isInitialized) {
+      return
+    }
+    try {
+      if (ownsSchema) {
+        await dataSource.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`)
+      }
+    } finally {
+      await dataSource.destroy()
+    }
+  })
+
+  beforeEach(async () => {
+    await dataSource.query(`DELETE FROM "${schemaName}"."box_last_activity"`)
+    await dataSource.query(`DELETE FROM "${schemaName}"."box"`)
+  })
+
+  it('allows exactly one of two fresh creates competing for the final slot', async () => {
+    const barrier = installInitialCountBarrier(dataSource)
+    try {
+      const results = await Promise.allSettled([
+        repository.insert(newBox('fresh-a'), 1),
+        repository.insert(newBox('fresh-b'), 1),
+      ])
+
+      expectOneSuccessAndOneLimitFailure(results)
+      expect(await boxes.countBy({ organizationId })).toBe(1)
+    } finally {
+      barrier.mockRestore()
+    }
+  })
+
+  it('serializes a fresh create against a warm-pool ownership assignment', async () => {
+    const warmPoolBox = newBox('warm', BOX_WARM_POOL_UNASSIGNED_ORGANIZATION)
+    warmPoolBox.state = BoxState.STARTED
+    warmPoolBox.pending = false
+    await boxes.insert(warmPoolBox)
+
+    const barrier = installInitialCountBarrier(dataSource)
+    try {
+      const results = await Promise.allSettled([
+        repository.insert(newBox('fresh'), 1),
+        repository.update(warmPoolBox.id, {
+          updateData: { organizationId, name: 'claimed-warm' },
+          entity: warmPoolBox,
+          maxCreatedBoxes: 1,
+        }),
+      ])
+
+      expectOneSuccessAndOneLimitFailure(results)
+      expect(await boxes.countBy({ organizationId })).toBe(1)
+    } finally {
+      barrier.mockRestore()
+    }
+  })
+
+  it.each(Object.values(BoxState))('applies the creation-count policy to state %s', async (state) => {
+    const existing = newBox(`existing-${state}`)
+    existing.state = state
+    existing.pending = false
+    await boxes.insert(existing)
+
+    const creating = repository.insert(newBox(`candidate-${state}`), 1)
+    if (excludedStates.has(state)) {
+      await expect(creating).resolves.toBeInstanceOf(Box)
+      expect(await boxes.countBy({ organizationId })).toBe(2)
+    } else {
+      await expect(creating).rejects.toBeInstanceOf(BoxCreationLimitExceededError)
+      expect(await boxes.countBy({ organizationId })).toBe(1)
+    }
+  })
+})

--- a/apps/api/src/box/repositories/box.repository.creation-limit.integration.spec.ts
+++ b/apps/api/src/box/repositories/box.repository.creation-limit.integration.spec.ts
@@ -19,7 +19,6 @@ const organizationId = '00000000-0000-4000-8000-0000000000aa'
 
 const excludedStates = new Set([
   BoxState.ERROR,
-  BoxState.UNKNOWN,
   BoxState.DESTROYING,
   BoxState.DESTROYED,
   BoxState.ARCHIVING,
@@ -165,8 +164,7 @@ describeIfDatabase('BoxRepository creation admission (integration, real Postgres
   it.each(Object.values(BoxState))('applies the creation-count policy to state %s', async (state) => {
     const existing = newBox(`existing-${state}`)
     existing.state = state
-    existing.pending = false
-    await boxes.insert(existing)
+    await repository.insert(existing)
 
     const creating = repository.insert(newBox(`candidate-${state}`), 1)
     if (excludedStates.has(state)) {

--- a/apps/api/src/box/repositories/box.repository.creation-limit.integration.spec.ts
+++ b/apps/api/src/box/repositories/box.repository.creation-limit.integration.spec.ts
@@ -19,6 +19,7 @@ const organizationId = '00000000-0000-4000-8000-0000000000aa'
 
 const excludedStates = new Set([
   BoxState.ERROR,
+  BoxState.UNKNOWN,
   BoxState.DESTROYING,
   BoxState.DESTROYED,
   BoxState.ARCHIVING,

--- a/apps/api/src/box/repositories/box.repository.creation-limit.spec.ts
+++ b/apps/api/src/box/repositories/box.repository.creation-limit.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { FindOperator, FindOptionsWhere } from 'typeorm'
+import { FindOperator } from 'typeorm'
 import { BoxRepository } from './box.repository'
 import { Box } from '../entities/box.entity'
 import { BoxState } from '../enums/box-state.enum'
@@ -66,28 +66,20 @@ describe('BoxRepository creation admission', () => {
     await expect(boxRepository.insert(entity, 2)).resolves.toBe(entity)
 
     expect(transaction).toHaveBeenCalledWith('SERIALIZABLE', expect.any(Function))
-    expect(entityManager.count).toHaveBeenCalledWith(Box, expect.objectContaining({ where: expect.any(Array) }))
+    expect(entityManager.count).toHaveBeenCalledWith(
+      Box,
+      expect.objectContaining({ where: expect.objectContaining({ organizationId: entity.organizationId }) }),
+    )
     expect(entityManager.insert).toHaveBeenCalledWith(Box, entity)
     expect(entityManager.upsert).toHaveBeenCalledTimes(1)
     expect(cacheInvalidation.invalidateOrgId).toHaveBeenCalledTimes(1)
 
-    const where = entityManager.count.mock.calls[0][1].where as FindOptionsWhere<Box>[]
-    expect(where).toEqual([
-      expect.objectContaining({ organizationId: entity.organizationId }),
-      {
-        organizationId: entity.organizationId,
-        state: BoxState.UNKNOWN,
-        pending: true,
-      },
-    ])
-
-    const stateFilter = where[0].state as FindOperator<BoxState>
+    const stateFilter = entityManager.count.mock.calls[0][1].where.state as FindOperator<BoxState>
     expect(stateFilter.type).toBe('not')
     const excludedStates = stateFilter.child as FindOperator<BoxState>
     expect(excludedStates.type).toBe('in')
     expect(excludedStates.value).toEqual([
       BoxState.ERROR,
-      BoxState.UNKNOWN,
       BoxState.DESTROYING,
       BoxState.DESTROYED,
       BoxState.ARCHIVING,
@@ -126,7 +118,7 @@ describe('BoxRepository creation admission', () => {
     expect(transaction).toHaveBeenCalledWith('SERIALIZABLE', expect.any(Function))
     expect(entityManager.count).toHaveBeenCalledWith(
       Box,
-      expect.objectContaining({ where: expect.arrayContaining([expect.objectContaining({ organizationId })]) }),
+      expect.objectContaining({ where: expect.objectContaining({ organizationId }) }),
     )
     expect(entityManager.update).toHaveBeenCalledTimes(1)
     expect(entityManager.upsert).toHaveBeenCalledTimes(1)

--- a/apps/api/src/box/repositories/box.repository.creation-limit.spec.ts
+++ b/apps/api/src/box/repositories/box.repository.creation-limit.spec.ts
@@ -80,6 +80,7 @@ describe('BoxRepository creation admission', () => {
     expect(excludedStates.type).toBe('in')
     expect(excludedStates.value).toEqual([
       BoxState.ERROR,
+      BoxState.UNKNOWN,
       BoxState.DESTROYING,
       BoxState.DESTROYED,
       BoxState.ARCHIVING,
@@ -156,6 +157,7 @@ describe('BoxRepository creation admission', () => {
     expect(error).toBeInstanceOf(BoxCreationAdmissionUnavailableError)
     expect(responseCode(error)).toBe(BOX_CREATION_ADMISSION_UNAVAILABLE_CODE)
     expect(error.getStatus()).toBe(503)
+    expect((error as unknown as { retryAfterSeconds?: number }).retryAfterSeconds).toBe(5)
     expect(transaction).toHaveBeenCalledTimes(5)
   })
 

--- a/apps/api/src/box/repositories/box.repository.creation-limit.spec.ts
+++ b/apps/api/src/box/repositories/box.repository.creation-limit.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { FindOperator } from 'typeorm'
+import { FindOperator, FindOptionsWhere } from 'typeorm'
 import { BoxRepository } from './box.repository'
 import { Box } from '../entities/box.entity'
 import { BoxState } from '../enums/box-state.enum'
@@ -66,15 +66,22 @@ describe('BoxRepository creation admission', () => {
     await expect(boxRepository.insert(entity, 2)).resolves.toBe(entity)
 
     expect(transaction).toHaveBeenCalledWith('SERIALIZABLE', expect.any(Function))
-    expect(entityManager.count).toHaveBeenCalledWith(
-      Box,
-      expect.objectContaining({ where: expect.objectContaining({ organizationId: entity.organizationId }) }),
-    )
+    expect(entityManager.count).toHaveBeenCalledWith(Box, expect.objectContaining({ where: expect.any(Array) }))
     expect(entityManager.insert).toHaveBeenCalledWith(Box, entity)
     expect(entityManager.upsert).toHaveBeenCalledTimes(1)
     expect(cacheInvalidation.invalidateOrgId).toHaveBeenCalledTimes(1)
 
-    const stateFilter = entityManager.count.mock.calls[0][1].where.state as FindOperator<BoxState>
+    const where = entityManager.count.mock.calls[0][1].where as FindOptionsWhere<Box>[]
+    expect(where).toEqual([
+      expect.objectContaining({ organizationId: entity.organizationId }),
+      {
+        organizationId: entity.organizationId,
+        state: BoxState.UNKNOWN,
+        pending: true,
+      },
+    ])
+
+    const stateFilter = where[0].state as FindOperator<BoxState>
     expect(stateFilter.type).toBe('not')
     const excludedStates = stateFilter.child as FindOperator<BoxState>
     expect(excludedStates.type).toBe('in')
@@ -119,7 +126,7 @@ describe('BoxRepository creation admission', () => {
     expect(transaction).toHaveBeenCalledWith('SERIALIZABLE', expect.any(Function))
     expect(entityManager.count).toHaveBeenCalledWith(
       Box,
-      expect.objectContaining({ where: expect.objectContaining({ organizationId }) }),
+      expect.objectContaining({ where: expect.arrayContaining([expect.objectContaining({ organizationId })]) }),
     )
     expect(entityManager.update).toHaveBeenCalledTimes(1)
     expect(entityManager.upsert).toHaveBeenCalledTimes(1)

--- a/apps/api/src/box/repositories/box.repository.creation-limit.spec.ts
+++ b/apps/api/src/box/repositories/box.repository.creation-limit.spec.ts
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { FindOperator } from 'typeorm'
+import { BoxRepository } from './box.repository'
+import { Box } from '../entities/box.entity'
+import { BoxState } from '../enums/box-state.enum'
+import {
+  BOX_CREATION_ADMISSION_UNAVAILABLE_CODE,
+  BOX_CREATION_LIMIT_EXCEEDED_CODE,
+  BoxCreationAdmissionUnavailableError,
+  BoxCreationLimitExceededError,
+} from '../errors/box-creation-limit.error'
+import { BOX_WARM_POOL_UNASSIGNED_ORGANIZATION } from '../constants/box.constants'
+
+type TransactionCallback = (entityManager: ReturnType<typeof makeEntityManager>) => Promise<unknown>
+
+function makeEntityManager(currentCount = 0) {
+  return {
+    count: jest.fn().mockResolvedValue(currentCount),
+    insert: jest.fn().mockResolvedValue(undefined),
+    update: jest.fn().mockResolvedValue({ affected: 1 }),
+    upsert: jest.fn().mockResolvedValue(undefined),
+  }
+}
+
+function makeRepository(currentCount = 0) {
+  const entityManager = makeEntityManager(currentCount)
+  const transaction: jest.Mock = jest.fn(async (...args: unknown[]) => {
+    const callback = (typeof args[0] === 'function' ? args[0] : args[1]) as TransactionCallback
+    return callback(entityManager)
+  })
+  const repository = { update: jest.fn(), manager: {} }
+  const dataSource = {
+    getRepository: jest.fn(() => repository),
+    transaction,
+  }
+  const eventEmitter = { emit: jest.fn() }
+  const cacheInvalidation = {
+    invalidateOrgId: jest.fn(),
+    invalidate: jest.fn(),
+  }
+  const boxRepository = new BoxRepository(dataSource as never, eventEmitter as never, cacheInvalidation as never)
+  return { boxRepository, entityManager, transaction, eventEmitter, cacheInvalidation }
+}
+
+function box(organizationId = '11111111-1111-4111-8111-111111111111'): Box {
+  const entity = new Box('region-1', 'test-box')
+  entity.organizationId = organizationId
+  entity.osUser = 'boxlite'
+  entity.pending = true
+  return entity
+}
+
+function responseCode(error: BoxCreationLimitExceededError | BoxCreationAdmissionUnavailableError): string {
+  return (error.getResponse() as { code: string }).code
+}
+
+describe('BoxRepository creation admission', () => {
+  it('counts and inserts with one SERIALIZABLE transactional manager', async () => {
+    const { boxRepository, entityManager, transaction, cacheInvalidation } = makeRepository(1)
+    const entity = box()
+
+    await expect(boxRepository.insert(entity, 2)).resolves.toBe(entity)
+
+    expect(transaction).toHaveBeenCalledWith('SERIALIZABLE', expect.any(Function))
+    expect(entityManager.count).toHaveBeenCalledWith(
+      Box,
+      expect.objectContaining({ where: expect.objectContaining({ organizationId: entity.organizationId }) }),
+    )
+    expect(entityManager.insert).toHaveBeenCalledWith(Box, entity)
+    expect(entityManager.upsert).toHaveBeenCalledTimes(1)
+    expect(cacheInvalidation.invalidateOrgId).toHaveBeenCalledTimes(1)
+
+    const stateFilter = entityManager.count.mock.calls[0][1].where.state as FindOperator<BoxState>
+    expect(stateFilter.type).toBe('not')
+    const excludedStates = stateFilter.child as FindOperator<BoxState>
+    expect(excludedStates.type).toBe('in')
+    expect(excludedStates.value).toEqual([
+      BoxState.ERROR,
+      BoxState.DESTROYING,
+      BoxState.DESTROYED,
+      BoxState.ARCHIVING,
+      BoxState.ARCHIVED,
+    ])
+  })
+
+  it('rejects at the limit before persistence or post-commit side effects', async () => {
+    const { boxRepository, entityManager, cacheInvalidation, eventEmitter } = makeRepository(2)
+
+    const error = await boxRepository.insert(box(), 2).catch((caught) => caught)
+
+    expect(error).toBeInstanceOf(BoxCreationLimitExceededError)
+    expect(responseCode(error)).toBe(BOX_CREATION_LIMIT_EXCEEDED_CODE)
+    expect(error.getStatus()).toBe(429)
+    expect(error.getResponse()).toEqual(expect.objectContaining({ message: expect.stringContaining('2 of 2') }))
+    expect(entityManager.insert).not.toHaveBeenCalled()
+    expect(entityManager.upsert).not.toHaveBeenCalled()
+    expect(cacheInvalidation.invalidateOrgId).not.toHaveBeenCalled()
+    expect(eventEmitter.emit).not.toHaveBeenCalled()
+  })
+
+  it('applies the same admission transaction when assigning a warm-pool box', async () => {
+    const { boxRepository, entityManager, transaction } = makeRepository(0)
+    const warmPoolBox = box(BOX_WARM_POOL_UNASSIGNED_ORGANIZATION)
+    warmPoolBox.state = BoxState.STARTED
+    warmPoolBox.pending = false
+    const organizationId = '22222222-2222-4222-8222-222222222222'
+
+    await boxRepository.update(warmPoolBox.id, {
+      updateData: { organizationId },
+      entity: warmPoolBox,
+      maxCreatedBoxes: 1,
+    })
+
+    expect(transaction).toHaveBeenCalledWith('SERIALIZABLE', expect.any(Function))
+    expect(entityManager.count).toHaveBeenCalledWith(
+      Box,
+      expect.objectContaining({ where: expect.objectContaining({ organizationId }) }),
+    )
+    expect(entityManager.update).toHaveBeenCalledTimes(1)
+    expect(entityManager.upsert).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries the complete count-and-write transaction after SQLSTATE 40001', async () => {
+    const { boxRepository, entityManager, transaction } = makeRepository(0)
+    let attempts = 0
+    transaction.mockImplementation(async (_isolation: string, callback: TransactionCallback) => {
+      const result = await callback(entityManager)
+      attempts++
+      if (attempts < 3) {
+        throw Object.assign(new Error('could not serialize access'), { code: '40001' })
+      }
+      return result
+    })
+
+    await boxRepository.insert(box(), 3)
+
+    expect(transaction).toHaveBeenCalledTimes(3)
+    expect(entityManager.count).toHaveBeenCalledTimes(3)
+    expect(entityManager.insert).toHaveBeenCalledTimes(3)
+    expect(entityManager.upsert).toHaveBeenCalledTimes(3)
+  })
+
+  it('returns a retryable 503 after five serialization failures', async () => {
+    const { boxRepository, entityManager, transaction } = makeRepository(0)
+    transaction.mockImplementation(async (_isolation: string, callback: TransactionCallback) => {
+      await callback(entityManager)
+      throw Object.assign(new Error('could not serialize access'), { code: '40001' })
+    })
+
+    const error = await boxRepository.insert(box(), 3).catch((caught) => caught)
+
+    expect(error).toBeInstanceOf(BoxCreationAdmissionUnavailableError)
+    expect(responseCode(error)).toBe(BOX_CREATION_ADMISSION_UNAVAILABLE_CODE)
+    expect(error.getStatus()).toBe(503)
+    expect(transaction).toHaveBeenCalledTimes(5)
+  })
+
+  it('does not retry database errors other than serialization failures', async () => {
+    const { boxRepository, transaction } = makeRepository(0)
+    transaction.mockRejectedValue(Object.assign(new Error('connection lost'), { code: '08006' }))
+
+    await expect(boxRepository.insert(box(), 3)).rejects.toThrow('connection lost')
+    expect(transaction).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves the existing non-serializable transaction when admission is disabled', async () => {
+    const { boxRepository, transaction, entityManager } = makeRepository()
+
+    await boxRepository.insert(box())
+
+    expect(transaction).toHaveBeenCalledWith(expect.any(Function))
+    expect(entityManager.count).not.toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/box/repositories/box.repository.ts
+++ b/apps/api/src/box/repositories/box.repository.ts
@@ -50,8 +50,8 @@ const CREATION_ADMISSION_RETRY_AFTER_SECONDS = 5
 
 const BOX_CREATION_LIMIT_EXCLUDED_STATES = [
   BoxState.ERROR,
-  // UNKNOWN is treated like ERROR for admission: it is not a usable Box the
-  // organization should have to destroy before creating a replacement.
+  // A settled UNKNOWN Box is treated like ERROR for admission: it is not
+  // usable, while a pending UNKNOWN Box still reserves its creation slot.
   BoxState.UNKNOWN,
   BoxState.DESTROYING,
   BoxState.DESTROYED,
@@ -179,10 +179,17 @@ export class BoxRepository extends BaseRepository<Box> {
       try {
         return await this.dataSource.transaction('SERIALIZABLE', async (entityManager) => {
           const currentCount = await entityManager.count(Box, {
-            where: {
-              organizationId,
-              state: Not(In(BOX_CREATION_LIMIT_EXCLUDED_STATES)),
-            },
+            where: [
+              {
+                organizationId,
+                state: Not(In(BOX_CREATION_LIMIT_EXCLUDED_STATES)),
+              },
+              {
+                organizationId,
+                state: BoxState.UNKNOWN,
+                pending: true,
+              },
+            ],
           })
           if (currentCount >= maxCreatedBoxes) {
             throw new BoxCreationLimitExceededError(currentCount, maxCreatedBoxes)

--- a/apps/api/src/box/repositories/box.repository.ts
+++ b/apps/api/src/box/repositories/box.repository.ts
@@ -22,10 +22,7 @@ import { BoxDesiredStateUpdatedEvent } from '../events/box-desired-state-updated
 import { BoxPublicStatusUpdatedEvent } from '../events/box-public-status-updated.event'
 import { BoxOrganizationUpdatedEvent } from '../events/box-organization-updated.event'
 import { BoxLookupCacheInvalidationService } from '../services/box-lookup-cache-invalidation.service'
-import {
-  BoxCreationAdmissionUnavailableError,
-  BoxCreationLimitExceededError,
-} from '../errors/box-creation-limit.error'
+import { BoxCreationAdmissionUnavailableError, BoxCreationLimitExceededError } from '../errors/box-creation-limit.error'
 
 // SQLSTATE lock_not_available — a statement waited longer than lock_timeout to
 // acquire a lock.
@@ -49,9 +46,13 @@ const CREATION_ADMISSION_MAX_ATTEMPTS = 5
 const CREATION_ADMISSION_BASE_BACKOFF_MS = 5
 const CREATION_ADMISSION_MAX_BACKOFF_MS = 40
 const CREATION_ADMISSION_JITTER_MS = 5
+const CREATION_ADMISSION_RETRY_AFTER_SECONDS = 5
 
 const BOX_CREATION_LIMIT_EXCLUDED_STATES = [
   BoxState.ERROR,
+  // UNKNOWN is treated like ERROR for admission: it is not a usable Box the
+  // organization should have to destroy before creating a replacement.
+  BoxState.UNKNOWN,
   BoxState.DESTROYING,
   BoxState.DESTROYED,
   BoxState.ARCHIVING,
@@ -194,14 +195,20 @@ export class BoxRepository extends BaseRepository<Box> {
           throw error
         }
         if (attempt === CREATION_ADMISSION_MAX_ATTEMPTS - 1) {
-          throw new BoxCreationAdmissionUnavailableError('Box creation admission remained contended; retry the request')
+          throw new BoxCreationAdmissionUnavailableError(
+            'Box creation admission remained contended; retry the request',
+            CREATION_ADMISSION_RETRY_AFTER_SECONDS,
+          )
         }
 
         await this.waitBeforeAdmissionRetry(attempt)
       }
     }
 
-    throw new BoxCreationAdmissionUnavailableError()
+    throw new BoxCreationAdmissionUnavailableError(
+      'Box creation admission remained contended; retry the request',
+      CREATION_ADMISSION_RETRY_AFTER_SECONDS,
+    )
   }
 
   private isSerializationFailure(error: unknown): boolean {

--- a/apps/api/src/box/repositories/box.repository.ts
+++ b/apps/api/src/box/repositories/box.repository.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { DataSource, EntityManager, FindOptionsWhere } from 'typeorm'
+import { DataSource, EntityManager, FindOptionsWhere, In, Not } from 'typeorm'
 import { Box } from '../entities/box.entity'
 import { BoxLastActivity } from '../entities/box-last-activity.entity'
 import { BoxMigration } from '../entities/box-migration.entity'
@@ -22,6 +22,10 @@ import { BoxDesiredStateUpdatedEvent } from '../events/box-desired-state-updated
 import { BoxPublicStatusUpdatedEvent } from '../events/box-public-status-updated.event'
 import { BoxOrganizationUpdatedEvent } from '../events/box-organization-updated.event'
 import { BoxLookupCacheInvalidationService } from '../services/box-lookup-cache-invalidation.service'
+import {
+  BoxCreationAdmissionUnavailableError,
+  BoxCreationLimitExceededError,
+} from '../errors/box-creation-limit.error'
 
 // SQLSTATE lock_not_available — a statement waited longer than lock_timeout to
 // acquire a lock.
@@ -36,6 +40,23 @@ const PG_LOCK_TIMEOUT_CODE = '55P03'
 // race-lost no-op. Aligned with the caller-side wait cap in
 // boxlite-proxy.controller.ts (PROXY_START_HINT_TIMEOUT_MS).
 const PROXY_START_LOCK_TIMEOUT_MS = 2000
+
+// SERIALIZABLE protects the count-and-write admission decision without a
+// per-organization mutex. PostgreSQL aborts one conflicting transaction with
+// SQLSTATE 40001; retry the whole decision, never only the write.
+const PG_SERIALIZATION_FAILURE_CODE = '40001'
+const CREATION_ADMISSION_MAX_ATTEMPTS = 5
+const CREATION_ADMISSION_BASE_BACKOFF_MS = 5
+const CREATION_ADMISSION_MAX_BACKOFF_MS = 40
+const CREATION_ADMISSION_JITTER_MS = 5
+
+const BOX_CREATION_LIMIT_EXCLUDED_STATES = [
+  BoxState.ERROR,
+  BoxState.DESTROYING,
+  BoxState.DESTROYED,
+  BoxState.ARCHIVING,
+  BoxState.ARCHIVED,
+]
 
 // A box the migration marker may claim, with the stamp its claim copies.
 type ParkedBox = { id: string; updatedAt: Date }
@@ -52,7 +73,7 @@ export class BoxRepository extends BaseRepository<Box> {
     super(dataSource, eventEmitter, Box)
   }
 
-  async insert(box: Box): Promise<Box> {
+  async insert(box: Box, maxCreatedBoxes?: number): Promise<Box> {
     const now = new Date()
     if (!box.createdAt) {
       box.createdAt = now
@@ -64,7 +85,7 @@ export class BoxRepository extends BaseRepository<Box> {
     box.assertValid()
     box.enforceInvariants()
 
-    await this.dataSource.transaction(async (entityManager) => {
+    await this.withCreationAdmission(box.organizationId, maxCreatedBoxes, async (entityManager) => {
       await entityManager.insert(Box, box)
       await this.upsertLastActivity(entityManager, box.id, box.createdAt)
     })
@@ -80,7 +101,7 @@ export class BoxRepository extends BaseRepository<Box> {
    *
    * @returns `void` because a raw update is performed.
    */
-  async update(id: string, params: { updateData: Partial<Box> }, raw: true): Promise<void>
+  async update(id: string, params: { updateData: Partial<Box>; maxCreatedBoxes?: number }, raw: true): Promise<void>
   /**
    * @param id - The ID of the box to update.
    * @param params.updateData - The partial data to update.
@@ -88,9 +109,17 @@ export class BoxRepository extends BaseRepository<Box> {
    *
    * @returns The updated box.
    */
-  async update(id: string, params: { updateData: Partial<Box>; entity?: Box }, raw?: false): Promise<Box>
-  async update(id: string, params: { updateData: Partial<Box>; entity?: Box }, raw = false): Promise<Box | void> {
-    const { updateData, entity } = params
+  async update(
+    id: string,
+    params: { updateData: Partial<Box>; entity?: Box; maxCreatedBoxes?: number },
+    raw?: false,
+  ): Promise<Box>
+  async update(
+    id: string,
+    params: { updateData: Partial<Box>; entity?: Box; maxCreatedBoxes?: number },
+    raw = false,
+  ): Promise<Box | void> {
+    const { updateData, entity, maxCreatedBoxes } = params
 
     if (raw) {
       await this.repository.update(id, updateData)
@@ -108,7 +137,7 @@ export class BoxRepository extends BaseRepository<Box> {
     box.assertValid()
     const invariantChanges = box.enforceInvariants()
 
-    await this.dataSource.transaction(async (entityManager) => {
+    await this.withCreationAdmission(box.organizationId, maxCreatedBoxes, async (entityManager) => {
       const result = await entityManager.update(
         Box,
         {
@@ -134,6 +163,63 @@ export class BoxRepository extends BaseRepository<Box> {
     this.invalidateLookupCacheOnUpdate(box, previousBox)
 
     return box
+  }
+
+  private async withCreationAdmission<T>(
+    organizationId: string,
+    maxCreatedBoxes: number | undefined,
+    persist: (entityManager: EntityManager) => Promise<T>,
+  ): Promise<T> {
+    if (maxCreatedBoxes === undefined) {
+      return this.dataSource.transaction(persist)
+    }
+
+    for (let attempt = 0; attempt < CREATION_ADMISSION_MAX_ATTEMPTS; attempt++) {
+      try {
+        return await this.dataSource.transaction('SERIALIZABLE', async (entityManager) => {
+          const currentCount = await entityManager.count(Box, {
+            where: {
+              organizationId,
+              state: Not(In(BOX_CREATION_LIMIT_EXCLUDED_STATES)),
+            },
+          })
+          if (currentCount >= maxCreatedBoxes) {
+            throw new BoxCreationLimitExceededError(currentCount, maxCreatedBoxes)
+          }
+
+          return persist(entityManager)
+        })
+      } catch (error) {
+        if (!this.isSerializationFailure(error)) {
+          throw error
+        }
+        if (attempt === CREATION_ADMISSION_MAX_ATTEMPTS - 1) {
+          throw new BoxCreationAdmissionUnavailableError('Box creation admission remained contended; retry the request')
+        }
+
+        await this.waitBeforeAdmissionRetry(attempt)
+      }
+    }
+
+    throw new BoxCreationAdmissionUnavailableError()
+  }
+
+  private isSerializationFailure(error: unknown): boolean {
+    return (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      (error as { code?: unknown }).code === PG_SERIALIZATION_FAILURE_CODE
+    )
+  }
+
+  private async waitBeforeAdmissionRetry(attempt: number): Promise<void> {
+    const exponentialBackoff = Math.min(
+      CREATION_ADMISSION_BASE_BACKOFF_MS * 2 ** attempt,
+      CREATION_ADMISSION_MAX_BACKOFF_MS,
+    )
+    const jitter = Math.floor(Math.random() * (CREATION_ADMISSION_JITTER_MS + 1))
+    await new Promise((resolve) => setTimeout(resolve, exponentialBackoff + jitter))
   }
 
   /**

--- a/apps/api/src/box/repositories/box.repository.ts
+++ b/apps/api/src/box/repositories/box.repository.ts
@@ -50,9 +50,6 @@ const CREATION_ADMISSION_RETRY_AFTER_SECONDS = 5
 
 const BOX_CREATION_LIMIT_EXCLUDED_STATES = [
   BoxState.ERROR,
-  // A settled UNKNOWN Box is treated like ERROR for admission: it is not
-  // usable, while a pending UNKNOWN Box still reserves its creation slot.
-  BoxState.UNKNOWN,
   BoxState.DESTROYING,
   BoxState.DESTROYED,
   BoxState.ARCHIVING,
@@ -179,17 +176,10 @@ export class BoxRepository extends BaseRepository<Box> {
       try {
         return await this.dataSource.transaction('SERIALIZABLE', async (entityManager) => {
           const currentCount = await entityManager.count(Box, {
-            where: [
-              {
-                organizationId,
-                state: Not(In(BOX_CREATION_LIMIT_EXCLUDED_STATES)),
-              },
-              {
-                organizationId,
-                state: BoxState.UNKNOWN,
-                pending: true,
-              },
-            ],
+            where: {
+              organizationId,
+              state: Not(In(BOX_CREATION_LIMIT_EXCLUDED_STATES)),
+            },
           })
           if (currentCount >= maxCreatedBoxes) {
             throw new BoxCreationLimitExceededError(currentCount, maxCreatedBoxes)

--- a/apps/api/src/box/services/box.service.spec.ts
+++ b/apps/api/src/box/services/box.service.spec.ts
@@ -290,7 +290,7 @@ describe('BoxService public defaults', () => {
       await service.create({ name: 'restricted-box', image: 'base', ...request } as any, { id: 'org-1', ...org } as any)
 
       expect(warmPoolService.fetchWarmPoolBox).not.toHaveBeenCalled()
-      expect(boxRepository.insert).toHaveBeenCalledWith(expect.objectContaining(expected))
+      expect(boxRepository.insert).toHaveBeenCalledWith(expect.objectContaining(expected), undefined)
     },
   )
 
@@ -302,7 +302,7 @@ describe('BoxService public defaults', () => {
 
     await service.create({ name: 'fresh-box', public: requestedPublic } as any, { id: 'org-1' } as any)
 
-    expect(boxRepository.insert).toHaveBeenCalledWith(expect.objectContaining({ public: expectedPublic }))
+    expect(boxRepository.insert).toHaveBeenCalledWith(expect.objectContaining({ public: expectedPublic }), undefined)
   })
 
   it('persists secrets on a freshly created box', async () => {
@@ -315,6 +315,7 @@ describe('BoxService public defaults', () => {
 
     expect(boxRepository.insert).toHaveBeenCalledWith(
       expect.objectContaining({ secrets: [{ name: 'openai', value: 'sk-test' }] }),
+      undefined,
     )
   })
 

--- a/apps/api/src/box/services/box.service.ts
+++ b/apps/api/src/box/services/box.service.ts
@@ -315,10 +315,10 @@ export class BoxService {
       // the chosen runner is still fine, it was the name that collided.
       const insertedBox = await this.persistOnAvailableRunner(box, { regions: [region.id], boxClass }, () =>
         createBoxDto.name
-          ? this.insertWithCreationAdmission(box, options.maxCreatedBoxes)
+          ? this.boxRepository.insert(box, options.maxCreatedBoxes)
           : persistWithGeneratedBoxName(box.id, (name) => {
               box.name = name
-              return this.insertWithCreationAdmission(box, options.maxCreatedBoxes)
+              return this.boxRepository.insert(box, options.maxCreatedBoxes)
             }),
       )
 
@@ -340,12 +340,6 @@ export class BoxService {
     }
   }
 
-  private insertWithCreationAdmission(box: Box, maxCreatedBoxes?: number): Promise<Box> {
-    return maxCreatedBoxes === undefined
-      ? this.boxRepository.insert(box)
-      : this.boxRepository.insert(box, maxCreatedBoxes)
-  }
-
   private async assignWarmPoolBox(
     warmPoolBox: Box,
     createBoxDto: CreateBoxDto,
@@ -353,7 +347,6 @@ export class BoxService {
     maxCreatedBoxes?: number,
   ): Promise<BoxDto> {
     const now = new Date()
-    const creationAdmission = maxCreatedBoxes === undefined ? {} : { maxCreatedBoxes }
     const updateData: Partial<Box> = {
       // POL-205: same default as the fresh-box path — see the comment there.
       public: createBoxDto.public ?? false,
@@ -392,12 +385,12 @@ export class BoxService {
       ? await this.boxRepository.update(warmPoolBox.id, {
           updateData: { ...updateData, name: createBoxDto.name },
           entity: warmPoolBox,
-          ...creationAdmission,
+          maxCreatedBoxes,
         })
       : await persistWithGeneratedBoxName(warmPoolBox.id, (name) =>
           this.boxRepository.update(warmPoolBox.id, {
             updateData: { ...updateData, name },
-            ...creationAdmission,
+            maxCreatedBoxes,
           }),
         )
 

--- a/apps/api/src/box/services/box.service.ts
+++ b/apps/api/src/box/services/box.service.ts
@@ -91,6 +91,10 @@ const DEFAULT_BOX_DISK = 10
 const DEFAULT_BOX_GPU = 0
 const TERMINAL_PREVIEW_PORT = 22222
 
+export type BoxCreationOptions = {
+  maxCreatedBoxes?: number
+}
+
 @Injectable()
 export class BoxService {
   private readonly logger = new Logger(BoxService.name)
@@ -180,7 +184,11 @@ export class BoxService {
     )
   }
 
-  async create(createBoxDto: CreateBoxDto, organization: Organization): Promise<BoxDto> {
+  async create(
+    createBoxDto: CreateBoxDto,
+    organization: Organization,
+    options: BoxCreationOptions = {},
+  ): Promise<BoxDto> {
     const region = await this.getValidatedOrDefaultRegion(organization, createBoxDto.target)
 
     try {
@@ -241,7 +249,7 @@ export class BoxService {
           })
 
           if (warmPoolBox) {
-            return await this.assignWarmPoolBox(warmPoolBox, createBoxDto, organization)
+            return await this.assignWarmPoolBox(warmPoolBox, createBoxDto, organization, options.maxCreatedBoxes)
           }
         }
       }
@@ -307,10 +315,10 @@ export class BoxService {
       // the chosen runner is still fine, it was the name that collided.
       const insertedBox = await this.persistOnAvailableRunner(box, { regions: [region.id], boxClass }, () =>
         createBoxDto.name
-          ? this.boxRepository.insert(box)
+          ? this.insertWithCreationAdmission(box, options.maxCreatedBoxes)
           : persistWithGeneratedBoxName(box.id, (name) => {
               box.name = name
-              return this.boxRepository.insert(box)
+              return this.insertWithCreationAdmission(box, options.maxCreatedBoxes)
             }),
       )
 
@@ -332,12 +340,20 @@ export class BoxService {
     }
   }
 
+  private insertWithCreationAdmission(box: Box, maxCreatedBoxes?: number): Promise<Box> {
+    return maxCreatedBoxes === undefined
+      ? this.boxRepository.insert(box)
+      : this.boxRepository.insert(box, maxCreatedBoxes)
+  }
+
   private async assignWarmPoolBox(
     warmPoolBox: Box,
     createBoxDto: CreateBoxDto,
     organization: Organization,
+    maxCreatedBoxes?: number,
   ): Promise<BoxDto> {
     const now = new Date()
+    const creationAdmission = maxCreatedBoxes === undefined ? {} : { maxCreatedBoxes }
     const updateData: Partial<Box> = {
       // POL-205: same default as the fresh-box path — see the comment there.
       public: createBoxDto.public ?? false,
@@ -376,9 +392,13 @@ export class BoxService {
       ? await this.boxRepository.update(warmPoolBox.id, {
           updateData: { ...updateData, name: createBoxDto.name },
           entity: warmPoolBox,
+          ...creationAdmission,
         })
       : await persistWithGeneratedBoxName(warmPoolBox.id, (name) =>
-          this.boxRepository.update(warmPoolBox.id, { updateData: { ...updateData, name } }),
+          this.boxRepository.update(warmPoolBox.id, {
+            updateData: { ...updateData, name },
+            ...creationAdmission,
+          }),
         )
 
     // Defensive invalidation of orgId cache since the box moved from unassigned to a real organization

--- a/apps/api/src/boxlite-rest/boxlite-box.controller.creation-limit.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-box.controller.creation-limit.spec.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BoxliteBoxController } from './boxlite-box.controller'
+import { BoxState } from '../box/enums/box-state.enum'
+import { BoxCreationLimitExceededError } from '../box/errors/box-creation-limit.error'
+
+const organization = { id: '11111111-1111-4111-8111-111111111111' }
+const authContext = { organization, organizationId: organization.id }
+const startedBox = {
+  id: 'box-1',
+  organizationId: organization.id,
+  name: 'box-1',
+  state: BoxState.STARTED,
+  image: 'boxlite/base',
+  cpu: 1,
+  memory: 1,
+  labels: {},
+}
+
+function makeController() {
+  const boxService = {
+    create: jest.fn().mockResolvedValue(startedBox),
+    findOneByIdOrName: jest.fn().mockResolvedValue(startedBox),
+    start: jest.fn().mockResolvedValue(startedBox),
+    stop: jest.fn().mockResolvedValue({ id: 'box-1' }),
+    toBoxDto: jest.fn().mockResolvedValue(startedBox),
+  }
+  const boxStateWaiter = { waitForStarted: jest.fn() }
+  const commerceBoxLimitService = { resolveMaxCreatedBoxes: jest.fn().mockResolvedValue(3) }
+  const controller = new BoxliteBoxController(
+    boxService as never,
+    boxStateWaiter as never,
+    commerceBoxLimitService as never,
+  )
+  return { controller, boxService, boxStateWaiter, commerceBoxLimitService }
+}
+
+describe('BoxliteBoxController creation limit', () => {
+  it('resolves the organization limit and passes it only to create', async () => {
+    const { controller, boxService, boxStateWaiter, commerceBoxLimitService } = makeController()
+
+    const response = await controller.createBox(authContext as never, { image: 'boxlite/base' } as never)
+
+    expect(commerceBoxLimitService.resolveMaxCreatedBoxes).toHaveBeenCalledWith(organization.id)
+    expect(boxService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ image: 'boxlite/base' }),
+      organization,
+      { maxCreatedBoxes: 3 },
+    )
+    expect(boxStateWaiter.waitForStarted).not.toHaveBeenCalled()
+    expect(response).toEqual(expect.objectContaining({ box_id: 'box-1', status: 'running' }))
+
+    await controller.startBox(authContext as never, 'box-1')
+    await controller.stopBox(authContext as never, 'box-1')
+    expect(commerceBoxLimitService.resolveMaxCreatedBoxes).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not persist or wait for startup when Commerce admission fails', async () => {
+    const { controller, boxService, boxStateWaiter, commerceBoxLimitService } = makeController()
+    commerceBoxLimitService.resolveMaxCreatedBoxes.mockRejectedValue(new Error('commerce unavailable'))
+
+    await expect(controller.createBox(authContext as never, {} as never)).rejects.toThrow('commerce unavailable')
+    expect(boxService.create).not.toHaveBeenCalled()
+    expect(boxStateWaiter.waitForStarted).not.toHaveBeenCalled()
+  })
+
+  it('does not wait for startup when the repository rejects at the limit', async () => {
+    const { controller, boxService, boxStateWaiter } = makeController()
+    boxService.create.mockRejectedValue(new BoxCreationLimitExceededError(3, 3))
+
+    await expect(controller.createBox(authContext as never, {} as never)).rejects.toBeInstanceOf(
+      BoxCreationLimitExceededError,
+    )
+    expect(boxStateWaiter.waitForStarted).not.toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/boxlite-rest/boxlite-box.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-box.controller.ts
@@ -37,6 +37,7 @@ import { boxToBoxResponse, createBoxToCreateBox } from './mappers/box-to-box.map
 import { Audit, MASKED_AUDIT_VALUE, TypedRequest } from '../audit/decorators/audit.decorator'
 import { AuditAction } from '../audit/enums/audit-action.enum'
 import { AuditTarget } from '../audit/enums/audit-target.enum'
+import { CommerceBoxLimitService } from './commerce-box-limit.service'
 
 // Spec-first surface: the contract is openapi/box.openapi.yaml, not the
 // generated product spec (which `:prefix` routes would render invalid).
@@ -67,6 +68,7 @@ export class BoxliteBoxController {
   constructor(
     private readonly boxService: BoxService,
     private readonly boxStateWaiter: BoxStateWaiterService,
+    private readonly commerceBoxLimitService: CommerceBoxLimitService,
   ) {}
 
   @Post()
@@ -113,8 +115,9 @@ export class BoxliteBoxController {
   ): Promise<BoxResponseDto> {
     const organization = authContext.organization
     const createBoxDto = createBoxToCreateBox(dto)
+    const maxCreatedBoxes = await this.commerceBoxLimitService.resolveMaxCreatedBoxes(organization.id)
 
-    let box = await this.boxService.create(createBoxDto, organization)
+    let box = await this.boxService.create(createBoxDto, organization, { maxCreatedBoxes })
     if (box.state !== BoxState.STARTED) {
       box = await this.boxStateWaiter.waitForStarted(box.id, organization.id, 30)
     }

--- a/apps/api/src/boxlite-rest/boxlite-rest-routing.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-rest-routing.spec.ts
@@ -16,6 +16,7 @@ import { BoxliteBoxController } from './boxlite-box.controller'
 import { BoxliteProxyController } from './boxlite-proxy.controller'
 import { BoxliteWsProxyService } from './boxlite-ws-proxy.service'
 import { BoxliteVolumeController } from './boxlite-volume.controller'
+import { CommerceBoxLimitService } from './commerce-box-limit.service'
 
 jest.mock('http-proxy-middleware', () => ({
   createProxyMiddleware: jest.fn(),
@@ -42,6 +43,10 @@ describe('BoxLite REST routing', () => {
         },
         {
           provide: BoxStateWaiterService,
+          useValue: {},
+        },
+        {
+          provide: CommerceBoxLimitService,
           useValue: {},
         },
       ],

--- a/apps/api/src/boxlite-rest/boxlite-rest.module.ts
+++ b/apps/api/src/boxlite-rest/boxlite-rest.module.ts
@@ -16,6 +16,7 @@ import { BoxliteProxyController } from './boxlite-proxy.controller'
 import { BoxliteWsProxyService } from './boxlite-ws-proxy.service'
 import { BoxAutoResumeService } from './box-auto-resume.service'
 import { BoxliteVolumeController } from './boxlite-volume.controller'
+import { CommerceBoxLimitService } from './commerce-box-limit.service'
 
 @Module({
   imports: [BoxModule, AuthModule, ApiKeyModule, OrganizationModule],
@@ -26,7 +27,7 @@ import { BoxliteVolumeController } from './boxlite-volume.controller'
     BoxliteProxyController,
     BoxliteVolumeController,
   ],
-  providers: [BoxliteWsProxyService, BoxAutoResumeService],
+  providers: [BoxliteWsProxyService, BoxAutoResumeService, CommerceBoxLimitService],
   exports: [BoxliteWsProxyService],
 })
 export class BoxliteRestModule {}

--- a/apps/api/src/boxlite-rest/commerce-box-limit.contract.spec.ts
+++ b/apps/api/src/boxlite-rest/commerce-box-limit.contract.spec.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: { get: jest.fn() },
+}))
+
+import { execFileSync } from 'node:child_process'
+import { resolve } from 'node:path'
+import axios from 'axios'
+import { CommerceBoxLimitService } from './commerce-box-limit.service'
+
+const commerceRepository = process.env.BOXLITE_COMMERCE_REPOSITORY
+const describeWithCommerce = commerceRepository ? describe : describe.skip
+const get = axios.get as jest.Mock
+
+describeWithCommerce('Commerce box limit cross-repository contract', () => {
+  it('consumes the no-subscription and ordered catalog responses produced by Commerce', async () => {
+    if (!commerceRepository) {
+      throw new Error('BOXLITE_COMMERCE_REPOSITORY is required for the cross-repository contract test')
+    }
+
+    const providerResponses = JSON.parse(
+      execFileSync(
+        process.execPath,
+        [
+          '-r',
+          resolve(commerceRepository, 'node_modules/ts-node/register/transpile-only.js'),
+          resolve(__dirname, '../../scripts/probe-commerce-box-limit-contract.cjs'),
+        ],
+        { cwd: commerceRepository, encoding: 'utf8' },
+      ),
+    ) as { catalog: unknown; noSubscription: unknown }
+    const catalogResponse = providerResponses.catalog
+    const organizationPlanResponse = providerResponses.noSubscription
+    get.mockResolvedValueOnce({ data: catalogResponse }).mockResolvedValueOnce({ data: organizationPlanResponse })
+
+    const configService = {
+      get: jest.fn((key: string) => (key === 'billingApiUrl' ? 'https://commerce.test/api/billing' : 'shared-token')),
+    }
+    const redis = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue('OK'),
+    }
+    const service = new CommerceBoxLimitService(configService as never, redis as never)
+
+    expect(organizationPlanResponse).toEqual({})
+    await expect(service.resolveMaxCreatedBoxes('org-1')).resolves.toBe(2)
+  })
+})

--- a/apps/api/src/boxlite-rest/commerce-box-limit.service.spec.ts
+++ b/apps/api/src/boxlite-rest/commerce-box-limit.service.spec.ts
@@ -173,14 +173,31 @@ describe('CommerceBoxLimitService', () => {
     await expect(makeService().service.resolveMaxCreatedBoxes('org-1')).resolves.toBeUndefined()
   })
 
-  it('does not limit a subscribed plan that is absent from the public catalog', async () => {
-    get.mockResolvedValueOnce({ data: catalog }).mockResolvedValueOnce({ data: { plan: { planId: 'custom' } } })
-    const { service, redis } = makeService()
+  it('does not cache an unmatched subscribed plan and rechecks Commerce on the next request', async () => {
+    get
+      .mockResolvedValueOnce({ data: catalog })
+      .mockResolvedValueOnce({ data: { plan: { planId: 'custom' } } })
+      .mockResolvedValueOnce({ data: catalog })
+      .mockResolvedValueOnce({ data: { plan: { planId: 'pro' } } })
+    let cachedLimit: string | null = null
+    const { service, redis } = makeService(
+      {},
+      {
+        get: jest.fn().mockImplementation(async () => cachedLimit),
+        set: jest.fn().mockImplementation(async (_key: string, value: string) => {
+          cachedLimit = value
+          return 'OK'
+        }),
+      },
+    )
     const warn = jest.spyOn((service as unknown as { logger: { warn: (message: string) => void } }).logger, 'warn')
 
     await expect(service.resolveMaxCreatedBoxes('org-1')).resolves.toBeUndefined()
+    await expect(service.resolveMaxCreatedBoxes('org-1')).resolves.toBe(8)
     expect(warn).toHaveBeenCalledWith(expect.stringMatching(/org-1.*custom.*public catalog/))
-    expect(redis.set).toHaveBeenCalledWith('commerce:box-limit:v1:org-1', 'unlimited', 'EX', 30)
+    expect(get).toHaveBeenCalledTimes(4)
+    expect(redis.set).toHaveBeenCalledTimes(1)
+    expect(redis.set).toHaveBeenCalledWith('commerce:box-limit:v1:org-1', 'limit:8', 'EX', 30)
   })
 
   it('rejects a configured Commerce API without the shared token before making a request', async () => {

--- a/apps/api/src/boxlite-rest/commerce-box-limit.service.spec.ts
+++ b/apps/api/src/boxlite-rest/commerce-box-limit.service.spec.ts
@@ -175,8 +175,12 @@ describe('CommerceBoxLimitService', () => {
 
   it('does not limit a subscribed plan that is absent from the public catalog', async () => {
     get.mockResolvedValueOnce({ data: catalog }).mockResolvedValueOnce({ data: { plan: { planId: 'custom' } } })
+    const { service, redis } = makeService()
+    const warn = jest.spyOn((service as unknown as { logger: { warn: (message: string) => void } }).logger, 'warn')
 
-    await expect(makeService().service.resolveMaxCreatedBoxes('org-1')).resolves.toBeUndefined()
+    await expect(service.resolveMaxCreatedBoxes('org-1')).resolves.toBeUndefined()
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/org-1.*custom.*public catalog/))
+    expect(redis.set).toHaveBeenCalledWith('commerce:box-limit:v1:org-1', 'unlimited', 'EX', 30)
   })
 
   it('rejects a configured Commerce API without the shared token before making a request', async () => {
@@ -188,8 +192,20 @@ describe('CommerceBoxLimitService', () => {
   })
 
   it.each([
-    ['timeout', Object.assign(new Error('timeout'), { code: 'ECONNABORTED' }), { data: {} }],
-    ['Commerce 5xx', Object.assign(new Error('unavailable'), { response: { status: 503 } }), { data: {} }],
+    ['timeout', Object.assign(new Error('timeout'), { code: 'ECONNABORTED' })],
+    ['Commerce 5xx', Object.assign(new Error('unavailable'), { response: { status: 502 } })],
+  ])('temporarily allows creation without caching when Commerce is unavailable due to %s', async (_label, failure) => {
+    get.mockRejectedValueOnce(failure).mockResolvedValueOnce({ data: {} })
+    const { service, redis } = makeService()
+    const warn = jest.spyOn((service as unknown as { logger: { warn: (message: string) => void } }).logger, 'warn')
+
+    await expect(service.resolveMaxCreatedBoxes('org-1')).resolves.toBeUndefined()
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/org-1.*temporarily allowing/))
+    expect(redis.set).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['Commerce 4xx', Object.assign(new Error('unauthorized'), { response: { status: 401 } }), { data: {} }],
     ['empty catalog', { data: [] }, { data: {} }],
     ['invalid catalog', { data: [{ id: 'starter', concurrencyLimit: -1 }] }, { data: {} }],
     ['invalid organization response', { data: catalog }, { data: { plan: null } }],

--- a/apps/api/src/boxlite-rest/commerce-box-limit.service.spec.ts
+++ b/apps/api/src/boxlite-rest/commerce-box-limit.service.spec.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: { get: jest.fn() },
+}))
+
+import axios from 'axios'
+import { HttpStatus } from '@nestjs/common'
+import { CommerceBoxLimitService } from './commerce-box-limit.service'
+import {
+  BOX_CREATION_ADMISSION_UNAVAILABLE_CODE,
+  BoxCreationAdmissionUnavailableError,
+} from '../box/errors/box-creation-limit.error'
+
+const get = axios.get as jest.Mock
+
+const makeService = (settings: Record<string, unknown> = {}) => {
+  const values = {
+    billingApiUrl: 'https://commerce.test/api/billing/',
+    'usageExport.token': 'shared-token',
+    ...settings,
+  }
+  const configService = {
+    get: jest.fn((key: string) => values[key as keyof typeof values]),
+  }
+  return { service: new CommerceBoxLimitService(configService as never), configService }
+}
+
+const catalog = [
+  { id: 'starter', concurrencyLimit: 2 },
+  { id: 'pro', concurrencyLimit: 8 },
+]
+
+function expectUnavailable(error: unknown): void {
+  expect(error).toBeInstanceOf(BoxCreationAdmissionUnavailableError)
+  const exception = error as BoxCreationAdmissionUnavailableError
+  expect(exception.getStatus()).toBe(HttpStatus.SERVICE_UNAVAILABLE)
+  expect(exception.getResponse()).toEqual(
+    expect.objectContaining({ code: BOX_CREATION_ADMISSION_UNAVAILABLE_CODE }),
+  )
+}
+
+beforeEach(() => {
+  get.mockReset()
+})
+
+describe('CommerceBoxLimitService', () => {
+  it('does not contact Commerce when BILLING_API_URL is absent', async () => {
+    const { service } = makeService({ billingApiUrl: undefined })
+
+    await expect(service.resolveMaxCreatedBoxes('org-1')).resolves.toBeUndefined()
+    expect(get).not.toHaveBeenCalled()
+  })
+
+  it('fetches the catalog and organization plan in parallel and resolves the subscribed limit', async () => {
+    let resolveCatalog!: (value: { data: unknown }) => void
+    let resolveOrganization!: (value: { data: unknown }) => void
+    get
+      .mockReturnValueOnce(new Promise((resolve) => (resolveCatalog = resolve)))
+      .mockReturnValueOnce(new Promise((resolve) => (resolveOrganization = resolve)))
+
+    const resolving = makeService().service.resolveMaxCreatedBoxes('org/with space')
+
+    expect(get).toHaveBeenCalledTimes(2)
+    expect(get).toHaveBeenNthCalledWith(
+      1,
+      'https://commerce.test/api/billing/plan',
+      expect.objectContaining({ timeout: 2_000, headers: { authorization: 'Bearer shared-token' } }),
+    )
+    expect(get).toHaveBeenNthCalledWith(
+      2,
+      'https://commerce.test/api/billing/organization/org%2Fwith%20space/plan',
+      expect.objectContaining({ timeout: 2_000, headers: { authorization: 'Bearer shared-token' } }),
+    )
+
+    resolveCatalog({ data: catalog })
+    resolveOrganization({ data: { plan: { planId: 'pro', entitlements: 'active' } } })
+    await expect(resolving).resolves.toBe(8)
+  })
+
+  it.each([
+    ['no subscription', {}],
+    ['suspended entitlements', { plan: { planId: 'pro', entitlements: 'suspended' } }],
+  ])('uses the first public plan for %s', async (_label, organizationPlan) => {
+    get.mockResolvedValueOnce({ data: catalog }).mockResolvedValueOnce({ data: organizationPlan })
+
+    await expect(makeService().service.resolveMaxCreatedBoxes('org-1')).resolves.toBe(2)
+  })
+
+  it('treats a null concurrency limit as unlimited', async () => {
+    get
+      .mockResolvedValueOnce({ data: [{ id: 'enterprise', concurrencyLimit: null }] })
+      .mockResolvedValueOnce({ data: { plan: { planId: 'enterprise' } } })
+
+    await expect(makeService().service.resolveMaxCreatedBoxes('org-1')).resolves.toBeUndefined()
+  })
+
+  it('rejects a configured Commerce API without the shared token before making a request', async () => {
+    const { service } = makeService({ 'usageExport.token': undefined })
+
+    const error = await service.resolveMaxCreatedBoxes('org-1').catch((caught) => caught)
+    expectUnavailable(error)
+    expect(get).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['timeout', Object.assign(new Error('timeout'), { code: 'ECONNABORTED' }), { data: {} }],
+    ['Commerce 5xx', Object.assign(new Error('unavailable'), { response: { status: 503 } }), { data: {} }],
+    ['empty catalog', { data: [] }, { data: {} }],
+    ['invalid catalog', { data: [{ id: 'starter', concurrencyLimit: -1 }] }, { data: {} }],
+    ['invalid organization response', { data: catalog }, { data: { plan: null } }],
+    ['unexpected no-plan fields', { data: catalog }, { data: { subscription: null } }],
+    ['unknown subscribed plan', { data: catalog }, { data: { plan: { planId: 'custom' } } }],
+  ])('fails closed for %s', async (_label, catalogResult, organizationResult) => {
+    if (catalogResult instanceof Error) {
+      get.mockRejectedValueOnce(catalogResult).mockResolvedValueOnce(organizationResult)
+    } else {
+      get.mockResolvedValueOnce(catalogResult).mockResolvedValueOnce(organizationResult)
+    }
+
+    const error = await makeService().service.resolveMaxCreatedBoxes('org-1').catch((caught) => caught)
+    expectUnavailable(error)
+  })
+})

--- a/apps/api/src/boxlite-rest/commerce-box-limit.service.spec.ts
+++ b/apps/api/src/boxlite-rest/commerce-box-limit.service.spec.ts
@@ -18,7 +18,12 @@ import {
 
 const get = axios.get as jest.Mock
 
-const makeService = (settings: Record<string, unknown> = {}) => {
+type RedisMock = {
+  get: jest.Mock
+  set: jest.Mock
+}
+
+const makeService = (settings: Record<string, unknown> = {}, redisOverrides: Partial<RedisMock> = {}) => {
   const values = {
     billingApiUrl: 'https://commerce.test/api/billing/',
     'usageExport.token': 'shared-token',
@@ -27,7 +32,16 @@ const makeService = (settings: Record<string, unknown> = {}) => {
   const configService = {
     get: jest.fn((key: string) => values[key as keyof typeof values]),
   }
-  return { service: new CommerceBoxLimitService(configService as never), configService }
+  const redis = {
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue('OK'),
+    ...redisOverrides,
+  }
+  return {
+    service: new CommerceBoxLimitService(configService as never, redis as never),
+    configService,
+    redis,
+  }
 }
 
 const catalog = [
@@ -39,9 +53,7 @@ function expectUnavailable(error: unknown): void {
   expect(error).toBeInstanceOf(BoxCreationAdmissionUnavailableError)
   const exception = error as BoxCreationAdmissionUnavailableError
   expect(exception.getStatus()).toBe(HttpStatus.SERVICE_UNAVAILABLE)
-  expect(exception.getResponse()).toEqual(
-    expect.objectContaining({ code: BOX_CREATION_ADMISSION_UNAVAILABLE_CODE }),
-  )
+  expect(exception.getResponse()).toEqual(expect.objectContaining({ code: BOX_CREATION_ADMISSION_UNAVAILABLE_CODE }))
 }
 
 beforeEach(() => {
@@ -50,9 +62,23 @@ beforeEach(() => {
 
 describe('CommerceBoxLimitService', () => {
   it('does not contact Commerce when BILLING_API_URL is absent', async () => {
-    const { service } = makeService({ billingApiUrl: undefined })
+    const { service, redis } = makeService({ billingApiUrl: undefined })
 
     await expect(service.resolveMaxCreatedBoxes('org-1')).resolves.toBeUndefined()
+    expect(get).not.toHaveBeenCalled()
+    expect(redis.get).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['limit:8', 8],
+    ['unlimited', undefined],
+  ])('uses the cached resolved limit %s without contacting Commerce', async (cached, expected) => {
+    get.mockResolvedValueOnce({ data: catalog }).mockResolvedValueOnce({ data: { plan: { planId: 'pro' } } })
+    const { service, redis } = makeService({}, { get: jest.fn().mockResolvedValue(cached) })
+
+    await expect(service.resolveMaxCreatedBoxes('org-1')).resolves.toBe(expected)
+    expect(redis.get).toHaveBeenCalledWith('commerce:box-limit:v1:org-1')
+    expect(redis.set).not.toHaveBeenCalled()
     expect(get).not.toHaveBeenCalled()
   })
 
@@ -63,8 +89,11 @@ describe('CommerceBoxLimitService', () => {
       .mockReturnValueOnce(new Promise((resolve) => (resolveCatalog = resolve)))
       .mockReturnValueOnce(new Promise((resolve) => (resolveOrganization = resolve)))
 
-    const resolving = makeService().service.resolveMaxCreatedBoxes('org/with space')
+    const { service, redis } = makeService()
+    const resolving = service.resolveMaxCreatedBoxes('org/with space')
 
+    await Promise.resolve()
+    await Promise.resolve()
     expect(get).toHaveBeenCalledTimes(2)
     expect(get).toHaveBeenNthCalledWith(
       1,
@@ -80,6 +109,51 @@ describe('CommerceBoxLimitService', () => {
     resolveCatalog({ data: catalog })
     resolveOrganization({ data: { plan: { planId: 'pro', entitlements: 'active' } } })
     await expect(resolving).resolves.toBe(8)
+    expect(redis.set).toHaveBeenCalledWith('commerce:box-limit:v1:org%2Fwith%20space', 'limit:8', 'EX', 30)
+  })
+
+  it.each([
+    ['zero', [{ id: 'free', concurrencyLimit: 0 }], 'free', 0, 'limit:0'],
+    ['unlimited', [{ id: 'enterprise', concurrencyLimit: null }], 'enterprise', undefined, 'unlimited'],
+  ])('caches a successful %s limit without losing its meaning', async (_label, plans, planId, expected, cached) => {
+    get.mockResolvedValueOnce({ data: plans }).mockResolvedValueOnce({ data: { plan: { planId } } })
+    const { service, redis } = makeService()
+
+    await expect(service.resolveMaxCreatedBoxes('org-1')).resolves.toBe(expected)
+    expect(redis.set).toHaveBeenCalledWith('commerce:box-limit:v1:org-1', cached, 'EX', 30)
+  })
+
+  it('coalesces concurrent cache misses for the same organization', async () => {
+    get
+      .mockResolvedValueOnce({ data: catalog })
+      .mockResolvedValueOnce({ data: { plan: { planId: 'pro' } } })
+      .mockResolvedValueOnce({ data: catalog })
+      .mockResolvedValueOnce({ data: { plan: { planId: 'pro' } } })
+    const { service, redis } = makeService()
+
+    const resolved = await Promise.all([
+      service.resolveMaxCreatedBoxes('org-1'),
+      service.resolveMaxCreatedBoxes('org-1'),
+    ])
+
+    expect(resolved).toEqual([8, 8])
+    expect(redis.get).toHaveBeenCalledTimes(1)
+    expect(get).toHaveBeenCalledTimes(2)
+    expect(redis.set).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to Commerce when Redis reads or writes fail', async () => {
+    get.mockResolvedValueOnce({ data: catalog }).mockResolvedValueOnce({ data: { plan: { planId: 'pro' } } })
+    const { service, redis } = makeService(
+      {},
+      {
+        get: jest.fn().mockRejectedValue(new Error('Redis read failed')),
+        set: jest.fn().mockRejectedValue(new Error('Redis write failed')),
+      },
+    )
+
+    await expect(service.resolveMaxCreatedBoxes('org-1')).resolves.toBe(8)
+    expect(redis.set).toHaveBeenCalledWith('commerce:box-limit:v1:org-1', 'limit:8', 'EX', 30)
   })
 
   it.each([
@@ -100,9 +174,7 @@ describe('CommerceBoxLimitService', () => {
   })
 
   it('does not limit a subscribed plan that is absent from the public catalog', async () => {
-    get
-      .mockResolvedValueOnce({ data: catalog })
-      .mockResolvedValueOnce({ data: { plan: { planId: 'custom' } } })
+    get.mockResolvedValueOnce({ data: catalog }).mockResolvedValueOnce({ data: { plan: { planId: 'custom' } } })
 
     await expect(makeService().service.resolveMaxCreatedBoxes('org-1')).resolves.toBeUndefined()
   })
@@ -129,7 +201,9 @@ describe('CommerceBoxLimitService', () => {
       get.mockResolvedValueOnce(catalogResult).mockResolvedValueOnce(organizationResult)
     }
 
-    const error = await makeService().service.resolveMaxCreatedBoxes('org-1').catch((caught) => caught)
+    const { service, redis } = makeService()
+    const error = await service.resolveMaxCreatedBoxes('org-1').catch((caught) => caught)
     expectUnavailable(error)
+    expect(redis.set).not.toHaveBeenCalled()
   })
 })

--- a/apps/api/src/boxlite-rest/commerce-box-limit.service.spec.ts
+++ b/apps/api/src/boxlite-rest/commerce-box-limit.service.spec.ts
@@ -99,6 +99,14 @@ describe('CommerceBoxLimitService', () => {
     await expect(makeService().service.resolveMaxCreatedBoxes('org-1')).resolves.toBeUndefined()
   })
 
+  it('does not limit a subscribed plan that is absent from the public catalog', async () => {
+    get
+      .mockResolvedValueOnce({ data: catalog })
+      .mockResolvedValueOnce({ data: { plan: { planId: 'custom' } } })
+
+    await expect(makeService().service.resolveMaxCreatedBoxes('org-1')).resolves.toBeUndefined()
+  })
+
   it('rejects a configured Commerce API without the shared token before making a request', async () => {
     const { service } = makeService({ 'usageExport.token': undefined })
 
@@ -114,7 +122,6 @@ describe('CommerceBoxLimitService', () => {
     ['invalid catalog', { data: [{ id: 'starter', concurrencyLimit: -1 }] }, { data: {} }],
     ['invalid organization response', { data: catalog }, { data: { plan: null } }],
     ['unexpected no-plan fields', { data: catalog }, { data: { subscription: null } }],
-    ['unknown subscribed plan', { data: catalog }, { data: { plan: { planId: 'custom' } } }],
   ])('fails closed for %s', async (_label, catalogResult, organizationResult) => {
     if (catalogResult instanceof Error) {
       get.mockRejectedValueOnce(catalogResult).mockResolvedValueOnce(organizationResult)

--- a/apps/api/src/boxlite-rest/commerce-box-limit.service.ts
+++ b/apps/api/src/boxlite-rest/commerce-box-limit.service.ts
@@ -63,11 +63,9 @@ export class CommerceBoxLimitService {
         ? catalog[0]
         : catalog.find((plan) => plan.id === organizationPlan.planId)
 
-    if (!selectedPlan) {
-      throw new BoxCreationAdmissionUnavailableError('Organization subscription plan is not in the public catalog')
-    }
-
-    return selectedPlan.concurrencyLimit ?? undefined
+    // A plan absent from the public catalog may be a negotiated subscription;
+    // leave it unlimited until Commerce exposes its effective limit.
+    return selectedPlan?.concurrencyLimit ?? undefined
   }
 
   private normalizeBaseUrl(rawBaseUrl: string): string {

--- a/apps/api/src/boxlite-rest/commerce-box-limit.service.ts
+++ b/apps/api/src/boxlite-rest/commerce-box-limit.service.ts
@@ -40,6 +40,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 @Injectable()
 export class CommerceBoxLimitService {
   private readonly logger = new Logger(CommerceBoxLimitService.name)
+  // Coalesces concurrent misses only within this Node process. Redis shares
+  // completed resolutions, but does not provide cross-instance singleflight.
   private readonly inFlightResolutions = new Map<string, Promise<number | undefined>>()
 
   constructor(
@@ -170,6 +172,7 @@ export class CommerceBoxLimitService {
       this.logger.warn(
         `Organization ${organizationId} uses Commerce plan ${organizationPlan.planId}, which is absent from the public catalog; leaving Box creation unlimited`,
       )
+      return { maxCreatedBoxes: undefined, isCacheable: false }
     }
     return { maxCreatedBoxes: selectedPlan?.concurrencyLimit ?? undefined, isCacheable: true }
   }

--- a/apps/api/src/boxlite-rest/commerce-box-limit.service.ts
+++ b/apps/api/src/boxlite-rest/commerce-box-limit.service.ts
@@ -3,12 +3,18 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { Injectable } from '@nestjs/common'
+import { InjectRedis } from '@nestjs-modules/ioredis'
+import { Injectable, Logger } from '@nestjs/common'
 import axios from 'axios'
+import { Redis } from 'ioredis'
 import { TypedConfigService } from '../config/typed-config.service'
 import { BoxCreationAdmissionUnavailableError } from '../box/errors/box-creation-limit.error'
 
 const COMMERCE_REQUEST_TIMEOUT_MS = 2_000
+const COMMERCE_BOX_LIMIT_CACHE_KEY_PREFIX = 'commerce:box-limit:v1:'
+const COMMERCE_BOX_LIMIT_CACHE_TTL_SECONDS = 30
+const UNLIMITED_CACHE_VALUE = 'unlimited'
+const LIMIT_CACHE_VALUE_PREFIX = 'limit:'
 
 type PublicPlan = {
   id: string
@@ -20,13 +26,21 @@ type OrganizationPlan = {
   entitlements?: 'active' | 'suspended'
 }
 
+type CachedBoxLimit = { hit: true; maxCreatedBoxes: number | undefined } | { hit: false }
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
 @Injectable()
 export class CommerceBoxLimitService {
-  constructor(private readonly configService: TypedConfigService) {}
+  private readonly logger = new Logger(CommerceBoxLimitService.name)
+  private readonly inFlightResolutions = new Map<string, Promise<number | undefined>>()
+
+  constructor(
+    private readonly configService: TypedConfigService,
+    @InjectRedis() private readonly redis: Redis,
+  ) {}
 
   async resolveMaxCreatedBoxes(organizationId: string): Promise<number | undefined> {
     const rawBaseUrl = this.configService.get('billingApiUrl')?.trim()
@@ -40,6 +54,80 @@ export class CommerceBoxLimitService {
     }
 
     const baseUrl = this.normalizeBaseUrl(rawBaseUrl)
+    const cacheKey = `${COMMERCE_BOX_LIMIT_CACHE_KEY_PREFIX}${encodeURIComponent(organizationId)}`
+    const inFlightResolution = this.inFlightResolutions.get(cacheKey)
+    if (inFlightResolution) {
+      return inFlightResolution
+    }
+
+    const resolution = this.resolveFromCacheOrCommerce(organizationId, cacheKey, baseUrl, token).finally(() => {
+      this.inFlightResolutions.delete(cacheKey)
+    })
+    this.inFlightResolutions.set(cacheKey, resolution)
+
+    return resolution
+  }
+
+  private async resolveFromCacheOrCommerce(
+    organizationId: string,
+    cacheKey: string,
+    baseUrl: string,
+    token: string,
+  ): Promise<number | undefined> {
+    const cachedLimit = await this.getCachedLimit(cacheKey)
+    if (cachedLimit.hit) {
+      return cachedLimit.maxCreatedBoxes
+    }
+
+    const maxCreatedBoxes = await this.fetchMaxCreatedBoxes(organizationId, baseUrl, token)
+    await this.cacheResolvedLimit(cacheKey, maxCreatedBoxes)
+    return maxCreatedBoxes
+  }
+
+  private async getCachedLimit(cacheKey: string): Promise<CachedBoxLimit> {
+    let cached: string | null
+    try {
+      cached = await this.redis.get(cacheKey)
+    } catch {
+      this.logger.warn(`Failed to read Commerce box limit cache for ${cacheKey}; falling back to Commerce`)
+      return { hit: false }
+    }
+
+    if (cached === null) {
+      return { hit: false }
+    }
+    if (cached === UNLIMITED_CACHE_VALUE) {
+      return { hit: true, maxCreatedBoxes: undefined }
+    }
+
+    if (cached.startsWith(LIMIT_CACHE_VALUE_PREFIX)) {
+      const rawLimit = cached.slice(LIMIT_CACHE_VALUE_PREFIX.length)
+      const limit = Number(rawLimit)
+      if (/^(0|[1-9]\d*)$/.test(rawLimit) && Number.isSafeInteger(limit)) {
+        return { hit: true, maxCreatedBoxes: limit }
+      }
+    }
+
+    this.logger.warn(`Ignoring invalid Commerce box limit cache value for ${cacheKey}`)
+    return { hit: false }
+  }
+
+  private async cacheResolvedLimit(cacheKey: string, maxCreatedBoxes: number | undefined): Promise<void> {
+    const cachedValue =
+      maxCreatedBoxes === undefined ? UNLIMITED_CACHE_VALUE : `${LIMIT_CACHE_VALUE_PREFIX}${maxCreatedBoxes}`
+
+    try {
+      await this.redis.set(cacheKey, cachedValue, 'EX', COMMERCE_BOX_LIMIT_CACHE_TTL_SECONDS)
+    } catch {
+      this.logger.warn(`Failed to write Commerce box limit cache for ${cacheKey}`)
+    }
+  }
+
+  private async fetchMaxCreatedBoxes(
+    organizationId: string,
+    baseUrl: string,
+    token: string,
+  ): Promise<number | undefined> {
     const requestConfig = {
       timeout: COMMERCE_REQUEST_TIMEOUT_MS,
       headers: { authorization: `Bearer ${token}` },

--- a/apps/api/src/boxlite-rest/commerce-box-limit.service.ts
+++ b/apps/api/src/boxlite-rest/commerce-box-limit.service.ts
@@ -28,6 +28,11 @@ type OrganizationPlan = {
 
 type CachedBoxLimit = { hit: true; maxCreatedBoxes: number | undefined } | { hit: false }
 
+type CommerceBoxLimitResolution = {
+  maxCreatedBoxes: number | undefined
+  isCacheable: boolean
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
@@ -79,9 +84,11 @@ export class CommerceBoxLimitService {
       return cachedLimit.maxCreatedBoxes
     }
 
-    const maxCreatedBoxes = await this.fetchMaxCreatedBoxes(organizationId, baseUrl, token)
-    await this.cacheResolvedLimit(cacheKey, maxCreatedBoxes)
-    return maxCreatedBoxes
+    const resolution = await this.fetchMaxCreatedBoxes(organizationId, baseUrl, token)
+    if (resolution.isCacheable) {
+      await this.cacheResolvedLimit(cacheKey, resolution.maxCreatedBoxes)
+    }
+    return resolution.maxCreatedBoxes
   }
 
   private async getCachedLimit(cacheKey: string): Promise<CachedBoxLimit> {
@@ -127,7 +134,7 @@ export class CommerceBoxLimitService {
     organizationId: string,
     baseUrl: string,
     token: string,
-  ): Promise<number | undefined> {
+  ): Promise<CommerceBoxLimitResolution> {
     const requestConfig = {
       timeout: COMMERCE_REQUEST_TIMEOUT_MS,
       headers: { authorization: `Bearer ${token}` },
@@ -139,7 +146,13 @@ export class CommerceBoxLimitService {
         axios.get<unknown>(`${baseUrl}/plan`, requestConfig),
         axios.get<unknown>(`${baseUrl}/organization/${encodeURIComponent(organizationId)}/plan`, requestConfig),
       ])
-    } catch {
+    } catch (error) {
+      if (this.isTemporarilyUnavailable(error)) {
+        this.logger.warn(
+          `Commerce box limit lookup for organization ${organizationId} is unavailable (${this.unavailabilityReason(error)}); temporarily allowing Box creation`,
+        )
+        return { maxCreatedBoxes: undefined, isCacheable: false }
+      }
       throw new BoxCreationAdmissionUnavailableError('Commerce plan service is unavailable')
     }
 
@@ -153,7 +166,36 @@ export class CommerceBoxLimitService {
 
     // A plan absent from the public catalog may be a negotiated subscription;
     // leave it unlimited until Commerce exposes its effective limit.
-    return selectedPlan?.concurrencyLimit ?? undefined
+    if (organizationPlan && organizationPlan.entitlements !== 'suspended' && !selectedPlan) {
+      this.logger.warn(
+        `Organization ${organizationId} uses Commerce plan ${organizationPlan.planId}, which is absent from the public catalog; leaving Box creation unlimited`,
+      )
+    }
+    return { maxCreatedBoxes: selectedPlan?.concurrencyLimit ?? undefined, isCacheable: true }
+  }
+
+  private isTemporarilyUnavailable(error: unknown): boolean {
+    if (!isRecord(error)) {
+      return false
+    }
+
+    const response = error.response
+    if (response === undefined) {
+      return true
+    }
+    return isRecord(response) && typeof response.status === 'number' && response.status >= 500 && response.status <= 599
+  }
+
+  private unavailabilityReason(error: unknown): string {
+    if (!isRecord(error)) {
+      return 'request failed'
+    }
+
+    const response = error.response
+    if (isRecord(response) && typeof response.status === 'number') {
+      return `HTTP ${response.status}`
+    }
+    return typeof error.code === 'string' ? error.code : 'transport failure'
   }
 
   private normalizeBaseUrl(rawBaseUrl: string): string {

--- a/apps/api/src/boxlite-rest/commerce-box-limit.service.ts
+++ b/apps/api/src/boxlite-rest/commerce-box-limit.service.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Injectable } from '@nestjs/common'
+import axios from 'axios'
+import { TypedConfigService } from '../config/typed-config.service'
+import { BoxCreationAdmissionUnavailableError } from '../box/errors/box-creation-limit.error'
+
+const COMMERCE_REQUEST_TIMEOUT_MS = 2_000
+
+type PublicPlan = {
+  id: string
+  concurrencyLimit: number | null
+}
+
+type OrganizationPlan = {
+  planId: string
+  entitlements?: 'active' | 'suspended'
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+@Injectable()
+export class CommerceBoxLimitService {
+  constructor(private readonly configService: TypedConfigService) {}
+
+  async resolveMaxCreatedBoxes(organizationId: string): Promise<number | undefined> {
+    const rawBaseUrl = this.configService.get('billingApiUrl')?.trim()
+    if (!rawBaseUrl) {
+      return undefined
+    }
+
+    const token = this.configService.get('usageExport.token')?.trim()
+    if (!token) {
+      throw new BoxCreationAdmissionUnavailableError('Commerce authentication is not configured')
+    }
+
+    const baseUrl = this.normalizeBaseUrl(rawBaseUrl)
+    const requestConfig = {
+      timeout: COMMERCE_REQUEST_TIMEOUT_MS,
+      headers: { authorization: `Bearer ${token}` },
+    }
+
+    let responses: [{ data: unknown }, { data: unknown }]
+    try {
+      responses = await Promise.all([
+        axios.get<unknown>(`${baseUrl}/plan`, requestConfig),
+        axios.get<unknown>(`${baseUrl}/organization/${encodeURIComponent(organizationId)}/plan`, requestConfig),
+      ])
+    } catch {
+      throw new BoxCreationAdmissionUnavailableError('Commerce plan service is unavailable')
+    }
+
+    const [catalogResponse, organizationPlanResponse] = responses
+    const catalog = this.parseCatalog(catalogResponse.data)
+    const organizationPlan = this.parseOrganizationPlan(organizationPlanResponse.data)
+    const selectedPlan =
+      !organizationPlan || organizationPlan.entitlements === 'suspended'
+        ? catalog[0]
+        : catalog.find((plan) => plan.id === organizationPlan.planId)
+
+    if (!selectedPlan) {
+      throw new BoxCreationAdmissionUnavailableError('Organization subscription plan is not in the public catalog')
+    }
+
+    return selectedPlan.concurrencyLimit ?? undefined
+  }
+
+  private normalizeBaseUrl(rawBaseUrl: string): string {
+    let parsed: URL
+    try {
+      parsed = new URL(rawBaseUrl)
+    } catch {
+      throw new BoxCreationAdmissionUnavailableError('Commerce API URL is invalid')
+    }
+
+    if (
+      !['http:', 'https:'].includes(parsed.protocol) ||
+      parsed.username ||
+      parsed.password ||
+      parsed.search ||
+      parsed.hash
+    ) {
+      throw new BoxCreationAdmissionUnavailableError('Commerce API URL is invalid')
+    }
+
+    return rawBaseUrl.replace(/\/+$/, '')
+  }
+
+  private parseCatalog(value: unknown): PublicPlan[] {
+    if (!Array.isArray(value) || value.length === 0) {
+      throw new BoxCreationAdmissionUnavailableError('Commerce returned an empty or invalid plan catalog')
+    }
+
+    return value.map((candidate) => {
+      if (!isRecord(candidate) || typeof candidate.id !== 'string' || candidate.id.length === 0) {
+        throw new BoxCreationAdmissionUnavailableError('Commerce returned an invalid plan catalog')
+      }
+
+      const concurrencyLimit = candidate.concurrencyLimit
+      if (
+        concurrencyLimit !== null &&
+        (typeof concurrencyLimit !== 'number' || !Number.isSafeInteger(concurrencyLimit) || concurrencyLimit < 0)
+      ) {
+        throw new BoxCreationAdmissionUnavailableError('Commerce returned an invalid box concurrency limit')
+      }
+
+      return { id: candidate.id, concurrencyLimit: concurrencyLimit as number | null }
+    })
+  }
+
+  private parseOrganizationPlan(value: unknown): OrganizationPlan | undefined {
+    if (!isRecord(value)) {
+      throw new BoxCreationAdmissionUnavailableError('Commerce returned an invalid organization plan')
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(value, 'plan')) {
+      if (Object.keys(value).length === 0) {
+        return undefined
+      }
+      throw new BoxCreationAdmissionUnavailableError('Commerce returned an invalid organization plan')
+    }
+
+    const plan = value.plan
+    if (!isRecord(plan) || typeof plan.planId !== 'string' || plan.planId.length === 0) {
+      throw new BoxCreationAdmissionUnavailableError('Commerce returned an invalid organization plan')
+    }
+    if (plan.entitlements !== undefined && !['active', 'suspended'].includes(plan.entitlements as string)) {
+      throw new BoxCreationAdmissionUnavailableError('Commerce returned invalid organization entitlements')
+    }
+
+    return {
+      planId: plan.planId,
+      entitlements: plan.entitlements as OrganizationPlan['entitlements'],
+    }
+  }
+}

--- a/apps/api/src/config/billing-api-config.spec.ts
+++ b/apps/api/src/config/billing-api-config.spec.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+describe('BILLING_API_URL startup configuration', () => {
+  const environmentKeys = ['BILLING_API_URL', 'USAGE_EXPORT_TOKEN'] as const
+  const savedEnvironment: Partial<Record<(typeof environmentKeys)[number], string>> = {}
+
+  beforeEach(() => {
+    for (const key of environmentKeys) {
+      savedEnvironment[key] = process.env[key]
+      delete process.env[key]
+    }
+    jest.resetModules()
+  })
+
+  afterEach(() => {
+    for (const key of environmentKeys) {
+      const value = savedEnvironment[key]
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+    jest.resetModules()
+  })
+
+  function loadBillingApiUrl(): string | undefined {
+    const { configuration } = require('./configuration') as typeof import('./configuration')
+    return configuration.billingApiUrl
+  }
+
+  it('keeps admission disabled when BILLING_API_URL is absent', () => {
+    expect(loadBillingApiUrl()).toBeUndefined()
+  })
+
+  it.each([undefined, '   '])('refuses a configured Commerce URL with token %p', (token) => {
+    process.env.BILLING_API_URL = 'https://commerce.test/api/billing'
+    if (token !== undefined) {
+      process.env.USAGE_EXPORT_TOKEN = token
+    }
+
+    expect(() => loadBillingApiUrl()).toThrow(/USAGE_EXPORT_TOKEN is required when BILLING_API_URL is set/)
+  })
+
+  it.each([
+    ['a bare hostname', 'commerce.test', /absolute http\(s\) URL/],
+    ['an unsupported scheme', 'ftp://commerce.test/api/billing', /must use http or https/],
+    ['userinfo', 'https://user:secret@commerce.test/api/billing', /must not carry credentials/],
+    ['a query', 'https://commerce.test/api/billing?tenant=one', /must not carry a query or fragment/],
+    ['a fragment', 'https://commerce.test/api/billing#plans', /must not carry a query or fragment/],
+  ])('refuses %s at startup', (_case, url, expected) => {
+    process.env.BILLING_API_URL = url
+    process.env.USAGE_EXPORT_TOKEN = 'shared-token'
+
+    expect(() => loadBillingApiUrl()).toThrow(expected)
+  })
+
+  it.each([
+    ['http for local development', 'http://commerce.test:3100/api/billing', 'http://commerce.test:3100/api/billing'],
+    ['https', 'https://commerce.test/api/billing', 'https://commerce.test/api/billing'],
+    ['a trailing slash', 'https://commerce.test/api/billing/', 'https://commerce.test/api/billing'],
+  ])('accepts and normalizes %s', (_case, url, expected) => {
+    process.env.BILLING_API_URL = url
+    process.env.USAGE_EXPORT_TOKEN = 'shared-token'
+
+    expect(loadBillingApiUrl()).toBe(expected)
+  })
+})

--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -78,6 +78,30 @@ function requiredHttpUrl(value: string, name: string): string {
   return value.replace(/\/+$/, '')
 }
 
+/**
+ * Validate the authenticated Commerce read surface when it is enabled.
+ *
+ * Unlike usage export, the presence of BILLING_API_URL itself enables these
+ * reads. A bad URL or missing shared token must therefore fail at startup,
+ * before the first hosted CREATE request discovers the deployment error.
+ */
+function billingApiUrlConfig(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const rawUrl = env.BILLING_API_URL?.trim()
+  if (!rawUrl) {
+    return undefined
+  }
+  if (!env.USAGE_EXPORT_TOKEN?.trim()) {
+    throw new Error('USAGE_EXPORT_TOKEN is required when BILLING_API_URL is set')
+  }
+
+  const url = requiredHttpUrl(rawUrl, 'BILLING_API_URL')
+  const parsed = new URL(url)
+  if (parsed.username || parsed.password) {
+    throw new Error('BILLING_API_URL must not carry credentials')
+  }
+  return url
+}
+
 function validateOidcManagementHttpsUrl(value: string, name: string): void {
   let parsed: URL
   try {
@@ -481,7 +505,7 @@ const configuration = {
   },
   organizationBoxDefaultLimitedNetworkEgress: process.env.ORGANIZATION_BOX_DEFAULT_LIMITED_NETWORK_EGRESS === 'true',
   pylonAppId: process.env.PYLON_APP_ID,
-  billingApiUrl: process.env.BILLING_API_URL,
+  billingApiUrl: billingApiUrlConfig(),
   analyticsApiUrl: process.env.ANALYTICS_API_URL,
   usageExport: usageExportConfig(),
   incidentIo: incidentIoConfig(),

--- a/apps/api/src/filters/all-exceptions.filter.spec.ts
+++ b/apps/api/src/filters/all-exceptions.filter.spec.ts
@@ -7,6 +7,7 @@
 import { ArgumentsHost, HttpStatus } from '@nestjs/common'
 import { AllExceptionsFilter } from './all-exceptions.filter'
 import { RunnerApiError } from '../box/errors/runner-api-error'
+import { BoxCreationAdmissionUnavailableError } from '../box/errors/box-creation-limit.error'
 
 describe('AllExceptionsFilter', () => {
   it('serializes HttpException code fields into the JSON response', async () => {
@@ -35,5 +36,24 @@ describe('AllExceptionsFilter', () => {
         code: 'runner_non_json_error',
       }),
     )
+  })
+
+  it('sets Retry-After for a temporarily contended creation admission', async () => {
+    const json = jest.fn()
+    const status = jest.fn().mockReturnValue({ json })
+    const setHeader = jest.fn()
+    const filter = new AllExceptionsFilter({ incrementFailedAuth: jest.fn() } as never)
+    const host = {
+      switchToHttp: () => ({
+        getResponse: () => ({ setHeader, status }),
+        getRequest: () => ({ path: '/api/v1/org/boxes', url: '/api/v1/org/boxes' }),
+      }),
+    } as ArgumentsHost
+    const exception = new BoxCreationAdmissionUnavailableError('Box creation admission remained contended', 5)
+
+    await filter.catch(exception, host)
+
+    expect(setHeader).toHaveBeenCalledWith('Retry-After', '5')
+    expect(status).toHaveBeenCalledWith(HttpStatus.SERVICE_UNAVAILABLE)
   })
 })

--- a/apps/api/src/filters/all-exceptions.filter.ts
+++ b/apps/api/src/filters/all-exceptions.filter.ts
@@ -70,6 +70,11 @@ export class AllExceptionsFilter implements ExceptionFilter {
         const responseCode = (exceptionResponse as Record<string, unknown>).code
         code = typeof responseCode === 'string' ? responseCode : undefined
       }
+
+      const retryAfterSeconds = (exception as { retryAfterSeconds?: unknown }).retryAfterSeconds
+      if (typeof retryAfterSeconds === 'number' && Number.isSafeInteger(retryAfterSeconds) && retryAfterSeconds > 0) {
+        response.setHeader('Retry-After', retryAfterSeconds.toString())
+      }
     } else {
       this.logger.error(exception)
       error = STATUS_CODES[HttpStatus.INTERNAL_SERVER_ERROR]

--- a/apps/infra/.env.example
+++ b/apps/infra/.env.example
@@ -243,15 +243,18 @@ OIDC_AUDIENCE=https://dev.example.com/api
 # instead of advertising a service that would fail every request. Suspension
 # does not key off it (REQUIRE_PAYMENT_METHOD does).
 # BILLING_API_URL=https://billing.example.com/api/billing
-#   Setting it also arms usage export to that same service, since a stage with
-#   somewhere to bill has somewhere to send usage. USAGE_EXPORT_URL defaults to
+#   Setting it enables CREATE BOX admission reads against GET /plan and
+#   GET /organization/{organizationId}/plan. Those reads fail closed with 503
+#   until USAGE_EXPORT_TOKEN is set. It also arms usage export to the same
+#   service. USAGE_EXPORT_URL defaults to
 #   BILLING_API_URL's origin and rarely needs setting: the publisher appends
 #   /internal/usage-events, which the billing service serves off its bare origin
 #   because that route authenticates a service rather than a user, so the
 #   /api/billing value would 404 every batch. Override only if the two live at
 #   different origins.
 # USAGE_EXPORT_URL=https://billing.example.com
-#   [required SST secret to export] USAGE_EXPORT_TOKEN is what turns delivery on:
+#   [required SST secret for CREATE admission and export] USAGE_EXPORT_TOKEN
+#   authenticates plan reads and turns delivery on:
 #   until the stage's secret store holds one, the exporter stays off and writes no
 #   outbox rows. It must equal the string the billing service reads as
 #   USAGE_INGEST_TOKEN — for boxlite-commerce, the value its own stack keeps in

--- a/apps/infra/.env.example
+++ b/apps/infra/.env.example
@@ -244,9 +244,11 @@ OIDC_AUDIENCE=https://dev.example.com/api
 # does not key off it (REQUIRE_PAYMENT_METHOD does).
 # BILLING_API_URL=https://billing.example.com/api/billing
 #   Setting it enables CREATE BOX admission reads against GET /plan and
-#   GET /organization/{organizationId}/plan. Those reads fail closed with 503
-#   until USAGE_EXPORT_TOKEN is set. It also arms usage export to the same
-#   service. USAGE_EXPORT_URL defaults to
+#   GET /organization/{organizationId}/plan. The API validates this URL and
+#   requires USAGE_EXPORT_TOKEN at startup. A request-time transport or 5xx
+#   outage logs a warning and temporarily disables the creation limit; rejected
+#   credentials or malformed responses still return 503. It also arms usage
+#   export to the same service. USAGE_EXPORT_URL defaults to
 #   BILLING_API_URL's origin and rarely needs setting: the publisher appends
 #   /internal/usage-events, which the billing service serves off its bare origin
 #   because that route authenticates a service rather than a user, so the

--- a/apps/infra/deployment/test-workflow.test.ts
+++ b/apps/infra/deployment/test-workflow.test.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+import { load as loadYaml } from 'js-yaml'
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
+const TEST_WORKFLOW = resolve(REPO_ROOT, '.github/workflows/test.yml')
+
+test('API contract checkout preserves the fork PR secret boundary', () => {
+  const workflow: any = loadYaml(readFileSync(TEST_WORKFLOW, 'utf8'))
+  const steps: any[] = workflow.jobs.api.steps
+  const checkout = steps.find((step) => step.name === 'Checkout Commerce contract provider')
+
+  assert.ok(checkout, 'API tests no longer check out the Commerce contract provider')
+  assert.equal(checkout.id, 'commerce_checkout')
+  assert.match(String(checkout.if), /github\.event_name != 'pull_request'/)
+  assert.match(String(checkout.if), /github\.event\.pull_request\.head\.repo\.full_name == github\.repository/)
+  assert.match(String(checkout.if), /github\.actor != 'dependabot\[bot\]'/)
+  assert.equal(checkout.with.token, '${{ secrets.GH_PAT }}')
+  assert.equal(checkout.with['persist-credentials'], '${{ false }}')
+
+  const install = steps.find((step) => step.name === 'Install Commerce contract dependencies')
+  assert.equal(install.if, "steps.commerce_checkout.outcome == 'success'")
+
+  const apiTests = steps.find((step) => step.name === 'Run API unit tests')
+  assert.equal(
+    apiTests.env.BOXLITE_COMMERCE_REPOSITORY,
+    "${{ steps.commerce_checkout.outcome == 'success' && format('{0}/.contract/boxlite-commerce', github.workspace) || '' }}",
+  )
+})

--- a/apps/infra/docs/deployment.md
+++ b/apps/infra/docs/deployment.md
@@ -408,7 +408,7 @@ each stage you run.
 
 | What | Stored in | Set by |
 | --- | --- | --- |
-| App secrets (`OIDC_CLIENT_ID`, Auth0 Management API, Svix, PostHog, `USAGE_EXPORT_TOKEN`) | SST secret store | `npm run bootstrap`; others via `npm run sst -- secret set <NAME> --stage <stage>` reading stdin |
+| App secrets (`OIDC_CLIENT_ID`, Auth0 Management API, Svix, PostHog, `USAGE_EXPORT_TOKEN`) | SST secret store | `npm run bootstrap`; others via `npm run sst -- secret set <NAME> --stage <stage>` reading stdin. `USAGE_EXPORT_TOKEN` also authenticates Commerce plan reads for CREATE BOX admission |
 | SES SMTP credential (`SMTP_USER`, `SMTP_PASSWORD`) | SST secret store | `npm run bootstrap -- --stage <stage> --provision-ses`, which mints the send-only IAM user the deploy role cannot create and derives the SMTP password from its key. Rerunning rotates it |
 | Cloudflare creds (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_DEFAULT_ACCOUNT_ID`) | AWS SSM SecureString for local use; GitHub Environment secrets for CI (which win) | `npm run bootstrap` |
 | Stage config (`STACK_DOMAIN`, `OIDC_*`, toggles) | SST secret store | `npm run bootstrap`, from your local `.env` |

--- a/apps/infra/stack/api.ts
+++ b/apps/infra/stack/api.ts
@@ -333,8 +333,10 @@ export function buildApi(input: ApiInputs) {
         ...(process.env.BILLING_API_URL && {
           BILLING_API_URL: process.env.BILLING_API_URL,
 
-          // Where finalized usage periods are shipped, from the outbox in
-          // apps/api/src/usage/services/usage-export-publisher.service.ts.
+          // Shared service credential for CREATE admission reads and finalized
+          // usage export. Admission calls BILLING_API_URL's plan routes directly;
+          // the usage publisher needs a different base path on the same service.
+          //
           // The same signal and the same service as BILLING_API_URL, but
           // deliberately not the same value: the publisher appends
           // /internal/usage-events, which Commerce serves off its bare origin
@@ -345,7 +347,8 @@ export function buildApi(input: ApiInputs) {
           // pointed somewhere else.
           USAGE_EXPORT_URL: envOr('USAGE_EXPORT_URL', new URL(process.env.BILLING_API_URL).origin),
           USAGE_EXPORT_TOKEN: usageExportToken.value,
-          // Derived from the credential rather than set outright, because
+          // Export enablement is derived from the credential rather than set
+          // outright, because
           // configuration.ts refuses to boot when export is on without a
           // token: a stage pointed at a billing service but never given the
           // shared secret would crash-loop on deploy instead of simply not

--- a/openapi/box.openapi.yaml
+++ b/openapi/box.openapi.yaml
@@ -1328,7 +1328,7 @@ components:
             $ref: "#/components/schemas/ErrorResponse"
 
     ResourceExhaustedError:
-      description: The organization has reached its active Box creation limit
+      description: The organization has reached its plan's non-finalized Box limit
       content:
         application/json:
           schema:
@@ -1343,6 +1343,13 @@ components:
 
     ServiceUnavailableError:
       description: A required backend service is not configured or available
+      headers:
+        Retry-After:
+          description: Seconds to wait when Box creation admission is temporarily contended
+          schema:
+            type: integer
+            minimum: 1
+            example: 5
       content:
         application/json:
           schema:

--- a/openapi/box.openapi.yaml
+++ b/openapi/box.openapi.yaml
@@ -1334,11 +1334,12 @@ components:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
           example:
-            error:
-              message: "Organization box creation limit reached: 2 of 2 boxes are already counted"
-              type: ResourceExhaustedError
-              code: resource_exhausted
-              request_id: req_01HZK4TNRPQSXYZ8WM6NCVT9R5
+            path: /api/v1/org/boxes
+            timestamp: "2026-09-02T06:55:28.000Z"
+            statusCode: 429
+            error: Too Many Requests
+            message: "Organization box creation limit reached: 2 of 2 boxes are already counted"
+            code: resource_exhausted
 
     ServiceUnavailableError:
       description: A required backend service is not configured or available

--- a/openapi/box.openapi.yaml
+++ b/openapi/box.openapi.yaml
@@ -305,6 +305,10 @@ paths:
           $ref: "#/components/responses/ConflictError"
         "422":
           $ref: "#/components/responses/UnprocessableEntityError"
+        "429":
+          $ref: "#/components/responses/ResourceExhaustedError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailableError"
 
     get:
       operationId: listBoxes
@@ -1322,6 +1326,19 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
+
+    ResourceExhaustedError:
+      description: The organization has reached its active Box creation limit
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error:
+              message: "Organization box creation limit reached: 2 of 2 boxes are already counted"
+              type: ResourceExhaustedError
+              code: resource_exhausted
+              request_id: req_01HZK4TNRPQSXYZ8WM6NCVT9R5
 
     ServiceUnavailableError:
       description: A required backend service is not configured or available


### PR DESCRIPTION
## Call graph

```text
Before
createBox (BoxliteBoxController · apps/api/src/boxlite-rest/boxlite-box.controller.ts:112)
└─ create (BoxService · apps/api/src/box/services/box.service.ts:187)
   ├─ fresh Box → select Runner → insert (BoxRepository:77)
   │  └─ persist without organization subscription admission
   └─ warm-pool Box → select candidate → update ownership (BoxRepository:118)
      └─ persist without organization subscription admission

After
createBox (BoxliteBoxController · apps/api/src/boxlite-rest/boxlite-box.controller.ts:112)
├─ resolveMaxCreatedBoxes (CommerceBoxLimitService:52)
│  ├─ BILLING_API_URL unset → unlimited
│  ├─ inFlightResolutions → coalesce same-key work within this Node process
│  ├─ Redis GET commerce:box-limit:v1:<organizationId>
│  │  └─ hit → return shared plan resolution cached for 30 seconds
│  └─ miss → fetchMaxCreatedBoxes (CommerceBoxLimitService:135)
│     ├─ Promise.all
│     │  ├─ GET /plan
│     │  └─ GET /organization/{organizationId}/plan
│     ├─ valid matched/default plan → Redis SET EX 30 → return limit or unlimited
│     ├─ unmatched active plan, timeout, transport error, or 5xx
│     │  └─ warning → unlimited for this request → do not cache
│     └─ 4xx or malformed successful response → 503 upstream_unavailable
└─ create (..., { maxCreatedBoxes }) (BoxService:187)
   ├─ existing validation and resource preparation
   ├─ fresh Box → select Runner → insert (BoxRepository:77)
   ├─ warm-pool Box → select candidate → update ownership (BoxRepository:118)
   └─ both persistence paths → withCreationAdmission (BoxRepository:169)
      └─ PostgreSQL SERIALIZABLE transaction
         ├─ COUNT organization Boxes, excluding ERROR, DESTROYING, DESTROYED,
         │  ARCHIVING, and ARCHIVED (all UNKNOWN Boxes count)
         ├─ count >= limit → rollback → 429 resource_exhausted
         ├─ count < limit → INSERT or UPDATE plus last activity → commit
         └─ SQLSTATE 40001 → retry complete decision, at most 5 attempts
            └─ exhausted → 503 upstream_unavailable + Retry-After: 5
```

## Summary

Enforce the Commerce subscription limit on hosted CREATE BOX requests used by
Dashboard, CLI REST, and SDK REST clients. The Commerce result is resolved before
creation, while PostgreSQL remains the source of truth for the counted Box total
and makes the final concurrent admission decision.

Successful per-organization plan resolutions are shared through Redis for 30
seconds. Concurrent misses are coalesced within each Node process. Redis stores
neither Box counts nor quota reservations and is not an admission lock.

Local SDK creation, START, RECOVER, and warm-pool provisioning remain outside
this change.

Supersedes #1400

Refs boxlite-ai/boxlite-commerce#68

## Changes

- Resolve the effective limit from Commerce with parallel, two-second
  `GET /plan` and `GET /organization/{organizationId}/plan` requests using
  `BILLING_API_URL` and bearer `USAGE_EXPORT_TOKEN`.
- Validate the Commerce URL and shared token at API startup when
  `BILLING_API_URL` is configured. An unset URL preserves unlimited
  self-hosted and private-deployment behavior.
- Use the first ordered public plan for unsubscribed or suspended organizations,
  match active public plan ids, and treat `concurrencyLimit: null` as a real
  unlimited result.
- Cache successful finite and unlimited resolutions in shared Redis for 30
  seconds, and coalesce same-key work with a process-local in-flight promise.
  Redis read or write failures do not block the request.
- On a timeout, transport failure, or Commerce 5xx, log a warning and allow the
  current request without caching that fallback. Apply the same warning,
  unlimited, and no-cache behavior when an active plan id is absent from the
  public catalog, so the next request rechecks Commerce.
- Return `503 upstream_unavailable` for Commerce 4xx responses or malformed
  successful responses.
- Pass the optional limit only through hosted CREATE. For both fresh inserts and
  warm-pool ownership updates, count and persist in one PostgreSQL
  `SERIALIZABLE` transaction.
- Count the organization non-finalized Box total while excluding `ERROR`,
  `DESTROYING`, `DESTROYED`, `ARCHIVING`, and `ARCHIVED`. `UNKNOWN`, `STOPPED`,
  and every other state remain counted.
- Return `429 resource_exhausted` when `count >= limit`. Retry only SQLSTATE
  `40001` by rerunning the complete transaction up to five times; exhaustion
  returns `503 upstream_unavailable` with `Retry-After: 5`.
- Keep lookup-cache invalidation and events after commit, extend portable
  OpenAPI responses, document the Commerce contract, and exercise the current
  Commerce controllers through a cross-repository contract test.

## How to verify

- `make test:apps FILTER="creation limit|CommerceBoxLimit"`
- `make test:apps:infra`
- `make test:unit:openapi`
- `make lint:apps`
- `git diff --check`
- The API CI job provisions Redis 7 and PostgreSQL 16, checks out the current
  boxlite-commerce repository, and runs the API and cross-repository contract
  suites.

## Risks / rollout

- Deploy boxlite-ai/boxlite-commerce#68 before this change and configure matching
  `USAGE_EXPORT_TOKEN` and Commerce `USAGE_INGEST_TOKEN` values.
- A successful Commerce change can take up to 30 seconds to propagate through
  the Redis cache.
- In-flight request coalescing is process-local. Redis shares completed
  resolutions, but separate API instances may refresh the same expired key.
- Temporary Commerce transport or 5xx failures and unmatched active plan ids
  intentionally fail open for the current request and are never cached.
- `SERIALIZABLE` contention can trigger five short complete-transaction
  attempts. Persistent contention returns 503 with a five-second retry hint.
- No database migration, schema or index change, PostgreSQL advisory lock, Redis
  Box-count cache, Redis quota reservation, START or RECOVER restriction,
  Dashboard UI change, or SDK implementation change is included.
