### PR TITLE
fix(api): wake a stopped autoResume box when a tunnel is opened, instead of rejecting it

### DIFF
--- a/apps/api/src/boxlite-rest/box-auto-resume.service.ts
+++ b/apps/api/src/boxlite-rest/box-auto-resume.service.ts
@@ -13,7 +13,7 @@ import { BoxState } from '../box/enums/box-state.enum'
 import { BoxDesiredState } from '../box/enums/box-desired-state.enum'
 import { Organization } from '../organization/entities/organization.entity'
 
-const AUTO_RESUME_TIMEOUT_SECONDS = 30
+export const AUTO_RESUME_TIMEOUT_SECONDS = 30
 
 @Injectable()
 export class BoxAutoResumeService {

--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.spec.ts
@@ -5,7 +5,7 @@
  */
 
 import { EventEmitter } from 'node:events'
-import { ForbiddenException } from '@nestjs/common'
+import { ForbiddenException, RequestTimeoutException } from '@nestjs/common'
 import { createProxyMiddleware } from 'http-proxy-middleware'
 import { BoxliteProxyController } from './boxlite-proxy.controller'
 
@@ -95,15 +95,12 @@ describe('BoxliteProxyController', () => {
     expect(boxService.getNetworkTunnelUrl).not.toHaveBeenCalled()
   })
 
-  it('rejects a tunnel request for a stopped box with 409, without auto-resuming it', async () => {
-    // Wake-on-CONNECT is explicitly out of scope for POL-214 (tracked
-    // separately) — a stopped box stays stopped and is rejected, even when
-    // box.autoResume is on.
+  it('rejects a tunnel request for a stopped, non-autoResume box with 409', async () => {
     const { controller, boxService, autoResume } = makeHarness()
     boxService.findOneByIdOrName.mockResolvedValue({
       id: 'box-uuid',
       runnerId: 'runner-1',
-      autoResume: true,
+      autoResume: false,
       state: 'stopped',
     })
 
@@ -111,6 +108,39 @@ describe('BoxliteProxyController', () => {
       status: 409,
     })
     expect(autoResume.ensureReady).not.toHaveBeenCalled()
+    expect(boxService.getNetworkTunnelUrl).not.toHaveBeenCalled()
+  })
+
+  it('wakes a stopped autoResume box before minting the tunnel URI (POL-352)', async () => {
+    const { controller, boxService, autoResume } = makeHarness()
+    boxService.findOneByIdOrName.mockResolvedValue({
+      id: 'box-uuid',
+      runnerId: 'runner-1',
+      autoResume: true,
+      state: 'stopped',
+      public: true,
+    })
+
+    const result = await controller.proxyNetworkTunnel(activeAuth as never, 'public-box', 3000)
+
+    expect(autoResume.ensureReady).toHaveBeenCalledWith('box-uuid', activeAuth.organization)
+    expect(boxService.getNetworkTunnelUrl).toHaveBeenCalledWith('public-box', 'org-1', 3000)
+    expect(result).toEqual({ uri: 'https://3000-box.proxy.test' })
+  })
+
+  it('propagates the resume timeout instead of minting a tunnel URI', async () => {
+    const { controller, boxService, autoResume } = makeHarness()
+    boxService.findOneByIdOrName.mockResolvedValue({
+      id: 'box-uuid',
+      runnerId: 'runner-1',
+      autoResume: true,
+      state: 'stopped',
+      public: true,
+    })
+    const timeout = new RequestTimeoutException('Timed out waiting to resume box box-uuid')
+    autoResume.ensureReady.mockRejectedValue(timeout)
+
+    await expect(controller.proxyNetworkTunnel(activeAuth as never, 'public-box', 3000)).rejects.toBe(timeout)
     expect(boxService.getNetworkTunnelUrl).not.toHaveBeenCalled()
   })
 

--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.spec.ts
@@ -95,6 +95,27 @@ describe('BoxliteProxyController', () => {
     expect(boxService.getNetworkTunnelUrl).not.toHaveBeenCalled()
   })
 
+  it('rejects a stopped, autoResume, private box without waking it', async () => {
+    // The visibility gate must run before the resume: waking a box only to
+    // reject it here for being private wastes a real resume (and briefly
+    // makes a private box's state observable) for a request that was always
+    // going to be denied.
+    const { controller, boxService, autoResume } = makeHarness()
+    boxService.findOneByIdOrName.mockResolvedValue({
+      id: 'box-uuid',
+      runnerId: 'runner-1',
+      autoResume: true,
+      state: 'stopped',
+      public: false,
+    })
+
+    await expect(controller.proxyNetworkTunnel(activeAuth as never, 'public-box', 3000)).rejects.toMatchObject({
+      status: 409,
+    })
+    expect(autoResume.ensureReady).not.toHaveBeenCalled()
+    expect(boxService.getNetworkTunnelUrl).not.toHaveBeenCalled()
+  })
+
   it('rejects a tunnel request for a stopped, non-autoResume box with 409', async () => {
     const { controller, boxService, autoResume } = makeHarness()
     boxService.findOneByIdOrName.mockResolvedValue({
@@ -125,6 +146,11 @@ describe('BoxliteProxyController', () => {
 
     expect(autoResume.ensureReady).toHaveBeenCalledWith('box-uuid', activeAuth.organization)
     expect(boxService.getNetworkTunnelUrl).toHaveBeenCalledWith('public-box', 'org-1', 3000)
+    // Order matters: minting the URI before the box is actually STARTED
+    // would hand out an address that CONNECTs into a still-stopped box.
+    expect(autoResume.ensureReady.mock.invocationCallOrder[0]).toBeLessThan(
+      boxService.getNetworkTunnelUrl.mock.invocationCallOrder[0],
+    )
     expect(result).toEqual({ uri: 'https://3000-box.proxy.test' })
   })
 

--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.spec.ts
@@ -128,12 +128,16 @@ describe('BoxliteProxyController', () => {
       runnerId: 'runner-1',
       autoResume: false,
       state: 'stopped',
+      public: true,
     })
 
     await expect(
       controller.proxyNetworkTunnel(activeAuth as never, 'public-box', 3000, tunnelRes as never),
     ).rejects.toMatchObject({
       status: 409,
+      // Pin the reason: without public: true this 409s at the visibility
+      // gate instead, and the state policy under test never runs.
+      message: expect.stringContaining('is not running'),
     })
     expect(autoResume.ensureReady).not.toHaveBeenCalled()
     expect(boxService.getNetworkTunnelUrl).not.toHaveBeenCalled()
@@ -276,12 +280,14 @@ describe('BoxliteProxyController', () => {
         runnerId: 'runner-1',
         autoResume: false,
         state,
+        public: true,
       })
 
       await expect(
         controller.proxyNetworkTunnel(activeAuth as never, 'public-box', 3000, tunnelRes as never),
       ).rejects.toMatchObject({
         status: 409,
+        message: expect.stringContaining('is not running'),
       })
       expect(boxService.getNetworkTunnelUrl).not.toHaveBeenCalled()
     },

--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.spec.ts
@@ -32,8 +32,9 @@ function makeHarness() {
     findOne: jest.fn().mockResolvedValue({ apiUrl: 'http://runner.local', apiKey: 'runner-key' }),
   }
   const autoResume = { ensureReady: jest.fn().mockResolvedValue(undefined) }
+  const tunnelRes = { setHeader: jest.fn() }
   const controller = new BoxliteProxyController(boxService as never, runnerService as never, autoResume as never)
-  return { controller, boxService, autoResume }
+  return { controller, boxService, autoResume, tunnelRes }
 }
 
 describe('BoxliteProxyController', () => {
@@ -71,16 +72,16 @@ describe('BoxliteProxyController', () => {
   })
 
   it('returns the public endpoint for JSON tunnel requests', async () => {
-    const { controller, boxService } = makeHarness()
+    const { controller, boxService, tunnelRes } = makeHarness()
 
-    const result = await controller.proxyNetworkTunnel(activeAuth as never, 'public-box', 3000)
+    const result = await controller.proxyNetworkTunnel(activeAuth as never, 'public-box', 3000, tunnelRes as never)
 
     expect(boxService.getNetworkTunnelUrl).toHaveBeenCalledWith('public-box', 'org-1', 3000)
     expect(result).toEqual({ uri: 'https://3000-box.proxy.test' })
   })
 
   it('rejects a tunnel request for a private box with 409', async () => {
-    const { controller, boxService } = makeHarness()
+    const { controller, boxService, tunnelRes } = makeHarness()
     boxService.findOneByIdOrName.mockResolvedValue({
       id: 'box-uuid',
       runnerId: 'runner-1',
@@ -89,7 +90,9 @@ describe('BoxliteProxyController', () => {
       public: false,
     })
 
-    await expect(controller.proxyNetworkTunnel(activeAuth as never, 'public-box', 3000)).rejects.toMatchObject({
+    await expect(
+      controller.proxyNetworkTunnel(activeAuth as never, 'public-box', 3000, tunnelRes as never),
+    ).rejects.toMatchObject({
       status: 409,
     })
     expect(boxService.getNetworkTunnelUrl).not.toHaveBeenCalled()
@@ -100,7 +103,7 @@ describe('BoxliteProxyController', () => {
     // reject it here for being private wastes a real resume (and briefly
     // makes a private box's state observable) for a request that was always
     // going to be denied.
-    const { controller, boxService, autoResume } = makeHarness()
+    const { controller, boxService, autoResume, tunnelRes } = makeHarness()
     boxService.findOneByIdOrName.mockResolvedValue({
       id: 'box-uuid',
       runnerId: 'runner-1',
@@ -109,7 +112,9 @@ describe('BoxliteProxyController', () => {
       public: false,
     })
 
-    await expect(controller.proxyNetworkTunnel(activeAuth as never, 'public-box', 3000)).rejects.toMatchObject({
+    await expect(
+      controller.proxyNetworkTunnel(activeAuth as never, 'public-box', 3000, tunnelRes as never),
+    ).rejects.toMatchObject({
       status: 409,
     })
     expect(autoResume.ensureReady).not.toHaveBeenCalled()
@@ -117,7 +122,7 @@ describe('BoxliteProxyController', () => {
   })
 
   it('rejects a tunnel request for a stopped, non-autoResume box with 409', async () => {
-    const { controller, boxService, autoResume } = makeHarness()
+    const { controller, boxService, autoResume, tunnelRes } = makeHarness()
     boxService.findOneByIdOrName.mockResolvedValue({
       id: 'box-uuid',
       runnerId: 'runner-1',
@@ -125,7 +130,9 @@ describe('BoxliteProxyController', () => {
       state: 'stopped',
     })
 
-    await expect(controller.proxyNetworkTunnel(activeAuth as never, 'public-box', 3000)).rejects.toMatchObject({
+    await expect(
+      controller.proxyNetworkTunnel(activeAuth as never, 'public-box', 3000, tunnelRes as never),
+    ).rejects.toMatchObject({
       status: 409,
     })
     expect(autoResume.ensureReady).not.toHaveBeenCalled()
@@ -133,7 +140,7 @@ describe('BoxliteProxyController', () => {
   })
 
   it('wakes a stopped autoResume box before minting the tunnel URI (POL-352)', async () => {
-    const { controller, boxService, autoResume } = makeHarness()
+    const { controller, boxService, autoResume, tunnelRes } = makeHarness()
     boxService.findOneByIdOrName.mockResolvedValue({
       id: 'box-uuid',
       runnerId: 'runner-1',
@@ -142,7 +149,7 @@ describe('BoxliteProxyController', () => {
       public: true,
     })
 
-    const result = await controller.proxyNetworkTunnel(activeAuth as never, 'public-box', 3000)
+    const result = await controller.proxyNetworkTunnel(activeAuth as never, 'public-box', 3000, tunnelRes as never)
 
     expect(autoResume.ensureReady).toHaveBeenCalledWith('box-uuid', activeAuth.organization)
     expect(boxService.getNetworkTunnelUrl).toHaveBeenCalledWith('public-box', 'org-1', 3000)
@@ -154,8 +161,10 @@ describe('BoxliteProxyController', () => {
     expect(result).toEqual({ uri: 'https://3000-box.proxy.test' })
   })
 
-  it('propagates the resume timeout instead of minting a tunnel URI', async () => {
-    const { controller, boxService, autoResume } = makeHarness()
+  it('maps a resume timeout to 504 with Retry-After instead of minting a tunnel URI', async () => {
+    // POL-352: the start is still in flight, so this is a "come back later",
+    // not the 408 client-side timeout ensureReady raises internally.
+    const { controller, boxService, autoResume, tunnelRes } = makeHarness()
     boxService.findOneByIdOrName.mockResolvedValue({
       id: 'box-uuid',
       runnerId: 'runner-1',
@@ -163,17 +172,105 @@ describe('BoxliteProxyController', () => {
       state: 'stopped',
       public: true,
     })
-    const timeout = new RequestTimeoutException('Timed out waiting to resume box box-uuid')
-    autoResume.ensureReady.mockRejectedValue(timeout)
+    autoResume.ensureReady.mockRejectedValue(new RequestTimeoutException('Timed out waiting to resume box box-uuid'))
 
-    await expect(controller.proxyNetworkTunnel(activeAuth as never, 'public-box', 3000)).rejects.toBe(timeout)
+    await expect(
+      controller.proxyNetworkTunnel(activeAuth as never, 'public-box', 3000, tunnelRes as never),
+    ).rejects.toMatchObject({ status: 504 })
+    expect(tunnelRes.setHeader).toHaveBeenCalledWith('Retry-After', '30')
     expect(boxService.getNetworkTunnelUrl).not.toHaveBeenCalled()
   })
+
+  it('surfaces a non-timeout resume failure unchanged', async () => {
+    const { controller, boxService, autoResume, tunnelRes } = makeHarness()
+    boxService.findOneByIdOrName.mockResolvedValue({
+      id: 'box-uuid',
+      runnerId: 'runner-1',
+      autoResume: true,
+      state: 'stopped',
+      public: true,
+    })
+    const failure = new Error('start failed')
+    autoResume.ensureReady.mockRejectedValue(failure)
+
+    await expect(
+      controller.proxyNetworkTunnel(activeAuth as never, 'public-box', 3000, tunnelRes as never),
+    ).rejects.toBe(failure)
+    expect(tunnelRes.setHeader).not.toHaveBeenCalled()
+    expect(boxService.getNetworkTunnelUrl).not.toHaveBeenCalled()
+  })
+
+  it('counts a tunnel request as activity so AutoStop does not reap the box', async () => {
+    // POL-326: without this the box we just handed out (or woke) stays
+    // eligible for the idle sweeper, so the caller's tunnel dies under it.
+    const { controller, boxService, tunnelRes } = makeHarness()
+
+    await controller.proxyNetworkTunnel(activeAuth as never, 'public-box', 3000, tunnelRes as never)
+
+    expect(boxService.updateLastActivityAt).toHaveBeenCalledWith('box-uuid', expect.any(Date))
+  })
+
+  it('does not record activity for a box it refuses to expose', async () => {
+    const { controller, boxService, tunnelRes } = makeHarness()
+    boxService.findOneByIdOrName.mockResolvedValue({
+      id: 'box-uuid',
+      runnerId: 'runner-1',
+      autoResume: true,
+      state: 'started',
+      public: false,
+    })
+
+    await expect(
+      controller.proxyNetworkTunnel(activeAuth as never, 'public-box', 3000, tunnelRes as never),
+    ).rejects.toMatchObject({ status: 409 })
+    expect(boxService.updateLastActivityAt).not.toHaveBeenCalled()
+  })
+
+  it.each(['error', 'archived', 'archiving', 'destroying', 'resizing', 'unknown'])(
+    'rejects state %s with 409 instead of waiting out the resume timeout, even with autoResume',
+    async (state) => {
+      // These never reach STARTED on their own, so ensureReady would just
+      // block for its full 30s window before failing the caller anyway.
+      const { controller, boxService, autoResume, tunnelRes } = makeHarness()
+      boxService.findOneByIdOrName.mockResolvedValue({
+        id: 'box-uuid',
+        runnerId: 'runner-1',
+        autoResume: true,
+        state,
+        public: true,
+      })
+
+      await expect(
+        controller.proxyNetworkTunnel(activeAuth as never, 'public-box', 3000, tunnelRes as never),
+      ).rejects.toMatchObject({ status: 409 })
+      expect(autoResume.ensureReady).not.toHaveBeenCalled()
+      expect(boxService.getNetworkTunnelUrl).not.toHaveBeenCalled()
+    },
+  )
+
+  it.each(['stopping', 'starting', 'creating', 'restoring'])(
+    'waits out state %s for an autoResume box',
+    async (state) => {
+      const { controller, boxService, autoResume, tunnelRes } = makeHarness()
+      boxService.findOneByIdOrName.mockResolvedValue({
+        id: 'box-uuid',
+        runnerId: 'runner-1',
+        autoResume: true,
+        state,
+        public: true,
+      })
+
+      await controller.proxyNetworkTunnel(activeAuth as never, 'public-box', 3000, tunnelRes as never)
+
+      expect(autoResume.ensureReady).toHaveBeenCalledWith('box-uuid', activeAuth.organization)
+      expect(boxService.getNetworkTunnelUrl).toHaveBeenCalled()
+    },
+  )
 
   it.each(['creating', 'starting', 'error', 'archived', 'unknown'])(
     'rejects a tunnel request for a non-started box in state %s',
     async (state) => {
-      const { controller, boxService } = makeHarness()
+      const { controller, boxService, tunnelRes } = makeHarness()
       boxService.findOneByIdOrName.mockResolvedValue({
         id: 'box-uuid',
         runnerId: 'runner-1',
@@ -181,7 +278,9 @@ describe('BoxliteProxyController', () => {
         state,
       })
 
-      await expect(controller.proxyNetworkTunnel(activeAuth as never, 'public-box', 3000)).rejects.toMatchObject({
+      await expect(
+        controller.proxyNetworkTunnel(activeAuth as never, 'public-box', 3000, tunnelRes as never),
+      ).rejects.toMatchObject({
         status: 409,
       })
       expect(boxService.getNetworkTunnelUrl).not.toHaveBeenCalled()

--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
@@ -215,12 +215,18 @@ export class BoxliteProxyController {
     // dead. Whitelist STARTED rather than blacklist STOPPED: a box that's
     // still CREATING/STARTING/ERROR/ARCHIVED/etc. isn't reachable either.
     //
-    // No auto-resume here, even for autoResume boxes: wake-on-CONNECT is
-    // out of scope for POL-214 and tracked separately.
+    // POL-352: mirror proxyToRunner's policy — a stopped box that opted into
+    // autoResume gets woken here rather than rejected, since minting the
+    // tunnel URI is the caller's only touchpoint before the CONNECT itself
+    // (which has no box row to check against). ensureReady throws a 408 if
+    // the box never reaches STARTED within its timeout.
     const box = await this.boxService.findOneByIdOrName(boxId, authContext.organizationId)
 
     if (box.state !== BoxState.STARTED) {
-      throw new ConflictException(`Box ${boxId} is not running (state: ${box.state})`)
+      if (!box.autoResume) {
+        throw new ConflictException(`Box ${boxId} is not running (state: ${box.state})`)
+      }
+      await this.autoResume.ensureReady(box.id, authContext.organization)
     }
 
     // POL-205: tunnel URLs expose the box to the public internet. Require the

--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
@@ -215,25 +215,28 @@ export class BoxliteProxyController {
     // dead. Whitelist STARTED rather than blacklist STOPPED: a box that's
     // still CREATING/STARTING/ERROR/ARCHIVED/etc. isn't reachable either.
     //
+    const box = await this.boxService.findOneByIdOrName(boxId, authContext.organizationId)
+
+    // POL-205: tunnel URLs expose the box to the public internet. Require the
+    // caller to have explicitly opted in by setting public: true on the box.
+    // A private box should be accessed via the authenticated API, not a
+    // tunnel. Checked before the state gate below so a private box is never
+    // woken (ensureReady is a real resume, not a free status read) only to
+    // be rejected here anyway.
+    if (!box.public) {
+      throw new ConflictException(`Box ${boxId} is not public; set public: true before opening a tunnel`)
+    }
+
     // POL-352: mirror proxyToRunner's policy — a stopped box that opted into
     // autoResume gets woken here rather than rejected, since minting the
     // tunnel URI is the caller's only touchpoint before the CONNECT itself
     // (which has no box row to check against). ensureReady throws a 408 if
     // the box never reaches STARTED within its timeout.
-    const box = await this.boxService.findOneByIdOrName(boxId, authContext.organizationId)
-
     if (box.state !== BoxState.STARTED) {
       if (!box.autoResume) {
         throw new ConflictException(`Box ${boxId} is not running (state: ${box.state})`)
       }
       await this.autoResume.ensureReady(box.id, authContext.organization)
-    }
-
-    // POL-205: tunnel URLs expose the box to the public internet. Require the
-    // caller to have explicitly opted in by setting public: true on the box.
-    // A private box should be accessed via the authenticated API, not a tunnel.
-    if (!box.public) {
-      throw new ConflictException(`Box ${boxId} is not public; set public: true before opening a tunnel`)
     }
 
     const uri = await this.boxService.getNetworkTunnelUrl(boxId, authContext.organizationId, port)

--- a/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-proxy.controller.ts
@@ -18,6 +18,8 @@ import {
   NotFoundException,
   ConflictException,
   ForbiddenException,
+  GatewayTimeoutException,
+  RequestTimeoutException,
   HttpCode,
   HttpStatus,
   ParseIntPipe,
@@ -33,12 +35,26 @@ import { AuthContext } from '../common/decorators/auth-context.decorator'
 import { OrganizationAuthContext } from '../common/interfaces/auth-context.interface'
 import { BoxService } from '../box/services/box.service'
 import { RunnerService } from '../box/services/runner.service'
-import { BoxAutoResumeService } from './box-auto-resume.service'
+import { AUTO_RESUME_TIMEOUT_SECONDS, BoxAutoResumeService } from './box-auto-resume.service'
 import { BoxState } from '../box/enums/box-state.enum'
 
 type ProxyActivityPolicy = { activity: boolean; autoResume: boolean }
 const USER_OPERATION: ProxyActivityPolicy = { activity: true, autoResume: true }
 const OBSERVATION_ONLY: ProxyActivityPolicy = { activity: false, autoResume: false }
+
+// States a tunnel request may wait out: either the box is stopped (or on its
+// way there) and can be started again, or it is already on its way up. Every
+// other non-STARTED state — ERROR, ARCHIVED/ARCHIVING, DESTROYED/DESTROYING,
+// RESIZING, UNKNOWN — either never reaches STARTED on its own or needs an
+// explicit operator action, so waiting 30s to time out is strictly worse for
+// the caller than an immediate 409.
+const TUNNEL_RESUMABLE_STATES: readonly BoxState[] = [
+  BoxState.STOPPED,
+  BoxState.STOPPING,
+  BoxState.STARTING,
+  BoxState.CREATING,
+  BoxState.RESTORING,
+]
 
 // Spec-first surface (openapi/box.openapi.yaml). Must stay out of the product
 // spec: @All() expands to the SEARCH verb, which OpenAPI 3.0 cannot express.
@@ -207,6 +223,7 @@ export class BoxliteProxyController {
     @AuthContext() authContext: OrganizationAuthContext,
     @Param('boxId') boxId: string,
     @Query('port', ParseIntPipe) port: number,
+    @Res({ passthrough: true }) res: Response,
   ) {
     // findOneByIdOrName already 404s for a missing/destroyed box. Unlike
     // proxyToRunner's other routes, this endpoint just resolves a URL — it
@@ -227,20 +244,44 @@ export class BoxliteProxyController {
       throw new ConflictException(`Box ${boxId} is not public; set public: true before opening a tunnel`)
     }
 
+    // POL-326/POL-352: opening a tunnel is user activity, exactly like the
+    // proxyToRunner routes. Persist it before the readiness gate so the
+    // AutoStop sweeper cannot reap the box we are about to hand out (or just
+    // woke up); the sweeper rechecks this Redis-buffered timestamp after
+    // taking its state lock.
+    await this.boxService
+      .updateLastActivityAt(box.id, new Date())
+      .catch((err) => this.logger.warn(`updateLastActivityAt failed for ${box.id}: ${err}`))
+
     // POL-352: mirror proxyToRunner's policy — a stopped box that opted into
     // autoResume gets woken here rather than rejected, since minting the
     // tunnel URI is the caller's only touchpoint before the CONNECT itself
-    // (which has no box row to check against). ensureReady throws a 408 if
-    // the box never reaches STARTED within its timeout.
+    // (which has no box row to check against).
     if (box.state !== BoxState.STARTED) {
-      if (!box.autoResume) {
+      if (!box.autoResume || !TUNNEL_RESUMABLE_STATES.includes(box.state)) {
         throw new ConflictException(`Box ${boxId} is not running (state: ${box.state})`)
       }
-      await this.autoResume.ensureReady(box.id, authContext.organization)
+      await this.resumeForTunnel(box.id, authContext, res)
     }
 
     const uri = await this.boxService.getNetworkTunnelUrl(boxId, authContext.organizationId, port)
     return { uri }
+  }
+
+  // A resume that outlives its window is a "come back later", not a client
+  // error: POL-352 asks for 504 + Retry-After so a caller (or an SDK mapping
+  // this to BoxResumeTimeoutError) can retry the same request instead of
+  // treating the box as broken. The underlying start is still in flight.
+  private async resumeForTunnel(boxId: string, authContext: OrganizationAuthContext, res: Response): Promise<void> {
+    try {
+      await this.autoResume.ensureReady(boxId, authContext.organization)
+    } catch (err) {
+      if (err instanceof RequestTimeoutException) {
+        res.setHeader('Retry-After', String(AUTO_RESUME_TIMEOUT_SECONDS))
+        throw new GatewayTimeoutException(`Timed out waiting to resume box ${boxId}`)
+      }
+      throw err
+    }
   }
 
   private async proxyToRunner(


### PR DESCRIPTION
## What this does — and what it explicitly does not

This wakes a stopped box **when the client opens a tunnel** (`POST :boxId/network/tunnel`, the call that mints the URI). It does **not** wake a box on inbound traffic: a client that already holds a URI and CONNECTs straight to the Go proxy still lands on a stopped box.

```
open a tunnel   client → POST :boxId/network/tunnel → API   ✅ wakes the box (this PR)
use the tunnel  client → CONNECT 3000-box.proxy.test → Go proxy   ❌ still no wake
```

So POL-352's headline case — "reconnect through the tunnel and it wakes up" — is only half fixed here. See [Out of scope](#out-of-scope) below before closing the issue.

## Why

`proxyNetworkTunnel` minted a tunnel URI only for a `STARTED` box and returned `409` for every other state — including a stopped box with `autoResume: true`. That flag already wakes the box on every other proxied route (`exec`, `files`), so the tunnel-open route was the one place it was a silent no-op: a caller with a long-idle box got rejected instead of resumed, and had to go make an unrelated SDK call first just to bring the box up.

Before:
```
client → POST :boxId/network/tunnel → box.state !== STARTED
  → 409, even when box.autoResume is true      ← BUG (POL-352)
```

After:
```
client → POST :boxId/network/tunnel
  → not public?        → 409 (never woken)
  → record activity
  → state !== STARTED  → autoResume + resumable state? → ensureReady() → URI → 200
                       → otherwise                     → 409
  → resume timed out   → 504 + Retry-After
```

## How

Mirror `proxyToRunner`'s policy in `proxyNetworkTunnel`, plus the three things a bare `ensureReady()` call gets wrong on this route:

- **Visibility before the wake.** The `public` gate runs first, so a private box is never resumed (`ensureReady` is a real start, not a status read) only to be rejected anyway.
- **Resume timeout is `504` + `Retry-After`, not `408`.** The start is still in flight, so this is a retryable "come back later" — an SDK can map it to `BoxResumeTimeoutError`. Non-timeout failures (e.g. the waiter's fast-fail on `ERROR`/`DESTROYED`) surface unchanged.
- **Opening a tunnel counts as activity** (POL-326). Without it the box we just woke stays eligible for the AutoStop sweeper and dies under the caller. Recorded after the visibility gate, so a rejected box leaves no trace.
- **Only resumable states wait.** `STOPPED`/`STOPPING`/`STARTING`/`CREATING`/`RESTORING` go through `ensureReady`; `ERROR`/`ARCHIVED`/`ARCHIVING`/`DESTROYING`/`RESIZING`/`UNKNOWN` never reach `STARTED` on their own, so they keep the immediate `409` instead of hanging for the full 30s window.

<a name="out-of-scope"></a>
## Out of scope — POL-352 does not close with this PR

1. **Wake on inbound traffic (CONNECT).** `apps/proxy` has no box lookup and no resume path, so a reused URI cannot wake anything. Doing it there overlaps the tunnel-lease gate in #1391 / [POL-355](https://linear.app/polygala/issue/POL-355), which is tightening the opposite direction (no active lease → no passage); the two need to be designed together.
2. **Keeping an active tunnel alive.** Activity is recorded once, at open. Bytes flowing over an established tunnel still do not bump `lastActivity`, so a long-lived SSH session can be idle-stopped mid-use — that is [POL-326](https://linear.app/polygala/issue/POL-326) / [POL-384](https://linear.app/polygala/issue/POL-384).
3. **SDK error mapping.** POL-352 item 3 asks for `BoxResumeTimeoutError`; this PR only makes the HTTP status discriminable (`504`), no SDK changes.

Because of (1), **auto_resume still should not be marketed as working on the tunnel path** — the product note on POL-352 makes this a release-gating condition.

Refs POL-352

## Test plan

- `jest apps/api/src/boxlite-rest/` — 143/143 pass. `boxlite-proxy.controller.spec.ts` covers: wakes a stopped autoResume box **before** minting the URI (asserted on `invocationCallOrder`); `504` + `Retry-After: 30` on resume timeout; non-timeout resume failure propagates untouched; activity recorded on success; no activity recorded for a rejected private box; 6 unresumable states `409` immediately without calling `ensureReady`; 4 resumable states wait and then mint.
- Two-side verified: reverted the production change with the new tests in place — the wake, `504`, activity and fast-fail cases all failed at the old `409` call site; restored, green.
- `tsc -p apps/api/tsconfig.app.json --noEmit` — clean. `prettier --check` — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Tunnel requests now record user activity when access is permitted.
  - Private boxes are rejected before any resume attempt.
  - Unsupported box states now fail immediately with a conflict response instead of waiting for a timeout.
  - Eligible transitional and stopped boxes can resume before establishing a tunnel.
  - Resume timeouts now return a gateway-timeout response with a 30-second retry interval; other resume failures continue to propagate normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->