### PR TITLE
fix(rest): classify codeless error bodies by HTTP status

### DIFF
--- a/apps/runner/pkg/api/controllers/boxlite_files.go
+++ b/apps/runner/pkg/api/controllers/boxlite_files.go
@@ -261,9 +261,11 @@ func respondCopyError(ctx *gin.Context, err error) {
 // these routes: `{error: {message, type, code}}`.
 //
 // A bare `{"error": "<text>"}` names no class, so the client
-// (src/boxlite/src/rest/error.rs) falls back to reading the status alone — and
-// that fallback has no 400 arm, so every refusal these routes state plainly
-// still reached the caller as a server fault.
+// (src/boxlite/src/rest/error.rs) reads the status alone. That baseline is
+// coarser than what these routes state — `already_exists` and `invalid_state`
+// both collapse into the 409 baseline — and the 410 and 422 they use have no
+// baseline arm at all, so such a refusal still reaches the caller as a server
+// fault.
 func respondError(ctx *gin.Context, status int, message, errorType, code string) {
 	ctx.JSON(status, gin.H{"error": gin.H{
 		"message": message,

--- a/openapi/reference-server/errors.py
+++ b/openapi/reference-server/errors.py
@@ -55,11 +55,10 @@ def classify_error(message: str) -> tuple[int, str, str]:
 def error_envelope(message: str, error_type: str, code: str) -> dict:
     """The error body `box.openapi.yaml` declares: `{error: {message, type, code}}`.
 
-    `code` is the stable snake_case identifier, which is the only field clients
-    dispatch on (`map_http_error`, src/boxlite/src/rest/error.rs). The HTTP
-    status belongs in the status line and repeating it here left the body
-    undecodable — the client then reads the status alone, and that fallback has
-    no 400 arm, so a refusal this server states plainly arrived as a server
-    fault.
+    `code` is the stable snake_case identifier that refines the variant the
+    client derives from the HTTP status (src/boxlite/src/rest/error.rs). The
+    status belongs in the status line: repeating it here puts a value in `code`
+    that no arm matches, so the refusal loses the specific variant this server
+    named and arrives as the status baseline instead.
     """
     return {"error": {"message": message, "type": error_type, "code": code}}

--- a/openapi/reference-server/tests/test_error_envelope.py
+++ b/openapi/reference-server/tests/test_error_envelope.py
@@ -148,12 +148,11 @@ class ErrorEnvelopeTests(unittest.TestCase):
     def test_the_envelope_carries_the_machine_code_clients_dispatch_on(self) -> None:
         """`error.code` is the stable snake_case identifier, not the status.
 
-        Clients pattern-match on it (`map_http_error` in
-        src/boxlite/src/rest/error.rs dispatches on nothing else), and
-        box.openapi.yaml types it `string`. Repeating the numeric status there
-        left the body undecodable: the client falls back to reading the status
-        alone, which has no 400 arm, so a refusal this server states plainly
-        still reached the caller as a server fault.
+        The client derives a baseline variant from the HTTP status and lets
+        `code` refine it (src/boxlite/src/rest/error.rs), and box.openapi.yaml
+        types it `string`. Repeating the numeric status there matches no arm,
+        so the specific variant this server named is lost and the caller is
+        left with the status baseline.
         """
         status, error_type, code = ERRORS.classify_error(self.REFUSAL)
         body = ERRORS.error_envelope(self.REFUSAL, error_type, code)
@@ -186,8 +185,8 @@ class ErrorEnvelopeTests(unittest.TestCase):
 
         `test_every_class_is_one_the_spec_declares` covers the table; these are
         the sites that bypass it. A class outside the enums is one the client's
-        `map_http_error` has no arm for, so it falls back to reading the status
-        alone — the same way the numeric `code` used to.
+        code table has no arm for, so the caller is left with the variant the
+        HTTP status implies — the same way a numeric `code` is.
         """
         allowed_types = spec_enum("type")
         allowed_codes = spec_enum("code")

--- a/src/boxlite/src/rest/client.rs
+++ b/src/boxlite/src/rest/client.rs
@@ -11,7 +11,7 @@ use tokio::sync::RwLock;
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 
 use super::credential::{AccessToken, Credential};
-use super::error::{map_http_body, map_http_status};
+use super::error::{map_http_body, map_plain_reply};
 use super::options::BoxliteRestOptions;
 use super::types::ServerConfig;
 use crate::runtime::auth::Principal;
@@ -21,6 +21,37 @@ const REFRESH_LEEWAY: Duration = Duration::from_secs(60);
 /// File transfers cannot outlive the runner's 24-hour box lifetime cap.
 const FILE_REQUEST_TIMEOUT: Duration = Duration::from_secs(24 * 60 * 60);
 const TUNNEL_SETUP_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// The proxy states a refused tunnel in one short line (Go's `http.Error`).
+/// The limit is enforced while reading, not after: a peer that answers a
+/// handshake with megabytes is not stating a reason, and buffering it first
+/// would be trusting it for length. Past the limit the status speaks alone.
+const CONNECT_REFUSAL_MAX_BYTES: usize = 512;
+
+/// Reading the sentence off an already-arrived refusal is instant against
+/// `apps/proxy` (`http.Error` flushes the body with the headers); this bound
+/// only covers a peer that stalls mid-body, and a refusal should fail fast.
+const CONNECT_REFUSAL_READ_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Read the sentence a peer sent with its non-2xx CONNECT reply.
+async fn read_connect_refusal(response: hyper::Response<hyper::body::Incoming>) -> String {
+    use http_body_util::{BodyExt, Limited};
+
+    const FALLBACK: &str = "CONNECT proxy rejected tunnel";
+    let body = Limited::new(response.into_body(), CONNECT_REFUSAL_MAX_BYTES);
+    let Ok(Ok(collected)) =
+        tokio::time::timeout(CONNECT_REFUSAL_READ_TIMEOUT, body.collect()).await
+    else {
+        return FALLBACK.to_string();
+    };
+    let bytes = collected.to_bytes();
+    let text = String::from_utf8_lossy(&bytes);
+    let text = text.trim();
+    if text.is_empty() {
+        return FALLBACK.to_string();
+    }
+    text.to_string()
+}
 
 type TunnelConnector =
     hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>;
@@ -390,7 +421,12 @@ impl ApiClient {
             .map_err(|e| BoxliteError::Network(format!("CONNECT request failed: {e}")))?;
         let status = response.status();
         if !status.is_success() {
-            return Err(map_http_status(status, "CONNECT proxy rejected tunnel"));
+            // Our own proxy answers this handshake with a verdict of its own,
+            // in plain text rather than our envelope. Carry its sentence and
+            // read the class off the status; a refusal it wrote is never an
+            // intermediary's fault.
+            let detail = read_connect_refusal(response).await;
+            return Err(map_plain_reply(status, &detail));
         }
         let upgraded = hyper::upgrade::on(response)
             .await
@@ -564,19 +600,31 @@ pub(super) fn transport_error(err: reqwest::Error) -> BoxliteError {
     BoxliteError::Network(detail)
 }
 
-/// Map a tungstenite connect error to a typed `BoxliteError`. The WS
-/// upgrade returns HTTP status codes for rejections (404 for a missing
-/// session, 409 for an already-attached one, 410 once an exec has been
-/// reaped). Symmetric with the REST mapper in [`super::error`].
+/// Map a tungstenite connect error to a typed `BoxliteError`.
+///
+/// The explicit arms below are the WS attach contract, not a copy of the
+/// REST baseline: on this handshake 404 means the session is gone, 409 that
+/// the single attach slot is taken, 410 that the reaper got there first —
+/// and the reattach loop in `litebox` branches on exactly those classes
+/// (`AlreadyExists` to back off, `NotFound`/`SessionReaped` to stop), with
+/// its tests pinning them. The backends also do not agree on a body shape
+/// here (`serve` rejects with the wire envelope, the runner with gin's
+/// `{"error": text}`), so the classes stay keyed on the status; the envelope,
+/// when present, contributes its sentence rather than raw JSON. Statuses
+/// with no meaning of their own on this handshake are read like any other
+/// REST reply.
 fn map_ws_error(err: tokio_tungstenite::tungstenite::Error) -> BoxliteError {
     use tokio_tungstenite::tungstenite::Error as TgErr;
     if let TgErr::Http(resp) = &err {
         let status = resp.status();
-        let body = resp
+        let raw = resp
             .body()
             .as_ref()
             .map(|b| String::from_utf8_lossy(b).into_owned())
             .unwrap_or_default();
+        // `serve` rejects the upgrade with the same envelope every REST
+        // route answers with; carry its sentence, never the JSON itself.
+        let body = super::error::envelope_message(&raw).unwrap_or_else(|| raw.clone());
         return match status.as_u16() {
             404 => BoxliteError::NotFound(if body.is_empty() {
                 "session not found".to_string()
@@ -594,12 +642,12 @@ fn map_ws_error(err: tokio_tungstenite::tungstenite::Error) -> BoxliteError {
                 body
             }),
             401 | 403 => BoxliteError::Config(format!("WS auth rejected ({}): {}", status, body)),
-            502..=504 => BoxliteError::Network(format!(
-                "WS upstream returned HTTP {} (proxy or load balancer): {}",
-                status,
-                if body.is_empty() { "<empty>" } else { &body }
-            )),
-            _ => BoxliteError::Internal(format!("WS upgrade failed (HTTP {}): {}", status, body)),
+            // No WS-specific meaning — 5xx included: read it like any other
+            // REST reply, envelope, flat body, or bare status alike. A
+            // refusal the server names (`invalid_argument` on a 400,
+            // `engine_unavailable` on a 503) keeps its class instead of
+            // arriving as a server fault or an intermediary's.
+            _ => map_http_body(status, &raw),
         };
     }
     BoxliteError::Network(format!("WS connect failed: {}", err))
@@ -624,8 +672,7 @@ mod tests {
     use super::ensure_capability;
     use super::*;
     use crate::rest::credential::{AccessToken, Credential};
-    use crate::rest::error::map_http_error;
-    use crate::rest::types::FlatErrorResponse;
+    use crate::rest::error::map_http_body;
     use async_trait::async_trait;
     use boxlite_shared::errors::BoxliteError;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -805,6 +852,199 @@ mod tests {
         server.await.unwrap();
     }
 
+    /// Our proxy answers this handshake with a verdict of its own and states
+    /// it in plain text. Each refusal must keep the class its status names and
+    /// the sentence the proxy wrote: a bad target is the caller's error, a
+    /// private box is an auth failure the CLI keys on, and a runner the proxy
+    /// could not reach is an upstream failure — never an intermediary's, since
+    /// the proxy plainly answered.
+    #[tokio::test]
+    #[allow(clippy::result_large_err)]
+    async fn connect_box_network_tunnel_keeps_the_proxys_own_verdict() {
+        /// One tunnel-refusal case: `(status_line, proxy_sentence,
+        /// variant_predicate)`. Aliased so clippy doesn't flag the tuple.
+        type RefusalCase = (&'static str, &'static str, fn(&BoxliteError) -> bool);
+        let cases: &[RefusalCase] = &[
+            ("400 Bad Request", "bad tunnel target", |e| {
+                matches!(e, BoxliteError::InvalidArgument(_))
+            }),
+            (
+                "403 Forbidden",
+                "box is not public",
+                |e| matches!(e, BoxliteError::Config(msg) if msg.starts_with("auth:")),
+            ),
+            ("502 Bad Gateway", "runner unavailable", |e| {
+                matches!(e, BoxliteError::Network(_))
+            }),
+        ];
+
+        for (status_line, body, is_expected) in cases {
+            let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+            let port = listener.local_addr().unwrap().port();
+            let reply = format!(
+                "HTTP/1.1 {status_line}\r\nContent-Length: {}\r\n\r\n{body}",
+                body.len()
+            );
+            let server = tokio::spawn(async move {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let mut headers = Vec::new();
+                while !headers.ends_with(b"\r\n\r\n") {
+                    headers.push(socket.read_u8().await.unwrap());
+                }
+                socket.write_all(reply.as_bytes()).await.unwrap();
+            });
+
+            let client =
+                ApiClient::new(&BoxliteRestOptions::new(format!("http://127.0.0.1:{port}")))
+                    .unwrap();
+            let err = client
+                .connect_box_network_tunnel(&format!("http://127.0.0.1:{port}"))
+                .await
+                .expect_err("a non-2xx CONNECT reply is a refusal");
+
+            assert!(
+                is_expected(&err),
+                "{status_line} lost the class its status names: {err:?}"
+            );
+            let rendered = err.to_string();
+            assert!(
+                rendered.contains(body),
+                "the proxy's own sentence must survive {status_line}: {rendered}"
+            );
+            assert!(
+                !rendered.contains("no error envelope"),
+                "the proxy answered, so {status_line} is not an intermediary's \
+                 fault: {rendered}"
+            );
+
+            server.await.unwrap();
+        }
+    }
+
+    /// A peer answering a handshake with more than a sentence is not stating a
+    /// reason, and buffering whatever it sends would trust it for length. Past
+    /// the read limit the status is reported on its own.
+    #[tokio::test]
+    #[allow(clippy::result_large_err)]
+    async fn connect_box_network_tunnel_caps_an_oversized_refusal() {
+        let flood = "x".repeat(CONNECT_REFUSAL_MAX_BYTES * 4);
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let reply = format!(
+            "HTTP/1.1 403 Forbidden\r\nContent-Length: {}\r\n\r\n{flood}",
+            flood.len()
+        );
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut headers = Vec::new();
+            while !headers.ends_with(b"\r\n\r\n") {
+                headers.push(socket.read_u8().await.unwrap());
+            }
+            let _ = socket.write_all(reply.as_bytes()).await;
+        });
+
+        let client =
+            ApiClient::new(&BoxliteRestOptions::new(format!("http://127.0.0.1:{port}"))).unwrap();
+        let err = client
+            .connect_box_network_tunnel(&format!("http://127.0.0.1:{port}"))
+            .await
+            .expect_err("a 403 CONNECT reply is a refusal");
+
+        let rendered = err.to_string();
+        assert!(
+            rendered.len() < CONNECT_REFUSAL_MAX_BYTES * 2,
+            "an oversized refusal must not reach the message: {} bytes",
+            rendered.len()
+        );
+        assert!(
+            !rendered.contains(&"x".repeat(CONNECT_REFUSAL_MAX_BYTES)),
+            "the flood must not be buffered into the error"
+        );
+        assert!(
+            matches!(err, BoxliteError::Config(ref msg) if msg.starts_with("auth:")),
+            "the status still names the class: {err:?}"
+        );
+
+        let _ = server.await;
+    }
+
+    /// A WS-upgrade rejection from `serve` carries the wire envelope. The
+    /// explicit arms keep the attach contract's classes, but the text they
+    /// surface must be the server's sentence, never the JSON itself — and a
+    /// status with no attach meaning takes the envelope's own class instead
+    /// of arriving as a server fault.
+    #[test]
+    fn ws_upgrade_rejections_read_the_envelope() {
+        use tokio_tungstenite::tungstenite::Error as TgErr;
+
+        let http_reject = |status: u16, body: &str| {
+            TgErr::Http(
+                tokio_tungstenite::tungstenite::http::Response::builder()
+                    .status(status)
+                    .body(Some(body.as_bytes().to_vec()))
+                    .unwrap(),
+            )
+        };
+
+        // 409 keeps the attach contract's AlreadyExists, with the sentence.
+        let err = map_ws_error(http_reject(
+            409,
+            r#"{"error":{"message":"execution e1 already has an attached client","type":"InvalidStateError","code":"invalid_state"}}"#,
+        ));
+        match err {
+            BoxliteError::AlreadyExists(msg) => {
+                assert!(msg.contains("already has an attached client"), "{msg}");
+                assert!(!msg.contains('{'), "raw JSON must not leak: {msg}");
+            }
+            other => panic!("attach 409 keeps its contract class, got {other:?}"),
+        }
+
+        // 400 has no attach meaning of its own: the envelope's code decides.
+        let err = map_ws_error(http_reject(
+            400,
+            r#"{"error":{"message":"box name contains a slash","type":"InvalidArgumentError","code":"invalid_argument"}}"#,
+        ));
+        assert!(
+            matches!(err, BoxliteError::InvalidArgument(_)),
+            "a named caller error must not arrive as a server fault: {err:?}"
+        );
+
+        // Neither has a 5xx: a 503 the server answered with a named code is
+        // the class that code names, never an intermediary's fault.
+        let err = map_ws_error(http_reject(
+            503,
+            r#"{"error":{"message":"engine is down","type":"EngineError","code":"engine_unavailable"}}"#,
+        ));
+        match err {
+            BoxliteError::Engine(msg) => {
+                assert!(msg.contains("engine is down"), "{msg}");
+            }
+            other => panic!("a named 503 must keep its class, got {other:?}"),
+        }
+        let rendered = map_ws_error(http_reject(
+            503,
+            r#"{"error":{"message":"engine is down","type":"EngineError","code":"engine_unavailable"}}"#,
+        ))
+        .to_string();
+        assert!(
+            !rendered.contains("proxy or load balancer"),
+            "an answered 503 must not be attributed to an intermediary: {rendered}"
+        );
+
+        // The runner rejects with gin's `{"error": "<text>"}` — its only
+        // attach rejection shape, and the API's WS proxy passes it through
+        // verbatim. The 404 arm keeps its class; the sentence, not the JSON,
+        // is what the user reads.
+        let err = map_ws_error(http_reject(404, r#"{"error":"execution e1 not found"}"#));
+        match err {
+            BoxliteError::NotFound(msg) => {
+                assert!(msg.contains("execution e1 not found"), "{msg}");
+                assert!(!msg.contains('{'), "raw JSON must not leak: {msg}");
+            }
+            other => panic!("a runner 404 keeps its class, got {other:?}"),
+        }
+    }
+
     /// `prepare_box_tunnel` sends its descriptor request through the shared
     /// control-request path, so this pins the wire contract that path owes it:
     /// POST to the prefixed tunnel URL, JSON accepted, descriptor parsed back.
@@ -927,12 +1167,10 @@ mod tests {
 
     #[test]
     fn flat_nest_error_response_maps_by_code() {
-        let parsed: FlatErrorResponse = serde_json::from_str(
+        let err = map_http_body(
+            StatusCode::BAD_GATEWAY,
             r#"{"statusCode":502,"error":"Bad Gateway","message":"Runner API returned a non-JSON error response","code":"runner_non_json_error"}"#,
-        )
-        .expect("flat error response");
-
-        let err = map_http_error(StatusCode::BAD_GATEWAY, &parsed.into_error_model());
+        );
 
         match err {
             BoxliteError::Network(message) => {

--- a/src/boxlite/src/rest/error.rs
+++ b/src/boxlite/src/rest/error.rs
@@ -1,10 +1,16 @@
 //! HTTP error → BoxliteError mapping.
 //!
 //! Symmetric inverse of [`boxlite_shared::errors::BoxliteError::http`].
-//! The server emits `(status, error.type, error.code)` per that table;
-//! we dispatch on `error.code` (stable snake_case) to reconstruct the
-//! `BoxliteError` variant. Falling back to status-only mapping when
-//! the body is missing or doesn't parse.
+//!
+//! `error.code` (stable snake_case) names the variant whenever this client
+//! knows it. When the body names no code it knows, the HTTP status decides
+//! instead — for the statuses the server answers codelessly, which is what
+//! stops a refusal the caller caused from arriving as a server fault. What
+//! the status table has no arm for stays `Internal`, and so does a 5xx whose
+//! envelope named no code at all. A named code refines even a 5xx —
+//! `network_unavailable` on a 503 is `Network`. An unknown code uses the
+//! status baseline when one exists; otherwise it stays `Internal`.
+//! See [`refine_by_status`] for why the omitted statuses are never guessed.
 
 use boxlite_shared::errors::BoxliteError;
 use reqwest::StatusCode;
@@ -21,23 +27,52 @@ use super::types::{ErrorModel, ErrorResponse, FlatErrorResponse};
 /// are preserved on the other backend.
 pub(crate) fn map_http_body(status: StatusCode, text: &str) -> BoxliteError {
     if let Ok(err_resp) = serde_json::from_str::<ErrorResponse>(text) {
-        map_http_error(status, &err_resp.error)
+        map_enveloped(status, &err_resp.error)
     } else if let Ok(err_resp) = serde_json::from_str::<FlatErrorResponse>(text) {
-        map_http_error(status, &err_resp.into_error_model())
+        map_enveloped(status, &err_resp.into_error_model())
     } else {
-        map_http_status(status, text)
+        // A body that is not one of our envelopes may still carry a sentence
+        // — the runner rejects with gin's `{"error": "<text>"}`. The class
+        // stays status-derived either way; only the message improves.
+        match envelope_message(text) {
+            Some(sentence) => map_status(status, &sentence),
+            None => map_status(status, text),
+        }
     }
 }
 
-/// Map a parsed structured error body to a `BoxliteError`.
-///
-/// Dispatch is on `body.code` (the stable snake string), making this
-/// the symmetric inverse of `BoxliteError::http()`. Unknown codes fall
-/// back on the HTTP status — keeps the client forward-compatible with
-/// future server-side variants.
-pub(crate) fn map_http_error(status: StatusCode, body: &ErrorModel) -> BoxliteError {
+/// Shared by both envelope shapes: a recognized `code` names the variant,
+/// otherwise the status does. Which fallback applies when neither knows the
+/// status depends on what the body left out, and the two cases are not the
+/// same failure.
+fn map_enveloped(status: StatusCode, body: &ErrorModel) -> BoxliteError {
     let msg = body.message.clone();
-    match body.code.as_str() {
+    if let Some(err) = refine_by_code(&body.code, &msg) {
+        return err;
+    }
+    if let Some(err) = refine_by_status(status, &msg) {
+        return err;
+    }
+    if body.code.is_empty() {
+        // The server named nothing beyond the status. A 5xx it stated itself
+        // is its own fault to report — what the fabricated `internal` code
+        // used to render — and never an intermediary's: the API answers
+        // codelessly at 503 while under maintenance or missing object
+        // storage, and calling that a proxy failure is this bug in mirror.
+        return BoxliteError::Internal(msg);
+    }
+    // A code this client has not learned yet: the server named a class, this
+    // client just cannot read it — but it did answer, so no intermediary is
+    // implicated. The status baseline above already had its say.
+    BoxliteError::Internal(msg)
+}
+
+/// The `code` → variant table. `None` means "this client does not know the
+/// code" — including the empty string a body without the field decodes to —
+/// and the caller keeps its status baseline.
+fn refine_by_code(code: &str, msg: &str) -> Option<BoxliteError> {
+    let msg = msg.to_string();
+    Some(match code {
         "invalid_argument" => BoxliteError::InvalidArgument(msg),
         "unsupported" => BoxliteError::Unsupported(msg),
         "unauthenticated" | "permission_denied" => BoxliteError::Config(format!("auth: {}", msg)),
@@ -58,22 +93,25 @@ pub(crate) fn map_http_error(status: StatusCode, body: &ErrorModel) -> BoxliteEr
         "config_error" => BoxliteError::Config(msg),
         "timeout" => BoxliteError::Internal(format!("server timed out: {}", msg)),
         "internal" => BoxliteError::Internal(msg),
-        // Forward-compat: unknown code from a newer server — fall back
-        // to status-driven mapping, preserving the body text.
-        _ => map_http_status(status, &msg),
-    }
+        _ => return None,
+    })
 }
 
-/// Map a raw HTTP status to a `BoxliteError` when the body is missing
-/// or not the envelope shape.
+/// The status baseline: the statuses this API answers with *codelessly*,
+/// where the status alone fixes the class. 409 covers several server-side
+/// variants (`already_exists` / `invalid_state` / `stopped`) so the baseline
+/// takes the most general of them — only an explicit `code` singles out the
+/// others.
 ///
-/// Distinguishes intermediary 5xx (proxy / unreachable upstream — we
-/// emit the envelope for our own 5xx) by routing **502/503/504 with
-/// no envelope** to `Network`, since the server we deployed never
-/// produces a bare 5xx without our wire envelope.
-pub(crate) fn map_http_status(status: StatusCode, text: &str) -> BoxliteError {
-    match status.as_u16() {
-        404 => BoxliteError::NotFound(text.to_string()),
+/// A status the server only ever answers with a code attached gets no arm
+/// (410 is always `session_reaped`; 422 always `image_pull_failed` or
+/// `execution_failed`): inventing a baseline would hand callers a class no
+/// server here states. 5xx is absent by the same rule — what an unavailable
+/// server deserves is decided by its caller, not by this table.
+fn refine_by_status(status: StatusCode, text: &str) -> Option<BoxliteError> {
+    let msg = text.to_string();
+    Some(match status.as_u16() {
+        400 => BoxliteError::InvalidArgument(msg),
         // Keep the `auth:` prefix (callers key on it) but state the actual
         // failure: 401 = credentials rejected (expired, or wrong credential
         // type for this endpoint — e.g. cloud exec's WS attach requires an API
@@ -81,6 +119,66 @@ pub(crate) fn map_http_status(status: StatusCode, text: &str) -> BoxliteError {
         // (often a stale org/path_prefix — `auth login` re-resolves it).
         401 => BoxliteError::Config(format!("auth: unauthorized (HTTP 401): {}", text)),
         403 => BoxliteError::Config(format!("auth: forbidden (HTTP 403): {}", text)),
+        404 => BoxliteError::NotFound(msg),
+        // The API raises RequestTimeoutException while waiting on a volume, a
+        // box state, or a resume — always without a code.
+        408 => BoxliteError::Internal(format!("server timed out: {}", text)),
+        409 => BoxliteError::InvalidState(msg),
+        // 428 has no variant of its own; the API answers with it when a
+        // runner or region is not in a state that permits the request.
+        428 => BoxliteError::InvalidState(msg),
+        429 => BoxliteError::ResourceExhausted(msg),
+        _ => return None,
+    })
+}
+
+/// The human sentence inside a body, whichever of our envelope shapes carries
+/// it — for a caller that keeps status semantics of its own (the WS upgrade)
+/// but must not surface raw JSON as the error text.
+pub(crate) fn envelope_message(text: &str) -> Option<String> {
+    /// gin's `{"error": "<text>"}` — the runner's rejection shape on its
+    /// exec and attach routes. It names no class, only the sentence.
+    #[derive(serde::Deserialize)]
+    struct BareError {
+        error: String,
+    }
+
+    if let Ok(resp) = serde_json::from_str::<ErrorResponse>(text) {
+        return Some(resp.error.message);
+    }
+    if let Ok(resp) = serde_json::from_str::<FlatErrorResponse>(text) {
+        return Some(resp.message);
+    }
+    serde_json::from_str::<BareError>(text)
+        .ok()
+        .map(|resp| resp.error)
+}
+
+/// A peer that answered with a status and a plain sentence rather than one of
+/// our envelopes — the CONNECT tunnel handshake, which our own proxy answers
+/// with 405 for the wrong method, 400 for a bad target, 403 for a box that is
+/// not public, and 502 for a runner or visibility lookup it cannot reach.
+///
+/// It plainly answered, so nothing here may be attributed to an intermediary:
+/// that is the misattribution the codeless-body path exists to remove, and a
+/// 502 the proxy itself wrote is the same mistake one hop further out. The
+/// peer's own sentence is carried through in every arm.
+pub(crate) fn map_plain_reply(status: StatusCode, text: &str) -> BoxliteError {
+    refine_by_status(status, text).unwrap_or_else(|| {
+        if status.is_server_error() {
+            // The peer could not reach what it needed on our behalf — the
+            // proxy answers 502 for an unreachable runner. That is an
+            // upstream availability failure, reported in the peer's words.
+            BoxliteError::Network(text.to_string())
+        } else {
+            BoxliteError::Internal(format!("HTTP {}: {}", status, text))
+        }
+    })
+}
+
+/// Nothing decoded as one of our envelopes, so the status is all there is.
+fn map_status(status: StatusCode, text: &str) -> BoxliteError {
+    refine_by_status(status, text).unwrap_or_else(|| match status.as_u16() {
         // Bare 5xx with no envelope ⇒ an intermediary spoke, not us.
         // The most common cause is a proxy / load balancer that
         // couldn't reach the destination (Clash returns 502 with
@@ -93,7 +191,7 @@ pub(crate) fn map_http_status(status: StatusCode, text: &str) -> BoxliteError {
             if text.is_empty() { "<empty>" } else { text }
         )),
         _ => BoxliteError::Internal(format!("HTTP {}: {}", status, text)),
-    }
+    })
 }
 
 #[cfg(test)]
@@ -114,13 +212,20 @@ mod tests {
     /// flag the tuple as overly complex.
     type RoundTripRow = (u16, &'static str, &'static str, fn(&BoxliteError) -> bool);
 
+    /// One row of the status-baseline table: `(http_status,
+    /// variant_predicate, variant_name_for_the_failure_message)`.
+    type BaselineRow = (u16, fn(&BoxliteError) -> bool, &'static str);
+
     /// Canonical round-trip table — for every `(status, type, code)`
     /// the server can emit per `BoxliteError::http()`, the client must
     /// reconstruct a `BoxliteError` of the matching variant.
     ///
     /// Pinning the full table here is the second wall: even if the
     /// server-side mapping changes silently, this test fails — making
-    /// the wire contract bilateral.
+    /// the wire contract bilateral. Each row is checked twice, because
+    /// the status baseline would otherwise cover for a deleted `code`
+    /// arm: once end-to-end through the envelope, once against the code
+    /// table alone.
     #[test]
     fn round_trip_canonical_table() {
         let cases: &[RoundTripRow] = &[
@@ -194,7 +299,7 @@ mod tests {
 
         for (status_u16, etype, code, predicate) in cases {
             let status = StatusCode::from_u16(*status_u16).expect("valid HTTP status");
-            let err = map_http_error(status, &body("msg", etype, code));
+            let err = map_enveloped(status, &body("msg", etype, code));
             assert!(
                 predicate(&err),
                 "code {:?} (HTTP {}) mapped to unexpected variant: {:?}",
@@ -202,27 +307,93 @@ mod tests {
                 status_u16,
                 err
             );
+
+            // The status baseline alone already yields the right variant for
+            // most rows, so the assertion above would survive deleting the
+            // row's `code` arm. Pin the code table separately, off any
+            // status, so a dropped arm fails here.
+            let refined = refine_by_code(code, "msg")
+                .unwrap_or_else(|| panic!("code {:?} has no arm of its own", code));
+            assert!(
+                predicate(&refined),
+                "code {:?} refined to unexpected variant: {:?}",
+                code,
+                refined
+            );
         }
     }
 
-    /// Unknown code from a newer server falls back to status-driven
-    /// mapping — forward-compat. The body text must be preserved.
+    /// Forward-compat is the status floor doing its job: a newer server
+    /// naming a code this client cannot read yet must degrade to the class
+    /// the status states, never to `Internal` — a 400 is the caller's error
+    /// whatever the server called it. Gating the baseline on "no code at
+    /// all" would reintroduce the fabricated-`internal` bug for every code
+    /// added after this client shipped.
     #[test]
-    fn unknown_code_falls_back_to_status_mapping() {
-        let err = map_http_error(
+    fn unknown_code_keeps_the_status_baseline() {
+        let err = map_http_body(
+            StatusCode::BAD_REQUEST,
+            r#"{"statusCode":400,"error":"Bad Request","message":"cpus is negative","code":"future_error"}"#,
+        );
+        assert!(
+            matches!(err, BoxliteError::InvalidArgument(_)),
+            "unknown code on a 400 stays the caller's error: {err:?}"
+        );
+        assert!(err.to_string().contains("cpus is negative"), "{err:?}");
+
+        let err = map_http_body(
+            StatusCode::TOO_MANY_REQUESTS,
+            r#"{"statusCode":429,"error":"Too Many Requests","message":"slow down","code":"quota_exceeded"}"#,
+        );
+        assert!(
+            matches!(err, BoxliteError::ResourceExhausted(_)),
+            "unknown code on a 429 stays resource exhaustion: {err:?}"
+        );
+    }
+
+    /// Unknown code from a newer server: the baseline has its say, and past
+    /// it the refusal stays the server's own fault — the server answered, so
+    /// no intermediary is implicated. The body text must be preserved.
+    #[test]
+    fn unknown_code_stays_a_server_fault() {
+        let err = map_enveloped(
             StatusCode::IM_A_TEAPOT,
             &body("can't brew", "TeapotError", "teapot_brewing_failed"),
         );
         match err {
             BoxliteError::Internal(s) => {
-                assert!(s.contains("418"), "fallback should mention status: {s}");
                 assert!(
                     s.contains("can't brew"),
-                    "fallback should mention body: {s}"
+                    "the server's sentence must survive: {s}"
                 );
             }
             other => panic!("expected Internal fallback, got {other:?}"),
         }
+
+        // The forward-compat case the module header names: a newer server
+        // adds a code on a 503. An older client must not blame the caller's
+        // proxy for a failure the server stated itself.
+        let err = map_enveloped(
+            StatusCode::SERVICE_UNAVAILABLE,
+            &body(
+                "draining us-east-1",
+                "RegionDrainingError",
+                "region_draining",
+            ),
+        );
+        assert!(
+            matches!(err, BoxliteError::Internal(_)),
+            "an unknown 503 code stays the server's own fault: {err:?}"
+        );
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("draining us-east-1"),
+            "the server's sentence must survive: {rendered}"
+        );
+        assert!(
+            !rendered.contains("proxy"),
+            "an answered 503 must not be attributed to a proxy: {rendered}"
+        );
     }
 
     /// Empty-body 502/503/504 ⇒ `Network`, not `Internal`. Pinned
@@ -233,7 +404,7 @@ mod tests {
     fn bare_5xx_without_envelope_is_network_error() {
         for status_u16 in [502, 503, 504] {
             let status = StatusCode::from_u16(status_u16).unwrap();
-            let err = map_http_status(status, "");
+            let err = map_status(status, "");
             assert!(
                 matches!(err, BoxliteError::Network(_)),
                 "HTTP {} with empty body should map to Network, got {:?}",
@@ -248,7 +419,7 @@ mod tests {
     /// different remediation hints.
     #[test]
     fn bare_500_without_envelope_is_internal() {
-        let err = map_http_status(StatusCode::INTERNAL_SERVER_ERROR, "");
+        let err = map_status(StatusCode::INTERNAL_SERVER_ERROR, "");
         assert!(matches!(err, BoxliteError::Internal(_)));
     }
 
@@ -257,16 +428,182 @@ mod tests {
     /// somehow emits 401 without our envelope.
     #[test]
     fn bare_auth_status_routes_to_config() {
-        let err = map_http_status(StatusCode::UNAUTHORIZED, "no token");
+        let err = map_status(StatusCode::UNAUTHORIZED, "no token");
         assert!(matches!(err, BoxliteError::Config(_)));
-        let err = map_http_status(StatusCode::FORBIDDEN, "wrong scope");
+        let err = map_status(StatusCode::FORBIDDEN, "wrong scope");
         assert!(matches!(err, BoxliteError::Config(_)));
     }
 
     /// 404 status-only is `NotFound` regardless of body shape.
     #[test]
     fn bare_404_is_not_found() {
-        let err = map_http_status(StatusCode::NOT_FOUND, "");
+        let err = map_status(StatusCode::NOT_FOUND, "");
         assert!(matches!(err, BoxliteError::NotFound(_)));
+    }
+
+    /// The cloud API's NestJS filter emits `{path,timestamp,statusCode,
+    /// error,message}` and omits `code` for every exception that does not
+    /// set one itself. Such a body must be classified by its HTTP status —
+    /// a refusal the caller caused stays a caller error. Reporting it as
+    /// `Internal` blames the server for the client's own bad request.
+    #[test]
+    fn codeless_flat_body_is_classified_by_status() {
+        let cases: &[BaselineRow] = &[
+            (
+                400,
+                |e| matches!(e, BoxliteError::InvalidArgument(_)),
+                "InvalidArgument",
+            ),
+            (404, |e| matches!(e, BoxliteError::NotFound(_)), "NotFound"),
+            (
+                409,
+                |e| matches!(e, BoxliteError::InvalidState(_)),
+                "InvalidState",
+            ),
+            // `Internal(_)` alone would also match the no-arm fallback;
+            // the prefix is what proves the 408 arm answered.
+            (
+                408,
+                |e| matches!(e, BoxliteError::Internal(m) if m.starts_with("server timed out:")),
+                "Internal(server timed out)",
+            ),
+            (
+                428,
+                |e| matches!(e, BoxliteError::InvalidState(_)),
+                "InvalidState",
+            ),
+            (
+                429,
+                |e| matches!(e, BoxliteError::ResourceExhausted(_)),
+                "ResourceExhausted",
+            ),
+        ];
+        for (status, is_expected, name) in cases {
+            let text = format!(
+                r#"{{"path":"/api/v1/org/boxes","timestamp":"2026-01-01T00:00:00.000Z","statusCode":{status},"error":"Whatever","message":"boom-{status}"}}"#
+            );
+            let err = map_http_body(StatusCode::from_u16(*status).unwrap(), &text);
+            assert!(
+                is_expected(&err),
+                "codeless {status} should map to {name}, got {err:?}"
+            );
+            assert!(
+                err.to_string().contains(&format!("boom-{status}")),
+                "message must survive: {err:?}"
+            );
+        }
+    }
+
+    /// An explicit `code` still wins over the status baseline: the server
+    /// naming `already_exists` on a 409 must not be flattened to the
+    /// status-derived `InvalidState`.
+    #[test]
+    fn explicit_code_overrides_the_status_baseline() {
+        let text =
+            r#"{"statusCode":409,"error":"Conflict","message":"dup","code":"already_exists"}"#;
+        let err = map_http_body(StatusCode::CONFLICT, text);
+        assert!(matches!(err, BoxliteError::AlreadyExists(_)), "got {err:?}");
+    }
+
+    /// A nested envelope that names no code must still decode as an
+    /// envelope, so the mapper classifies by status and carries the server's
+    /// own sentence. While `ErrorModel::code` was a required field such a
+    /// body failed to parse entirely and the caller was handed the raw JSON.
+    #[test]
+    fn nested_codeless_envelope_keeps_its_message() {
+        // With `type`, without `code` — and the minimal shape carrying
+        // neither: every field nothing dispatches on must be optional, or a
+        // dead field decides whether the body decodes at all.
+        let bodies = [
+            r#"{"error":{"message":"cpu 200 exceeds the limit","type":"HttpError"}}"#,
+            r#"{"error":{"message":"cpu 200 exceeds the limit"}}"#,
+        ];
+        for text in bodies {
+            let err = map_http_body(StatusCode::BAD_REQUEST, text);
+
+            assert!(
+                matches!(err, BoxliteError::InvalidArgument(_)),
+                "codeless 400 is a caller error: {err:?}"
+            );
+            let rendered = err.to_string();
+            assert!(
+                rendered.contains("cpu 200 exceeds the limit"),
+                "server message must survive: {rendered}"
+            );
+            assert!(
+                !rendered.contains('{'),
+                "the raw body must not leak into the message: {rendered}"
+            );
+        }
+    }
+
+    /// The API answers codelessly at 503 too — under maintenance, or with
+    /// object storage unconfigured. Such a body is the server stating its own
+    /// fault, so it must not be re-attributed to a proxy: `Network` is what
+    /// the CLI turns into "check your HTTP_PROXY", which is this bug in
+    /// mirror. Only a body that decoded as nothing at all earns that.
+    #[test]
+    fn codeless_5xx_is_the_servers_own_fault_not_a_proxys() {
+        let text = r#"{"statusCode":503,"error":"Service Unavailable","message":"Service is currently under maintenance"}"#;
+        let err = map_http_body(StatusCode::SERVICE_UNAVAILABLE, text);
+
+        assert!(
+            matches!(err, BoxliteError::Internal(_)),
+            "an answered 503 is not a transport failure: {err:?}"
+        );
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("under maintenance"),
+            "server message must survive: {rendered}"
+        );
+        assert!(
+            !rendered.contains("proxy"),
+            "an answered 503 must not be attributed to a proxy: {rendered}"
+        );
+    }
+
+    /// The statuses left out of the baseline on purpose. Each is one the
+    /// server only ever answers with a code attached, so a codeless one has
+    /// no producer and gets no guess — it stays `Internal` rather than
+    /// inventing `SessionReaped` or `Execution` for a caller to branch on.
+    /// Adding an arm for either is a wire-contract change, not a tidy-up.
+    #[test]
+    fn statuses_without_a_codeless_producer_get_no_baseline() {
+        for status in [410u16, 422] {
+            let text = format!(
+                r#"{{"statusCode":{status},"error":"Whatever","message":"boom-{status}"}}"#
+            );
+            let err = map_http_body(StatusCode::from_u16(status).unwrap(), &text);
+            assert!(
+                matches!(err, BoxliteError::Internal(_)),
+                "codeless {status} must not be given a baseline variant: {err:?}"
+            );
+            assert!(
+                err.to_string().contains(&format!("boom-{status}")),
+                "message must survive: {err:?}"
+            );
+        }
+    }
+
+    /// The runner's REST routes reject with gin's `{"error": "<text>"}` —
+    /// not one of our envelopes. The class must still come from the status
+    /// and the message must be the sentence, not the JSON that carried it.
+    #[test]
+    fn bare_gin_error_body_keeps_its_sentence() {
+        let err = map_http_body(
+            StatusCode::NOT_FOUND,
+            r#"{"error":"execution e1 not found"}"#,
+        );
+
+        assert!(matches!(err, BoxliteError::NotFound(_)), "got {err:?}");
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("execution e1 not found"),
+            "the sentence must survive: {rendered}"
+        );
+        assert!(
+            !rendered.contains('{'),
+            "the raw body must not leak into the message: {rendered}"
+        );
     }
 }

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -29,11 +29,16 @@ pub(crate) struct FlatErrorResponse {
 }
 
 impl FlatErrorResponse {
+    /// A body with no `code` decodes to the empty string, not to a
+    /// synthesized one. Inventing `"internal"` here made every codeless
+    /// refusal — which is every cloud exception that does not set the field —
+    /// arrive as a server fault, and hid the HTTP status from the mapper for
+    /// good: the status-driven fallback was unreachable behind it.
     pub(crate) fn into_error_model(self) -> ErrorModel {
         ErrorModel {
             message: self.message,
             error_type: "HttpError".to_string(),
-            code: self.code.unwrap_or_else(|| "internal".to_string()),
+            code: self.code.unwrap_or_default(),
             request_id: None,
         }
     }
@@ -45,18 +50,25 @@ impl FlatErrorResponse {
 /// - `error_type` — stable PascalCase identifier (K8s `Status.reason`
 ///   style). Mirrors `BoxliteError::http().1` server-side.
 /// - `code` — stable snake_case machine identifier (Stripe `code` style).
-///   The mapper in [`super::error::map_http_error`] dispatches on this
-///   field; `error_type` is kept for diagnostics / logging.
+///   Refines the status-derived baseline in [`super::error`]; an empty
+///   string means the server named no code and that baseline stands.
+///   `error_type` is kept for diagnostics / logging.
 /// - `request_id` — propagated from server's `X-Request-Id` middleware
 ///   when present; absent on older servers (forward-compat).
 #[derive(Debug, Deserialize)]
 pub(crate) struct ErrorModel {
     pub message: String,
-    /// Preserved for diagnostics / log enrichment; dispatch happens on
-    /// `code` (the snake string).
-    #[serde(rename = "type")]
+    /// Preserved for diagnostics / log enrichment; the variant is chosen
+    /// from the status and `code`, never from this field.
+    #[serde(rename = "type", default)]
     #[allow(dead_code)]
     pub error_type: String,
+    /// Absent on any server that does not name a code. Defaulting to the
+    /// empty string keeps such a body a decodable envelope, so the mapper
+    /// classifies it by status and reports the server's own sentence; as a
+    /// required field it made the whole body unparseable and the caller was
+    /// handed the raw JSON instead.
+    #[serde(default)]
     pub code: String,
     #[serde(default)]
     #[allow(dead_code)]

--- a/src/cli/src/commands/auth/api_key.rs
+++ b/src/cli/src/commands/auth/api_key.rs
@@ -169,9 +169,10 @@ async fn validate(profile: &Profile) -> Result<Option<Principal>> {
 /// Turn a client error into a focused, non-secret message.
 ///
 /// Three buckets: an auth rejection from the server (`Config("auth: …")`
-/// — produced by `map_http_error` for 401/403), a transport-level
-/// failure that never reached the server (`Network(_)` — including the
-/// "bare 5xx → proxy" path in `map_http_status`), and everything else.
+/// — produced by the 401/403 arms of the status table in `rest::error`), a
+/// network-class failure (`Network(_)` — a transport error, a bare 5xx from
+/// an intermediary, or a `network_unavailable` the server named itself),
+/// and everything else.
 /// We never persist credentials in any of the failure cases.
 fn classify(profile: &Profile, err: BoxliteError) -> anyhow::Error {
     match err {

--- a/src/cli/src/commands/serve/mod.rs
+++ b/src/cli/src/commands/serve/mod.rs
@@ -1344,7 +1344,7 @@ fn error_from_boxlite(err: &boxlite::BoxliteError) -> Response {
 /// Panic handler for [`CatchPanicLayer`]. Turns a handler panic into a
 /// `500 InternalError internal` response with our wire envelope —
 /// otherwise axum's default returns an empty `500 Internal Server Error`
-/// with no body, breaking the client's `map_http_status` 500-vs-Network
+/// with no body, breaking the client's status-table 500-vs-Network
 /// distinction.
 fn handle_panic(err: Box<dyn std::any::Any + Send + 'static>) -> Response {
     let detail = err


### PR DESCRIPTION
## Summary

A structured error body that names no `error.code` was reported to callers as
`BoxliteError::Internal`, blaming the server for refusals the caller caused. A
recognized `error.code` still names the variant; otherwise the HTTP status now
decides, through a baseline table of the statuses the API answers codelessly —
so a codeless refusal keeps the class its status states, and a failure the
server answered for itself is never attributed to an intermediary.

## Call graph

Before
```
create                    (CreateCmd · src/cli/src/commands/create.rs:59)
  └─ handle_error         (RestClient · src/boxlite/src/rest/client.rs)
       └─ map_http_body   (rest::error)
            └─ into_error_model (FlatErrorResponse · src/boxlite/src/rest/types.rs)
                 │                        ← BUG: a body with no `code` is given
                 │                          the fabricated code "internal"
                 └─ map_http_error  (rest::error)   — dispatches on it ⇒ Internal
                      └─ map_http_status (rest::error) — unreachable behind it
```

After
```
create                    (CreateCmd · src/cli/src/commands/create.rs:59)
  └─ handle_error         (RestClient · src/boxlite/src/rest/client.rs:239)
       └─ map_http_body   (rest::error · src/boxlite/src/rest/error.rs:28)
            ├─ into_error_model (FlatErrorResponse · types.rs:37) — absent code stays empty
            ├─ map_enveloped      (error.rs:48)
            │    ├─ refine_by_code   (error.rs:73)  — a known code wins
            │    ├─ refine_by_status (error.rs:111) — 400 ⇒ InvalidArgument,
            │    │                     404/408/409/428/429 likewise
            │    └─ else ⇒ Internal — codeless or unknown-code alike: the
            │                server answered, no intermediary is implicated
            └─ else: envelope_message (error.rs:138) — gin `{"error": text}`
                     lends its sentence; class from map_status (error.rs:180)

connect_box_network_tunnel (RestClient · client.rs)
  └─ read_connect_refusal  (client.rs:37)   — proxy's sentence; bounded read,
       │                     2s dedicated timeout (client.rs:34)
       └─ map_plain_reply  (error.rs:166)   — never blames an intermediary

attach (WS upgrade)
  └─ map_ws_error          (client.rs:616)  — attach arms only (404/409/410 +
                             auth); envelope or gin sentence surfaced; all
                             else, 5xx included, reads like a REST reply
```

Fixes #<issue>

## Changes

- `FlatErrorResponse::into_error_model` no longer invents `code: "internal"`;
  a missing code decodes to the empty string. `ErrorModel` is a tolerant
  reader — `code` and `type` both default — so an envelope missing either
  still decodes instead of handing the caller raw JSON.
- Status baseline holds one arm per status the API answers codelessly (400,
  404, 408, 409, 428, 429, plus the 401/403 auth arms). Statuses only ever
  answered with a code (410, 422) deliberately get no arm.
- Any enveloped body that resolves no further — codeless, or naming a code
  this client has not learned yet — stays `Internal`: the server answered
  for itself. The bare-5xx "likely a proxy" attribution fires only when
  nothing decoded at all.
- The runner's bare `{"error": "<text>"}` rejections lend their sentence to
  the message; the class stays status-derived.
- CONNECT tunnel: the proxy's own sentence is read off the reply (limit
  enforced while reading, under a dedicated 2s timeout) and a refusal the
  proxy wrote is never attributed to an intermediary.
- WS upgrade: only the attach contract's arms remain (the reattach loop pins
  404/409/410); the envelope's or gin's sentence is surfaced instead of raw
  JSON, and every other status — 5xx included — is read like any other REST
  reply, so a 503 named `engine_unavailable` arrives as `Engine`, not as a
  proxy fault.

## How to verify

```
make test:unit:rust FILTER=rest::error
```

Against a running control plane, a box create above the org's per-box CPU
ceiling is refused as `invalid argument` rather than `internal error`:

```
boxlite --profile <p> create --cpus 200 <image>
```

## Risks / rollout

Client-side error classification only; no wire or server change. Callers that
matched on `Internal` for these refusals now see the status-derived variant
(`InvalidArgument`, `NotFound`, `InvalidState`, `ResourceExhausted`); a
framework route-miss 404 (stale `path_prefix`) is now `NotFound` as well,
which resource-probing callers treat as absence. An unknown-code 5xx moves
from the proxy-attributed `Network` text to `Internal` with the server's own
sentence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of connection refusals by preserving proxy messages with size and timeout safeguards.
  - Improved WebSocket rejection handling with clearer messages and consistent HTTP error mapping.
  - Refined error classification when response codes or error details are missing, including clearer handling of server and network errors.
  - Preserved meaningful messages from plain-text and common server error responses.
  - Improved tolerance for incomplete error responses while retaining diagnostic details.

- **Documentation**
  - Clarified error-response behavior and fallback classification in developer-facing documentation and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->