### PR TITLE
feat(dashboard): add network section to box detail page

### DIFF
--- a/apps/dashboard/src/components/boxes/BoxDetails.test.tsx
+++ b/apps/dashboard/src/components/boxes/BoxDetails.test.tsx
@@ -41,6 +41,12 @@ vi.mock('@/components/OnboardingGuideDialog', () => ({
   OnboardingGuideDialog: () => null,
 }))
 
+// Owns its own mutations and needs an ApiProvider; these tests cover the detail
+// shell, and the network panel has its own stories.
+vi.mock('./BoxNetworkSection', () => ({
+  BoxNetworkSection: () => null,
+}))
+
 vi.mock('@/hooks/useConfig', () => ({
   useConfig: () => ({}),
 }))

--- a/apps/dashboard/src/components/boxes/BoxDetails.tsx
+++ b/apps/dashboard/src/components/boxes/BoxDetails.tsx
@@ -48,6 +48,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } fro
 import { useAuth } from 'react-oidc-context'
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { toast } from 'sonner'
+import { BoxNetworkSection } from './BoxNetworkSection'
 import { BoxTerminalTab } from './BoxTerminalTab'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 
@@ -470,10 +471,6 @@ export default function BoxDetails() {
               </SpecRow>
               <SpecRow label="region">{(getRegionName(box.target) ?? box.target ?? '—').toUpperCase()}</SpecRow>
 
-              <SectionHeader
-                title="resources"
-                right={<span className="text-[10px] tracking-[1px] text-muted-foreground">quota</span>}
-              />
               <SpecRow label="cpu">{box.cpu} vcpu</SpecRow>
               <SpecRow label="memory">{box.memory} gib</SpecRow>
               <SpecRow label="disk">{box.disk} gib</SpecRow>
@@ -502,7 +499,12 @@ export default function BoxDetails() {
                 </>
               )}
 
-              <SectionHeader title="timestamps" />
+              <BoxNetworkSection box={box} canManage={writePermitted} />
+
+              {/* `activity` names the subject, not the value type — and it is
+                  the platform's own term for it (POST /:boxId/last-activity),
+                  which is also what auto-stop is measured against. */}
+              <SectionHeader title="activity" />
               <SpecRow label="created">{getRelativeTimeString(box.createdAt).relativeTimeString}</SpecRow>
               <SpecRow label="last event">{getRelativeTimeString(box.updatedAt).relativeTimeString}</SpecRow>
 

--- a/apps/dashboard/src/components/boxes/BoxNetworkPanel.stories.tsx
+++ b/apps/dashboard/src/components/boxes/BoxNetworkPanel.stories.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import type { Meta, StoryObj } from '@storybook/react'
+import { useState, type ReactNode } from 'react'
+import { BoxNetworkPanel } from './BoxNetworkPanel'
+
+/**
+ * Reproduces the real detail-page column: 340px wide, monospace 13px, and the
+ * neighbouring spec sections. Without this the section renders in a vacuum and
+ * you cannot tell whether it belongs on the page.
+ */
+function SidebarContext({ children }: { children: ReactNode }) {
+  return (
+    <div className="w-[340px] bg-background px-4 py-4 font-mono text-[13px] text-foreground">
+      <div className="mb-[10px] mt-0 flex items-center gap-[9px]">
+        <span className="size-[6px] flex-none bg-brand" />
+        <span className="text-[11px] uppercase tracking-[2px]">general</span>
+        <span className="flex-1 border-t border-dashed border-border" />
+      </div>
+      {[
+        ['box id', 'aB3cD4eF5gH6'],
+        ['image', 'boxlite/base'],
+        ['region', 'US'],
+      ].map(([label, value]) => (
+        <div key={label} className="mb-[6px] flex items-baseline gap-2">
+          <span className="whitespace-nowrap text-muted-foreground">{label}</span>
+          <span className="-translate-y-1 flex-1 border-b border-dotted border-border" />
+          <span className="min-w-0 max-w-[66%] truncate text-right">{value}</span>
+        </div>
+      ))}
+      {children}
+      <div className="mb-[10px] mt-[34px] flex items-center gap-[9px]">
+        <span className="size-[6px] flex-none bg-brand" />
+        <span className="text-[11px] uppercase tracking-[2px]">activity</span>
+        <span className="flex-1 border-t border-dashed border-border" />
+      </div>
+      <div className="mb-[6px] flex items-baseline gap-2">
+        <span className="whitespace-nowrap text-muted-foreground">created</span>
+        <span className="-translate-y-1 flex-1 border-b border-dotted border-border" />
+        <span className="text-right">2 hours ago</span>
+      </div>
+    </div>
+  )
+}
+
+const meta: Meta<typeof BoxNetworkPanel> = {
+  title: 'Boxes/BoxNetworkPanel',
+  component: BoxNetworkPanel,
+  parameters: { layout: 'centered' },
+  decorators: [
+    (Story) => (
+      <SidebarContext>
+        <Story />
+      </SidebarContext>
+    ),
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof BoxNetworkPanel>
+
+const noop = () => {}
+
+/** The default: preview URLs require an organization sign-in. */
+export const Restricted: Story = {
+  name: '1 · Restricted to the organization',
+  args: { isPublic: false, canManage: true, onTogglePublic: noop, onGetUrl: noop },
+}
+
+/** Anonymous access, so the value is the only amber thing on the sheet. */
+export const Public: Story = {
+  name: '2 · Public',
+  args: { isPublic: true, canManage: true, onTogglePublic: noop, onGetUrl: noop },
+}
+
+export const Saving: Story = {
+  name: '3 · Saving',
+  args: { isPublic: false, canManage: true, isPublicPending: true, onTogglePublic: noop, onGetUrl: noop },
+}
+
+/** Viewers see the state but get no control that changes exposure. */
+export const ReadOnlyViewer: Story = {
+  name: '4 · Viewer (read-only)',
+  args: { isPublic: true, canManage: false, onTogglePublic: noop, onGetUrl: noop },
+}
+
+/** Click through the confirmation dialog without a backend. */
+export const Interactive: Story = {
+  name: '5 · Interactive (click through)',
+  render: () => {
+    const [isPublic, setIsPublic] = useState(false)
+    return <BoxNetworkPanel isPublic={isPublic} canManage onTogglePublic={setIsPublic} onGetUrl={noop} />
+  },
+}

--- a/apps/dashboard/src/components/boxes/BoxNetworkPanel.tsx
+++ b/apps/dashboard/src/components/boxes/BoxNetworkPanel.tsx
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { cn } from '@/lib/utils'
+import { useState, type ReactNode } from 'react'
+
+/**
+ * Mirrors the palette in BoxDetails so the network section reads as part of the
+ * same spec sheet rather than a widget bolted onto it.
+ */
+const STATUS = { idle: '#e0b341' } as const
+
+/**
+ * Local copy of the section header from BoxDetails. It is module private there,
+ * so duplicating this one small helper is cheaper than reaching into it. Worth
+ * extracting to a shared module the next time either file is touched.
+ */
+function SectionHeader({ title, right }: { title: string; right?: ReactNode }) {
+  return (
+    <div className="mb-[10px] mt-[34px] flex items-center gap-[9px] first:mt-0">
+      <span className="size-[6px] flex-none bg-brand" />
+      <span className="text-[11px] uppercase tracking-[2px]">{title}</span>
+      <span className="flex-1 border-t border-dashed border-border" />
+      {right}
+    </div>
+  )
+}
+
+/**
+ * A secondary text action. Underlined because bare muted text read as a static
+ * annotation rather than a control. Stays muted on purpose: exposing a box to
+ * the internet should not be the brightest thing on the sheet.
+ *
+ * Labels here stay short. This column is ~40px wide after the value takes its
+ * share of 340px, so a label that spelled out the consequence
+ * (`open to anyone`) wrapped onto a second line and squeezed the leader dots
+ * to nothing. The consequence belongs in the confirmation dialog, which has
+ * room for a paragraph.
+ */
+function InlineAction({
+  children,
+  onClick,
+  disabled,
+}: {
+  children: ReactNode
+  onClick: () => void
+  disabled?: boolean
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        'text-[11px] uppercase tracking-[1px] text-muted-foreground underline decoration-dotted underline-offset-[3px]',
+        'transition-colors hover:text-foreground hover:decoration-solid',
+        'disabled:pointer-events-none disabled:no-underline disabled:opacity-40',
+      )}
+    >
+      {children}
+    </button>
+  )
+}
+
+export type BoxNetworkPanelProps = {
+  isPublic: boolean
+  isPublicPending?: boolean
+  /** False for viewers, who see the state but cannot change exposure. */
+  canManage: boolean
+  onTogglePublic: (next: boolean) => void
+  /** Opens the port prompt that resolves a preview URL. */
+  onGetUrl: () => void
+}
+
+/**
+ * Who can reach this box, and a way to get a preview URL for one of its ports.
+ *
+ * The section does not list ports, because the console cannot enumerate what is
+ * listening inside a guest — see `BoxPreviewUrlDialog` for why. Rather than
+ * showing a list of guesses, the URL is fetched on demand for a port the user
+ * names, which is something the REST surface answers reliably.
+ */
+export function BoxNetworkPanel({
+  isPublic,
+  isPublicPending = false,
+  canManage,
+  onTogglePublic,
+  onGetUrl,
+}: BoxNetworkPanelProps) {
+  const [confirmingPublic, setConfirmingPublic] = useState(false)
+
+  return (
+    <>
+      <SectionHeader title="network" right={<InlineAction onClick={onGetUrl}>get url</InlineAction>} />
+
+      {/* `access` answers the only question this row is asked — can a stranger
+          open this box? — rather than naming the mechanism.
+
+          The URLs it governs carry no credential (`getPortPreviewUrl` returns
+          `url` and `token` separately), so a non-member is bounced through
+          OIDC and then refused by the org-membership check in
+          preview.controller.ts:142. Access is credential-based, not
+          network-based: there is no inbound IP allowlist (openapi/box.openapi
+          .yaml — "no layer enforces an inbound allowlist today").
+
+          Sheet convention: grey key, foreground value; hue carries the risk
+          signal (amber when exposed). */}
+      <div className="mb-[6px] flex items-baseline gap-2">
+        <span className="whitespace-nowrap text-muted-foreground">access</span>
+        <span className="-translate-y-1 min-w-[8px] flex-1 border-b border-dotted border-border" />
+        <span className="whitespace-nowrap" style={isPublic ? { color: STATUS.idle } : undefined}>
+          {isPublic ? 'anyone' : 'your organization'}
+        </span>
+        {canManage ? (
+          <InlineAction
+            disabled={isPublicPending}
+            onClick={() => (isPublic ? onTogglePublic(false) : setConfirmingPublic(true))}
+          >
+            {isPublicPending ? '…' : 'change'}
+          </InlineAction>
+        ) : null}
+      </div>
+
+      <AlertDialog open={confirmingPublic} onOpenChange={setConfirmingPublic}>
+        <AlertDialogContent className="font-mono">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Open this box&apos;s preview URLs to anyone?</AlertDialogTitle>
+            {/* Scoped deliberately. The flag only makes the proxy skip
+                authentication for preview traffic (get_box_target.go:87) and
+                raw tunnel CONNECTs (tunnel.go:43). The web terminal stays
+                authenticated even when public — the same line exempts
+                TERMINAL_PORT — and the management API is untouched. An earlier
+                "Make this box public?" read as handing over the whole box. */}
+            <AlertDialogDescription>
+              Anyone who knows a preview URL will reach <strong>any port your box is serving</strong> without signing
+              in. The URL is not a secret — it ends up in browser history, proxy logs and Referer headers.
+              <br />
+              <br />
+              The web terminal and the box&apos;s files, commands and settings are not affected; those still require
+              signing in to your organization.
+              <br />
+              <br />
+              If a port serves API keys or customer data, leave this restricted.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                onTogglePublic(true)
+                setConfirmingPublic(false)
+              }}
+            >
+              Open to anyone
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}

--- a/apps/dashboard/src/components/boxes/BoxNetworkSection.tsx
+++ b/apps/dashboard/src/components/boxes/BoxNetworkSection.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { useBoxPreviewUrlMutation } from '@/hooks/mutations/useBoxPreviewUrlMutation'
+import { useUpdateBoxPublicStatusMutation } from '@/hooks/mutations/useUpdateBoxPublicStatusMutation'
+import { Box } from '@boxlite-ai/api-client'
+import { useCallback, useState } from 'react'
+import { toast } from 'sonner'
+import { BoxNetworkPanel } from './BoxNetworkPanel'
+import { BoxPreviewUrlDialog } from './BoxPreviewUrlDialog'
+
+/**
+ * Wires the network section to the box APIs.
+ *
+ * Both server calls live in the hooks layer — `useUpdateBoxPublicStatusMutation`
+ * (which also owns cache invalidation) and `useBoxPreviewUrlMutation` — so this
+ * component issues no HTTP of its own and only orchestrates.
+ */
+export function BoxNetworkSection({ box, canManage }: { box: Box; canManage: boolean }) {
+  const togglePublic = useUpdateBoxPublicStatusMutation()
+  const previewUrl = useBoxPreviewUrlMutation()
+
+  const [dialogOpen, setDialogOpen] = useState(false)
+
+  const setPublic = useCallback(
+    (next: boolean) => {
+      togglePublic.mutate(
+        { boxId: box.id, isPublic: next },
+        {
+          // Named for what actually changed: preview reachability, not the
+          // box as a whole.
+          onSuccess: () =>
+            toast.success(next ? 'Preview URLs are open to anyone' : 'Preview URLs require signing in'),
+          onError: () => toast.error('Could not change preview access'),
+        },
+      )
+    },
+    [box.id, togglePublic],
+  )
+
+  const openDialog = useCallback(() => {
+    // Start clean each time: a URL left over from a previous port would read as
+    // the answer to the port about to be typed.
+    previewUrl.reset()
+    setDialogOpen(true)
+  }, [previewUrl])
+
+  const fetchUrl = useCallback(
+    (port: number) => {
+      previewUrl.mutate({ boxId: box.id, port })
+    },
+    [box.id, previewUrl],
+  )
+
+  return (
+    <>
+      <BoxNetworkPanel
+        isPublic={box.public ?? false}
+        isPublicPending={togglePublic.isPending}
+        canManage={canManage}
+        onTogglePublic={setPublic}
+        onGetUrl={openDialog}
+      />
+      <BoxPreviewUrlDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        isPublic={box.public ?? false}
+        url={previewUrl.data}
+        isFetching={previewUrl.isPending}
+        error={previewUrl.isError ? 'Could not get a URL for that port.' : undefined}
+        onFetchUrl={fetchUrl}
+      />
+    </>
+  )
+}

--- a/apps/dashboard/src/components/boxes/BoxPreviewUrlDialog.stories.tsx
+++ b/apps/dashboard/src/components/boxes/BoxPreviewUrlDialog.stories.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import type { Meta, StoryObj } from '@storybook/react'
+import { useState } from 'react'
+import { BoxPreviewUrlDialog } from './BoxPreviewUrlDialog'
+
+const RESTRICTED_URL = 'https://3000-d-3874534e7a76373849495666.proxy.dev.boxlite.ai'
+
+const meta: Meta<typeof BoxPreviewUrlDialog> = {
+  title: 'Boxes/BoxPreviewUrlDialog',
+  component: BoxPreviewUrlDialog,
+}
+
+export default meta
+type Story = StoryObj<typeof BoxPreviewUrlDialog>
+
+const noop = () => {}
+
+/** Opened, nothing asked for yet. */
+export const Empty: Story = {
+  name: '1 · Asking for a port',
+  args: { open: true, onOpenChange: noop, isPublic: false, onFetchUrl: noop },
+}
+
+export const Fetching: Story = {
+  name: '2 · Fetching',
+  args: { open: true, onOpenChange: noop, isPublic: false, isFetching: true, onFetchUrl: noop },
+}
+
+/** Restricted box: the URL only opens for organization members. */
+export const RestrictedResult: Story = {
+  name: '3 · URL on a restricted box',
+  args: { open: true, onOpenChange: noop, isPublic: false, url: RESTRICTED_URL, onFetchUrl: noop },
+}
+
+/** Public box: the wording has to make the anonymous reach unmissable. */
+export const PublicResult: Story = {
+  name: '4 · URL on a public box',
+  args: { open: true, onOpenChange: noop, isPublic: true, url: RESTRICTED_URL, onFetchUrl: noop },
+}
+
+export const Failed: Story = {
+  name: '5 · Request failed',
+  args: {
+    open: true,
+    onOpenChange: noop,
+    isPublic: false,
+    error: 'Could not get a URL for that port.',
+    onFetchUrl: noop,
+  },
+}
+
+/** Type a port and watch the URL resolve, without a backend. */
+export const Interactive: Story = {
+  name: '6 · Interactive (type a port)',
+  render: () => {
+    const [url, setUrl] = useState<string | undefined>()
+    const [isFetching, setIsFetching] = useState(false)
+
+    return (
+      <BoxPreviewUrlDialog
+        open
+        onOpenChange={noop}
+        isPublic={false}
+        url={url}
+        isFetching={isFetching}
+        onFetchUrl={(port) => {
+          setIsFetching(true)
+          setUrl(undefined)
+          setTimeout(() => {
+            setUrl(`https://${port}-d-3874534e7a76373849495666.proxy.dev.boxlite.ai`)
+            setIsFetching(false)
+          }, 600)
+        }}
+      />
+    )
+  },
+}

--- a/apps/dashboard/src/components/boxes/BoxPreviewUrlDialog.tsx
+++ b/apps/dashboard/src/components/boxes/BoxPreviewUrlDialog.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { CopyButton } from '@/components/CopyButton'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { useState } from 'react'
+
+export type BoxPreviewUrlDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** True while anyone with the URL can open it, i.e. the box is public. */
+  isPublic: boolean
+  /** Resolved URL for the port last submitted, if any. */
+  url?: string
+  isFetching?: boolean
+  error?: string
+  onFetchUrl: (port: number) => void
+}
+
+/**
+ * Asks for a port and returns that port's preview URL.
+ *
+ * The port has to be asked for: the console cannot enumerate what is listening
+ * inside a guest. `POST /exec` returns only an `execution_id` and its output is
+ * reachable solely over a WebSocket attach whose `Authorization` header a
+ * browser cannot set; neither the box record, the metrics endpoint nor file
+ * transfer (which refuses `/proc`) carries port data. Rather than guess with a
+ * list of common ports, the port is asked for here, out of the detail sheet
+ * until wanted.
+ */
+export function BoxPreviewUrlDialog({
+  open,
+  onOpenChange,
+  isPublic,
+  url,
+  isFetching = false,
+  error,
+  onFetchUrl,
+}: BoxPreviewUrlDialogProps) {
+  const [value, setValue] = useState('')
+
+  const port = Number(value)
+  const valid = Number.isInteger(port) && port > 0 && port <= 65535
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="font-mono sm:max-w-[600px]">
+        <DialogHeader>
+          <DialogTitle>Get a preview URL</DialogTitle>
+          <DialogDescription>
+            Make sure a server is already listening on that port inside the box.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form
+          className="flex items-center gap-2"
+          onSubmit={(event) => {
+            event.preventDefault()
+            if (valid) onFetchUrl(port)
+          }}
+        >
+          <label className="text-[13px] text-muted-foreground" htmlFor="preview-url-port">
+            port
+          </label>
+          <Input
+            id="preview-url-port"
+            autoFocus
+            inputMode="numeric"
+            placeholder="3000"
+            value={value}
+            onChange={(event) => setValue(event.target.value.replace(/\D/g, ''))}
+            className="w-[110px] font-mono"
+          />
+          <Button type="submit" size="sm" disabled={!valid || isFetching}>
+            {isFetching ? 'Getting…' : 'Get URL'}
+          </Button>
+        </form>
+
+        {error ? <p className="text-[12px] text-destructive-foreground">{error}</p> : null}
+
+        {url ? (
+          <div className="space-y-2">
+            <div className="group/copy-button flex min-w-0 items-center gap-1 border border-border bg-[hsl(var(--code-background))] px-[8px] py-[6px]">
+              <span className="min-w-0 flex-1 truncate text-[12px]" title={url}>
+                {url.replace(/^https?:\/\//, '')}
+              </span>
+              <CopyButton value={url} size="icon-xs" tooltipText="Copy URL" className="flex-none" />
+            </div>
+
+            {/* Who can use it matters at the moment of copying, which is here
+                rather than back on the sheet. */}
+            <p className="text-[11px] uppercase tracking-[1px] text-muted-foreground">
+              {isPublic ? 'anyone with this url can open it' : 'only your organization can open it'}
+            </p>
+
+            {/* Stated here because it cannot be diagnosed afterwards: the URL
+                opens in a new tab, so a failure there is invisible to the
+                console. A server on 127.0.0.1 is listening but unreachable
+                through the tunnel — the most common reason this looks broken. */}
+            <p className="text-[11px] leading-relaxed text-muted-foreground">
+              Not loading? Your server has to bind <span className="text-foreground">0.0.0.0</span>, not{' '}
+              <span className="text-foreground">127.0.0.1</span>.
+            </p>
+          </div>
+        ) : null}
+
+        {/* `Open` occupies the footer's primary slot and stays disabled until a
+            URL exists, so the dialog's main action is the one the user came
+            for. Dismissal is the header's × / Escape — a Close button here
+            would compete with it for the same slot. */}
+        <DialogFooter>
+          {url ? (
+            <Button asChild size="sm">
+              <a href={url} target="_blank" rel="noreferrer noopener">
+                Open ↗
+              </a>
+            </Button>
+          ) : (
+            <Button size="sm" disabled>
+              Open ↗
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/dashboard/src/hooks/mutations/useBoxPreviewUrlMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useBoxPreviewUrlMutation.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { useApi } from '@/hooks/useApi'
+import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
+import { useMutation } from '@tanstack/react-query'
+
+interface BoxPreviewUrlVariables {
+  boxId: string
+  port: number
+}
+
+/**
+ * Resolves the preview URL for one port of a box.
+ *
+ * A mutation rather than a query, even though it reads: it runs in response to a
+ * click for a port the user names, and the result must not be cached — the
+ * endpoint also returns the box auth token, which has no reason to sit in a
+ * shared store where devtools, a HAR capture or error reporting would pick it
+ * up. `useMutation` gives the imperative call, `isPending` and `error` without
+ * a cache entry.
+ */
+export const useBoxPreviewUrlMutation = () => {
+  const api = useApi()
+  const { selectedOrganization } = useSelectedOrganization()
+
+  return useMutation({
+    mutationFn: async ({ boxId, port }: BoxPreviewUrlVariables): Promise<string> => {
+      if (!selectedOrganization?.id) throw new Error('Missing organization')
+      const { data } = await api.boxApi.getPortPreviewUrl(boxId, port, selectedOrganization.id)
+      return data.url
+    },
+  })
+}

--- a/apps/dashboard/src/hooks/mutations/useUpdateBoxPublicStatusMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useUpdateBoxPublicStatusMutation.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { queryKeys } from '@/hooks/queries/queryKeys'
+import { useApi } from '@/hooks/useApi'
+import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+interface UpdateBoxPublicStatusVariables {
+  boxId: string
+  isPublic: boolean
+}
+
+/**
+ * Flips whether a box's preview URLs are reachable without a credential.
+ *
+ * Invalidating the box detail query is the point: `public` lives on the box
+ * record, so the detail sheet has to re-read it before it can show the new
+ * value. Kept here with the other box mutations rather than inline in the
+ * network section, so cache invalidation is defined once per resource.
+ */
+export const useUpdateBoxPublicStatusMutation = () => {
+  const api = useApi()
+  const { selectedOrganization } = useSelectedOrganization()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ boxId, isPublic }: UpdateBoxPublicStatusVariables) => {
+      if (!selectedOrganization?.id) throw new Error('Missing organization')
+      await api.boxApi.updatePublicStatus(boxId, isPublic, selectedOrganization.id)
+    },
+    onSuccess: (_, { boxId }) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.boxes.detail(selectedOrganization?.id ?? '', boxId),
+      })
+    },
+  })
+}

--- a/apps/dashboard/src/mocks/handlers.ts
+++ b/apps/dashboard/src/mocks/handlers.ts
@@ -78,6 +78,48 @@ export const handlers = [
     const box = MOCK_BOXES.find((b) => b.id === params.boxIdOrName) ?? MOCK_BOXES[0]
     return box ? HttpResponse.json(box) : new HttpResponse(null, { status: 404 })
   }),
+  // Network / preview surface. `public` is mutated in place so the detail page
+  // reflects the toggle after its query is invalidated, the way it does against
+  // a real API.
+  http.post(`${API_URL}/box/:boxIdOrName/public/:isPublic`, ({ params }) => {
+    const box = MOCK_BOXES.find((b) => b.id === params.boxIdOrName)
+    if (!box) return new HttpResponse(null, { status: 404 })
+    box.public = params.isPublic === 'true'
+    return HttpResponse.json(box)
+  }),
+  http.get(`${API_URL}/box/:boxIdOrName/ports/:port/preview-url`, ({ params }) => {
+    const boxId = String(params.boxIdOrName)
+    // Mirrors the real hex-encoded direct-preview host shape. Hand-rolled
+    // rather than via Buffer, which does not exist in the browser.
+    const encodedBoxId = [...boxId].map((char) => char.charCodeAt(0).toString(16).padStart(2, '0')).join('')
+    return HttpResponse.json({
+      boxId,
+      url: `https://${params.port}-d-${encodedBoxId}.proxy.mock.boxlite.ai`,
+      token: 'mock0boxauthtoken0000000000000000',
+    })
+  }),
+  http.get(`${API_URL}/box/:boxIdOrName/ports/:port/signed-preview-url`, ({ params, request }) => {
+    // The real service only signs the terminal port today; keeping that
+    // restriction in mock is what surfaces the fallback message in the UI.
+    const port = Number(params.port)
+    if (port !== 22222) {
+      return HttpResponse.json(
+        { statusCode: 400, message: 'Signed port preview is only supported for terminal port 22222' },
+        { status: 400 },
+      )
+    }
+    const expiresIn = new URL(request.url).searchParams.get('expiresInSeconds') ?? '60'
+    const token = `mock${Math.random().toString(36).slice(2, 14)}`
+    return HttpResponse.json({
+      boxId: String(params.boxIdOrName),
+      port,
+      token,
+      url: `https://${port}-${token}.proxy.mock.boxlite.ai?ttl=${expiresIn}`,
+    })
+  }),
+  http.post(`${API_URL}/box/:boxIdOrName/ports/:port/signed-preview-url/:token/expire`, () => {
+    return new HttpResponse(null, { status: 201 })
+  }),
   // Volumes. Deletion mirrors the real service (volume.service.ts:74-113):
   // a volume still mounted by a live box is refused with 409, and a successful
   // delete only moves the row to `pending_delete` — the reconciler finishes it


### PR DESCRIPTION
## Summary

The box detail page showed nothing about networking. A user who started a server inside a box had no way to learn its preview URL, or whether the box was reachable from outside the organization, without leaving the console for the API.

This adds a `network` section to the detail sheet with two things: what `access` the preview URLs require, and a way to get the URL for a port.

```
▪ NETWORK ─────────────────────── GET URL
access ·········· your organization  CHANGE
```

`GET URL` opens a dialog that asks for a port and returns that port's preview URL, with copy, open, who-can-open-it and the bind hint.

## Screenshots

**The section on the detail sheet**

![network section](https://raw.githubusercontent.com/Mandalorian-Wang/boxlite/pr-assets/box-detail-network/pr-assets/01-network.png)

Two rows: what `access` the preview URLs require, and `get url`. It sits between `volumes` and `activity` in the same spec-sheet idiom as the rest of the column.

**`GET URL` asks for a port**

![get url dialog](https://raw.githubusercontent.com/Mandalorian-Wang/boxlite/pr-assets/box-detail-network/pr-assets/02-dialog.png)

`Open ↗` stays disabled until a URL exists.

**…and returns that port's URL**

![resolved url](https://raw.githubusercontent.com/Mandalorian-Wang/boxlite/pr-assets/box-detail-network/pr-assets/03-url.png)

With copy, who can open it, and the bind hint — stated here because the URL opens in a new tab, where a failure is invisible to the console.

**`CHANGE` confirms before opening access**

![confirmation](https://raw.githubusercontent.com/Mandalorian-Wang/boxlite/pr-assets/box-detail-network/pr-assets/04-confirm.png)

The dialog says what opens *and* what does not: the web terminal and the management API are unaffected.

**Once open, the value carries the risk**

![public](https://raw.githubusercontent.com/Mandalorian-Wang/boxlite/pr-assets/box-detail-network/pr-assets/05-public.png)

`anyone` is amber — hue marks the risk, while the key/value greyscale convention the rest of the sheet uses is left intact. The confirmation is symmetric, so the state can be closed again from the same control.

## Call graph

### Before

```
BoxDetails (apps/dashboard/src/components/boxes/BoxDetails.tsx)
├── SectionHeader "general"     → box id · image · region
├── SectionHeader "resources"   → cpu · memory · disk        ← two headers, 6 rows
├── SectionHeader "volumes"     → mounts (conditional)
├── SectionHeader "timestamps"  → created · last event       ← names the value type
└── (no networking anywhere)                                 ← BUG: preview URL and
                                                               exposure unreachable
                                                               from the console
```

### After

```
BoxDetails
├── SectionHeader "general"     → box id · image · region · cpu · memory · disk
├── SectionHeader "volumes"     → mounts (conditional)
├── BoxNetworkSection ────────────────────────────────────────────────────┐
│     useUpdateBoxPublicStatusMutation                                    │
│       └── boxApi.updatePublicStatus → invalidate boxes.detail           │
│     useBoxPreviewUrlMutation                                            │
│       └── boxApi.getPortPreviewUrl(box, port) → url                     │
│                                                                         │
│     ├── BoxNetworkPanel      (presentational)                           │
│     │     SectionHeader "network" → get url                             │
│     │     access row → your organization | anyone  ·  change            │
│     │     AlertDialog → scoped confirmation                             │
│     └── BoxPreviewUrlDialog  (presentational)                           │
│           port input → get url → url · copy · open ↗                    │
└─────────────────────────────────────────────────────────────────────────┘
└── SectionHeader "activity"    → created · last event
```

No component issues HTTP: both server calls sit in the hooks layer.

## Design notes

**The port is asked for, not discovered.** The console cannot enumerate what is listening inside a guest, and every route was checked: `POST /exec` returns only an `execution_id`; `GET /executions/{id}` returns only status and exit code; output is reachable solely over `GET /executions/{id}/attach`, a WebSocket upgrade whose `Authorization` header a browser cannot set (`boxlite-ws-proxy.service.ts:176`); `GET /box/{id}` and `GET /metrics` carry no port data; and file transfer refuses `/proc` outright. Offering a list of common ports would have dressed a guess up as discovery, so the dialog asks instead. A `GET /boxes/{id}/listening-ports` endpoint would settle this — see the follow-up below.

**The confirmation is scoped to preview traffic.** `public` makes the proxy skip authentication for preview requests (`get_box_target.go:87`) and raw tunnel CONNECTs (`tunnel.go:43`). It does not touch the web terminal — the same line exempts `TERMINAL_PORT` — nor the management API. The dialog says both what opens and what does not, because an unscoped "make this box public" reads as handing over the whole box.

**`access: your organization`** describes the URL the dialog hands out, which carries no credential: `getPortPreviewUrl` returns `url` and `token` as separate fields and only `url` is shown. A non-member opening it is bounced through OIDC and refused by the membership check in `preview.controller.ts:142`. Access is credential-based, not network-based — there is no inbound IP allowlist (`openapi/box.openapi.yaml`: "no layer enforces an inbound allowlist today").

**The preview URL is a mutation, not a query.** It runs on click for a port the user names, and its response also carries the box auth token, which should not sit in a shared cache where devtools, a HAR capture or error reporting would pick it up.

**Two section renames come along.** `resources` folds into `general` — six rows did not need two headers — and `timestamps` becomes `activity`, which names the subject rather than the data type and is the platform's own term for it (`POST /:boxId/last-activity`), as well as what auto-stop is measured against.

## Tests

```
✓ src/components/boxes/BoxDetails.test.tsx (3 tests)

Test Files  1 passed (1)
     Tests  3 passed (3)
```

`BoxNetworkPanel` and `BoxPreviewUrlDialog` are presentational and driven by props; their states — restricted, public, saving, viewer-only, fetching, resolved, failed — are covered by stories rather than assertions, since there is no logic to assert beyond what renders.

## Review feedback addressed

- **Network I/O moved out of the component.** Both calls are hooks now (`useUpdateBoxPublicStatusMutation`, `useBoxPreviewUrlMutation`), cache invalidation is defined once per resource, and no raw Axios remains — the earlier hand-written `POST /exec` request is gone with the port probe it served.
- **The exec response shape.** The review was right that `POST /exec` returns `execution_id` rather than `stdout`, which meant the port probe would have silently parsed an empty string in production while the mock hid it. Verified against dev, and the probe was removed rather than patched, since its output is only reachable over a WebSocket the browser cannot authenticate.

## Follow-up, not in this PR

A `GET /boxes/{id}/listening-ports` endpoint — the runner can read `/proc/net/tcp` server-side without the browser's WebSocket constraint. With it, this section can list the reachable URLs directly and flag a service bound to `127.0.0.1` before the user opens a tab that fails. Only `BoxNetworkSection` would change.
