### PR TITLE
fix(python-sdk): Secret.placeholder always returns the effective value

### DIFF
--- a/sdks/python/src/options.rs
+++ b/sdks/python/src/options.rs
@@ -323,9 +323,11 @@ pub(crate) struct PySecret {
     pub(crate) hosts: Vec<String>,
 
     /// The placeholder string that appears in guest HTTP headers.
-    /// Defaults to ``<BOXLITE_SECRET:{name}>`` if not set explicitly.
+    /// When not supplied at construction time, defaults to
+    /// ``<BOXLITE_SECRET:{name}>``. Always holds the effective value;
+    /// never ``None``.
     #[pyo3(get, set)]
-    pub(crate) placeholder: Option<String>,
+    pub(crate) placeholder: String,
 }
 
 #[pymethods]
@@ -333,6 +335,7 @@ impl PySecret {
     #[new]
     #[pyo3(signature = (name, value, hosts=vec![], placeholder=None))]
     fn new(name: String, value: String, hosts: Vec<String>, placeholder: Option<String>) -> Self {
+        let placeholder = placeholder.unwrap_or_else(|| format!("<BOXLITE_SECRET:{}>", name));
         Self {
             name,
             value,
@@ -342,10 +345,12 @@ impl PySecret {
     }
 
     /// Return the effective placeholder string.
+    ///
+    /// Equivalent to reading ``.placeholder`` directly; kept for
+    /// backwards-compatibility with code that called ``get_placeholder()``
+    /// before ``.placeholder`` was guaranteed to hold the effective value.
     fn get_placeholder(&self) -> String {
-        self.placeholder
-            .clone()
-            .unwrap_or_else(|| format!("<BOXLITE_SECRET:{}>", self.name))
+        self.placeholder.clone()
     }
 
     fn __repr__(&self) -> String {
@@ -353,7 +358,7 @@ impl PySecret {
             "Secret(name={:?}, hosts={:?}, placeholder={:?}, value=[REDACTED])",
             self.name,
             self.hosts,
-            self.get_placeholder(),
+            self.placeholder,
         )
     }
 }
@@ -583,16 +588,15 @@ impl TryFrom<PyBoxOptions> for BoxOptions {
             }
         }
 
-        // Convert Python secrets to Rust secrets
+        // Convert Python secrets to Rust secrets. `s.placeholder` is always
+        // the effective value (computed eagerly in PySecret::new).
         opts.secrets = py_opts
             .secrets
             .into_iter()
             .map(|s| boxlite::runtime::options::Secret {
-                name: s.name.clone(),
+                name: s.name,
                 hosts: s.hosts,
-                placeholder: s
-                    .placeholder
-                    .unwrap_or_else(|| format!("<BOXLITE_SECRET:{}>", s.name)),
+                placeholder: s.placeholder,
                 value: s.value,
             })
             .collect();


### PR DESCRIPTION
## Before

```python
s = boxlite.Secret(name="openai", value="sk-...", hosts=["api.openai.com"])
s.placeholder        # None  ← bug
s.get_placeholder()  # "<BOXLITE_SECRET:openai>"
```

## After

```python
s = boxlite.Secret(name="openai", value="sk-...", hosts=["api.openai.com"])
s.placeholder        # "<BOXLITE_SECRET:openai>"  ← always the effective value
s.get_placeholder()  # "<BOXLITE_SECRET:openai>"  ← kept, now a clone of the field
```

## Change

In `sdks/python/src/options.rs`:

- `PySecret.placeholder`: `Option<String>` → `String`
- `PySecret::new()`: compute the default (`<BOXLITE_SECRET:{name}>`) eagerly when none is supplied
- `get_placeholder()`: now just `self.placeholder.clone()`; kept for backwards-compatibility
- `TryFrom<PyBoxOptions> for BoxOptions`: remove the now-redundant `unwrap_or_else`

## Why it matters

Any code that reads `.placeholder` to build REST payloads or validate the substitution token saw `None` instead of the generated string, making the property useless and a likely root cause for silent secret-injection failures on the REST path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)