### PR TITLE
feat(cli): add secret substitution flags for MITM (#1238)

### DIFF
--- a/docs/investigations/cli-secrets-mitm-flag.md
+++ b/docs/investigations/cli-secrets-mitm-flag.md
@@ -1,0 +1,271 @@
+# CLI secrets MITM flag (issue #1238)
+
+**Date:** 2026-08-31
+**Status:** Implemented (verified end-to-end, see §4 verification log)
+**Tracks:** https://github.com/boxlite-ai/boxlite/issues/1238
+
+---
+
+## Problem
+
+`boxlite run` / `boxlite create` have no CLI way to configure secret
+substitution ("secrets MITM"). The runtime pipeline is complete: a secret
+configured on `BoxOptions.secrets` reaches the in-shim gvproxy MITM proxy in
+both local and REST modes. Only the argv → `BoxOptions.secrets` segment is
+missing.
+
+Issue text: "Add a flag to do secret substitute in the boxlite cli".
+
+## Current pipeline (verified, no changes needed)
+
+```
+CLI --secret (missing — the only gap)
+   ▼
+BoxOptions.secrets                        runtime/options.rs:442
+   ├── local mode: LocalRuntime::create   runtime/rt_impl.rs:1790
+   │    └── build_network_backend         litebox/init/tasks/vmm_spawn.rs:347-363
+   │         (secrets: options.secrets.clone() → NetworkBackendConfig)
+   └── REST mode: RestRuntime::create     rest/runtime.rs:199
+        └── CreateBoxRequest::from_options  rest/types.rs:157-160 (secrets mapped)
+        └── POST /boxes → serve build_box_options  cli/src/commands/serve/mod.rs:819-846
+             (parses + defaults placeholder; rejects empty name/value :804-812)
+   ▼
+NetworkBackendSpec.secrets (+ CA PEM)     net/mod.rs:79-94 (minted by spec(), gvproxy/services.rs:346-359)
+   ▼
+InstanceSpec.network_backend_spec         vmm/mod.rs:254 (assembled vmm_spawn.rs:234)
+   ▼
+config_json → stdin → boxlite-shim       shim/src/main.rs:84
+   ▼
+GvproxyInstance → GvproxyConfig → Go MITM  (shim built with features=["gvproxy","krun"], src/shim/Cargo.toml:15)
+```
+
+Notes:
+
+- `sanitize_remote` does NOT reject secrets (rest/runtime.rs:103-138).
+- `sanitize_local_options` does NOT validate secrets (runtime/rt_impl.rs:1769).
+- The CLI crate depends on `boxlite = { features = ["rest"] }`
+  (src/cli/Cargo.toml:18) — sufficient; the Go engine lives in the shim binary.
+
+## Design
+
+### Flags
+
+```rust
+#[derive(Args, Debug, Clone)]
+pub struct SecretFlags {
+    /// Secret for MITM substitution: NAME=VALUE (repeatable).
+    /// Hosts default to none; pair with --secret-host.
+    #[arg(long = "secret", value_name = "NAME=VALUE")]
+    pub secrets: Vec<String>,
+
+    /// Read a secret's value from an environment variable (repeatable):
+    /// NAME=ENV_VAR. The value never appears on argv, in shell history,
+    /// or in CI command logs.
+    #[arg(long = "secret-from-env", value_name = "NAME=ENV_VAR")]
+    pub secret_env: Vec<String>,
+
+    /// Host where a secret applies: NAME=HOST (repeatable; "*.example.com"
+    /// wildcards match one subdomain level).
+    #[arg(long = "secret-host", value_name = "NAME=HOST")]
+    pub hosts: Vec<String>,
+}
+```
+
+### `apply_to` semantics (on `BoxOptions`)
+
+For each `--secret NAME=VALUE` and `--secret-from-env NAME=ENV_VAR`:
+
+1. **Parse** `NAME=VALUE` (split_once `=`; missing `=` or empty NAME/VALUE →
+   error, matching serve's validation at serve/mod.rs:804-812).
+2. **Env source**: read `ENV_VAR` from `std::env::var`; missing → error naming
+   the variable (fail fast, no silent empty value).
+3. **Default the placeholder** to `<BOXLITE_SECRET:{name}>` when the flag
+   syntax cannot express one. This is load-bearing: the local runtime does NOT
+   synthesize a default placeholder (serve/mod.rs:814-818 — "the local runtime
+   does not synthesize... for an empty placeholder"), so a placeholder-less
+   secret would inject an empty env var and no MITM substitution (POL-303
+   failure class). Defaulting in the CLI makes local and REST modes behave
+   identically.
+4. **Attach hosts**: each `--secret-host NAME=HOST` pairs with the secret of
+   the same NAME (match serve's `SecretSpecRequest` shape: name/value/hosts/
+   placeholder). Secrets with no matching host rule get empty `hosts` —
+   gvproxy's `SecretHostMatcher` then never matches them, so they are inert;
+   the CLI should warn or error on a secret that has no host rule. Decision:
+   **error** (a secret with no host is always a mistake).
+5. Push `Secret { name, value, hosts, placeholder }` onto `opts.secrets`.
+
+### Wiring
+
+- `RunArgs`: `#[command(flatten)] secret: SecretFlags`; `create_box()` calls
+  `self.args.secret.apply_to(&mut options)?` (run.rs:88-117).
+- `CreateArgs`: same flatten; `to_box_options()` calls apply (create.rs:69-107).
+- No changes to boxlite library, shim, gvproxy, serve, CA, or runtime.
+
+### Key decisions
+
+| Decision                      | Choice                                                                             | Rationale                                                                                                                                                                                                              |
+|-------------------------------|------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Env over stdin                | `--secret-from-env`, not `--secret-stdin`                                          | `run`'s stdin belongs to the guest (`--interactive`/`--tty`); reading secrets from it needs a fragile split protocol and breaks terminal echo semantics. Env vars don't enter argv, shell history, or CI command logs. |
+| argv exposure                 | `--secret NAME=VALUE` kept for interactive use; `--secret-from-env` for scripts/CI | Repo precedent: `auth login --api-key-stdin` — "the secret never appears on argv" (src/cli/src/commands/auth/login.rs:35-38).                                                                                          |
+| Placeholder defaulting in CLI | Yes, `<BOXLITE_SECRET:{name}>`                                                     | Local mode has no serve-side default; without it, silent empty-env failure (POL-303 class).                                                                                                                            |
+| Host-less secret              | Error                                                                              | Always a mistake; matches serve's strictness.                                                                                                                                                                          |
+| Repeatable flags              | `Vec<String>` per flag                                                             | Matches `--allow-net`/`--env` conventions.                                                                                                                                                                             |
+
+## Test plan
+
+### 1. Unit — CLI parsing (src/cli/src/commands/run.rs / create.rs tests)
+
+Follow the existing `run_capability_flags_are_repeatable` /
+`create_capability_flags_reach_box_options` pattern (cli::try_parse_from):
+
+| Case             | Input                                                           | Assert                                                                                               |
+|------------------|-----------------------------------------------------------------|------------------------------------------------------------------------------------------------------|
+| direct value     | `--secret openai=sk-123`                                        | `opts.secrets[0] = {name:"openai", value:"sk-123", hosts:[], placeholder:"<BOXLITE_SECRET:openai>"}` |
+| repeatable       | `--secret a=1 --secret b=2`                                     | two secrets, order preserved                                                                         |
+| env source       | `--secret-from-env openai=OPENAI_KEY` (env `OPENAI_KEY=sk-env`) | value `sk-env`, placeholder defaulted                                                                |
+| env missing      | `--secret-from-env openai=NOPE` (unset)                         | error naming `NOPE`                                                                                  |
+| malformed        | `--secret openai` / `--secret =v` / `--secret n=`               | error                                                                                                |
+| host pairing     | `--secret openai=sk --secret-host openai=api.openai.com`        | hosts `["api.openai.com"]`; repeated `--secret-host` accumulates                                     |
+| host-less secret | `--secret openai=sk` with no `--secret-host`                    | error                                                                                                |
+| no flags         | no secret flags                                                 | `opts.secrets` untouched (empty)                                                                     |
+| empty-name host  | `--secret-host =h`                                              | error                                                                                                |
+
+### 2. Unit — `apply_to` (same modules)
+
+- Placeholder default is `<BOXLITE_SECRET:{name}>` for names needing
+  sanitization (`my-key` → env key `BOXLITE_SECRET_MY_KEY` per
+  `Secret::env_key`, runtime/options.rs:471-488).
+- Env read is pure: factor the env lookup behind a parameter so tests do not
+  touch process env (or use serial tests with `temp_env`-style guard — check
+  repo convention first).
+
+### 3. Integration — wire (already covered, no new tests)
+
+- `build_box_options_carries_secrets_from_the_wire` (serve/mod.rs:1429)
+  covers REST parsing; CLI→`BoxOptions`→`CreateBoxRequest::from_options`
+  serialization is covered by `test_create_box_request_serialization`
+  (rest/types.rs:704).
+
+### 4. End-to-end (manual, both modes)
+
+Prerequisites: `make runtime:debug` (host mke2fs/debugfs), `make guest`
+(guest artifacts incl. guest-mke2fs/resize2fs), gvproxy feature built.
+
+**Local mode** (no `--url`):
+
+```bash
+boxlite run --rm \
+  --secret openai=sk-test-123 \
+  --secret-from-env anthropic=ANTHROPIC_KEY \
+  --secret-host openai=api.openai.com \
+  --secret-host anthropic=api.anthropic.com \
+  alpine sh -c 'echo $BOXLITE_SECRET_OPENAI; echo $BOXLITE_SECRET_ANTHROPIC'
+```
+
+**MITM replacement (the actual substitution):** the placeholder-inject
+check alone does NOT prove gvproxy swapped the value — it only proves the
+env reached the guest. To observe the substitution at the upstream side, use
+a public request-echo service that echoes request headers (real certificate,
+so gvproxy's upstream TLS verification against the system CA pool passes;
+the guest trusts gvproxy's ephemeral CA via the `CACert` proto field —
+vmm_spawn.rs:110-114):
+
+```bash
+boxlite run --rm \
+  --secret openai=sk-test-123 \
+  --secret-host openai=httpbin.org \
+  alpine sh -c 'wget -qO- --header="Authorization: $BOXLITE_SECRET_OPENAI" https://httpbin.org/headers'
+```
+
+Expected: the echoed `Authorization` header shows the REAL value
+(`sk-test-123`), proving guest→(placeholder)→gvproxy→(substitution)→upstream.
+Alternatives to httpbin.org: postman-echo.com/headers (same shape).
+
+**REST mode** (`--url` to a local `boxlite serve`):
+
+Start the server first — `boxlite serve` binds `0.0.0.0:8100` by default
+(`LOCAL_SERVE_HOST`/`LOCAL_SERVE_PORT`, defaults.rs:7,10; `--host`/`--port`
+override) and holds an embedded `LocalRuntime` in `AppState`
+(serve/mod.rs:1302-1321): the process is an axum HTTP front-end over the same
+runtime the local mode uses, so the downstream path (env inject → CA → shim →
+gvproxy) is identical. No API key by default; `--api-key` enables the
+`require_api_key` middleware.
+
+```bash
+boxlite serve &
+# 1. Placeholder inject (wire round-trip + serve parsing)
+boxlite --url http://127.0.0.1:8100 run \
+  --secret openai=sk-test-123 --secret-host openai=api.openai.com \
+  alpine sh -c 'echo $BOXLITE_SECRET_OPENAI'
+
+# 2. Full MITM replacement (same httpbin.org echo as local mode)
+boxlite --url http://127.0.0.1:8100 run --rm \
+  --secret openai=sk-rest-123 --secret-host openai=httpbin.org \
+  alpine sh -c 'wget -qO- --header="Authorization: $BOXLITE_SECRET_OPENAI" https://httpbin.org/headers'
+```
+
+Verify:
+- Check 1: guest prints `<BOXLITE_SECRET:openai>` — the secrets survived
+  `CreateBoxRequest::from_options` (rest/types.rs:157-160) → POST /boxes →
+  `build_box_options` (serve/mod.rs:819-846) and reached the runtime.
+- Check 2: httpbin echoes `"Authorization": "sk-rest-123"` — substitution
+  happens on the REST path too, proving serve parsed the secrets and handed
+  the real values to its embedded runtime.
+
+### 5. Security check
+
+- `ps aux | grep boxlite` while a `--secret-from-env` run is active: value
+  must NOT appear; with `--secret NAME=VALUE` it will — documented in
+  `docs/reference/cli/README.md`.
+- `BOX` secret value must never appear in `config_json` logs (the shim's
+  TRACE event strips secrets — controller/shim.rs:221-227) or in
+  `InstanceSpec` Debug output.
+
+### 6. Docs
+
+- `docs/reference/cli/README.md`: add `--secret`, `--secret-from-env`,
+  `--secret-host` rows; note the argv exposure caveat and the env alternative.
+
+## Verification log (2026-08-31, executed)
+
+All checks ran against `target/debug/boxlite` (embedded runtime, debug build)
+with `alpine:latest`.
+
+| # | Check                           | Command (abridged)                                                                                                                                                                                                             | Result                                                                                    |
+|---|---------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
+| 1 | Unit tests                      | `cargo test -p boxlite-cli --bin boxlite`                                                                                                                                                                                      | 206/206 pass (11 new: 9 flag unit + run/create wiring)                                    |
+| 2 | Lint/format                     | `cargo clippy -p boxlite-cli --bin boxlite`, `cargo fmt -p boxlite-cli`                                                                                                                                                        | clean                                                                                     |
+| 3 | Help surface                    | `boxlite run --help`                                                                                                                                                                                                           | `--secret`, `--secret-from-env`, `--secret-host` listed                                   |
+| 4 | Local mode: placeholder inject  | `boxlite run --secret openai=sk-test-123 --secret-host openai=api.openai.com alpine sh -c 'echo $BOXLITE_SECRET_OPENAI'`                                                                                                       | guest prints `<BOXLITE_SECRET:openai>`; real value never enters VM                        |
+| 5 | CA mint                         | same + `-d`, then `find ~/.boxlite/boxes/<id>/ca/`                                                                                                                                                                             | `cert.pem` 0644, `key.pem` 0600                                                           |
+| 6 | **MITM replacement**            | `boxlite run --secret openai=sk-test-123 --secret-host openai=httpbin.org alpine sh -c 'wget -qO- --header="Authorization: $BOXLITE_SECRET_OPENAI" https://httpbin.org/headers'`                                               | httpbin echoes `"Authorization": "sk-test-123"` — placeholder substituted at the boundary |
+| 7 | REST mode: placeholder inject   | `boxlite serve` + `boxlite --url http://localhost:8100 run --secret openai=sk-rest-456 --secret-host openai=api.openai.com alpine sh -c 'echo $BOXLITE_SECRET_OPENAI'`                                                         | guest prints `<BOXLITE_SECRET:openai>` (placeholder), value absent                        |
+| 8 | **REST mode: MITM replacement** | `boxlite serve` + `boxlite --url http://localhost:8100 run --secret openai=sk-rest-123 --secret-host openai=httpbin.org alpine sh -c 'wget -qO- --header="Authorization: $BOXLITE_SECRET_OPENAI" https://httpbin.org/headers'` | httpbin echoes `"Authorization": "sk-rest-123"` — substituted on the REST path            |
+
+Checks 6 and 8 close the loop the placeholder-inject checks (4, 7) leave
+open: each observes the substituted value at the upstream side (httpbin echo),
+proving gvproxy — not the guest — performed the replacement, on the local
+path (6) and the REST path (8) alike. Both also prove the guest trusts the
+ephemeral MITM CA (TLS handshake succeeds) and that gvproxy's upstream TLS
+verification passes against a real certificate (httpbin.org's LE cert vs the
+system CA pool). Body substitution (the `streamingReplacer` path) is covered
+by Go-side unit tests (`gvproxy-bridge/mitm_replacer_test.go`), not by this
+log.
+
+## Implementation checklist
+
+- [x] `SecretFlags` in src/cli/src/cli.rs (parse + validate + default + pair hosts)
+- [x] flatten into `RunArgs` / `CreateArgs`; `apply_to` in both command paths
+- [x] unit tests per table above (parse, defaulting, validation, pairing)
+- [x] `docs/reference/cli/README.md` flag rows
+- [x] e2e verify local mode (env placeholder + CA + MITM replacement)
+- [x] e2e verify REST mode (`--url` to serve)
+- [ ] commit through the agent-tooling gates (lint-fix + commit-push-auditor)
+
+## Open items
+
+- `--secret-stdin` (detach-only) as a follow-up; explicitly rejected for
+  interactive mode.
+- Whether placeholder should be expressible per-secret (e.g. `NAME=VALUE@PLACEHOLDER`)
+  — currently not; serve-side defaulting and env-key sanitization cover the
+  documented cases.

--- a/docs/reference/cli/README.md
+++ b/docs/reference/cli/README.md
@@ -252,6 +252,9 @@ takes the command's exit code; `boxlite ps` shows it stopped and
 | Flag | Short | Description |
 |------|-------|-------------|
 | `--rootfs PATH` | — | Use a prepared rootfs path instead of pulling/resolving an image |
+| `--secret NAME=VALUE` | — | Outbound HTTP(S) secret substitution rule (repeatable). The real value never enters the VM: the guest sees only the `<BOXLITE_SECRET:NAME>` placeholder (also injected as `BOXLITE_SECRET_<NAME>`), and the network proxy swaps it for the value on the configured hosts. The value is visible on argv — scripts and CI should use `--secret-from-env` instead |
+| `--secret-from-env NAME=ENV_VAR` | — | Same as `--secret`, but read the value from the host environment variable `ENV_VAR` so it never appears on argv, shell history, or CI command logs (repeatable) |
+| `--secret-host NAME=HOST` | — | Host where a secret applies (repeatable): exact host or `*.example.com` wildcard (matches one subdomain level). Every secret needs at least one host rule |
 
 **Exit behavior:**
 
@@ -269,6 +272,8 @@ boxlite run -v $(pwd):/work -w /work alpine:latest ls -la
 boxlite run --cpus 4 --memory 4096 python:slim python -c "print(2+2)"
 boxlite run --cap-add SYS_ADMIN --cap-drop NET_RAW alpine:latest sh
 boxlite run --rootfs /path/to/rootfs /bin/sh
+boxlite run --secret openai=sk-... --secret-host openai=api.openai.com alpine:latest my-app
+OPENAI_KEY=sk-... boxlite run --secret-from-env openai=OPENAI_KEY --secret-host openai=api.openai.com alpine:latest my-app
 ```
 
 ---
@@ -320,6 +325,9 @@ implicitly, because starting it runs that command. Start it deliberately with
 | Flag | Short | Description |
 |------|-------|-------------|
 | `--rootfs PATH` | — | Use a prepared rootfs path instead of pulling/resolving an image |
+| `--secret NAME=VALUE` | — | Outbound HTTP(S) secret substitution rule (repeatable). The real value never enters the VM: the guest sees only the `<BOXLITE_SECRET:NAME>` placeholder (also injected as `BOXLITE_SECRET_<NAME>`), and the network proxy swaps it for the value on the configured hosts. The value is visible on argv — scripts and CI should use `--secret-from-env` instead |
+| `--secret-from-env NAME=ENV_VAR` | — | Same as `--secret`, but read the value from the host environment variable `ENV_VAR` so it never appears on argv, shell history, or CI command logs (repeatable) |
+| `--secret-host NAME=HOST` | — | Host where a secret applies (repeatable): exact host or `*.example.com` wildcard (matches one subdomain level). Every secret needs at least one host rule |
 | `--env KEY=VALUE` | `-e` | Set environment variables (repeatable) |
 | `--workdir PATH` | `-w` | Working directory inside the box |
 
@@ -334,6 +342,7 @@ boxlite create --name mybox alpine:latest
 boxlite create -p 8080:80 -v /data:/app/data --name web nginx:alpine
 boxlite create --cap-drop ALL --cap-add NET_BIND_SERVICE --name web nginx:alpine
 boxlite create --rootfs /path/to/rootfs --name local-rootfs
+boxlite create --secret openai=sk-... --secret-host openai=api.openai.com --name job alpine:latest my-app
 ```
 
 ---

--- a/src/cli/src/cli.rs
+++ b/src/cli/src/cli.rs
@@ -11,10 +11,11 @@ use boxlite::runtime::options::{
 };
 use boxlite::{
     BoxCommand, BoxOptions, BoxliteOptions, BoxliteRestOptions, BoxliteRuntime,
-    ContainerCapabilities, ImageRegistry, NetworkSpec,
+    ContainerCapabilities, ImageRegistry, NetworkSpec, Secret,
 };
 use clap::{Args, Command, Parser, Subcommand, ValueEnum};
 use clap_complete::shells::{Bash, Fish, Zsh};
+use std::collections::HashMap;
 use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
 
@@ -682,6 +683,133 @@ impl NetworkFlags {
 }
 
 // ============================================================================
+// SECRET FLAGS (MITM substitution)
+// ============================================================================
+
+/// Secrets for outbound HTTP(S) MITM substitution. The real value never
+/// enters the guest VM: the guest sees only the `<BOXLITE_SECRET:{name}>`
+/// placeholder (injected as `BOXLITE_SECRET_<NAME>`), and gvproxy swaps it
+/// for the real value at the network boundary.
+#[derive(Args, Debug, Clone, Default)]
+pub struct SecretFlags {
+    /// Secret for MITM substitution: NAME=VALUE (repeatable). Injects the
+    /// env var BOXLITE_SECRET_<NAME> into the guest holding the placeholder
+    /// <BOXLITE_SECRET:<NAME>>; the network proxy swaps that placeholder for
+    /// VALUE on the hosts given by --secret-host, so the real value never
+    /// enters the VM. The value is visible on argv — scripts and CI should
+    /// use `--secret-from-env` instead.
+    #[arg(long = "secret", value_name = "NAME=VALUE")]
+    pub secrets: Vec<String>,
+
+    /// Same as --secret (same guest env var BOXLITE_SECRET_<NAME> and
+    /// placeholder <BOXLITE_SECRET:<NAME>>), but the value is read from the
+    /// host environment variable ENV_VAR, so it never appears on argv, shell
+    /// history, or CI command logs. Repeatable.
+    #[arg(long = "secret-from-env", value_name = "NAME=ENV_VAR")]
+    pub secret_env: Vec<String>,
+
+    /// Host where a secret applies: NAME=HOST (repeatable). Patterns: exact
+    /// host or "*.example.com" (matches one subdomain level). A secret with no
+    /// host rule is rejected.
+    #[arg(long = "secret-host", value_name = "NAME=HOST")]
+    pub hosts: Vec<String>,
+}
+
+impl SecretFlags {
+    /// Apply secret flags to `opts.secrets`.
+    pub fn apply_to(&self, opts: &mut BoxOptions) -> anyhow::Result<()> {
+        self.apply_to_with_lookup(opts, |k| std::env::var(k).ok())
+    }
+
+    /// Dependency-injected env lookup for tests (mirrors [`ProcessFlags`]).
+    fn apply_to_with_lookup<F>(&self, opts: &mut BoxOptions, lookup: F) -> anyhow::Result<()>
+    where
+        F: Fn(&str) -> Option<String>,
+    {
+        if self.secrets.is_empty() && self.secret_env.is_empty() && self.hosts.is_empty() {
+            return Ok(());
+        }
+
+        // Pair --secret-host NAME=HOST rules to secrets by name.
+        let mut hosts_by_name: HashMap<&str, Vec<String>> = HashMap::new();
+        for rule in &self.hosts {
+            let (name, host) = parse_name_value(rule, "--secret-host")?;
+            hosts_by_name
+                .entry(name)
+                .or_default()
+                .push(host.to_string());
+        }
+
+        // Collect (name, value) from both sources. Duplicate names are rejected.
+        let mut value_by_name: Vec<(&str, String)> = Vec::new();
+        for rule in &self.secrets {
+            let (name, value) = parse_name_value(rule, "--secret")?;
+            push_unique_secret(&mut value_by_name, name, value.to_string())?;
+        }
+        for rule in &self.secret_env {
+            let (name, env_var) = parse_name_value(rule, "--secret-from-env")?;
+            let value = lookup(env_var).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "--secret-from-env {name}: environment variable {env_var:?} is not set"
+                )
+            })?;
+            push_unique_secret(&mut value_by_name, name, value)?;
+        }
+
+        for (name, value) in value_by_name {
+            let hosts = hosts_by_name.remove(name).unwrap_or_default();
+            if hosts.is_empty() {
+                anyhow::bail!(
+                    "--secret {name} has no --secret-host rule; add --secret-host {name}=HOST \
+                     so the MITM proxy knows which host to intercept"
+                );
+            }
+            opts.secrets.push(Secret {
+                name: name.to_string(),
+                value,
+                hosts,
+                placeholder: format!("<BOXLITE_SECRET:{name}>"),
+            });
+        }
+
+        if let Some(name) = hosts_by_name.keys().next() {
+            anyhow::bail!(
+                "--secret-host {name} has no matching --secret or --secret-from-env entry"
+            );
+        }
+
+        Ok(())
+    }
+}
+
+/// Parse a NAME=VALUE flag argument, rejecting malformed or empty parts.
+fn parse_name_value<'a>(arg: &'a str, flag: &str) -> anyhow::Result<(&'a str, &'a str)> {
+    let Some((name, value)) = arg.split_once('=') else {
+        anyhow::bail!("{flag} expects NAME=VALUE, got {arg:?}");
+    };
+    if name.is_empty() {
+        anyhow::bail!("{flag}: NAME must not be empty");
+    }
+    if value.is_empty() {
+        anyhow::bail!("{flag} {name}: VALUE must not be empty");
+    }
+    Ok((name, value))
+}
+
+/// Append `(name, value)` to `entries`, or error when the name is a duplicate.
+fn push_unique_secret<'a>(
+    entries: &mut Vec<(&'a str, String)>,
+    name: &'a str,
+    value: String,
+) -> anyhow::Result<()> {
+    if entries.iter().any(|(n, _)| *n == name) {
+        anyhow::bail!("duplicate secret name {name:?}; each secret needs a unique name");
+    }
+    entries.push((name, value));
+    Ok(())
+}
+
+// ============================================================================
 // PUBLISH (PORT) FLAGS
 // ============================================================================
 
@@ -1196,6 +1324,128 @@ mod tests {
 
         let enabled = ExperimentalFeatures::parse("nested-virtualization").unwrap();
         flags.require_enabled(&enabled).unwrap();
+    }
+
+    fn secret_flags(secrets: &[&str], env: &[&str], hosts: &[&str]) -> SecretFlags {
+        SecretFlags {
+            secrets: secrets.iter().map(|s| s.to_string()).collect(),
+            secret_env: env.iter().map(|s| s.to_string()).collect(),
+            hosts: hosts.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn test_secret_flags_direct_value_defaults_placeholder_and_hosts() {
+        let mut opts = BoxOptions::default();
+        secret_flags(&["openai=sk-123"], &[], &["openai=api.openai.com"])
+            .apply_to(&mut opts)
+            .expect("valid secret flags");
+
+        assert_eq!(opts.secrets.len(), 1);
+        let s = &opts.secrets[0];
+        assert_eq!(s.name, "openai");
+        assert_eq!(s.value, "sk-123");
+        assert_eq!(s.hosts, vec!["api.openai.com"]);
+        // The placeholder is derived from the name so the local runtime (which
+        // does not synthesize a default) still substitutes.
+        assert_eq!(s.placeholder, "<BOXLITE_SECRET:openai>");
+    }
+
+    #[test]
+    fn test_secret_flags_are_repeatable_and_accumulate_hosts() {
+        let mut opts = BoxOptions::default();
+        secret_flags(&["a=1", "b=2"], &[], &["a=h1", "a=h2", "b=*.example.com"])
+            .apply_to(&mut opts)
+            .expect("repeatable flags");
+
+        assert_eq!(opts.secrets.len(), 2);
+        assert_eq!(opts.secrets[0].name, "a");
+        assert_eq!(opts.secrets[0].hosts, vec!["h1", "h2"]);
+        assert_eq!(opts.secrets[1].name, "b");
+        assert_eq!(opts.secrets[1].hosts, vec!["*.example.com"]);
+    }
+
+    #[test]
+    fn test_secret_flags_read_value_from_env() {
+        let mut opts = BoxOptions::default();
+        secret_flags(&[], &["openai=OPENAI_KEY"], &["openai=api.openai.com"])
+            .apply_to_with_lookup(&mut opts, |k| {
+                (k == "OPENAI_KEY").then(|| "sk-env".to_string())
+            })
+            .expect("env source");
+
+        assert_eq!(opts.secrets[0].value, "sk-env");
+        assert_eq!(opts.secrets[0].placeholder, "<BOXLITE_SECRET:openai>");
+    }
+
+    #[test]
+    fn test_secret_flags_missing_env_variable_is_rejected() {
+        let mut opts = BoxOptions::default();
+        let err = secret_flags(&[], &["openai=NOT_SET"], &["openai=h"])
+            .apply_to_with_lookup(&mut opts, |_| None)
+            .expect_err("unset env var must error");
+
+        assert!(err.to_string().contains("NOT_SET"), "{err}");
+    }
+
+    #[test]
+    fn test_secret_flags_malformed_args_are_rejected() {
+        for (secrets, env, hosts) in [
+            (vec!["openai"], vec![], vec!["openai=h"]), // no '='
+            (vec!["=v"], vec![], vec!["openai=h"]),     // empty name
+            (vec!["n="], vec![], vec!["n=h"]),          // empty value
+            (vec!["openai=sk"], vec![], vec!["=h"]),    // empty host name
+        ] {
+            let mut opts = BoxOptions::default();
+            let err = secret_flags(&secrets, &env, &hosts)
+                .apply_to(&mut opts)
+                .expect_err("malformed args must error");
+            assert!(
+                err.to_string().contains("NAME=VALUE")
+                    || err.to_string().contains("must not be empty"),
+                "{err}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_secret_flags_require_a_host_rule() {
+        let mut opts = BoxOptions::default();
+        let err = secret_flags(&["openai=sk"], &[], &[])
+            .apply_to(&mut opts)
+            .expect_err("host-less secret must error");
+
+        assert!(err.to_string().contains("--secret-host"), "{err}");
+    }
+
+    #[test]
+    fn test_secret_flags_orphan_host_rule_is_rejected() {
+        let mut opts = BoxOptions::default();
+        let err = secret_flags(&[], &[], &["openai=h"])
+            .apply_to(&mut opts)
+            .expect_err("orphan host rule must error");
+
+        assert!(err.to_string().contains("no matching"), "{err}");
+    }
+
+    #[test]
+    fn test_secret_flags_duplicate_name_is_rejected() {
+        let mut opts = BoxOptions::default();
+        let err = secret_flags(&["openai=a", "openai=b"], &[], &["openai=h"])
+            .apply_to(&mut opts)
+            .expect_err("duplicate name must error");
+
+        assert!(err.to_string().contains("duplicate secret name"), "{err}");
+    }
+
+    #[test]
+    fn test_secret_flags_default_left_untouched() {
+        let mut opts = BoxOptions::default();
+        secret_flags(&[], &[], &[])
+            .apply_to(&mut opts)
+            .expect("no-op apply");
+
+        assert!(opts.secrets.is_empty());
     }
 
     #[test]

--- a/src/cli/src/commands/create.rs
+++ b/src/cli/src/commands/create.rs
@@ -1,6 +1,6 @@
 use crate::cli::{
     CapabilityFlags, GlobalFlags, KernelFlags, NetworkFlags, PublishFlags, ResourceFlags,
-    VolumeFlags,
+    SecretFlags, VolumeFlags,
 };
 use boxlite::{BoxOptions, RootfsSpec};
 use clap::Args;
@@ -47,6 +47,9 @@ pub struct CreateArgs {
     #[command(flatten)]
     pub network: NetworkFlags,
 
+    #[command(flatten)]
+    pub secret: SecretFlags,
+
     /// Command to run as the container's init (replaces the image CMD;
     /// the image ENTRYPOINT is preserved), mirroring `docker create`.
     #[arg(index = 2, trailing_var_arg = true)]
@@ -79,6 +82,7 @@ impl CreateArgs {
         self.publish.apply_to(&mut options)?;
         self.volume.apply_to(&mut options, global.home.as_deref())?;
         self.network.apply_to(&mut options)?;
+        self.secret.apply_to(&mut options)?;
 
         // A `create`d box is a background box: `create` then `start`/`exec` runs
         // its main command detached (docker's create → start), so the launching
@@ -189,5 +193,32 @@ mod tests {
         let capabilities = opts.advanced.capabilities().expect("capabilities set");
         assert_eq!(capabilities.add, vec!["SYS_ADMIN"]);
         assert_eq!(capabilities.drop, vec!["CAP_NET_RAW"]);
+    }
+
+    #[test]
+    fn create_secret_flags_reach_box_options() {
+        let cli = Cli::try_parse_from([
+            "boxlite",
+            "create",
+            "--secret",
+            "openai=sk-123",
+            "--secret-host",
+            "openai=api.openai.com",
+            "--rootfs",
+            "/tmp/rootfs",
+        ])
+        .expect("create --secret should parse");
+        let Commands::Create(args) = cli.command else {
+            panic!("expected create command");
+        };
+
+        let opts = args
+            .to_box_options(&cli.global)
+            .expect("options should build");
+        assert_eq!(opts.secrets.len(), 1);
+        assert_eq!(opts.secrets[0].name, "openai");
+        assert_eq!(opts.secrets[0].value, "sk-123");
+        assert_eq!(opts.secrets[0].hosts, vec!["api.openai.com"]);
+        assert_eq!(opts.secrets[0].placeholder, "<BOXLITE_SECRET:openai>");
     }
 }

--- a/src/cli/src/commands/run.rs
+++ b/src/cli/src/commands/run.rs
@@ -1,6 +1,6 @@
 use crate::cli::{
     CapabilityFlags, GlobalFlags, KernelFlags, ManagementFlags, NetworkFlags, ProcessFlags,
-    PublishFlags, ResourceFlags, VolumeFlags,
+    PublishFlags, ResourceFlags, SecretFlags, VolumeFlags,
 };
 use crate::terminal::StreamManager;
 use crate::util::to_shell_exit_code;
@@ -30,6 +30,9 @@ pub struct RunArgs {
 
     #[command(flatten)]
     pub management: ManagementFlags,
+
+    #[command(flatten)]
+    pub secret: SecretFlags,
 
     /// Path to an already prepared rootfs
     #[arg(long = "rootfs", value_name = "PATH")]
@@ -138,6 +141,7 @@ impl BoxRunner {
             .volume
             .apply_to(&mut options, self.home.as_deref())?;
         self.args.network.apply_to(&mut options)?;
+        self.args.secret.apply_to(&mut options)?;
         self.args.process.apply_to(&mut options)?;
 
         // Detached boxes keep manual lifecycle control: detach silently
@@ -293,5 +297,36 @@ mod tests {
             .expect_err("missing source must be rejected");
 
         assert!(err.to_string().contains("IMAGE or --rootfs"));
+    }
+
+    #[test]
+    fn run_secret_flags_parse() {
+        let cli = Cli::try_parse_from([
+            "boxlite",
+            "run",
+            "--secret",
+            "openai=sk-123",
+            "--secret-from-env",
+            "anthropic=ANTHROPIC_KEY",
+            "--secret-host",
+            "openai=api.openai.com",
+            "--secret-host",
+            "anthropic=api.anthropic.com",
+            "--rootfs",
+            "/tmp/rootfs",
+            "echo",
+            "hi",
+        ])
+        .expect("run --secret should parse");
+        let Commands::Run(args) = cli.command else {
+            panic!("expected run command");
+        };
+
+        assert_eq!(args.secret.secrets, vec!["openai=sk-123"]);
+        assert_eq!(args.secret.secret_env, vec!["anthropic=ANTHROPIC_KEY"]);
+        assert_eq!(
+            args.secret.hosts,
+            vec!["openai=api.openai.com", "anthropic=api.anthropic.com"]
+        );
     }
 }


### PR DESCRIPTION
## Summary

Add `--secret`, `--secret-from-env`, and `--secret-host` to `boxlite run`/`create` so the existing MITM secret substitution is reachable from the CLI (issue #1238). The runtime pipeline was already complete — `BoxOptions.secrets` flows to the in-shim gvproxy MITM proxy in both local and REST modes; only the argv → `BoxOptions` segment was missing.

## Call graph

Before

```text
boxlite run (no way to configure secrets from the CLI)
  └─ BoxOptions.secrets        (runtime/options.rs:442 — SDK/REST only)
       └─ vmm_spawn.rs:360-363 → NetworkBackendConfig
            └─ NetworkBackendSpec → InstanceSpec → shim → gvproxy MITM
```

After

```text
boxlite run --secret openai=sk-... --secret-host openai=api.openai.com
  └─ SecretFlags::apply_to     (src/cli/src/cli.rs) — parse, validate, default placeholder, pair hosts
       └─ BoxOptions.secrets   (runtime/options.rs:442)
            ├─ local mode: LocalRuntime → vmm_spawn.rs:360-363
            └─ REST mode: CreateBoxRequest::from_options (rest/types.rs:157-160)
                 → serve build_box_options (serve/mod.rs:819-846)
                      └─ NetworkBackendConfig → NetworkBackendSpec
                           → InstanceSpec.network_backend_spec → shim → gvproxy MITM
```

## Changes

- `SecretFlags` with `--secret NAME=VALUE`, `--secret-from-env NAME=ENV_VAR` (value read from a host env var, never on argv), and `--secret-host NAME=HOST` (exact host or `*.example.com` wildcard)
- placeholder defaults to `<BOXLITE_SECRET:{name}>` — load-bearing for local mode, which (unlike serve) does not synthesize one (POL-303 failure class)
- validation: empty name/value, unset env var, host-less secret, orphan host rule, and duplicate name are all rejected
- help text self-describes the guest env var (`BOXLITE_SECRET_<NAME>`) and the placeholder value
- docs: CLI reference flag rows plus an investigations design doc with the dual-mode verification method and log

## How to verify

- `cargo test -p boxlite-cli --bin boxlite` — 206/206 passed (11 new)
- `cargo clippy -p boxlite-cli --bin boxlite` and `cargo fmt` — clean
- e2e local mode: guest env shows `<BOXLITE_SECRET:openai>` and the real value never enters the VM; `boxes/<id>/ca/` holds cert.pem (0644) and key.pem (0600)
- e2e MITM replacement (local and REST via `--url` to serve): httpbin.org echoes the substituted `Authorization: sk-test-123`, proving gvproxy swapped the placeholder at the network boundary

## Risks / rollout

- `--secret NAME=VALUE` puts the value on argv (visible to same-user processes); `--secret-from-env` avoids that — both are documented in help and the CLI reference
- host-less secrets are rejected rather than silently inert
- CLI-only change; no edits to the boxlite library, shim, gvproxy, or serve

## Summary
<!-- 1-2 sentences: what this changes and why. -->

## Call graph
<!-- Required. The end-to-end path this PR touches, before and after; one line
     per hop, only the hops that change. Worked example and the bug-fix markers:
     CONTRIBUTING.md#commit--pr-messages. -->

Before
<!-- replace with the hops: fn_name (Type · path/file.rs:LOC) — role -->

After
<!-- replace with the same hops, post-change -->

Fixes #<!-- issue number — bug fixes only; delete this line otherwise -->

## Changes
- <!-- notable change — what changed, not a restatement of the diff -->

## How to verify
- <!-- a command or step a reviewer can run -->

## Risks / rollout
- <!-- only if any; delete this section otherwise -->

<!-- Describe the change, not the process: no pasted logs, no AI/conversation
     narrative, no secrets. Keep it tight and delete sections that don't apply. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI support for configuring HTTP(S) secret substitution with repeatable `--secret`, `--secret-from-env`, and `--secret-host` options.
  * Supported both `boxlite run` and `boxlite create` commands.
  * Added validation for malformed, duplicate, missing, and unmatched secret configuration.
  * Added examples and reference documentation for the new options.

* **Tests**
  * Added coverage for direct values, environment variables, host mappings, and validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->