### PR TITLE
feat(rest): name the field a rejected unknown field probably meant

### DIFF
--- a/apps/api/src/boxlite-rest/boxlite-box.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-box.controller.ts
@@ -33,6 +33,7 @@ import { BoxState } from '../box/enums/box-state.enum'
 import { BoxDesiredState } from '../box/enums/box-desired-state.enum'
 import { BoxResponseDto, ListBoxesResponseDto } from './dto/box-response.dto'
 import { CreateBoxDto } from './dto/create-box.dto'
+import { unknownFieldExceptionFactory } from './pipes/unknown-field-hint'
 import { boxToBoxResponse, createBoxToCreateBox } from './mappers/box-to-box.mapper'
 import { Audit, MASKED_AUDIT_VALUE, TypedRequest } from '../audit/decorators/audit.decorator'
 import { AuditAction } from '../audit/enums/audit-action.enum'
@@ -59,7 +60,19 @@ import { AuditTarget } from '../audit/enums/audit-target.enum'
 //
 // `whitelist` alone only strips unknown fields; `forbidNonWhitelisted` is what
 // turns a stripped field into a 400. Both are required.
-@UsePipes(new ValidationPipe({ transform: true, whitelist: true, forbidNonWhitelisted: true }))
+//
+// `exceptionFactory` only rewrites whitelist violations, adding `hint` (the
+// closest valid field at that level) and `allowed` (every valid field there).
+// Stopping the request was the security fix; naming the right field is what
+// keeps a one-letter typo from costing the caller a debugging session.
+@UsePipes(
+  new ValidationPipe({
+    transform: true,
+    whitelist: true,
+    forbidNonWhitelisted: true,
+    exceptionFactory: unknownFieldExceptionFactory(CreateBoxDto),
+  }),
+)
 @ApiBearerAuth()
 export class BoxliteBoxController {
   private readonly logger = new Logger(BoxliteBoxController.name)

--- a/apps/api/src/boxlite-rest/pipes/unknown-field-hint.spec.ts
+++ b/apps/api/src/boxlite-rest/pipes/unknown-field-hint.spec.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BadRequestException, ValidationPipe } from '@nestjs/common'
+import { CreateBoxDto } from '../dto/create-box.dto'
+import { unknownFieldExceptionFactory } from './unknown-field-hint'
+
+// This suite drives the pipe BoxliteBoxController installs, not a hand-built
+// error tree — a change that moves the decorator, relaxes `whitelist`, or routes
+// creates through a different pipe lands here rather than in production.
+const pipe = new ValidationPipe({
+  transform: true,
+  whitelist: true,
+  forbidNonWhitelisted: true,
+  exceptionFactory: unknownFieldExceptionFactory(CreateBoxDto),
+})
+const meta = { type: 'body' as const, metatype: CreateBoxDto }
+
+async function rejectionBody(payload: Record<string, unknown>): Promise<Record<string, any>> {
+  try {
+    await pipe.transform(payload, meta)
+  } catch (e) {
+    expect(e).toBeInstanceOf(BadRequestException)
+    return (e as BadRequestException).getResponse() as Record<string, any>
+  }
+  throw new Error(`expected ${JSON.stringify(payload)} to be rejected, but it was accepted`)
+}
+
+// ---------------------------------------------------------------------------
+// The contract test the original fail-open bug never had: an unknown field must
+// be rejected at EVERY level, not just the top one. #1354 turned on
+// `forbidNonWhitelisted`; nothing pinned it, so a later re-widening would have
+// silently restored "201 and a box that ignored what you asked for".
+// ---------------------------------------------------------------------------
+describe('CreateBoxDto rejects unknown fields at every level', () => {
+  it.each([
+    ['top level', { image: 'alpine:latest', totally_bogus_field: 123 }, 'totally_bogus_field'],
+    ['network', { image: 'alpine:latest', network: { outbund: { mode: 'disabled' } } }, 'network.outbund'],
+    [
+      'network.outbound',
+      { image: 'alpine:latest', network: { outbound: { mode: 'enabled', allowNet: ['example.com'] } } },
+      'network.outbound.allowNet',
+    ],
+    [
+      'network.inbound',
+      { image: 'alpine:latest', network: { inbound: { mode: 'enabled', allowNet: ['1.2.3.4'] } } },
+      'network.inbound.allowNet',
+    ],
+  ])('rejects an unknown field at %s', async (_level, payload, _expectedField) => {
+    const body = await rejectionBody(payload as Record<string, unknown>)
+
+    // Deliberately asserts only the rejection, not the message. This block
+    // pins #1354's protection; the hint/allowed payload is pinned separately
+    // below, so removing the hint feature must not make these go red.
+    expect(body.statusCode).toBe(400)
+  })
+
+  it.each([
+    ['network', { image: 'alpine:latest', network: { outbund: { mode: 'disabled' } } }, 'network.outbund'],
+    [
+      'network.outbound',
+      { image: 'alpine:latest', network: { outbound: { mode: 'enabled', allowNet: ['example.com'] } } },
+      'network.outbound.allowNet',
+    ],
+    [
+      'network.inbound',
+      { image: 'alpine:latest', network: { inbound: { mode: 'enabled', allowNet: ['1.2.3.4'] } } },
+      'network.inbound.allowNet',
+    ],
+  ])('names the offending field by its full path at %s', async (_level, payload, expectedField) => {
+    const body = await rejectionBody(payload as Record<string, unknown>)
+
+    // NestJS's default message is just `property allowNet should not exist` —
+    // it never says which level the field was written at, which is the whole
+    // problem when the same name is valid one level up or down.
+    expect(body.message).toContain(`"${expectedField}"`)
+  })
+})
+
+describe('unknown-field rejections name the field the caller meant', () => {
+  it('hints at the correct spelling for a one-letter typo', async () => {
+    const body = await rejectionBody({ image: 'alpine:latest', network: { outbund: { mode: 'disabled' } } })
+
+    expect(body.message).toBe('unknown field "network.outbund"')
+    expect(body.hint).toBe('did you mean "network.outbound"?')
+    expect(body.allowed).toEqual(expect.arrayContaining(['network.outbound', 'network.inbound']))
+  })
+
+  it('hints across nesting levels for a camelCase allow_net', async () => {
+    const body = await rejectionBody({
+      image: 'alpine:latest',
+      network: { outbound: { mode: 'enabled', allowNet: ['example.com'] } },
+    })
+
+    expect(body.hint).toBe('did you mean "network.outbound.allow_net"?')
+    expect(body.allowed).toEqual(expect.arrayContaining(['network.outbound.allow_net', 'network.outbound.mode']))
+  })
+
+  // The legacy console API really does take a top-level `public`, so callers
+  // write it by habit. Edit distance cannot find `network.inbound.mode` from
+  // `public`; the relocation table has to.
+  it('points a top-level `public` at network.inbound.mode', async () => {
+    const body = await rejectionBody({ image: 'alpine:latest', public: false })
+
+    expect(body.message).toBe('unknown field "public"')
+    expect(body.hint).toBe('did you mean "network.inbound.mode"?')
+  })
+
+  it('points a top-level allow_net at the nested outbound field', async () => {
+    const body = await rejectionBody({ image: 'alpine:latest', allow_net: ['example.com'] })
+
+    expect(body.hint).toBe('did you mean "network.outbound.allow_net"?')
+  })
+
+  // Guessing is worse than staying quiet: a wrong `hint` sends the caller to
+  // edit a field that was never the problem.
+  it('omits hint when nothing is close, but still lists allowed fields', async () => {
+    const body = await rejectionBody({ image: 'alpine:latest', totally_bogus_field: 123 })
+
+    expect(body.message).toBe('unknown field "totally_bogus_field"')
+    expect(body.hint).toBeUndefined()
+    expect(body.allowed).toEqual(expect.arrayContaining(['image', 'name']))
+  })
+
+  it('reports every unknown field, not just the first', async () => {
+    const body = await rejectionBody({ image: 'alpine:latest', totally_bogus_field: 1, another_bogus: 2 })
+
+    expect(body.message).toContain('"totally_bogus_field"')
+    expect(body.message).toContain('"another_bogus"')
+    expect(body.message).toContain('unknown fields')
+  })
+})
+
+// An ordinary constraint failure must keep NestJS's default array-of-strings
+// shape. Rewriting it too would break every client and test that reads
+// `message` as a list.
+describe('non-whitelist validation failures keep the default shape', () => {
+  it('leaves a bad enum value alone', async () => {
+    const body = await rejectionBody({ image: 'alpine:latest', network: { outbound: { mode: 'sideways' } } })
+
+    expect(Array.isArray(body.message)).toBe(true)
+    expect(body.hint).toBeUndefined()
+    expect(body.allowed).toBeUndefined()
+  })
+})
+
+// Valid payloads must be untouched by the factory — it only runs on rejection,
+// but a regression that made it throw on success would be invisible above.
+describe('valid payloads still pass', () => {
+  it('accepts the nested network shape', async () => {
+    const dto: CreateBoxDto = await pipe.transform(
+      { image: 'alpine:latest', network: { outbound: { mode: 'disabled' }, inbound: { mode: 'disabled' } } },
+      meta,
+    )
+
+    expect(dto.network?.outbound?.mode).toBe('disabled')
+    expect(dto.network?.inbound?.mode).toBe('disabled')
+  })
+})

--- a/apps/api/src/boxlite-rest/pipes/unknown-field-hint.ts
+++ b/apps/api/src/boxlite-rest/pipes/unknown-field-hint.ts
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BadRequestException, ValidationError } from '@nestjs/common'
+import { getMetadataStorage } from 'class-validator'
+
+/**
+ * Turn `forbidNonWhitelisted`'s 400 into one that names the field the caller
+ * probably meant.
+ *
+ * `whitelist` + `forbidNonWhitelisted` (see `BoxliteBoxController`) already stop
+ * an unknown field from being silently stripped, which is what closed the
+ * fail-open hole where a misspelled `network.outbund` returned 201 and booted a
+ * box with no egress policy. What they do not do is say what the right spelling
+ * was: class-validator's own message is `property outbund should not exist`.
+ *
+ * For a one-letter difference, or a field written at the wrong nesting level,
+ * that leaves the caller to diff the payload against the spec by eye. This
+ * factory adds two fields to the response:
+ *
+ * - `hint`   — the closest valid field at that level, when one is close enough
+ * - `allowed` — every valid field at that level, always
+ *
+ * Only whitelist violations are rewritten. Ordinary constraint failures keep
+ * NestJS's default shape so existing clients and tests are unaffected.
+ */
+
+/** class-validator's constraint key for a `forbidNonWhitelisted` violation. */
+const WHITELIST_CONSTRAINT = 'whitelistValidation'
+
+/**
+ * Fields callers reach for that live somewhere else entirely, where edit
+ * distance cannot help.
+ *
+ * `public` is the load-bearing entry: the legacy console API really does take a
+ * top-level `public` boolean, so a developer moving to boxlite-rest writes it by
+ * habit. Before strict validation that silently left the box anonymously
+ * reachable; now it 400s, and this points at the field that actually controls
+ * inbound reachability.
+ */
+const RELOCATED_FIELDS: Record<string, Record<string, string>> = {
+  '': {
+    public: 'network.inbound.mode',
+    allow_net: 'network.outbound.allow_net',
+    networkAllowList: 'network.outbound.allow_net',
+    networkBlockAll: 'network.outbound.mode',
+  },
+}
+
+/**
+ * Longest edit distance still treated as a typo rather than a different word.
+ * Scales with the name so `mode` cannot match `user` (distance 4 on a 4-char
+ * name) while `outbund` still matches `outbound`.
+ */
+function typoBudget(name: string): number {
+  return Math.max(1, Math.floor(name.length * 0.34))
+}
+
+/** Levenshtein distance. Iterative single-row; inputs here are field names. */
+function editDistance(a: string, b: string): number {
+  if (a === b) return 0
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i)
+  for (let i = 1; i <= a.length; i++) {
+    const row = [i]
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1
+      row[j] = Math.min(row[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost)
+    }
+    prev = row
+  }
+  return prev[b.length]
+}
+
+/**
+ * Every property class-validator validates on `target`.
+ *
+ * This is the same metadata `whitelist` consults to decide what to strip, so
+ * `allowed` cannot drift from what the pipe actually accepts — a new field with
+ * a decorator shows up here automatically, and one without a decorator is
+ * genuinely not accepted.
+ */
+function validatedProperties(target: Function): string[] {
+  const metadatas = getMetadataStorage().getTargetValidationMetadatas(target, target.name, false, false)
+  return [...new Set(metadatas.map((m) => m.propertyName))].filter(Boolean).sort()
+}
+
+const PRIMITIVES: unknown[] = [Object, Array, String, Number, Boolean, Date]
+
+/**
+ * The DTO class a nested property holds, from `emitDecoratorMetadata`'s
+ * `design:type`. Returns undefined for primitives and for containers, which
+ * have no field list of their own to report.
+ */
+function nestedTarget(target: Function, property: string): Function | undefined {
+  const declared: unknown = Reflect.getMetadata?.('design:type', target.prototype, property)
+  if (typeof declared !== 'function' || PRIMITIVES.includes(declared)) return undefined
+  return declared as Function
+}
+
+/** Walk a dotted path from the root DTO, returning the class that owns its last segment. */
+function resolveTarget(root: Function, path: string[]): Function | undefined {
+  let current: Function | undefined = root
+  for (const segment of path) {
+    if (!current) return undefined
+    current = nestedTarget(current, segment)
+  }
+  return current
+}
+
+interface UnknownField {
+  /** Dotted path of the offending field, e.g. `network.outbund`. */
+  field: string
+  /** Dotted paths of the fields valid at that level. */
+  allowed: string[]
+  /** Dotted path of the field the caller probably meant, when one is close enough. */
+  hint?: string
+}
+
+function dotted(prefix: string[], name: string): string {
+  return [...prefix, name].join('.')
+}
+
+/**
+ * Collect whitelist violations across the error tree, resolving each one's
+ * level against the DTO so `allowed`/`hint` describe the level the caller wrote
+ * at rather than the root.
+ */
+function collectUnknownFields(errors: ValidationError[], root: Function, prefix: string[] = []): UnknownField[] {
+  const found: UnknownField[] = []
+
+  for (const error of errors) {
+    if (error.constraints?.[WHITELIST_CONSTRAINT]) {
+      const owner = resolveTarget(root, prefix)
+      const allowed = owner ? validatedProperties(owner) : []
+      const relocated = RELOCATED_FIELDS[prefix.join('.')]?.[error.property]
+      const nearest = relocated ? undefined : nearestField(error.property, allowed)
+
+      found.push({
+        field: dotted(prefix, error.property),
+        allowed: allowed.map((name) => dotted(prefix, name)),
+        hint: relocated ?? (nearest ? dotted(prefix, nearest) : undefined),
+      })
+      continue
+    }
+
+    if (error.children?.length) {
+      found.push(...collectUnknownFields(error.children, root, [...prefix, error.property]))
+    }
+  }
+
+  return found
+}
+
+/** Closest candidate within the typo budget, or undefined when nothing is close. */
+function nearestField(property: string, candidates: string[]): string | undefined {
+  const budget = typoBudget(property)
+  let best: { name: string; distance: number } | undefined
+
+  for (const candidate of candidates) {
+    const distance = editDistance(property.toLowerCase(), candidate.toLowerCase())
+    if (distance > budget) continue
+    if (!best || distance < best.distance) best = { name: candidate, distance }
+  }
+
+  return best?.name
+}
+
+/**
+ * `exceptionFactory` for a `forbidNonWhitelisted` pipe.
+ *
+ * Pass the DTO class so nested levels can be resolved; NestJS does not hand the
+ * metatype to `exceptionFactory`.
+ */
+export function unknownFieldExceptionFactory(root: Function) {
+  return (errors: ValidationError[]): BadRequestException => {
+    const unknown = collectUnknownFields(errors, root)
+
+    // Not an unknown-field rejection — keep NestJS's default shape.
+    if (unknown.length === 0) return new BadRequestException(flattenMessages(errors))
+
+    const fields = unknown.map((u) => `"${u.field}"`).join(', ')
+    const hints = unknown.filter((u) => u.hint)
+
+    return new BadRequestException({
+      statusCode: 400,
+      error: 'Bad Request',
+      message: `unknown field${unknown.length > 1 ? 's' : ''} ${fields}`,
+      ...(hints.length > 0 && {
+        hint: hints.map((u) => `did you mean "${u.hint}"?`).join(' '),
+      }),
+      allowed: [...new Set(unknown.flatMap((u) => u.allowed))],
+    })
+  }
+}
+
+/** NestJS's own default: the flattened constraint messages. */
+function flattenMessages(errors: ValidationError[]): string[] {
+  return errors.flatMap((error) => [
+    ...Object.values(error.constraints ?? {}),
+    ...flattenMessages(error.children ?? []),
+  ])
+}


### PR DESCRIPTION
#1354 turned on `whitelist` + `forbidNonWhitelisted`, so a misspelled network-policy field now 400s instead of being stripped and forgotten — that closed the fail-open hole where `network.outbund` returned 201 and booted a box with no egress policy.

What it left is the message: class-validator's default is `property outbund should not exist`. It stops the request without saying what the right spelling was, or which nesting level the field belonged at.

## Before/after

```
Before
BoxliteBoxController   @UsePipes(ValidationPipe{transform, whitelist, forbidNonWhitelisted})
  └─ class-validator → ValidationError{property:"outbund", constraints:{whitelistValidation}}
       └─ NestJS default exceptionFactory
            └─ 400 {message:["property outbund should not exist"]}
               ← BUG: never names the valid field, never names the level;
                 a one-letter typo costs the caller a spec diff by eye

After
BoxliteBoxController   @UsePipes(ValidationPipe{..., exceptionFactory})
  └─ unknownFieldExceptionFactory(CreateBoxDto)     (boxlite-rest/pipes/unknown-field-hint.ts, 210 LOC)
       ├─ collectUnknownFields()    walks the error tree, builds the dotted path
       ├─ resolveTarget()           descends CreateBoxDto by design:type to that level's DTO
       ├─ validatedProperties()     that level's valid fields, from class-validator metadata
       └─ nearestField()            edit distance within a length-scaled budget
            └─ 400 {message:'unknown field "network.outbund"',
                    hint:'did you mean "network.outbound"?',
                    allowed:["network.outbound","network.inbound"]}
```

## Notes on the two halves

`allowed` reads the same class-validator metadata `whitelist` consults to decide what to strip, so it cannot drift from what the pipe actually accepts: a new decorated field appears automatically, and an undecorated one is genuinely not accepted.

`hint` is edit distance with a budget that scales with the name — `mode` cannot match `user` (distance 4 on a 4-char name) while `outbund` still matches `outbound` — plus a relocation table for fields that live somewhere else entirely, where edit distance cannot help:

| written | hint |
| -- | -- |
| `public` | `network.inbound.mode` |
| `allow_net` (top level) | `network.outbound.allow_net` |
| `networkAllowList` | `network.outbound.allow_net` |
| `networkBlockAll` | `network.outbound.mode` |

`public` is the load-bearing entry: the legacy console API really does take a top-level `public` boolean, so callers moving to boxlite-rest write it by habit. When nothing is close enough, `hint` is omitted rather than guessed — a wrong hint sends the caller to edit a field that was never the problem.

Non-whitelist failures keep NestJS's default array-of-strings `message`, so clients and tests that read it as a list are unaffected.

## Test plan

`apps/api/src/boxlite-rest/pipes/unknown-field-hint.spec.ts` — 15 cases, driving the pipe configuration `BoxliteBoxController` installs rather than a hand-built error tree, so moving the decorator or relaxing `whitelist` lands here instead of in production.

- Contract cases #1354 never had: an unknown field injected at **each** level of `CreateBoxRequest` (top level, `network`, `network.outbound`, `network.inbound`) must 400. These assert only the rejection — removing the hint feature must not make them red.
- Naming cases: the 400 names the offending field by its full dotted path at each nested level.
- Hint cases: one-letter typo, camelCase `allowNet` across a nesting level, top-level `public`, top-level `allow_net`, nothing-close (hint omitted, `allowed` still present), and multiple unknown fields in one body.
- Shape case: a bad enum value keeps the default array-of-strings `message` with no `hint`/`allowed`.

**Two-sided verification** — dropping `exceptionFactory` from the pipe config (a full revert of the production wiring): **9 failed, 6 passed**. The 4 contract cases and the 2 default-shape/valid-payload cases stay green, which is the point: the two groups pin different things.

- `nx test api --testPathPatterns=boxlite-rest` — 10 suites, 142 tests, all green (including the existing `boxlite-box.controller.spec.ts`, so the pipe change does not disturb the controller contract).
- `nx lint api` clean; `prettier --check` clean on touched files.

Not run: the full `make test:apps` matrix (infra typecheck + Go). Scoped to the narrowest relevant target per AGENTS.md.

## Not in scope

- The global `ValidationPipe` in `main.ts` is untouched. #1354 deliberately scoped strictness to this controller because the global pipe also serves dashboard, admin, runner-callback and webhook routes; that decision stands.
- The duplicated path segment in `network.inbound.inbound.allow_net` messages is POL-356.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved validation errors for unknown or misspelled fields.
  * Error responses now identify the invalid field, list allowed fields, and suggest likely corrections.
  * Added guidance for legacy fields that have moved to nested locations.
* **Bug Fixes**
  * Validation now provides clearer, more consistent feedback across nested request fields while preserving existing validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->