### PR TITLE
fix(ci): read the promote source in its own region

### DIFF
--- a/.github/workflows/build-apps-api-image.yml
+++ b/.github/workflows/build-apps-api-image.yml
@@ -4,7 +4,8 @@ name: Build apps/api image
 #
 #   commit  — called by deploy-infra.yml for the commit being deployed, tagged v<version>-<ref>
 #   build   — dispatched for a release, tagged <version>, into dev
-#   promote — copies a released tag from one stage's repository to another
+#   promote — copies a released tag from one stage's repository to another, in either the same
+#             region or another one (source_region)
 #
 # Named per service because it is one of three the stack builds from source — apps/proxy and
 # apps/otel-collector are the others (sst.config.ts) and have no published-image path yet, so a
@@ -63,6 +64,11 @@ on:
         options:
           - dev
           - prod
+      source_region:
+        description: 'Region holding source_stage, when it differs from the target (promote only).'
+        required: false
+        default: ''
+        type: string
       version:
         description: 'Stable X.Y.Z, matching the release tag being published.'
         required: true
@@ -85,6 +91,14 @@ jobs:
     timeout-minutes: 60
     env:
       AWS_REGION: ${{ vars.AWS_REGION || 'ap-southeast-1' }}
+      # Where the image being promoted already lives, which `vars` cannot answer: a job binds to
+      # one Environment and that one is the target's, so `vars.AWS_REGION` is always the region
+      # receiving the image. Stages are not required to share a region — dev is ap-southeast-1
+      # while prod is us-west-2 — and a registry is one account in one region, so a promote that
+      # assumes they match looks for the source repository in the target's region and reports the
+      # repository as missing rather than as elsewhere. Empty means "the same region as the
+      # target", which is every same-region promote and what this workflow assumed before.
+      SOURCE_REGION: ${{ inputs.source_region || vars.AWS_REGION || 'ap-southeast-1' }}
       # `ref` is the workflow_call-only input, so its presence is what selects commit mode.
       OPERATION: ${{ inputs.ref && 'commit' || inputs.operation }}
       TARGET_STAGE: ${{ inputs.stage || 'dev' }}
@@ -192,10 +206,19 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          registry="$(aws sts get-caller-identity --query Account --output text).dkr.ecr.${AWS_REGION}.amazonaws.com"
-          aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "$registry"
-          echo "target=${registry}/boxlite-app-${TARGET_STAGE}-api" >> "$GITHUB_OUTPUT"
-          echo "source=${registry}/boxlite-app-${SOURCE_STAGE}-api" >> "$GITHUB_OUTPUT"
+          account="$(aws sts get-caller-identity --query Account --output text)"
+          target_registry="${account}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+          source_registry="${account}.dkr.ecr.${SOURCE_REGION}.amazonaws.com"
+          aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "$target_registry"
+          # A second login when the source stage is in another region. The role already reaches it
+          # — github-deploy-role.yaml grants ecr:* on Resource '*', which no region scopes — but a
+          # docker credential is per registry host, and the copy below reads the source through
+          # docker rather than through the AWS CLI.
+          if [ "$source_registry" != "$target_registry" ]; then
+            aws ecr get-login-password --region "$SOURCE_REGION" | docker login --username AWS --password-stdin "$source_registry"
+          fi
+          echo "target=${target_registry}/boxlite-app-${TARGET_STAGE}-api" >> "$GITHUB_OUTPUT"
+          echo "source=${source_registry}/boxlite-app-${SOURCE_STAGE}-api" >> "$GITHUB_OUTPUT"
 
       - name: Verify bootstrap repositories and target tag
         id: target
@@ -213,11 +236,22 @@ jobs:
           source_digest=""
           if [ "$OPERATION" = promote ]; then
             source_name="boxlite-app-${SOURCE_STAGE}-api"
-            source_digest=$(aws ecr describe-images --region "$AWS_REGION" --repository-name "$source_name" \
+            # SOURCE_REGION, not AWS_REGION: the source stage need not share the target's region,
+            # and reading it in the wrong one returns RepositoryNotFoundException — which reads as
+            # "never published" when the image is published, just elsewhere. Both messages below
+            # name the region for that reason.
+            source_digest=$(aws ecr describe-images --region "$SOURCE_REGION" --repository-name "$source_name" \
               --image-ids "imageTag=$TAG" --query 'imageDetails[0].imageDigest' --output text) || {
-                echo "$source_name:$TAG has not been published" >&2
+                echo "$source_name:$TAG was not found in $SOURCE_REGION; pass source_region if that stage is in another region" >&2
                 exit 1
               }
+            # `--query` on a missing tag in an existing repository prints the literal None and
+            # exits zero, so the guard above cannot see it. Left unchecked it reaches the copy as
+            # "$SOURCE@None" — the same hole artifacts/api.ts:104 closes on the deploy side.
+            if [ -z "$source_digest" ] || [ "$source_digest" = None ]; then
+              echo "$source_name:$TAG has not been published in $SOURCE_REGION" >&2
+              exit 1
+            fi
           fi
           target_digest=$(aws ecr describe-images --region "$AWS_REGION" --repository-name "$target_name" \
             --image-ids "imageTag=$TAG" --query 'imageDetails[0].imageDigest' --output text 2>/dev/null || true)

--- a/apps/infra/deployment/release-safety.test.ts
+++ b/apps/infra/deployment/release-safety.test.ts
@@ -1778,6 +1778,58 @@ test('API publishing builds once and promotes that exact image without rebuildin
   assertShellLine(promoteRun, /if \[ "\$promoted" != "\$SOURCE_DIGEST" \]; then/)
 })
 
+test('promotion reads the source stage in the source stage\'s own region', () => {
+  // The defect this guards, observed promoting 0.10.0 from dev to prod: an ECR registry is one
+  // account in ONE region, and `vars` resolves against the single Environment a job binds to —
+  // the target's. So every source lookup ran in the target's region. With dev in ap-southeast-1
+  // and prod in us-west-2 that read boxlite-app-dev-api out of us-west-2, where it does not
+  // exist, and the guard reported the image as never published while it sat in the other region.
+  // The IAM side already spans regions (ecr:* on Resource '*'), so region is the whole of it.
+  const workflow = load(readFileSync(API_IMAGE_BUILD_WORKFLOW, 'utf8')) as any
+  const job = workflow.jobs.publish
+  const stepRun = (name: string) => job.steps.find((step: any) => step.name === name)?.run ?? ''
+
+  // Dispatch-only, like every other promote knob. The existing workflow_call assertion above
+  // pins that side by enumerating its inputs, so adding this one there fails there.
+  assert.equal(workflow.on.workflow_dispatch.inputs.source_region.required, false)
+  assert.equal(workflow.on.workflow_dispatch.inputs.source_region.default, '')
+
+  // Unset falls back to the target's region, which is what a same-region promote wants and what
+  // the workflow did unconditionally before. The order matters: the input has to win.
+  assert.equal(job.env.SOURCE_REGION, "${{ inputs.source_region || vars.AWS_REGION || 'ap-southeast-1' }}")
+  assert.equal(job.env.AWS_REGION, "${{ vars.AWS_REGION || 'ap-southeast-1' }}")
+
+  // A docker credential is per registry host, so the copy needs its own login when the source is
+  // elsewhere — the AWS-side grant does not carry docker.
+  const loginRun = stepRun('Log in to ECR')
+  assertShellLine(loginRun, /source_registry="\$\{account\}\.dkr\.ecr\.\$\{SOURCE_REGION\}\.amazonaws\.com"/)
+  assertShellLine(loginRun, /target_registry="\$\{account\}\.dkr\.ecr\.\$\{AWS_REGION\}\.amazonaws\.com"/)
+  assertShellLine(loginRun, /if \[ "\$source_registry" != "\$target_registry" \]; then/)
+  assertShellLine(loginRun, /get-login-password --region "\$SOURCE_REGION"/)
+  // $SOURCE is what the copy addresses; built from the target's registry it points at the wrong
+  // region however correct the digest is.
+  assertShellLine(loginRun, /echo "source=\$\{source_registry\}\/boxlite-app-\$\{SOURCE_STAGE\}-api"/)
+
+  const verifyRun = stepRun('Verify bootstrap repositories and target tag')
+  // The source read moves; the two target reads must not.
+  assertShellLine(verifyRun, /describe-images --region "\$SOURCE_REGION" --repository-name "\$source_name"/)
+  assertShellLine(verifyRun, /describe-repositories --region "\$AWS_REGION" --repository-names "\$target_name"/)
+  assertShellLine(verifyRun, /describe-images --region "\$AWS_REGION" --repository-name "\$target_name"/)
+  assert.doesNotMatch(
+    liveShell(verifyRun),
+    /describe-images --region "\$AWS_REGION" --repository-name "\$source_name"/,
+    'the source repository must never be read in the target region',
+  )
+  // Region in both refusals: "has not been published" with no location is what sent the operator
+  // looking for an unbuilt image instead of a misaddressed one.
+  assertShellLine(verifyRun, /was not found in \$SOURCE_REGION/)
+  assertShellLine(verifyRun, /has not been published in \$SOURCE_REGION/)
+  // `--query` on a present repository with an absent tag prints None and exits zero, so the `||`
+  // branch cannot catch it and the digest reaches the copy as "$SOURCE@None". Same hole as
+  // artifacts/api.ts:104, which is why the deploy side already guards it.
+  assertShellLine(verifyRun, /if \[ -z "\$source_digest" \] \|\| \[ "\$source_digest" = None \]; then/)
+})
+
 test('infrastructure tests cannot persist or write with the workflow token', () => {
   const source = readFileSync(LINT_WORKFLOW, 'utf8')
   const infraJobStart = source.indexOf('\n  infra:\n')

--- a/apps/infra/docs/deployment.md
+++ b/apps/infra/docs/deployment.md
@@ -311,10 +311,14 @@ verifies the ECR image and Runner release assets before invoking SST.
 calls it for the commit being deployed (`v<version>-<sha>`, into that stage);
 dispatching it with `operation=build` builds a released tag once into dev, and
 `operation=promote` copies that exact manifest registry-side, addressed by
-digest, rather than rebuilding. The dispatched operations run from `main`: a
-release event runs on a tag ref, and the deployment Environments that hold the
-AWS role are branch-scoped, so a tag-triggered job never reaches its
-credentials.
+digest, rather than rebuilding. An ECR registry is one account in one region,
+and the job binds to the *target* stage's Environment, so `source_region` is how
+a promote is told where to read when the two stages differ — dev in
+`ap-southeast-1`, prod in `us-west-2`. Omitted, it reads the source in the
+target's region, which is right whenever both share one. The dispatched
+operations run from `main`: a release event runs on a tag ref, and the
+deployment Environments that hold the AWS role are branch-scoped, so a
+tag-triggered job never reaches its credentials.
 
 Either path first runs deployment safety tests that require every Runner to
 retain `protect: true` and the AMI/user-data ignore rules. The build path then
@@ -485,7 +489,7 @@ all require the same manual token.
 gh workflow run deploy-infra.yml --ref main -f stage=dev -f apply=false -f ref=<full-commit-sha>
 
 gh workflow run build-apps-api-image.yml --ref main -f operation=build -f version=0.9.8
-gh workflow run build-apps-api-image.yml --ref main -f operation=promote -f stage=prod -f version=0.9.8
+gh workflow run build-apps-api-image.yml --ref main -f operation=promote -f stage=prod -f version=0.9.8 -f source_region=ap-southeast-1
 gh workflow run deploy-release.yml --ref main -f stage=prod -f version=0.9.8
 npm run runner:build-artifact -- --stage dev # local linux/amd64 build + private S3 stage
 


### PR DESCRIPTION
An ECR registry is one account in one region, and the publish job binds to the target stage's Environment, so `vars.AWS_REGION` always named the region receiving the image. Every source lookup ran there too. With dev in ap-southeast-1 and prod in us-west-2, promoting read boxlite-app-dev-api out of us-west-2 and reported the image as never published while it sat in the other region.

A new `source_region` dispatch input carries where to read; unset, it stays the target's region, which is every same-region promote. The copy gets a second docker login when the registries differ — the role already spans regions, but a docker credential is per registry host. Both refusals now name the region they searched.

Also guards the digest `--query` returning the literal None on a present repository with an absent tag, which exits zero and reached the copy as "$SOURCE@None".

## Summary
<!-- 1-2 sentences: what this changes and why. -->

## Call graph
<!-- Required. The end-to-end path this PR touches, before and after; one line
     per hop, only the hops that change. Worked example and the bug-fix markers:
     CONTRIBUTING.md#commit--pr-messages. -->

Before
<!-- replace with the hops: fn_name (Type · path/file.rs:LOC) — role -->

After
<!-- replace with the same hops, post-change -->

Fixes #<!-- issue number — bug fixes only; delete this line otherwise -->

## Changes
- <!-- notable change — what changed, not a restatement of the diff -->

## How to verify
- <!-- a command or step a reviewer can run -->

## Risks / rollout
- <!-- only if any; delete this section otherwise -->

<!-- Describe the change, not the process: no pasted logs, no AI/conversation
     narrative, no secrets. Keep it tight and delete sections that don't apply. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - API image promotions can now copy images across different regions.
  - Added an optional source-region setting for promotion workflows; same-region promotions remain supported by default.
  - Improved validation and region-specific errors for missing source images.

- **Documentation**
  - Updated deployment guidance with cross-region promotion details and an example command.

- **Tests**
  - Added coverage for source-region selection, registry authentication, image verification, and missing-image handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->