### PR TITLE
fix(api): destroy and reap boxes whose creation never finished

### DIFF
--- a/apps/api/src/box/services/box.service.spec.ts
+++ b/apps/api/src/box/services/box.service.spec.ts
@@ -372,8 +372,9 @@ describe('BoxService public defaults', () => {
 })
 
 // The reaper only touches boxRepository + jobRepository + configService +
-// eventEmitter, and decides purely from persisted state — which is what makes
-// it able to clean up after a request, or a whole API process, that is gone.
+// eventEmitter + redisLockProvider, and decides purely from persisted state —
+// which is what makes it able to clean up after a request, or a whole API
+// process, that is gone.
 function makeReaperService() {
   const boxRepository = {
     find: jest.fn().mockResolvedValue([]),
@@ -381,15 +382,15 @@ function makeReaperService() {
   } as any
   const jobRepository = {
     count: jest.fn().mockResolvedValue(0),
-    find: jest.fn().mockResolvedValue([]),
   } as any
   const configService = {
     getOrThrow: jest.fn((key: string) => {
-      if (key === 'boxSync.startConfirmationStallSeconds') return 60
+      if (key === 'boxSync.failedStartupReapSeconds') return 1800
       throw new Error(`unexpected config key ${key}`)
     }),
   } as any
   const eventEmitter = { emit: jest.fn(), emitAsync: jest.fn() } as any
+  const redisLockProvider = { lock: jest.fn().mockResolvedValue(true), unlock: jest.fn() } as any
   const noop = {} as any
   const service = new BoxService(
     boxRepository, // boxRepository
@@ -401,7 +402,7 @@ function makeReaperService() {
     eventEmitter, // eventEmitter
     noop, // organizationService
     noop, // runnerAdapterFactory
-    noop, // redisLockProvider
+    redisLockProvider, // redisLockProvider
     noop, // redis
     noop, // regionService
     noop, // boxLookupCacheInvalidationService
@@ -409,10 +410,10 @@ function makeReaperService() {
     jobRepository, // jobRepository
     noop, // jobService
   )
-  return { service, boxRepository, jobRepository, eventEmitter }
+  return { service, boxRepository, jobRepository, eventEmitter, redisLockProvider }
 }
 
-// A box as create() leaves it: pending, so destroy() refuses it.
+// A box as create() leaves it: pending, so destroy() would refuse it.
 const stuckCreatingBox = {
   id: 'box-stuck',
   name: 'cozy-otter',
@@ -430,7 +431,7 @@ const failedStartupBox = {
 }
 
 describe('BoxService.reapFailedBoxStartups', () => {
-  it('marks a box stuck in CREATING for destruction when nothing can still move it', async () => {
+  it('marks a box stuck in CREATING for destruction when no job can still move it', async () => {
     const { service, boxRepository, eventEmitter } = makeReaperService()
     boxRepository.find.mockResolvedValue([stuckCreatingBox])
 
@@ -470,34 +471,70 @@ describe('BoxService.reapFailedBoxStartups', () => {
     expect(boxRepository.updateWhere).not.toHaveBeenCalled()
   })
 
-  it('leaves a CREATING box alone while its create job is unclaimed', async () => {
+  it('leaves a CREATING box alone while a create job is still open', async () => {
     const { service, boxRepository, jobRepository } = makeReaperService()
     boxRepository.find.mockResolvedValue([stuckCreatingBox])
-    jobRepository.find.mockResolvedValue([{ status: 'PENDING', startedAt: null }])
+    // No completed create job, but one still open: job.service's stale-job
+    // timeout owns declaring it dead, not this sweep.
+    jobRepository.count.mockResolvedValueOnce(0).mockResolvedValueOnce(1)
 
     await service.reapFailedBoxStartups()
 
     expect(boxRepository.updateWhere).not.toHaveBeenCalled()
   })
 
-  it('leaves a CREATING box alone while its create job is still progressing', async () => {
-    const { service, boxRepository, jobRepository } = makeReaperService()
+  it('gives errored boxes a tombstone window before reaping them', async () => {
+    const { service, boxRepository } = makeReaperService()
+
+    await service.reapFailedBoxStartups()
+
+    const [where] = boxRepository.find.mock.calls[0]
+    const erroredClause = where.where.find((clause: any) => clause.state === BoxState.ERROR)
+    const cutoff = erroredClause.updatedAt.value as Date
+    const daysAgo = (Date.now() - cutoff.getTime()) / (24 * 60 * 60 * 1000)
+    expect(daysAgo).toBeCloseTo(7, 1)
+  })
+
+  it('uses a create window far longer than the job stall window', async () => {
+    const { service, boxRepository } = makeReaperService()
+
+    await service.reapFailedBoxStartups()
+
+    const [where] = boxRepository.find.mock.calls[0]
+    const creatingClause = where.where.find((clause: any) => clause.state === BoxState.CREATING)
+    const cutoff = creatingClause.updatedAt.value as Date
+    expect((Date.now() - cutoff.getTime()) / 1000).toBeCloseTo(1800, -1)
+  })
+
+  it('caps how many boxes one sweep reaps, oldest first', async () => {
+    const { service, boxRepository } = makeReaperService()
+
+    await service.reapFailedBoxStartups()
+
+    const [where] = boxRepository.find.mock.calls[0]
+    expect(where.take).toBe(100)
+    expect(where.order).toEqual({ updatedAt: 'ASC' })
+  })
+
+  it('skips a box whose state-change lock is held, and releases the locks it takes', async () => {
+    const { service, boxRepository, redisLockProvider } = makeReaperService()
     boxRepository.find.mockResolvedValue([stuckCreatingBox])
-    jobRepository.find.mockResolvedValue([{ status: 'IN_PROGRESS', startedAt: new Date() }])
+    redisLockProvider.lock.mockResolvedValue(false)
 
     await service.reapFailedBoxStartups()
 
     expect(boxRepository.updateWhere).not.toHaveBeenCalled()
+    expect(redisLockProvider.unlock).not.toHaveBeenCalled()
   })
 
-  it('reaps a CREATING box whose create job was claimed and then stalled', async () => {
-    const { service, boxRepository, jobRepository } = makeReaperService()
+  it('releases the lock even when the reap loses a race', async () => {
+    const { service, boxRepository, redisLockProvider } = makeReaperService()
     boxRepository.find.mockResolvedValue([stuckCreatingBox])
-    jobRepository.find.mockResolvedValue([{ status: 'IN_PROGRESS', startedAt: new Date(Date.now() - 10 * 60 * 1000) }])
+    boxRepository.updateWhere.mockRejectedValue(new Error('box was modified by another operation'))
 
     await service.reapFailedBoxStartups()
 
-    expect(boxRepository.updateWhere).toHaveBeenCalledTimes(1)
+    expect(redisLockProvider.unlock).toHaveBeenCalledWith('box:box-stuck:state-change')
   })
 
   it('keeps sweeping when one box loses the race', async () => {

--- a/apps/api/src/box/services/box.service.spec.ts
+++ b/apps/api/src/box/services/box.service.spec.ts
@@ -370,3 +370,145 @@ describe('BoxService public defaults', () => {
     )
   })
 })
+
+// The reaper only touches boxRepository + jobRepository + configService +
+// eventEmitter, and decides purely from persisted state — which is what makes
+// it able to clean up after a request, or a whole API process, that is gone.
+function makeReaperService() {
+  const boxRepository = {
+    find: jest.fn().mockResolvedValue([]),
+    updateWhere: jest.fn(async (id: string, { updateData }: any) => ({ id, ...updateData })),
+  } as any
+  const jobRepository = {
+    count: jest.fn().mockResolvedValue(0),
+    find: jest.fn().mockResolvedValue([]),
+  } as any
+  const configService = {
+    getOrThrow: jest.fn((key: string) => {
+      if (key === 'boxSync.startConfirmationStallSeconds') return 60
+      throw new Error(`unexpected config key ${key}`)
+    }),
+  } as any
+  const eventEmitter = { emit: jest.fn(), emitAsync: jest.fn() } as any
+  const noop = {} as any
+  const service = new BoxService(
+    boxRepository, // boxRepository
+    noop, // runnerRepository
+    noop, // runnerService
+    noop, // volumeService
+    configService, // configService
+    noop, // warmPoolService
+    eventEmitter, // eventEmitter
+    noop, // organizationService
+    noop, // runnerAdapterFactory
+    noop, // redisLockProvider
+    noop, // redis
+    noop, // regionService
+    noop, // boxLookupCacheInvalidationService
+    noop, // boxActivityService
+    jobRepository, // jobRepository
+    noop, // jobService
+  )
+  return { service, boxRepository, jobRepository, eventEmitter }
+}
+
+// A box as create() leaves it: pending, so destroy() refuses it.
+const stuckCreatingBox = {
+  id: 'box-stuck',
+  name: 'cozy-otter',
+  state: BoxState.CREATING,
+  desiredState: BoxDesiredState.STARTED,
+  pending: true,
+}
+
+const failedStartupBox = {
+  id: 'box-errored',
+  name: 'brave-otter',
+  state: BoxState.ERROR,
+  desiredState: BoxDesiredState.STARTED,
+  pending: false,
+}
+
+describe('BoxService.reapFailedBoxStartups', () => {
+  it('marks a box stuck in CREATING for destruction when nothing can still move it', async () => {
+    const { service, boxRepository, eventEmitter } = makeReaperService()
+    boxRepository.find.mockResolvedValue([stuckCreatingBox])
+
+    await service.reapFailedBoxStartups()
+
+    expect(boxRepository.updateWhere).toHaveBeenCalledWith('box-stuck', {
+      updateData: expect.objectContaining({
+        pending: true,
+        desiredState: BoxDesiredState.DESTROYED,
+      }),
+      whereCondition: { state: BoxState.CREATING, desiredState: BoxDesiredState.STARTED },
+    })
+    expect(eventEmitter.emit).toHaveBeenCalledWith(BoxEvents.DESTROYED, expect.anything())
+  })
+
+  it('reaps a box that errored on the way up', async () => {
+    const { service, boxRepository } = makeReaperService()
+    boxRepository.find.mockResolvedValue([failedStartupBox])
+
+    await service.reapFailedBoxStartups()
+
+    expect(boxRepository.updateWhere).toHaveBeenCalledWith(
+      'box-errored',
+      expect.objectContaining({
+        updateData: expect.objectContaining({ desiredState: BoxDesiredState.DESTROYED }),
+      }),
+    )
+  })
+
+  it('leaves a box that came up before it errored to the user', async () => {
+    const { service, boxRepository, jobRepository } = makeReaperService()
+    boxRepository.find.mockResolvedValue([failedStartupBox])
+    jobRepository.count.mockResolvedValue(1)
+
+    await service.reapFailedBoxStartups()
+
+    expect(boxRepository.updateWhere).not.toHaveBeenCalled()
+  })
+
+  it('leaves a CREATING box alone while its create job is unclaimed', async () => {
+    const { service, boxRepository, jobRepository } = makeReaperService()
+    boxRepository.find.mockResolvedValue([stuckCreatingBox])
+    jobRepository.find.mockResolvedValue([{ status: 'PENDING', startedAt: null }])
+
+    await service.reapFailedBoxStartups()
+
+    expect(boxRepository.updateWhere).not.toHaveBeenCalled()
+  })
+
+  it('leaves a CREATING box alone while its create job is still progressing', async () => {
+    const { service, boxRepository, jobRepository } = makeReaperService()
+    boxRepository.find.mockResolvedValue([stuckCreatingBox])
+    jobRepository.find.mockResolvedValue([{ status: 'IN_PROGRESS', startedAt: new Date() }])
+
+    await service.reapFailedBoxStartups()
+
+    expect(boxRepository.updateWhere).not.toHaveBeenCalled()
+  })
+
+  it('reaps a CREATING box whose create job was claimed and then stalled', async () => {
+    const { service, boxRepository, jobRepository } = makeReaperService()
+    boxRepository.find.mockResolvedValue([stuckCreatingBox])
+    jobRepository.find.mockResolvedValue([{ status: 'IN_PROGRESS', startedAt: new Date(Date.now() - 10 * 60 * 1000) }])
+
+    await service.reapFailedBoxStartups()
+
+    expect(boxRepository.updateWhere).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps sweeping when one box loses the race', async () => {
+    const { service, boxRepository } = makeReaperService()
+    boxRepository.find.mockResolvedValue([stuckCreatingBox, failedStartupBox])
+    boxRepository.updateWhere
+      .mockRejectedValueOnce(new Error('box was modified by another operation'))
+      .mockResolvedValueOnce({ id: 'box-errored' })
+
+    await service.reapFailedBoxStartups()
+
+    expect(boxRepository.updateWhere).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/api/src/box/services/box.service.ts
+++ b/apps/api/src/box/services/box.service.ts
@@ -55,7 +55,7 @@ import { customAlphabet as customNanoid, nanoid, urlAlphabet } from 'nanoid'
 import { WithInstrumentation } from '../../common/decorators/otel.decorator'
 import { validateMountPaths, validateSubpaths } from '../utils/volume-mount-path-validation.util'
 import { BoxRepository } from '../repositories/box.repository'
-import { getRunnerAssignmentLockKey } from '../utils/lock-key.util'
+import { getRunnerAssignmentLockKey, getStateChangeLockKey } from '../utils/lock-key.util'
 import { Job } from '../entities/job.entity'
 import { JobService } from './job.service'
 import { JobStatus, JobType, ResourceType } from '../dto/job.dto'
@@ -93,6 +93,15 @@ const DEFAULT_BOX_MEM = 1
 const DEFAULT_BOX_DISK = 10
 const DEFAULT_BOX_GPU = 0
 const TERMINAL_PREVIEW_PORT = 22222
+
+// How long an errored box stays readable before it is cleaned up. Errored
+// boxes are kept deliberately: the box list is where a user reads errorReason
+// and recoverable after a failure.
+const ERROR_BOX_TOMBSTONE_DAYS = 7
+
+// Boxes reaped per sweep. The cap matters on the first run after this ships,
+// which inherits every box that leaked while nothing could reap them.
+const REAP_FAILED_STARTUPS_BATCH_SIZE = 100
 
 @Injectable()
 export class BoxService {
@@ -1235,7 +1244,7 @@ export class BoxService {
   @WithInstrumentation()
   async cleanupStaleErrorBoxes() {
     const sevenDaysAgo = new Date()
-    sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7)
+    sevenDaysAgo.setDate(sevenDaysAgo.getDate() - ERROR_BOX_TOMBSTONE_DAYS)
 
     const result = await this.boxRepository.delete({
       state: BoxState.ERROR,
@@ -1269,16 +1278,23 @@ export class BoxService {
   @LogExecution('reap-failed-box-startups')
   @WithInstrumentation()
   async reapFailedBoxStartups() {
-    const stallSeconds: number = this.configService.getOrThrow('boxSync.startConfirmationStallSeconds')
-    const stalledBefore = new Date(Date.now() - stallSeconds * 1000)
+    const reapSeconds: number = this.configService.getOrThrow('boxSync.failedStartupReapSeconds')
+    const stuckBefore = new Date(Date.now() - reapSeconds * 1000)
+
+    // Errored boxes keep the tombstone window they have always had. Reaping
+    // them sooner would be a user-visible regression: an errored box stays in
+    // the box list so its errorReason and recoverable flag can be read, and
+    // that window is what `cleanupStaleErrorBoxes` was already built around.
+    // The bug being fixed is only that they never became reapable at all.
+    const erroredBefore = new Date(Date.now() - ERROR_BOX_TOMBSTONE_DAYS * 24 * 60 * 60 * 1000)
 
     const candidates = await this.boxRepository.find({
       where: [
-        // Still coming up, and has not been touched for a stall window.
+        // Still coming up, and has not been touched for a full reap window.
         {
           state: BoxState.CREATING,
           desiredState: Not(BoxDesiredState.DESTROYED),
-          updatedAt: LessThan(stalledBefore),
+          updatedAt: LessThan(stuckBefore),
         },
         // Failed. Whether it failed *during creation* is what matters, so this
         // is narrowed by the CREATE_BOX job below rather than by state alone —
@@ -1287,18 +1303,32 @@ export class BoxService {
         {
           state: BoxState.ERROR,
           desiredState: Not(BoxDesiredState.DESTROYED),
+          updatedAt: LessThan(erroredBefore),
         },
       ],
+      // Oldest first, capped: the first run after this ships has every box
+      // that ever leaked to work through, and draining that over several
+      // minutes is preferable to one tick issuing thousands of writes and
+      // destroy events at once.
+      order: { updatedAt: 'ASC' },
+      take: REAP_FAILED_STARTUPS_BATCH_SIZE,
     })
 
     let reaped = 0
 
     for (const box of candidates) {
+      // Same lock the sync loop takes before moving a box, so a reap cannot
+      // interleave with an in-flight state transition for the same box.
+      const lockKey = getStateChangeLockKey(box.id)
+      if (!(await this.redisLockProvider.lock(lockKey, 30))) {
+        continue
+      }
+
       try {
         if (await this.hasCompletedCreateJob(box)) {
           continue
         }
-        if (box.state === BoxState.CREATING && (await this.hasProgressingCreateJob(box, stalledBefore))) {
+        if (box.state === BoxState.CREATING && (await this.hasProgressingCreateJob(box))) {
           continue
         }
 
@@ -1318,6 +1348,8 @@ export class BoxService {
         // race, a concurrent destroy) is the expected miss, not a failure of
         // the sweep. Log it and keep going; the next run re-evaluates.
         this.logger.warn(`Failed to reap box ${box.id} after failed startup:`, error)
+      } finally {
+        await this.redisLockProvider.unlock(lockKey)
       }
     }
 
@@ -1329,6 +1361,11 @@ export class BoxService {
   /**
    * Whether the box ever finished being created. Distinguishes "failed on the
    * way up" from "came up, and failed later".
+   *
+   * This reads a completed job as proof of a past success, so it depends on
+   * CREATE_BOX jobs being kept for the lifetime of the box — nothing prunes
+   * the job table today. Adding a job retention window without revisiting
+   * this would make long-lived boxes look like they never started.
    */
   private async hasCompletedCreateJob(box: Box): Promise<boolean> {
     const count = await this.jobRepository.count({
@@ -1345,12 +1382,13 @@ export class BoxService {
 
   /**
    * Whether a CREATE_BOX job could still move this box on its own. An
-   * unclaimed (PENDING) job is waiting for a runner and a recently claimed one
-   * is presumed to be running normally; only a job claimed before the stall
-   * window — or no open job at all — means nothing is coming.
+   * unclaimed (PENDING) job is waiting for a runner, and a claimed one is
+   * presumed to be working — a claim is stamped once, at claim time, so its
+   * age says nothing about progress and is not used to condemn the box. Only
+   * the complete absence of an open job means nothing is coming.
    */
-  private async hasProgressingCreateJob(box: Box, stalledBefore: Date): Promise<boolean> {
-    const openJobs = await this.jobRepository.find({
+  private async hasProgressingCreateJob(box: Box): Promise<boolean> {
+    const openJobs = await this.jobRepository.count({
       where: {
         resourceType: ResourceType.BOX,
         resourceId: box.id,
@@ -1359,7 +1397,7 @@ export class BoxService {
       },
     })
 
-    return openJobs.some((job) => job.status === JobStatus.PENDING || !job.startedAt || job.startedAt >= stalledBefore)
+    return openJobs > 0
   }
 
   async setAutostopInterval(boxIdOrName: string, interval: number, organizationId?: string): Promise<Box> {

--- a/apps/api/src/box/services/box.service.ts
+++ b/apps/api/src/box/services/box.service.ts
@@ -1248,6 +1248,120 @@ export class BoxService {
     }
   }
 
+  /**
+   * Mark boxes whose creation never finished for destruction.
+   *
+   * The create endpoint destroys the box itself when startup fails, but that
+   * only covers a live request. Two cases it cannot cover:
+   *
+   *   - the API process dies between `create()` and the failure;
+   *   - the caller's wait expires while the box is still CREATING, where
+   *     `destroy()` refuses the box because `create()` left it pending.
+   *
+   * Neither did `cleanupStaleErrorBoxes`, which only matches boxes already
+   * marked for destruction — a box that never came up is left at
+   * `desiredState = STARTED`, so it matched nothing and stayed forever.
+   *
+   * The decision here is made entirely from persisted state, so it does not
+   * depend on the request, or the API process that served it, still existing.
+   */
+  @Cron(CronExpression.EVERY_MINUTE, { name: 'reap-failed-box-startups' })
+  @LogExecution('reap-failed-box-startups')
+  @WithInstrumentation()
+  async reapFailedBoxStartups() {
+    const stallSeconds: number = this.configService.getOrThrow('boxSync.startConfirmationStallSeconds')
+    const stalledBefore = new Date(Date.now() - stallSeconds * 1000)
+
+    const candidates = await this.boxRepository.find({
+      where: [
+        // Still coming up, and has not been touched for a stall window.
+        {
+          state: BoxState.CREATING,
+          desiredState: Not(BoxDesiredState.DESTROYED),
+          updatedAt: LessThan(stalledBefore),
+        },
+        // Failed. Whether it failed *during creation* is what matters, so this
+        // is narrowed by the CREATE_BOX job below rather than by state alone —
+        // a box that errored after serving traffic is the user's to see and to
+        // delete, not ours to reap.
+        {
+          state: BoxState.ERROR,
+          desiredState: Not(BoxDesiredState.DESTROYED),
+        },
+      ],
+    })
+
+    let reaped = 0
+
+    for (const box of candidates) {
+      try {
+        if (await this.hasCompletedCreateJob(box)) {
+          continue
+        }
+        if (box.state === BoxState.CREATING && (await this.hasProgressingCreateJob(box, stalledBefore))) {
+          continue
+        }
+
+        // `create()` leaves the box pending, so destroy() would refuse it.
+        // Writing the desired state directly is the point of this loop: the
+        // destroy action is the only thing that can still release whatever the
+        // runner allocated, so the box has to reach it even from CREATING.
+        const updatedBox = await this.boxRepository.updateWhere(box.id, {
+          updateData: Box.getSoftDeleteUpdate(box),
+          whereCondition: { state: box.state, desiredState: box.desiredState },
+        })
+
+        this.eventEmitter.emit(BoxEvents.DESTROYED, new BoxDestroyedEvent(updatedBox))
+        reaped++
+      } catch (error) {
+        // A box modified underneath us (its own request finally winning the
+        // race, a concurrent destroy) is the expected miss, not a failure of
+        // the sweep. Log it and keep going; the next run re-evaluates.
+        this.logger.warn(`Failed to reap box ${box.id} after failed startup:`, error)
+      }
+    }
+
+    if (reaped > 0) {
+      this.logger.log(`Marked ${reaped} boxes with a failed startup for destruction`)
+    }
+  }
+
+  /**
+   * Whether the box ever finished being created. Distinguishes "failed on the
+   * way up" from "came up, and failed later".
+   */
+  private async hasCompletedCreateJob(box: Box): Promise<boolean> {
+    const count = await this.jobRepository.count({
+      where: {
+        resourceType: ResourceType.BOX,
+        resourceId: box.id,
+        type: JobType.CREATE_BOX,
+        status: JobStatus.COMPLETED,
+      },
+    })
+
+    return count > 0
+  }
+
+  /**
+   * Whether a CREATE_BOX job could still move this box on its own. An
+   * unclaimed (PENDING) job is waiting for a runner and a recently claimed one
+   * is presumed to be running normally; only a job claimed before the stall
+   * window — or no open job at all — means nothing is coming.
+   */
+  private async hasProgressingCreateJob(box: Box, stalledBefore: Date): Promise<boolean> {
+    const openJobs = await this.jobRepository.find({
+      where: {
+        resourceType: ResourceType.BOX,
+        resourceId: box.id,
+        type: JobType.CREATE_BOX,
+        status: In([JobStatus.PENDING, JobStatus.IN_PROGRESS]),
+      },
+    })
+
+    return openJobs.some((job) => job.status === JobStatus.PENDING || !job.startedAt || job.startedAt >= stalledBefore)
+  }
+
   async setAutostopInterval(boxIdOrName: string, interval: number, organizationId?: string): Promise<Box> {
     const box = await this.findOneByIdOrName(boxIdOrName, organizationId)
 

--- a/apps/api/src/boxlite-rest/boxlite-box.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-box.controller.ts
@@ -116,7 +116,13 @@ export class BoxliteBoxController {
         // Box failed to start. Destroy the orphan record so it does not
         // accumulate in the user's box list — the caller already gets a 400
         // (or timeout) for this request and has no way to clean it up.
-        // Best-effort: if destroy also fails (rare race), log and move on.
+        //
+        // Best-effort by design, and it is expected to miss: on the timeout
+        // path the box is still CREATING and pending, which destroy() refuses.
+        // Cleaning up here is the fast path for the common case (the box
+        // reached ERROR, which clears pending); everything it misses — that
+        // timeout, and this process dying before the catch runs — is reaped
+        // from persisted state by BoxService.reapFailedBoxStartups.
         await this.boxService.destroy(box.id, organization.id).catch((destroyError: unknown) => {
           this.logger.warn(
             `Failed to destroy orphan box ${box.id} after creation failure: ${(destroyError as Error)?.message}`,

--- a/apps/api/src/boxlite-rest/boxlite-box.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-box.controller.ts
@@ -110,7 +110,20 @@ export class BoxliteBoxController {
 
     let box = await this.boxService.create(createBoxDto, organization)
     if (box.state !== BoxState.STARTED) {
-      box = await this.boxStateWaiter.waitForStarted(box.id, organization.id, 30)
+      try {
+        box = await this.boxStateWaiter.waitForStarted(box.id, organization.id, 30)
+      } catch (error) {
+        // Box failed to start. Destroy the orphan record so it does not
+        // accumulate in the user's box list — the caller already gets a 400
+        // (or timeout) for this request and has no way to clean it up.
+        // Best-effort: if destroy also fails (rare race), log and move on.
+        await this.boxService.destroy(box.id, organization.id).catch((destroyError: unknown) => {
+          this.logger.warn(
+            `Failed to destroy orphan box ${box.id} after creation failure: ${(destroyError as Error)?.message}`,
+          )
+        })
+        throw error
+      }
     }
     return boxToBoxResponse(box)
   }

--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -508,6 +508,15 @@ const configuration = {
     // a backstop for a lost job-completion callback, not a fast path: raise it
     // if legitimate startups ever get closed out ahead of their own callback.
     startConfirmationStallSeconds: parseInt(process.env.BOX_SYNC_START_CONFIRMATION_STALL_SECONDS || '60', 10),
+    // How long a box may sit in CREATING before it is treated as a creation
+    // that will never finish and destroyed. Deliberately much larger than
+    // startConfirmationStallSeconds: the cost of being wrong there is closing
+    // out a job the runner already finished, here it is destroying a box that
+    // is still legitimately coming up, so this has to clear the slowest
+    // realistic create (large image pull included) by a wide margin. It also
+    // has to outlast job.service's stale-job timeout, which is what turns a
+    // create abandoned by a dead runner into a closed job in the first place.
+    failedStartupReapSeconds: parseInt(process.env.BOX_SYNC_FAILED_STARTUP_REAP_SECONDS || '1800', 10),
   },
   encryption: {
     key: process.env.ENCRYPTION_KEY,


### PR DESCRIPTION
Destroys the box record when creation fails to start, and reaps the boxes that path cannot reach — a caller timeout (box still CREATING and pending, which `destroy()` refuses) or the API process dying mid-create.

`cleanupStaleErrorBoxes` never covered these: it only matches boxes already at `desiredState = DESTROYED`, while a box that never came up sits at `STARTED`, so it matched nothing and stayed forever. The new `reapFailedBoxStartups` cron decides from persisted state alone, and is deliberately conservative about what it condemns:

- an open `CREATE_BOX` job means hands off — declaring a create dead belongs to `job.service`'s stale-job timeout, not to this sweep;
- `CREATING` is reaped only after `boxSync.failedStartupReapSeconds` (30m default, well past that timeout);
- errored boxes keep their existing 7 day tombstone window, so `errorReason` and `recoverable` stay readable;
- a completed `CREATE_BOX` job exempts the box — one that came up and failed later stays the user's to delete;
- each sweep is capped at 100, oldest first, and holds the same state-change lock as the sync loop.

It soft-deletes through `desiredState = DESTROYED` rather than deleting rows, so the destroy action still releases whatever the runner allocated.

Test plan:
- [x] `jest src/box src/boxlite-rest src/config` — 389 passed, 0 failed (10 new cases for `reapFailedBoxStartups`)
- [x] `tsc --noEmit` on `tsconfig.app.json` and `tsconfig.spec.json` — clean
- [x] `eslint` + `prettier --check` on the changed files
- [ ] Not run: staging soak against a real stalled create (needs a runner that hangs mid-create)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Failed box startups are now cleaned up automatically, preventing orphaned boxes from remaining in the box list.
  - Stalled or errored box startups are identified and marked for destruction.
  - Box startup cleanup continues even if an individual cleanup operation encounters an error.
  - Boxes with active or progressing startup jobs are left unchanged.
  - Errors from failed startups are still reported after cleanup is attempted.
  - Cleanup safely handles concurrent state changes and limits each sweep to the oldest affected boxes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->