### PR TITLE
fix(api): gate listAvailableRegions behind ORGANIZATION_INFRASTRUCTURE flag

### DIFF
--- a/apps/api/src/organization/controllers/organization-region.controller.ts
+++ b/apps/api/src/organization/controllers/organization-region.controller.ts
@@ -61,6 +61,7 @@ export class OrganizationRegionController {
     summary: 'List all available regions for the organization',
     operationId: 'listAvailableRegions',
   })
+  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: false }] })
   @ApiResponse({
     status: 200,
     description: 'List of all available regions',


### PR DESCRIPTION
## Before

```
GET /regions → 500 (all orgs without infrastructure flag)
GET /runners → 403 ✓
```

`OrganizationRegionController` had `@RequireFlagsEnabled` on every method (POST, DELETE, PATCH, POST regenerate-key) **except** the `@Get()` list handler. That handler hit DB joins requiring infrastructure tables and returned 500.

## After

```
GET /regions → 403 (flag disabled) | 200 (flag enabled)
```

## Change

One line added to `apps/api/src/organization/controllers/organization-region.controller.ts`:

```ts
@Get()
// +
@RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: false }] })
```

Matches the pattern on all other methods in the same controller and every endpoint in `runner.controller.ts`.

## Call graph

**Before:**
`GET /regions` → `listAvailableRegions` ← BUG: no guard → DB join → 500

**After:**
`GET /regions` → `@RequireFlagsEnabled` → 403 (flag off) → `listAvailableRegions` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)