### PR TITLE
feat(net): cap per-box network bandwidth

### DIFF
--- a/docs/reference/cli/README.md
+++ b/docs/reference/cli/README.md
@@ -813,6 +813,18 @@ Used by `run` and `create` (defined in `src/cli/src/cli.rs`).
 | `--network <enabled\|disabled>` | Outbound mode; default `enabled`. Disabled mode creates no network interface. |
 | `--allow-net HOST` | Restrict TCP/UDP egress to exact hosts, `*.example.com`, IPs, or CIDRs; repeatable, implies enabled networking, and is incompatible with `--network disabled`. Hostname-only rules deny UDP unless an IP/CIDR is also allowed. |
 | `--inbound <enabled\|disabled>` | Inbound mode; default `enabled` (services exposed by the box are reachable). |
+| `--net-tx-kbps KBPS` | Cap what the box sends (guest to internet), in kilobits/sec. `0` or unset leaves it uncapped. |
+| `--net-rx-kbps KBPS` | Cap what reaches the box (internet to guest), in kilobits/sec. `0` or unset leaves it uncapped. |
+
+Bandwidth caps are enforced below IP by the local gvproxy bridge, so a single
+budget per direction covers TCP, UDP, ICMP and ARP together, and inbound
+port-forward traffic counts against the same budget as outbound requests —
+the cap is on the box's interface, not on a connection's direction.
+Directions are named from the box's point of view, matching Firecracker.
+Remote runtimes reject these flags: the server owns its own network policy.
+Verified on Linux; on macOS the guest link is a datagram socket whose sender
+behaviour under backpressure is not yet verified, so `--net-tx-kbps` may drop
+frames there instead of slowing the guest.
 
 ### `ManagementFlags`
 

--- a/docs/reference/rust/README.md
+++ b/docs/reference/rust/README.md
@@ -34,6 +34,7 @@ The Rust SDK is the core implementation of BoxLite. It provides async-first APIs
   - [RootfsSpec](#rootfsspec)
   - [VolumeSpec](#volumespec)
   - [NetworkSpec](#networkspec)
+  - [NetBandwidth](#netbandwidth)
   - [PortSpec](#portspec)
 - [Security](#security)
   - [SecurityOptions](#securityoptions)
@@ -599,6 +600,10 @@ pub struct BoxOptions {
     /// Port mappings
     pub ports: Vec<PortSpec>,
 
+    /// Per-direction bandwidth cap for the box's interface, in kilobits/sec.
+    /// Local runtime only; remote runtimes reject it.
+    pub net_bandwidth: NetBandwidth,
+
     /// Auto-remove box when stopped (default: true)
     pub auto_remove: bool,
 
@@ -773,6 +778,49 @@ controlled by enabled/disabled alone.
 
 Pre-split code needs no change: `network` keeps its name, type and meaning,
 and box configs persisted without `inbound_network` load with it defaulted.
+
+### NetBandwidth
+
+Bandwidth cap for the box's network interface, in kilobits per second.
+
+```rust
+pub struct NetBandwidth {
+    pub tx_kbps: Option<u64>,   // guest -> internet
+    pub rx_kbps: Option<u64>,   // internet -> guest
+}
+```
+
+Directions are named from the box's point of view, matching Firecracker's net
+device: `tx` is what the box sends, `rx` is what reaches it. Which side opened
+the connection does not matter — traffic arriving over an inbound port forward
+is charged to `rx` exactly like a reply to an outbound request. The cap is on
+the interface, not on a connection's direction.
+
+Shaping happens below IP in the gvproxy bridge, so one budget per direction
+covers TCP, UDP, ICMP and ARP together; there is no per-protocol split.
+
+`None` or `0` in a direction leaves that direction uncapped, the convention
+Firecracker, Kata and Cloud Hypervisor share.
+
+```rust
+let opts = BoxOptions {
+    net_bandwidth: NetBandwidth {
+        tx_kbps: Some(10_000),   // 10 Mbit/s up
+        rx_kbps: Some(100_000),  // 100 Mbit/s down
+    },
+    ..Default::default()
+};
+```
+
+Local runtime only. A remote server owns its own network policy, so the REST
+wire types carry no field for this and a remote create rejects it. Setting a cap
+while `network` is `Disabled` is also rejected — there is no interface to shape.
+
+**Platform support.** The cap is verified on Linux, where the guest link is a
+SOCK_STREAM socket and declining to read it applies backpressure all the way to
+the guest's virtio queue. macOS uses a SOCK_DGRAM link whose sender behaviour
+under a full receive buffer is not yet verified, so `tx_kbps` there may drop
+frames rather than slow the guest down. `rx_kbps` is paced the same way on both.
 
 ### Secret
 

--- a/docs/reference/rust/README.md
+++ b/docs/reference/rust/README.md
@@ -802,6 +802,8 @@ covers TCP, UDP, ICMP and ARP together; there is no per-protocol split.
 Firecracker, Kata and Cloud Hypervisor share.
 
 ```rust
+use boxlite::{AdvancedBoxOptions, BoxOptions, NetworkRateLimit};
+
 let mut advanced = AdvancedBoxOptions::default();
 advanced.network_rate_limit = NetworkRateLimit {
     tx_kbps: Some(10_000),   // 10 Mbit/s up

--- a/docs/reference/rust/README.md
+++ b/docs/reference/rust/README.md
@@ -34,7 +34,7 @@ The Rust SDK is the core implementation of BoxLite. It provides async-first APIs
   - [RootfsSpec](#rootfsspec)
   - [VolumeSpec](#volumespec)
   - [NetworkSpec](#networkspec)
-  - [NetBandwidth](#netbandwidth)
+  - [NetworkRateLimit](#networkratelimit)
   - [PortSpec](#portspec)
 - [Security](#security)
   - [SecurityOptions](#securityoptions)
@@ -600,10 +600,6 @@ pub struct BoxOptions {
     /// Port mappings
     pub ports: Vec<PortSpec>,
 
-    /// Per-direction bandwidth cap for the box's interface, in kilobits/sec.
-    /// Local runtime only; remote runtimes reject it.
-    pub net_bandwidth: NetBandwidth,
-
     /// Auto-remove box when stopped (default: true)
     pub auto_remove: bool,
 
@@ -662,6 +658,7 @@ pub struct AdvancedBoxOptions {
     pub security: SecurityOptions,
     pub isolate_mounts: bool,
     pub health_check: Option<HealthCheckOptions>,
+    pub network_rate_limit: NetworkRateLimit,
 }
 ```
 
@@ -671,6 +668,7 @@ pub struct AdvancedBoxOptions {
 | `security` | `SecurityOptions` | `SecurityOptions::default()` (fully enabled profile; jailer enabled) | Security isolation options (jailer, seccomp, namespaces) |
 | `isolate_mounts` | `bool` | `false` | Enable bind mount isolation (requires CAP_SYS_ADMIN on Linux) |
 | `health_check` | `Option<HealthCheckOptions>` | `None` | Optional guest-agent health monitoring |
+| `network_rate_limit` | `NetworkRateLimit` | Unlimited | Per-direction rate limit for the box's interface, in kilobits/sec. Local runtime only; see [NetworkRateLimit](#networkratelimit) |
 
 ### RootfsSpec
 
@@ -779,12 +777,13 @@ controlled by enabled/disabled alone.
 Pre-split code needs no change: `network` keeps its name, type and meaning,
 and box configs persisted without `inbound_network` load with it defaulted.
 
-### NetBandwidth
+### NetworkRateLimit
 
-Bandwidth cap for the box's network interface, in kilobits per second.
+Per-direction rate limit for the box's network interface, in kilobits per
+second. Set through `BoxOptions::advanced`.
 
 ```rust
-pub struct NetBandwidth {
+pub struct NetworkRateLimit {
     pub tx_kbps: Option<u64>,   // guest -> internet
     pub rx_kbps: Option<u64>,   // internet -> guest
 }
@@ -803,11 +802,13 @@ covers TCP, UDP, ICMP and ARP together; there is no per-protocol split.
 Firecracker, Kata and Cloud Hypervisor share.
 
 ```rust
+let mut advanced = AdvancedBoxOptions::default();
+advanced.network_rate_limit = NetworkRateLimit {
+    tx_kbps: Some(10_000),   // 10 Mbit/s up
+    rx_kbps: Some(100_000),  // 100 Mbit/s down
+};
 let opts = BoxOptions {
-    net_bandwidth: NetBandwidth {
-        tx_kbps: Some(10_000),   // 10 Mbit/s up
-        rx_kbps: Some(100_000),  // 100 Mbit/s down
-    },
+    advanced,
     ..Default::default()
 };
 ```

--- a/make/quality.mk
+++ b/make/quality.mk
@@ -190,13 +190,13 @@ lint\:c:
 fmt\:go:
 	@echo "🔧 Formatting Go code..."
 	@cd sdks/go && go fmt ./...
-	@cd src/deps/libgvproxy-sys/gvproxy-bridge && gofmt -w main.go
+	@cd src/deps/libgvproxy-sys/gvproxy-bridge && gofmt -w .
 
 fmt\:check\:go:
 	@echo "🔍 Checking Go formatting..."
 	@cd sdks/go && test -z "$$(gofmt -l .)" || (gofmt -l . && exit 1)
 	@cd src/deps/libgvproxy-sys/gvproxy-bridge && \
-		test -z "$$(gofmt -l main.go)" || (gofmt -l main.go && exit 1)
+		test -z "$$(gofmt -l .)" || (gofmt -l . && exit 1)
 
 lint\:go:
 	@echo "🔍 Linting Go code (vet)..."

--- a/sdks/node/src/options.rs
+++ b/sdks/node/src/options.rs
@@ -583,6 +583,10 @@ impl TryFrom<JsBoxOptions> for BoxOptions {
             // `tty`; Node has no such caller yet.
             tty: false,
             secrets,
+            // Options the core adds but this SDK does not surface yet default
+            // here, so a new core field is not a build break (Python does the
+            // same). Currently: net_bandwidth, a local-runtime bandwidth cap.
+            ..Default::default()
         })
     }
 }

--- a/sdks/node/src/options.rs
+++ b/sdks/node/src/options.rs
@@ -583,10 +583,6 @@ impl TryFrom<JsBoxOptions> for BoxOptions {
             // `tty`; Node has no such caller yet.
             tty: false,
             secrets,
-            // Options the core adds but this SDK does not surface yet default
-            // here, so a new core field is not a build break (Python does the
-            // same). Currently: net_bandwidth, a local-runtime bandwidth cap.
-            ..Default::default()
         })
     }
 }

--- a/src/boxlite/src/lib.rs
+++ b/src/boxlite/src/lib.rs
@@ -52,7 +52,8 @@ pub use litebox::{
 };
 pub use metrics::{BoxMetrics, RuntimeMetrics};
 pub use runtime::advanced_options::{
-    AdvancedBoxOptions, ContainerCapabilities, HealthCheckOptions, ResourceLimits, SecurityOptions,
+    AdvancedBoxOptions, ContainerCapabilities, HealthCheckOptions, NetworkRateLimit,
+    ResourceLimits, SecurityOptions,
 };
 pub use runtime::options::{
     BoxArchive, BoxOptions, BoxliteOptions, CloneOptions, ExportOptions, ImageRegistry,

--- a/src/boxlite/src/litebox/init/tasks/port_publish.rs
+++ b/src/boxlite/src/litebox/init/tasks/port_publish.rs
@@ -530,6 +530,7 @@ mod tests {
                 secrets: Vec::new(),
                 ca_cert_pem: None,
                 ca_key_pem: None,
+                net_bandwidth: Default::default(),
             }
         }
 

--- a/src/boxlite/src/litebox/init/tasks/port_publish.rs
+++ b/src/boxlite/src/litebox/init/tasks/port_publish.rs
@@ -530,7 +530,7 @@ mod tests {
                 secrets: Vec::new(),
                 ca_cert_pem: None,
                 ca_key_pem: None,
-                net_bandwidth: Default::default(),
+                rate_limit: Default::default(),
             }
         }
 

--- a/src/boxlite/src/litebox/init/tasks/vmm_attach.rs
+++ b/src/boxlite/src/litebox/init/tasks/vmm_attach.rs
@@ -37,9 +37,11 @@ impl PipelineTask<InitCtx> for VmmAttachTask {
             let ctx = ctx.lock().await;
             // Reattach still owns a control backend for the box's live gvproxy.
             let network = match &ctx.config.options.network {
-                NetworkSpec::Enabled { allow_net } => {
-                    Some((allow_net.clone(), ctx.config.options.secrets.clone()))
-                }
+                NetworkSpec::Enabled { allow_net } => Some((
+                    allow_net.clone(),
+                    ctx.config.options.secrets.clone(),
+                    ctx.config.options.net_bandwidth,
+                )),
                 NetworkSpec::Disabled => None,
             };
             (ctx.runtime.clone(), ctx.config.id.clone(), network)
@@ -98,12 +100,13 @@ impl PipelineTask<InitCtx> for VmmAttachTask {
         // live gvproxy. No wire spec is produced on reattach; PortPublishTask
         // uses this client to adopt or repair forwards before LiveState is
         // returned.
-        let network_backend = network.and_then(|(allow_net, secrets)| {
+        let network_backend = network.and_then(|(allow_net, secrets, net_bandwidth)| {
             let config = NetworkBackendConfig {
                 socket_path: layout.net_backend_socket_path(),
                 allow_net,
                 secrets,
                 ca_dir: layout.ca_dir(),
+                net_bandwidth,
             };
             runtime.network_factory.create(&config)
         });

--- a/src/boxlite/src/litebox/init/tasks/vmm_attach.rs
+++ b/src/boxlite/src/litebox/init/tasks/vmm_attach.rs
@@ -40,7 +40,7 @@ impl PipelineTask<InitCtx> for VmmAttachTask {
                 NetworkSpec::Enabled { allow_net } => Some((
                     allow_net.clone(),
                     ctx.config.options.secrets.clone(),
-                    ctx.config.options.net_bandwidth,
+                    ctx.config.options.advanced.network_rate_limit,
                 )),
                 NetworkSpec::Disabled => None,
             };
@@ -100,13 +100,13 @@ impl PipelineTask<InitCtx> for VmmAttachTask {
         // live gvproxy. No wire spec is produced on reattach; PortPublishTask
         // uses this client to adopt or repair forwards before LiveState is
         // returned.
-        let network_backend = network.and_then(|(allow_net, secrets, net_bandwidth)| {
+        let network_backend = network.and_then(|(allow_net, secrets, rate_limit)| {
             let config = NetworkBackendConfig {
                 socket_path: layout.net_backend_socket_path(),
                 allow_net,
                 secrets,
                 ca_dir: layout.ca_dir(),
-                net_bandwidth,
+                rate_limit,
             };
             runtime.network_factory.create(&config)
         });

--- a/src/boxlite/src/litebox/init/tasks/vmm_spawn.rs
+++ b/src/boxlite/src/litebox/init/tasks/vmm_spawn.rs
@@ -360,6 +360,7 @@ fn build_network_backend(
         allow_net,
         secrets: options.secrets.clone(),
         ca_dir: layout.ca_dir(),
+        net_bandwidth: options.net_bandwidth,
     };
 
     // Hand the config to the backend abstraction — the one backend for this box.

--- a/src/boxlite/src/litebox/init/tasks/vmm_spawn.rs
+++ b/src/boxlite/src/litebox/init/tasks/vmm_spawn.rs
@@ -360,7 +360,7 @@ fn build_network_backend(
         allow_net,
         secrets: options.secrets.clone(),
         ca_dir: layout.ca_dir(),
-        net_bandwidth: options.net_bandwidth,
+        rate_limit: options.advanced.network_rate_limit,
     };
 
     // Hand the config to the backend abstraction — the one backend for this box.

--- a/src/boxlite/src/net/gvproxy/config.rs
+++ b/src/boxlite/src/net/gvproxy/config.rs
@@ -97,6 +97,64 @@ pub struct GvproxyConfig {
     /// PEM-encoded MITM CA private key (PKCS8 format, consumed by Go).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ca_key_pem: Option<String>,
+
+    /// Per-direction bandwidth cap for the guest link. Absent means unlimited.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rate_limit: Option<GvproxyRateLimit>,
+}
+
+/// Token buckets handed to the Go bridge, one per direction. Field names match
+/// `RateLimitConfig` in gvproxy-bridge/shaper.go; the two must stay in sync.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GvproxyRateLimit {
+    /// Internet to guest.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rx: Option<GvproxyTokenBucket>,
+    /// Guest to internet.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tx: Option<GvproxyTokenBucket>,
+}
+
+/// Firecracker's bucket shape: a capacity in bytes and the time to refill it.
+/// Sustained rate is `size * 1000 / refill_time_ms` bytes per second.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GvproxyTokenBucket {
+    pub size: u64,
+    pub refill_time_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub one_time_burst: Option<u64>,
+}
+
+/// Refill period for a derived bucket. Fixed at 100ms: short enough to keep the
+/// burst small, long enough that the shaper is not waking on every frame.
+const RATE_LIMIT_REFILL_MS: u64 = 100;
+
+impl From<crate::runtime::options::NetBandwidth> for GvproxyRateLimit {
+    fn from(bw: crate::runtime::options::NetBandwidth) -> Self {
+        Self {
+            rx: bucket_from_kbps(bw.rx_kbps),
+            tx: bucket_from_kbps(bw.tx_kbps),
+        }
+    }
+}
+
+/// Kilobits per second to a token bucket. `None` and `0` both mean unlimited,
+/// so this is the one place the user-facing unit is converted.
+///
+/// `size` is not floored here even though the bridge floors bucket *capacity* at
+/// one maximum frame. The bridge derives the sustained rate from this exact
+/// (size, refill_time_ms) pair and keeps the capacity floor in a separate field,
+/// so raising `size` to that floor would not enlarge the burst — it would raise
+/// the rate itself, silently lifting every cap below ~5.2 Mbit/s.
+fn bucket_from_kbps(kbps: Option<u64>) -> Option<GvproxyTokenBucket> {
+    let kbps = kbps.filter(|k| *k > 0)?;
+    // kbit/s -> byte/s is * 1000 / 8, i.e. * 125.
+    let bytes_per_sec = kbps.saturating_mul(125);
+    Some(GvproxyTokenBucket {
+        size: bytes_per_sec / (1000 / RATE_LIMIT_REFILL_MS),
+        refill_time_ms: RATE_LIMIT_REFILL_MS,
+        one_time_burst: None,
+    })
 }
 
 /// Secret configuration for gvproxy MITM proxy.
@@ -139,6 +197,7 @@ impl std::fmt::Debug for GvproxyConfig {
                 "ca_key_pem",
                 &self.ca_key_pem.as_ref().map(|_| "[REDACTED]"),
             )
+            .field("rate_limit", &self.rate_limit)
             .finish()
     }
 }
@@ -187,6 +246,7 @@ fn defaults_with_socket_path(socket_path: PathBuf) -> GvproxyConfig {
         secrets: Vec::new(),
         ca_cert_pem: None,
         ca_key_pem: None,
+        rate_limit: None,
     }
 }
 
@@ -290,6 +350,17 @@ impl GvproxyConfig {
     /// Set secrets for MITM proxy injection.
     pub fn with_secrets(mut self, secrets: Vec<GvproxySecretConfig>) -> Self {
         self.secrets = secrets;
+        self
+    }
+
+    /// Set the per-direction bandwidth cap. An unlimited value is left off the
+    /// wire entirely rather than serialized as an empty object.
+    pub fn with_rate_limit(mut self, bandwidth: crate::runtime::options::NetBandwidth) -> Self {
+        self.rate_limit = if bandwidth.is_unlimited() {
+            None
+        } else {
+            Some(bandwidth.into())
+        };
         self
     }
 
@@ -569,5 +640,96 @@ mod tests {
             HOST_HOSTNAME,
             format!("{}.{}", record.name, zone.name.trim_end_matches('.'))
         );
+    }
+
+    #[test]
+    fn kbps_converts_to_a_bucket_at_the_configured_rate() {
+        use crate::runtime::options::NetBandwidth;
+
+        // 10 Mbit/s = 1_250_000 B/s; one 100ms refill period is 125_000 bytes.
+        let limit: GvproxyRateLimit = NetBandwidth {
+            tx_kbps: Some(10_000),
+            rx_kbps: None,
+        }
+        .into();
+
+        let tx = limit.tx.expect("tx bucket");
+        assert_eq!(tx.refill_time_ms, 100);
+        assert_eq!(tx.size, 125_000);
+        // size * 1000 / refill_time_ms is the rate the bridge derives.
+        assert_eq!(tx.size * 1000 / tx.refill_time_ms, 1_250_000);
+        assert!(limit.rx.is_none(), "an unset direction stays unlimited");
+    }
+
+    /// The bridge reads the sustained rate back out of (size, refill_time_ms), so
+    /// a slow cap must serialize its true 100ms window even when that is far
+    /// below one maximum frame. Flooring it here would raise the rate instead of
+    /// the burst and lift every cap under ~5.2 Mbit/s to that floor.
+    #[test]
+    fn slow_rates_keep_their_configured_rate() {
+        use crate::runtime::options::NetBandwidth;
+
+        let limit: GvproxyRateLimit = NetBandwidth {
+            tx_kbps: Some(64), // 8000 B/s; a 100ms window is only 800 bytes
+            rx_kbps: None,
+        }
+        .into();
+
+        let tx = limit.tx.expect("tx bucket");
+        assert_eq!(tx.size, 800);
+        assert_eq!(
+            tx.size * 1000 / tx.refill_time_ms,
+            8000,
+            "rate must survive"
+        );
+    }
+
+    #[test]
+    fn zero_and_none_both_mean_unlimited() {
+        use crate::runtime::options::NetBandwidth;
+
+        for bw in [
+            NetBandwidth::default(),
+            NetBandwidth {
+                tx_kbps: Some(0),
+                rx_kbps: Some(0),
+            },
+        ] {
+            assert!(bw.is_unlimited());
+            let config = GvproxyConfig::new(test_socket_path()).with_rate_limit(bw);
+            assert!(
+                config.rate_limit.is_none(),
+                "an unlimited cap must not reach the wire at all"
+            );
+        }
+    }
+
+    /// The Go side reads these keys by name (gvproxy-bridge/shaper.go). A rename
+    /// on either side silently disables shaping, so pin the shape.
+    #[test]
+    fn rate_limit_serializes_with_the_keys_the_bridge_reads() {
+        use crate::runtime::options::NetBandwidth;
+
+        let config = GvproxyConfig::new(test_socket_path()).with_rate_limit(NetBandwidth {
+            tx_kbps: Some(10_000),
+            rx_kbps: Some(20_000),
+        });
+        let json: serde_json::Value = serde_json::to_value(&config).unwrap();
+
+        let limit = &json["rate_limit"];
+        assert_eq!(limit["tx"]["size"], 125_000);
+        assert_eq!(limit["tx"]["refill_time_ms"], 100);
+        assert_eq!(limit["rx"]["size"], 250_000);
+        assert!(
+            limit["tx"].get("one_time_burst").is_none(),
+            "an unset burst must be omitted, not sent as null"
+        );
+    }
+
+    #[test]
+    fn default_config_omits_rate_limit_from_the_wire() {
+        let json: serde_json::Value =
+            serde_json::to_value(GvproxyConfig::new(test_socket_path())).unwrap();
+        assert!(json.get("rate_limit").is_none());
     }
 }

--- a/src/boxlite/src/net/gvproxy/config.rs
+++ b/src/boxlite/src/net/gvproxy/config.rs
@@ -661,6 +661,29 @@ mod tests {
         assert!(limit.rx.is_none(), "an unset direction stays unlimited");
     }
 
+    #[test]
+    fn maximum_bandwidth_maps_to_bridge_bucket_limit() {
+        use crate::runtime::options::{BoxOptions, NetBandwidth};
+
+        // Independent wire bound enforced by TokenBucketConfig.validate in shaper.go.
+        const BRIDGE_MAX_BUCKET_BYTES: u64 = (1_u64 << 62) / 1000;
+
+        let opts = BoxOptions {
+            net_bandwidth: NetBandwidth {
+                tx_kbps: Some(NetBandwidth::MAX_KBPS),
+                rx_kbps: Some(NetBandwidth::MAX_KBPS),
+            },
+            ..Default::default()
+        };
+        opts.sanitize_common().unwrap();
+        let limit: GvproxyRateLimit = opts.net_bandwidth.into();
+
+        for bucket in [limit.tx.unwrap(), limit.rx.unwrap()] {
+            assert_eq!(bucket.size, BRIDGE_MAX_BUCKET_BYTES);
+            assert_eq!(bucket.refill_time_ms, RATE_LIMIT_REFILL_MS);
+        }
+    }
+
     /// The bridge reads the sustained rate back out of (size, refill_time_ms), so
     /// a slow cap must serialize its true 100ms window even when that is far
     /// below one maximum frame. Flooring it here would raise the rate instead of

--- a/src/boxlite/src/net/gvproxy/config.rs
+++ b/src/boxlite/src/net/gvproxy/config.rs
@@ -129,11 +129,11 @@ pub struct GvproxyTokenBucket {
 /// burst small, long enough that the shaper is not waking on every frame.
 const RATE_LIMIT_REFILL_MS: u64 = 100;
 
-impl From<crate::runtime::options::NetBandwidth> for GvproxyRateLimit {
-    fn from(bw: crate::runtime::options::NetBandwidth) -> Self {
+impl From<crate::runtime::advanced_options::NetworkRateLimit> for GvproxyRateLimit {
+    fn from(limit: crate::runtime::advanced_options::NetworkRateLimit) -> Self {
         Self {
-            rx: bucket_from_kbps(bw.rx_kbps),
-            tx: bucket_from_kbps(bw.tx_kbps),
+            rx: bucket_from_kbps(limit.rx_kbps),
+            tx: bucket_from_kbps(limit.tx_kbps),
         }
     }
 }
@@ -353,13 +353,16 @@ impl GvproxyConfig {
         self
     }
 
-    /// Set the per-direction bandwidth cap. An unlimited value is left off the
+    /// Set the per-direction rate limit. An unlimited value is left off the
     /// wire entirely rather than serialized as an empty object.
-    pub fn with_rate_limit(mut self, bandwidth: crate::runtime::options::NetBandwidth) -> Self {
-        self.rate_limit = if bandwidth.is_unlimited() {
+    pub fn with_rate_limit(
+        mut self,
+        limit: crate::runtime::advanced_options::NetworkRateLimit,
+    ) -> Self {
+        self.rate_limit = if limit.is_unlimited() {
             None
         } else {
-            Some(bandwidth.into())
+            Some(limit.into())
         };
         self
     }
@@ -644,10 +647,10 @@ mod tests {
 
     #[test]
     fn kbps_converts_to_a_bucket_at_the_configured_rate() {
-        use crate::runtime::options::NetBandwidth;
+        use crate::runtime::advanced_options::NetworkRateLimit;
 
         // 10 Mbit/s = 1_250_000 B/s; one 100ms refill period is 125_000 bytes.
-        let limit: GvproxyRateLimit = NetBandwidth {
+        let limit: GvproxyRateLimit = NetworkRateLimit {
             tx_kbps: Some(10_000),
             rx_kbps: None,
         }
@@ -662,21 +665,24 @@ mod tests {
     }
 
     #[test]
-    fn maximum_bandwidth_maps_to_bridge_bucket_limit() {
-        use crate::runtime::options::{BoxOptions, NetBandwidth};
+    fn maximum_rate_limit_maps_to_bridge_bucket_limit() {
+        use crate::runtime::advanced_options::{AdvancedBoxOptions, NetworkRateLimit};
+        use crate::runtime::options::BoxOptions;
 
         // Independent wire bound enforced by TokenBucketConfig.validate in shaper.go.
         const BRIDGE_MAX_BUCKET_BYTES: u64 = (1_u64 << 62) / 1000;
 
+        let mut advanced = AdvancedBoxOptions::default();
+        advanced.network_rate_limit = NetworkRateLimit {
+            tx_kbps: Some(NetworkRateLimit::MAX_KBPS),
+            rx_kbps: Some(NetworkRateLimit::MAX_KBPS),
+        };
         let opts = BoxOptions {
-            net_bandwidth: NetBandwidth {
-                tx_kbps: Some(NetBandwidth::MAX_KBPS),
-                rx_kbps: Some(NetBandwidth::MAX_KBPS),
-            },
+            advanced,
             ..Default::default()
         };
         opts.sanitize_common().unwrap();
-        let limit: GvproxyRateLimit = opts.net_bandwidth.into();
+        let limit: GvproxyRateLimit = opts.advanced.network_rate_limit.into();
 
         for bucket in [limit.tx.unwrap(), limit.rx.unwrap()] {
             assert_eq!(bucket.size, BRIDGE_MAX_BUCKET_BYTES);
@@ -690,9 +696,9 @@ mod tests {
     /// the burst and lift every cap under ~5.2 Mbit/s to that floor.
     #[test]
     fn slow_rates_keep_their_configured_rate() {
-        use crate::runtime::options::NetBandwidth;
+        use crate::runtime::advanced_options::NetworkRateLimit;
 
-        let limit: GvproxyRateLimit = NetBandwidth {
+        let limit: GvproxyRateLimit = NetworkRateLimit {
             tx_kbps: Some(64), // 8000 B/s; a 100ms window is only 800 bytes
             rx_kbps: None,
         }
@@ -709,17 +715,17 @@ mod tests {
 
     #[test]
     fn zero_and_none_both_mean_unlimited() {
-        use crate::runtime::options::NetBandwidth;
+        use crate::runtime::advanced_options::NetworkRateLimit;
 
-        for bw in [
-            NetBandwidth::default(),
-            NetBandwidth {
+        for limit in [
+            NetworkRateLimit::default(),
+            NetworkRateLimit {
                 tx_kbps: Some(0),
                 rx_kbps: Some(0),
             },
         ] {
-            assert!(bw.is_unlimited());
-            let config = GvproxyConfig::new(test_socket_path()).with_rate_limit(bw);
+            assert!(limit.is_unlimited());
+            let config = GvproxyConfig::new(test_socket_path()).with_rate_limit(limit);
             assert!(
                 config.rate_limit.is_none(),
                 "an unlimited cap must not reach the wire at all"
@@ -731,9 +737,9 @@ mod tests {
     /// on either side silently disables shaping, so pin the shape.
     #[test]
     fn rate_limit_serializes_with_the_keys_the_bridge_reads() {
-        use crate::runtime::options::NetBandwidth;
+        use crate::runtime::advanced_options::NetworkRateLimit;
 
-        let config = GvproxyConfig::new(test_socket_path()).with_rate_limit(NetBandwidth {
+        let config = GvproxyConfig::new(test_socket_path()).with_rate_limit(NetworkRateLimit {
             tx_kbps: Some(10_000),
             rx_kbps: Some(20_000),
         });

--- a/src/boxlite/src/net/gvproxy/instance.rs
+++ b/src/boxlite/src/net/gvproxy/instance.rs
@@ -48,35 +48,20 @@ pub struct GvproxyInstance {
 }
 
 impl GvproxyInstance {
-    /// Create a new gvproxy instance with the given socket path.
+    /// Create a gvproxy instance from a fully-built config.
+    ///
+    /// Takes the assembled config rather than the individual pieces so the
+    /// signature stops growing as gvproxy gains settings; [`Self::from_config`]
+    /// is what maps a [`NetworkBackendSpec`] onto it.
     ///
     /// This automatically initializes the logging bridge on first use.
     ///
-    /// # Arguments
-    ///
-    /// * `socket_path` - Caller-provided Unix socket path (must be unique per box)
-    pub(crate) fn new(
-        socket_path: PathBuf,
-        allow_net: Vec<String>,
-        secrets: Vec<super::config::GvproxySecretConfig>,
-        ca_cert_pem: Option<&str>,
-        ca_key_pem: Option<&str>,
-    ) -> BoxliteResult<Self> {
+    /// [`NetworkBackendSpec`]: super::super::NetworkBackendSpec
+    pub(crate) fn new(config: super::config::GvproxyConfig) -> BoxliteResult<Self> {
         // Initialize logging callback (one-time setup)
         logging::init_logging();
 
-        // Derive gvproxy's control socket as a sibling of the data socket, so the
-        // path is never plumbed through neutral config/layout/socket types.
-        let control_socket_path = super::control_socket_path(&socket_path);
-        let mut config = super::config::GvproxyConfig::new(socket_path.clone())
-            .with_control_socket_path(control_socket_path)
-            .with_allow_net(allow_net)
-            .with_secrets(secrets);
-
-        if let (Some(cert), Some(key)) = (ca_cert_pem, ca_key_pem) {
-            config = config.with_ca(cert.to_string(), key.to_string());
-        }
-
+        let socket_path = config.socket_path.clone();
         let id = ffi::create_instance(&config)?;
 
         tracing::info!(id, ?socket_path, "Created GvproxyInstance");
@@ -102,13 +87,21 @@ impl GvproxyInstance {
         spec: &super::super::NetworkBackendSpec,
     ) -> BoxliteResult<(Self, super::super::NetworkBackendEndpoint)> {
         let secrets = spec.secrets.iter().map(Into::into).collect();
-        let instance = Self::new(
-            spec.socket_path.clone(),
-            spec.allow_net.clone(),
-            secrets,
-            spec.ca_cert_pem.as_deref(),
-            spec.ca_key_pem.as_deref(),
-        )?;
+
+        // Derive gvproxy's control socket as a sibling of the data socket, so the
+        // path is never plumbed through neutral config/layout/socket types.
+        let control_socket_path = super::control_socket_path(&spec.socket_path);
+        let mut config = crate::net::gvproxy::config::GvproxyConfig::new(spec.socket_path.clone())
+            .with_control_socket_path(control_socket_path)
+            .with_allow_net(spec.allow_net.clone())
+            .with_secrets(secrets)
+            .with_rate_limit(spec.net_bandwidth);
+
+        if let (Some(cert), Some(key)) = (spec.ca_cert_pem.as_deref(), spec.ca_key_pem.as_deref()) {
+            config = config.with_ca(cert.to_string(), key.to_string());
+        }
+
+        let instance = Self::new(config)?;
 
         let connection_type = if cfg!(target_os = "macos") {
             super::super::ConnectionType::UnixDgram
@@ -218,8 +211,10 @@ mod tests {
     #[ignore] // Requires libgvproxy.dylib to be available
     fn test_gvproxy_create_destroy() {
         let socket_path = PathBuf::from("/tmp/test-gvproxy-instance.sock");
-        let instance =
-            GvproxyInstance::new(socket_path.clone(), Vec::new(), Vec::new(), None, None).unwrap();
+        let instance = GvproxyInstance::new(crate::net::gvproxy::config::GvproxyConfig::new(
+            socket_path.clone(),
+        ))
+        .unwrap();
 
         // Socket path matches what we provided
         assert_eq!(instance.socket_path(), socket_path);
@@ -233,10 +228,14 @@ mod tests {
         let path1 = PathBuf::from("/tmp/test-gvproxy-1.sock");
         let path2 = PathBuf::from("/tmp/test-gvproxy-2.sock");
 
-        let instance1 =
-            GvproxyInstance::new(path1.clone(), Vec::new(), Vec::new(), None, None).unwrap();
-        let instance2 =
-            GvproxyInstance::new(path2.clone(), Vec::new(), Vec::new(), None, None).unwrap();
+        let instance1 = GvproxyInstance::new(crate::net::gvproxy::config::GvproxyConfig::new(
+            path1.clone(),
+        ))
+        .unwrap();
+        let instance2 = GvproxyInstance::new(crate::net::gvproxy::config::GvproxyConfig::new(
+            path2.clone(),
+        ))
+        .unwrap();
 
         assert_ne!(instance1.id(), instance2.id());
         assert_ne!(instance1.socket_path(), instance2.socket_path());

--- a/src/boxlite/src/net/gvproxy/instance.rs
+++ b/src/boxlite/src/net/gvproxy/instance.rs
@@ -95,7 +95,7 @@ impl GvproxyInstance {
             .with_control_socket_path(control_socket_path)
             .with_allow_net(spec.allow_net.clone())
             .with_secrets(secrets)
-            .with_rate_limit(spec.net_bandwidth);
+            .with_rate_limit(spec.rate_limit);
 
         if let (Some(cert), Some(key)) = (spec.ca_cert_pem.as_deref(), spec.ca_key_pem.as_deref()) {
             config = config.with_ca(cert.to_string(), key.to_string());

--- a/src/boxlite/src/net/gvproxy/services.rs
+++ b/src/boxlite/src/net/gvproxy/services.rs
@@ -1495,9 +1495,10 @@ mod tests {
 
         // Bind a real gvproxy instance; it derives + serves its control socket
         // (`gvproxy-ctl.sock`) as a sibling of net.sock.
-        let _instance = GvproxyInstance::new(crate::net::gvproxy::config::GvproxyConfig::new(
-            net_sock.clone(),
-        ))
+        let _instance = GvproxyInstance::new(
+            crate::net::gvproxy::config::GvproxyConfig::new(net_sock.clone())
+                .with_control_socket_path(super::super::control_socket_path(&net_sock)),
+        )
         .expect("create gvproxy instance");
 
         let config = NetworkBackendConfig {
@@ -1555,9 +1556,10 @@ mod tests {
             .tempdir_in("/tmp")
             .unwrap();
         let net_sock = dir.path().join("net.sock");
-        let _instance = GvproxyInstance::new(crate::net::gvproxy::config::GvproxyConfig::new(
-            net_sock.clone(),
-        ))
+        let _instance = GvproxyInstance::new(
+            crate::net::gvproxy::config::GvproxyConfig::new(net_sock.clone())
+                .with_control_socket_path(super::super::control_socket_path(&net_sock)),
+        )
         .expect("create gvproxy instance");
 
         let config = NetworkBackendConfig {

--- a/src/boxlite/src/net/gvproxy/services.rs
+++ b/src/boxlite/src/net/gvproxy/services.rs
@@ -341,6 +341,7 @@ impl NetworkBackend for GvproxyBackend {
             secrets: cfg.secrets.clone(),
             ca_cert_pem: None,
             ca_key_pem: None,
+            net_bandwidth: cfg.net_bandwidth,
         };
 
         // Mint the ephemeral MITM CA when secrets are configured. The cert+key
@@ -593,6 +594,7 @@ mod tests {
             allow_net: vec!["example.com".to_string()],
             secrets: Vec::new(),
             ca_dir: PathBuf::from("/tmp/bl-box/does-not-exist"),
+            net_bandwidth: Default::default(),
         };
         let spec = GvproxyBackend::from_config(&config).spec();
         assert_eq!(spec.socket_path, config.socket_path);
@@ -669,6 +671,7 @@ mod tests {
             allow_net: Vec::new(),
             secrets: Vec::new(),
             ca_dir: dir.path().to_path_buf(),
+            net_bandwidth: Default::default(),
         };
         (
             GvproxyBackend::from_config(&config),
@@ -768,6 +771,7 @@ mod tests {
             allow_net: Vec::new(),
             secrets: vec![test_secret()],
             ca_dir: ca_dir.path().to_path_buf(),
+            net_bandwidth: Default::default(),
         };
         let spec = GvproxyBackend::from_config(&config).spec();
         assert!(
@@ -799,6 +803,7 @@ mod tests {
             allow_net: Vec::new(),
             secrets: vec![test_secret()],
             ca_dir,
+            net_bandwidth: Default::default(),
         };
 
         let spec = GvproxyBackend::from_config(&config).spec();
@@ -1411,6 +1416,7 @@ mod tests {
             allow_net: Vec::new(),
             secrets: Vec::new(),
             ca_dir: dir.path().to_path_buf(),
+            net_bandwidth: Default::default(),
         };
         let target: SocketAddr = "192.168.127.2:8080".parse().unwrap();
         let mut tunnel = GvproxyBackend::from_config(&config)
@@ -1460,6 +1466,7 @@ mod tests {
             allow_net: Vec::new(),
             secrets: Vec::new(),
             ca_dir: dir.path().to_path_buf(),
+            net_bandwidth: Default::default(),
         };
         let target: SocketAddr = "192.168.127.2:8080".parse().unwrap();
         let err = GvproxyBackend::from_config(&config)
@@ -1488,14 +1495,17 @@ mod tests {
 
         // Bind a real gvproxy instance; it derives + serves its control socket
         // (`gvproxy-ctl.sock`) as a sibling of net.sock.
-        let _instance = GvproxyInstance::new(net_sock.clone(), Vec::new(), Vec::new(), None, None)
-            .expect("create gvproxy instance");
+        let _instance = GvproxyInstance::new(crate::net::gvproxy::config::GvproxyConfig::new(
+            net_sock.clone(),
+        ))
+        .expect("create gvproxy instance");
 
         let config = NetworkBackendConfig {
             socket_path: net_sock.clone(),
             allow_net: Vec::new(),
             secrets: Vec::new(),
             ca_dir: dir.path().to_path_buf(),
+            net_bandwidth: Default::default(),
         };
         let ctl = GvproxyBackend::from_config(&config);
 
@@ -1545,14 +1555,17 @@ mod tests {
             .tempdir_in("/tmp")
             .unwrap();
         let net_sock = dir.path().join("net.sock");
-        let _instance = GvproxyInstance::new(net_sock.clone(), Vec::new(), Vec::new(), None, None)
-            .expect("create gvproxy instance");
+        let _instance = GvproxyInstance::new(crate::net::gvproxy::config::GvproxyConfig::new(
+            net_sock.clone(),
+        ))
+        .expect("create gvproxy instance");
 
         let config = NetworkBackendConfig {
             socket_path: net_sock.clone(),
             allow_net: Vec::new(),
             secrets: Vec::new(),
             ca_dir: dir.path().to_path_buf(),
+            net_bandwidth: Default::default(),
         };
         let backend = GvproxyBackend::from_config(&config);
 

--- a/src/boxlite/src/net/gvproxy/services.rs
+++ b/src/boxlite/src/net/gvproxy/services.rs
@@ -341,7 +341,7 @@ impl NetworkBackend for GvproxyBackend {
             secrets: cfg.secrets.clone(),
             ca_cert_pem: None,
             ca_key_pem: None,
-            net_bandwidth: cfg.net_bandwidth,
+            rate_limit: cfg.rate_limit,
         };
 
         // Mint the ephemeral MITM CA when secrets are configured. The cert+key
@@ -594,7 +594,7 @@ mod tests {
             allow_net: vec!["example.com".to_string()],
             secrets: Vec::new(),
             ca_dir: PathBuf::from("/tmp/bl-box/does-not-exist"),
-            net_bandwidth: Default::default(),
+            rate_limit: Default::default(),
         };
         let spec = GvproxyBackend::from_config(&config).spec();
         assert_eq!(spec.socket_path, config.socket_path);
@@ -671,7 +671,7 @@ mod tests {
             allow_net: Vec::new(),
             secrets: Vec::new(),
             ca_dir: dir.path().to_path_buf(),
-            net_bandwidth: Default::default(),
+            rate_limit: Default::default(),
         };
         (
             GvproxyBackend::from_config(&config),
@@ -771,7 +771,7 @@ mod tests {
             allow_net: Vec::new(),
             secrets: vec![test_secret()],
             ca_dir: ca_dir.path().to_path_buf(),
-            net_bandwidth: Default::default(),
+            rate_limit: Default::default(),
         };
         let spec = GvproxyBackend::from_config(&config).spec();
         assert!(
@@ -803,7 +803,7 @@ mod tests {
             allow_net: Vec::new(),
             secrets: vec![test_secret()],
             ca_dir,
-            net_bandwidth: Default::default(),
+            rate_limit: Default::default(),
         };
 
         let spec = GvproxyBackend::from_config(&config).spec();
@@ -1416,7 +1416,7 @@ mod tests {
             allow_net: Vec::new(),
             secrets: Vec::new(),
             ca_dir: dir.path().to_path_buf(),
-            net_bandwidth: Default::default(),
+            rate_limit: Default::default(),
         };
         let target: SocketAddr = "192.168.127.2:8080".parse().unwrap();
         let mut tunnel = GvproxyBackend::from_config(&config)
@@ -1466,7 +1466,7 @@ mod tests {
             allow_net: Vec::new(),
             secrets: Vec::new(),
             ca_dir: dir.path().to_path_buf(),
-            net_bandwidth: Default::default(),
+            rate_limit: Default::default(),
         };
         let target: SocketAddr = "192.168.127.2:8080".parse().unwrap();
         let err = GvproxyBackend::from_config(&config)
@@ -1506,7 +1506,7 @@ mod tests {
             allow_net: Vec::new(),
             secrets: Vec::new(),
             ca_dir: dir.path().to_path_buf(),
-            net_bandwidth: Default::default(),
+            rate_limit: Default::default(),
         };
         let ctl = GvproxyBackend::from_config(&config);
 
@@ -1567,7 +1567,7 @@ mod tests {
             allow_net: Vec::new(),
             secrets: Vec::new(),
             ca_dir: dir.path().to_path_buf(),
-            net_bandwidth: Default::default(),
+            rate_limit: Default::default(),
         };
         let backend = GvproxyBackend::from_config(&config);
 

--- a/src/boxlite/src/net/mod.rs
+++ b/src/boxlite/src/net/mod.rs
@@ -8,6 +8,7 @@
 //! In the shim, the concrete gvproxy instance consumes the spec and yields the
 //! [`NetworkBackendEndpoint`] value type the engine wires into the NIC.
 
+use crate::runtime::options::NetBandwidth;
 use async_trait::async_trait;
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 use serde_json::Value;
@@ -66,6 +67,8 @@ pub struct NetworkBackendConfig {
     /// Directory in which to mint the ephemeral MITM CA — used only when
     /// `secrets` is non-empty. The backend mints the CA in [`NetworkBackend::spec`].
     pub ca_dir: PathBuf,
+    /// Per-direction bandwidth cap for the guest link. Default is unlimited.
+    pub net_bandwidth: NetBandwidth,
 }
 
 /// The wire blob a [`NetworkBackend`] produces (via [`NetworkBackend::spec`]) for
@@ -91,6 +94,10 @@ pub struct NetworkBackendSpec {
     /// PEM-encoded MITM CA private key (PKCS8, minted when secrets are configured).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ca_key_pem: Option<String>,
+    /// Per-direction bandwidth cap for the guest link. Defaulted so a spec
+    /// written by an older core still deserializes.
+    #[serde(default, skip_serializing_if = "NetBandwidth::is_unlimited")]
+    pub net_bandwidth: NetBandwidth,
 }
 
 impl std::fmt::Debug for NetworkBackendSpec {
@@ -107,6 +114,7 @@ impl std::fmt::Debug for NetworkBackendSpec {
                 "ca_key_pem",
                 &self.ca_key_pem.as_ref().map(|_| "[REDACTED]"),
             )
+            .field("net_bandwidth", &self.net_bandwidth)
             .finish()
     }
 }
@@ -488,6 +496,7 @@ mod tests {
             secrets: Vec::new(),
             ca_cert_pem: Some(cert_sentinel.to_string()),
             ca_key_pem: Some(key_sentinel.to_string()),
+            net_bandwidth: Default::default(),
         };
 
         let rendered = format!("{:?}", spec);
@@ -520,6 +529,7 @@ mod tests {
             secrets: Vec::new(),
             ca_cert_pem: Some("CERTDATA".to_string()),
             ca_key_pem: Some("KEYDATA".to_string()),
+            net_bandwidth: Default::default(),
         };
         let json = serde_json::to_string(&spec).unwrap();
         let back: NetworkBackendSpec = serde_json::from_str(&json).unwrap();
@@ -537,6 +547,40 @@ mod tests {
         assert!(spec.secrets.is_empty());
         assert!(spec.ca_cert_pem.is_none());
         assert!(spec.ca_key_pem.is_none());
+        // A spec written before shaping existed carries no cap and must
+        // deserialize as unlimited rather than failing.
+        assert!(spec.net_bandwidth.is_unlimited());
+    }
+
+    /// The cap must survive the core -> shim hop, and an unlimited one must not
+    /// take up room on that wire.
+    #[test]
+    fn spec_round_trips_net_bandwidth_and_omits_it_when_unlimited() {
+        let spec = NetworkBackendSpec {
+            socket_path: PathBuf::from("/tmp/net.sock"),
+            allow_net: Vec::new(),
+            secrets: Vec::new(),
+            ca_cert_pem: None,
+            ca_key_pem: None,
+            net_bandwidth: NetBandwidth {
+                tx_kbps: Some(10_000),
+                rx_kbps: None,
+            },
+        };
+        let json = serde_json::to_string(&spec).unwrap();
+        let back: NetworkBackendSpec = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.net_bandwidth.tx_kbps, Some(10_000));
+        assert_eq!(back.net_bandwidth.rx_kbps, None);
+
+        let unlimited = NetworkBackendSpec {
+            net_bandwidth: NetBandwidth::default(),
+            ..spec
+        };
+        let json = serde_json::to_string(&unlimited).unwrap();
+        assert!(
+            !json.contains("net_bandwidth"),
+            "an unlimited cap must be omitted; got: {json}"
+        );
     }
 
     #[test]
@@ -546,6 +590,7 @@ mod tests {
             allow_net: vec!["example.com".to_string()],
             secrets: Vec::new(),
             ca_dir: PathBuf::from("/tmp/default-factory/ca"),
+            net_bandwidth: Default::default(),
         };
 
         let backend = default_factory()
@@ -626,6 +671,7 @@ mod tests {
                 secrets: Vec::new(),
                 ca_cert_pem: None,
                 ca_key_pem: None,
+                net_bandwidth: Default::default(),
             }
         }
     }

--- a/src/boxlite/src/net/mod.rs
+++ b/src/boxlite/src/net/mod.rs
@@ -8,7 +8,7 @@
 //! In the shim, the concrete gvproxy instance consumes the spec and yields the
 //! [`NetworkBackendEndpoint`] value type the engine wires into the NIC.
 
-use crate::runtime::options::NetBandwidth;
+use crate::runtime::advanced_options::NetworkRateLimit;
 use async_trait::async_trait;
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 use serde_json::Value;
@@ -67,8 +67,8 @@ pub struct NetworkBackendConfig {
     /// Directory in which to mint the ephemeral MITM CA — used only when
     /// `secrets` is non-empty. The backend mints the CA in [`NetworkBackend::spec`].
     pub ca_dir: PathBuf,
-    /// Per-direction bandwidth cap for the guest link. Default is unlimited.
-    pub net_bandwidth: NetBandwidth,
+    /// Per-direction rate limit for the guest link. Default is unlimited.
+    pub rate_limit: NetworkRateLimit,
 }
 
 /// The wire blob a [`NetworkBackend`] produces (via [`NetworkBackend::spec`]) for
@@ -94,10 +94,10 @@ pub struct NetworkBackendSpec {
     /// PEM-encoded MITM CA private key (PKCS8, minted when secrets are configured).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ca_key_pem: Option<String>,
-    /// Per-direction bandwidth cap for the guest link. Defaulted so a spec
+    /// Per-direction rate limit for the guest link. Defaulted so a spec
     /// written by an older core still deserializes.
-    #[serde(default, skip_serializing_if = "NetBandwidth::is_unlimited")]
-    pub net_bandwidth: NetBandwidth,
+    #[serde(default, skip_serializing_if = "NetworkRateLimit::is_unlimited")]
+    pub rate_limit: NetworkRateLimit,
 }
 
 impl std::fmt::Debug for NetworkBackendSpec {
@@ -114,7 +114,7 @@ impl std::fmt::Debug for NetworkBackendSpec {
                 "ca_key_pem",
                 &self.ca_key_pem.as_ref().map(|_| "[REDACTED]"),
             )
-            .field("net_bandwidth", &self.net_bandwidth)
+            .field("rate_limit", &self.rate_limit)
             .finish()
     }
 }
@@ -496,7 +496,7 @@ mod tests {
             secrets: Vec::new(),
             ca_cert_pem: Some(cert_sentinel.to_string()),
             ca_key_pem: Some(key_sentinel.to_string()),
-            net_bandwidth: Default::default(),
+            rate_limit: Default::default(),
         };
 
         let rendered = format!("{:?}", spec);
@@ -529,7 +529,7 @@ mod tests {
             secrets: Vec::new(),
             ca_cert_pem: Some("CERTDATA".to_string()),
             ca_key_pem: Some("KEYDATA".to_string()),
-            net_bandwidth: Default::default(),
+            rate_limit: Default::default(),
         };
         let json = serde_json::to_string(&spec).unwrap();
         let back: NetworkBackendSpec = serde_json::from_str(&json).unwrap();
@@ -549,36 +549,36 @@ mod tests {
         assert!(spec.ca_key_pem.is_none());
         // A spec written before shaping existed carries no cap and must
         // deserialize as unlimited rather than failing.
-        assert!(spec.net_bandwidth.is_unlimited());
+        assert!(spec.rate_limit.is_unlimited());
     }
 
     /// The cap must survive the core -> shim hop, and an unlimited one must not
     /// take up room on that wire.
     #[test]
-    fn spec_round_trips_net_bandwidth_and_omits_it_when_unlimited() {
+    fn spec_round_trips_rate_limit_and_omits_it_when_unlimited() {
         let spec = NetworkBackendSpec {
             socket_path: PathBuf::from("/tmp/net.sock"),
             allow_net: Vec::new(),
             secrets: Vec::new(),
             ca_cert_pem: None,
             ca_key_pem: None,
-            net_bandwidth: NetBandwidth {
+            rate_limit: NetworkRateLimit {
                 tx_kbps: Some(10_000),
                 rx_kbps: None,
             },
         };
         let json = serde_json::to_string(&spec).unwrap();
         let back: NetworkBackendSpec = serde_json::from_str(&json).unwrap();
-        assert_eq!(back.net_bandwidth.tx_kbps, Some(10_000));
-        assert_eq!(back.net_bandwidth.rx_kbps, None);
+        assert_eq!(back.rate_limit.tx_kbps, Some(10_000));
+        assert_eq!(back.rate_limit.rx_kbps, None);
 
         let unlimited = NetworkBackendSpec {
-            net_bandwidth: NetBandwidth::default(),
+            rate_limit: NetworkRateLimit::default(),
             ..spec
         };
         let json = serde_json::to_string(&unlimited).unwrap();
         assert!(
-            !json.contains("net_bandwidth"),
+            !json.contains("rate_limit"),
             "an unlimited cap must be omitted; got: {json}"
         );
     }
@@ -590,7 +590,7 @@ mod tests {
             allow_net: vec!["example.com".to_string()],
             secrets: Vec::new(),
             ca_dir: PathBuf::from("/tmp/default-factory/ca"),
-            net_bandwidth: Default::default(),
+            rate_limit: Default::default(),
         };
 
         let backend = default_factory()
@@ -671,7 +671,7 @@ mod tests {
                 secrets: Vec::new(),
                 ca_cert_pem: None,
                 ca_key_pem: None,
-                net_bandwidth: Default::default(),
+                rate_limit: Default::default(),
             }
         }
     }

--- a/src/boxlite/src/rest/runtime.rs
+++ b/src/boxlite/src/rest/runtime.rs
@@ -109,6 +109,15 @@ impl BoxOptions {
             ));
         }
 
+        if !self.net_bandwidth.is_unlimited() {
+            return Err(BoxliteError::Unsupported(
+                "Network bandwidth limits are enforced by the local gvproxy bridge and \
+                 are local-only for remote runtimes; the remote server owns its own \
+                 network policy."
+                    .to_string(),
+            ));
+        }
+
         if self.advanced.security != SecurityOptions::default() {
             return Err(BoxliteError::Unsupported(
                 "sandbox security (advanced.security) is the remote server's own policy \
@@ -757,6 +766,56 @@ mod tests {
 
         assert!(matches!(error, BoxliteError::Unsupported(_)));
         assert!(error.to_string().contains("local runtime"));
+    }
+
+    #[tokio::test]
+    async fn create_rejects_net_bandwidth_in_rest_mode() {
+        let options = BoxliteRestOptions::new("http://localhost:1");
+        let runtime = RestRuntime::new(&options).expect("failed to create REST runtime");
+        let box_options = BoxOptions {
+            net_bandwidth: crate::runtime::options::NetBandwidth {
+                tx_kbps: Some(10_000),
+                rx_kbps: None,
+            },
+            ..Default::default()
+        };
+
+        let error = RuntimeBackend::create(&runtime, box_options, None)
+            .await
+            .err()
+            .expect("REST bandwidth limits must be rejected before network I/O");
+
+        assert!(matches!(error, BoxliteError::Unsupported(_)));
+        assert!(error.to_string().contains("local-only"));
+    }
+
+    /// A zero is the documented way to spell "no cap", so it must reach the same
+    /// point an absent cap does instead of tripping the remote refusal.
+    ///
+    /// The create still fails — nothing is listening on port 1 — but it has to
+    /// fail on the transport, not on `sanitize_remote`, which is what
+    /// distinguishes a zero from a real limit.
+    #[tokio::test]
+    async fn zero_net_bandwidth_passes_the_remote_refusal() {
+        let options = BoxliteRestOptions::new("http://localhost:1");
+        let runtime = RestRuntime::new(&options).expect("failed to create REST runtime");
+        let box_options = BoxOptions {
+            net_bandwidth: crate::runtime::options::NetBandwidth {
+                tx_kbps: Some(0),
+                rx_kbps: Some(0),
+            },
+            ..Default::default()
+        };
+
+        let error = RuntimeBackend::create(&runtime, box_options, None)
+            .await
+            .err()
+            .expect("nothing is listening, so the create cannot succeed");
+
+        assert!(
+            !matches!(error, BoxliteError::Unsupported(_)),
+            "a zero cap must not be refused as a bandwidth limit, got: {error}"
+        );
     }
 
     #[tokio::test]

--- a/src/boxlite/src/rest/runtime.rs
+++ b/src/boxlite/src/rest/runtime.rs
@@ -109,11 +109,11 @@ impl BoxOptions {
             ));
         }
 
-        if !self.net_bandwidth.is_unlimited() {
+        if !self.advanced.network_rate_limit.is_unlimited() {
             return Err(BoxliteError::Unsupported(
-                "Network bandwidth limits are enforced by the local gvproxy bridge and \
-                 are local-only for remote runtimes; the remote server owns its own \
-                 network policy."
+                "network rate limits (advanced.network_rate_limit) are enforced by the \
+                 local gvproxy bridge and are local-only for remote runtimes; the remote \
+                 server owns its own network policy."
                     .to_string(),
             ));
         }
@@ -769,21 +769,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_rejects_net_bandwidth_in_rest_mode() {
+    async fn create_rejects_network_rate_limit_in_rest_mode() {
         let options = BoxliteRestOptions::new("http://localhost:1");
         let runtime = RestRuntime::new(&options).expect("failed to create REST runtime");
+        let mut advanced = crate::runtime::advanced_options::AdvancedBoxOptions::default();
+        advanced.network_rate_limit = crate::runtime::advanced_options::NetworkRateLimit {
+            tx_kbps: Some(10_000),
+            rx_kbps: None,
+        };
         let box_options = BoxOptions {
-            net_bandwidth: crate::runtime::options::NetBandwidth {
-                tx_kbps: Some(10_000),
-                rx_kbps: None,
-            },
+            advanced,
             ..Default::default()
         };
 
         let error = RuntimeBackend::create(&runtime, box_options, None)
             .await
             .err()
-            .expect("REST bandwidth limits must be rejected before network I/O");
+            .expect("REST network rate limits must be rejected before network I/O");
 
         assert!(matches!(error, BoxliteError::Unsupported(_)));
         assert!(error.to_string().contains("local-only"));
@@ -796,14 +798,16 @@ mod tests {
     /// fail on the transport, not on `sanitize_remote`, which is what
     /// distinguishes a zero from a real limit.
     #[tokio::test]
-    async fn zero_net_bandwidth_passes_the_remote_refusal() {
+    async fn zero_network_rate_limit_passes_the_remote_refusal() {
         let options = BoxliteRestOptions::new("http://localhost:1");
         let runtime = RestRuntime::new(&options).expect("failed to create REST runtime");
+        let mut advanced = crate::runtime::advanced_options::AdvancedBoxOptions::default();
+        advanced.network_rate_limit = crate::runtime::advanced_options::NetworkRateLimit {
+            tx_kbps: Some(0),
+            rx_kbps: Some(0),
+        };
         let box_options = BoxOptions {
-            net_bandwidth: crate::runtime::options::NetBandwidth {
-                tx_kbps: Some(0),
-                rx_kbps: Some(0),
-            },
+            advanced,
             ..Default::default()
         };
 
@@ -814,7 +818,7 @@ mod tests {
 
         assert!(
             !matches!(error, BoxliteError::Unsupported(_)),
-            "a zero cap must not be refused as a bandwidth limit, got: {error}"
+            "a zero cap must not be refused as a rate limit, got: {error}"
         );
     }
 

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -200,6 +200,10 @@ impl CreateBoxRequest {
             disk_size_gb: options.disk_size_gb,
             working_dir: options.working_dir.clone(),
             env,
+            // net_bandwidth is intentionally NOT carried on the wire. Shaping is
+            // done by the local gvproxy bridge; a remote server enforces its own
+            // network policy, so there is no field for a client to set. The
+            // matching refusal lives in BoxOptions::sanitize_remote.
             network: Some(CreateBoxNetworkSpec::from_options(
                 &options.network,
                 &options.inbound_network,
@@ -997,6 +1001,28 @@ mod tests {
         assert!(
             !json.contains("security"),
             "wire form must NOT carry any security knob; got: {json}"
+        );
+    }
+
+    /// Bandwidth shaping is done by the local gvproxy bridge, so the wire form
+    /// has no field for it and a local value must not leak into the request.
+    #[test]
+    fn test_create_box_request_never_carries_net_bandwidth() {
+        use crate::runtime::options::{BoxOptions, NetBandwidth, RootfsSpec};
+
+        let opts = BoxOptions {
+            rootfs: RootfsSpec::Image("alpine:latest".into()),
+            net_bandwidth: NetBandwidth {
+                tx_kbps: Some(10_000),
+                rx_kbps: Some(20_000),
+            },
+            ..Default::default()
+        };
+        let req = CreateBoxRequest::from_options(&opts, None);
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(
+            !json.contains("bandwidth") && !json.contains("kbps"),
+            "wire form must NOT carry a bandwidth cap; got: {json}"
         );
     }
 

--- a/src/boxlite/src/rest/types.rs
+++ b/src/boxlite/src/rest/types.rs
@@ -200,10 +200,6 @@ impl CreateBoxRequest {
             disk_size_gb: options.disk_size_gb,
             working_dir: options.working_dir.clone(),
             env,
-            // net_bandwidth is intentionally NOT carried on the wire. Shaping is
-            // done by the local gvproxy bridge; a remote server enforces its own
-            // network policy, so there is no field for a client to set. The
-            // matching refusal lives in BoxOptions::sanitize_remote.
             network: Some(CreateBoxNetworkSpec::from_options(
                 &options.network,
                 &options.inbound_network,
@@ -215,6 +211,12 @@ impl CreateBoxRequest {
             volumes,
             detach: Some(options.detach),
             tty: options.tty.then_some(true),
+            // Only the capability policy crosses the wire. Like `security`,
+            // `advanced.network_rate_limit` is deliberately absent: shaping is
+            // done by the local gvproxy bridge and a remote server enforces its
+            // own network policy, so there is no field for a client to set. The
+            // matching refusal lives in BoxOptions::sanitize_remote.
+            //
             // `Some`, not "non-empty", decides whether this reaches the wire:
             // an explicitly empty policy is still explicit, and collapsing it
             // into the same shape as "never touched" would leave the server
@@ -1004,25 +1006,28 @@ mod tests {
         );
     }
 
-    /// Bandwidth shaping is done by the local gvproxy bridge, so the wire form
+    /// Network shaping is done by the local gvproxy bridge, so the wire form
     /// has no field for it and a local value must not leak into the request.
     #[test]
-    fn test_create_box_request_never_carries_net_bandwidth() {
-        use crate::runtime::options::{BoxOptions, NetBandwidth, RootfsSpec};
+    fn test_create_box_request_never_carries_network_rate_limit() {
+        use crate::runtime::advanced_options::{AdvancedBoxOptions, NetworkRateLimit};
+        use crate::runtime::options::{BoxOptions, RootfsSpec};
 
+        let mut advanced = AdvancedBoxOptions::default();
+        advanced.network_rate_limit = NetworkRateLimit {
+            tx_kbps: Some(10_000),
+            rx_kbps: Some(20_000),
+        };
         let opts = BoxOptions {
             rootfs: RootfsSpec::Image("alpine:latest".into()),
-            net_bandwidth: NetBandwidth {
-                tx_kbps: Some(10_000),
-                rx_kbps: Some(20_000),
-            },
+            advanced,
             ..Default::default()
         };
         let req = CreateBoxRequest::from_options(&opts, None);
         let json = serde_json::to_string(&req).unwrap();
         assert!(
-            !json.contains("bandwidth") && !json.contains("kbps"),
-            "wire form must NOT carry a bandwidth cap; got: {json}"
+            !json.contains("rate_limit") && !json.contains("kbps"),
+            "wire form must NOT carry a network rate limit; got: {json}"
         );
     }
 

--- a/src/boxlite/src/runtime/advanced_options.rs
+++ b/src/boxlite/src/runtime/advanced_options.rs
@@ -1,10 +1,10 @@
 //! Advanced options for expert users.
 //!
 //! This module contains [`AdvancedBoxOptions`], [`ContainerCapabilities`],
-//! [`SecurityOptions`], [`ResourceLimits`], and [`SecurityOptionsBuilder`] —
-//! configuration that entry-level users can safely ignore. Defaults prioritize
-//! compatibility. Direct custom-kernel boot is also grouped here because it
-//! changes the VM boot contract.
+//! [`SecurityOptions`], [`ResourceLimits`], [`SecurityOptionsBuilder`], and
+//! [`NetworkRateLimit`] — configuration that entry-level users can safely
+//! ignore. Defaults prioritize compatibility. Direct custom-kernel boot is also
+//! grouped here because it changes the VM boot contract.
 
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -667,6 +667,68 @@ fn validate_capability_names(
     Ok(())
 }
 
+// ============================================================================
+// Network Rate Limit
+// ============================================================================
+
+/// Per-direction rate limit for a box's network interface, in kilobits per
+/// second.
+///
+/// Directions are named from the box's point of view, matching Firecracker's
+/// net device: `tx` is what the box sends, `rx` is what reaches it. Which side
+/// opened the connection does not matter — an inbound port forward's traffic is
+/// charged the same as an outbound request's.
+///
+/// Shaping happens below IP in the gvproxy bridge, so one budget per direction
+/// covers TCP, UDP, ICMP and ARP together; there is no per-protocol split.
+///
+/// `None` or `0` in a direction leaves that direction unlimited, the same
+/// convention Firecracker, Kata and Cloud Hypervisor use. Each direction must
+/// fit within the bridge's token bucket limit; larger values are rejected.
+///
+/// Local runtime only: a remote server owns its own network policy, so the REST
+/// wire types carry no field for this and `sanitize_remote` rejects it.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct NetworkRateLimit {
+    /// Guest to internet, kilobits per second.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tx_kbps: Option<u64>,
+    /// Internet to guest, kilobits per second.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rx_kbps: Option<u64>,
+}
+
+impl NetworkRateLimit {
+    // The bridge caps bucket size at (1<<62)/1000 bytes. With a 100ms refill,
+    // size = floor(kbps * 125 / 10); this is the largest kbps that fits.
+    pub(crate) const MAX_KBPS: u64 = 368_934_881_474_191;
+
+    pub(crate) fn validate(&self) -> boxlite_shared::errors::BoxliteResult<()> {
+        for (field, kbps) in [("tx_kbps", self.tx_kbps), ("rx_kbps", self.rx_kbps)] {
+            if let Some(kbps) = kbps
+                && kbps > Self::MAX_KBPS
+            {
+                return Err(boxlite_shared::errors::BoxliteError::InvalidArgument(
+                    format!(
+                        "advanced.network_rate_limit.{field} must be at most {} kbps \
+                         (got {kbps})",
+                        Self::MAX_KBPS
+                    ),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// True when neither direction is capped. A `Some(0)` counts as uncapped,
+    /// so callers that pass a flag through unconditionally do not have to
+    /// special-case zero.
+    pub fn is_unlimited(&self) -> bool {
+        matches!(self.tx_kbps, None | Some(0)) && matches!(self.rx_kbps, None | Some(0))
+    }
+}
+
 /// Advanced options for expert users.
 ///
 /// Entry-level users can ignore this — the defaults are secure and sensible.
@@ -729,6 +791,22 @@ pub struct AdvancedBoxOptions {
     #[serde(default)]
     pub health_check: Option<HealthCheckOptions>,
 
+    /// Per-direction rate limit for the box's network interface.
+    ///
+    /// Grouped with the other local-only knobs (`security`, `isolate_mounts`,
+    /// `privileged`) rather than placed on `BoxOptions` next to `network`: the
+    /// object-shaped `NetworkConfig` types are the REST wire form and deny
+    /// unknown fields, while this never crosses the wire — `sanitize_remote`
+    /// rejects it and `CreateBoxRequest` has no field for it. It is also
+    /// bidirectional, so it belongs to neither the outbound nor the inbound
+    /// half.
+    ///
+    /// Omitted from the serialized form when unlimited, so an ordinary box's
+    /// exported manifest keeps the shape older importers already handle (the
+    /// same premise `capabilities` documents above).
+    #[serde(default, skip_serializing_if = "NetworkRateLimit::is_unlimited")]
+    pub network_rate_limit: NetworkRateLimit,
+
     /// Release-candidate direct Linux boot configuration.
     ///
     /// The runtime must explicitly enable
@@ -784,6 +862,7 @@ impl Clone for AdvancedBoxOptions {
             security: self.security.clone(),
             isolate_mounts: self.isolate_mounts,
             health_check: self.health_check.clone(),
+            network_rate_limit: self.network_rate_limit,
             kernel: self.kernel.clone(),
             nested_virtualization: self.nested_virtualization,
             privileged: self.privileged,

--- a/src/boxlite/src/runtime/options.rs
+++ b/src/boxlite/src/runtime/options.rs
@@ -343,6 +343,15 @@ pub struct BoxOptions {
     /// Remote runtimes reject port mappings; use a box network tunnel for
     /// portable local/remote access to a guest service.
     pub ports: Vec<PortSpec>,
+    /// Bandwidth cap for the box's network interface.
+    ///
+    /// A sibling of `network` rather than a field inside it, for the same
+    /// reason `ports` is: the object-shaped `NetworkConfig` types are the REST
+    /// wire form and deny unknown fields, while this is local-only. It is also
+    /// bidirectional, so it belongs to neither the outbound nor the inbound
+    /// half.
+    #[serde(default)]
+    pub net_bandwidth: NetBandwidth,
     /// Automatically remove the box when stopped.
     ///
     /// Deprecated: use [`BoxOptions::auto_delete`]. When `auto_delete` is set,
@@ -534,6 +543,7 @@ impl Default for BoxOptions {
             rootfs: RootfsSpec::default(),
             volumes: Vec::new(),
             network: NetworkSpec::default(),
+            net_bandwidth: NetBandwidth::default(),
             inbound_network: NetworkSpec::default(),
             ports: Vec::new(),
             auto_remove: default_auto_remove(),
@@ -599,6 +609,14 @@ impl BoxOptions {
         if matches!(self.network, NetworkSpec::Disabled) && !self.ports.is_empty() {
             return Err(boxlite_shared::errors::BoxliteError::InvalidArgument(
                 "ports require network.outbound.mode=\"enabled\"".to_string(),
+            ));
+        }
+
+        if matches!(self.network, NetworkSpec::Disabled) && !self.net_bandwidth.is_unlimited() {
+            return Err(boxlite_shared::errors::BoxliteError::InvalidArgument(
+                "net_bandwidth requires network.outbound.mode=\"enabled\" — there is \
+                 no interface to shape when the network is disabled"
+                    .to_string(),
             ));
         }
 
@@ -914,6 +932,40 @@ impl NetworkConfig {
             outbound: outbound.into(),
             inbound: inbound.into(),
         }
+    }
+}
+
+/// Bandwidth cap for a box's network interface, in kilobits per second.
+///
+/// Directions are named from the box's point of view, matching Firecracker's
+/// net device: `tx` is what the box sends, `rx` is what reaches it. Which side
+/// opened the connection does not matter — an inbound port forward's traffic is
+/// charged the same as an outbound request's.
+///
+/// Shaping happens below IP in the gvproxy bridge, so one budget per direction
+/// covers TCP, UDP, ICMP and ARP together; there is no per-protocol split.
+///
+/// `None` or `0` in a direction leaves that direction unlimited, the same
+/// convention Firecracker, Kata and Cloud Hypervisor use. Local runtime only:
+/// a remote server owns its own network policy, so the REST wire types carry no
+/// field for this and `sanitize_remote` rejects it.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
+pub struct NetBandwidth {
+    /// Guest to internet, kilobits per second.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tx_kbps: Option<u64>,
+    /// Internet to guest, kilobits per second.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rx_kbps: Option<u64>,
+}
+
+impl NetBandwidth {
+    /// True when neither direction is capped. A `Some(0)` counts as uncapped,
+    /// so callers that pass a flag through unconditionally do not have to
+    /// special-case zero.
+    pub fn is_unlimited(&self) -> bool {
+        matches!(self.tx_kbps, None | Some(0)) && matches!(self.rx_kbps, None | Some(0))
     }
 }
 
@@ -1256,6 +1308,60 @@ mod tests {
             !advanced.as_object().unwrap().contains_key("capabilities"),
             "unspecified capabilities must omit the key, not serialize null: {advanced}"
         );
+    }
+
+    /// There is no interface to shape when the network is off, so the pair must
+    /// be rejected rather than silently ignored — the same rule `ports` follows.
+    #[test]
+    fn box_options_sanitize_rejects_bandwidth_without_a_network() {
+        let mut opts = BoxOptions {
+            network: NetworkSpec::Disabled,
+            net_bandwidth: NetBandwidth {
+                tx_kbps: Some(10_000),
+                rx_kbps: None,
+            },
+            ..Default::default()
+        };
+
+        let error = opts
+            .sanitize()
+            .expect_err("a bandwidth cap with the network disabled must be rejected");
+        assert!(
+            error.to_string().contains("net_bandwidth"),
+            "error should name the offending option, got: {error}"
+        );
+    }
+
+    /// A zero is the documented spelling of "no cap", so it must not collide
+    /// with `network: Disabled` the way a real cap does.
+    #[test]
+    fn box_options_sanitize_allows_zero_bandwidth_without_a_network() {
+        let mut opts = BoxOptions {
+            network: NetworkSpec::Disabled,
+            net_bandwidth: NetBandwidth {
+                tx_kbps: Some(0),
+                rx_kbps: Some(0),
+            },
+            ..Default::default()
+        };
+
+        opts.sanitize()
+            .expect("a zero cap is not a cap and must not conflict with a disabled network");
+    }
+
+    /// The common case still has to pass: a cap alongside an enabled network.
+    #[test]
+    fn box_options_sanitize_accepts_bandwidth_with_a_network() {
+        let mut opts = BoxOptions {
+            net_bandwidth: NetBandwidth {
+                tx_kbps: Some(10_000),
+                rx_kbps: Some(20_000),
+            },
+            ..Default::default()
+        };
+
+        opts.sanitize()
+            .expect("a cap with the default enabled network must be accepted");
     }
 
     #[test]

--- a/src/boxlite/src/runtime/options.rs
+++ b/src/boxlite/src/runtime/options.rs
@@ -612,6 +612,7 @@ impl BoxOptions {
             ));
         }
 
+        self.net_bandwidth.validate()?;
         if matches!(self.network, NetworkSpec::Disabled) && !self.net_bandwidth.is_unlimited() {
             return Err(boxlite_shared::errors::BoxliteError::InvalidArgument(
                 "net_bandwidth requires network.outbound.mode=\"enabled\" — there is \
@@ -946,7 +947,9 @@ impl NetworkConfig {
 /// covers TCP, UDP, ICMP and ARP together; there is no per-protocol split.
 ///
 /// `None` or `0` in a direction leaves that direction unlimited, the same
-/// convention Firecracker, Kata and Cloud Hypervisor use. Local runtime only:
+/// convention Firecracker, Kata and Cloud Hypervisor use. Each direction must
+/// fit within the bridge's token bucket limit; larger values are rejected.
+/// Local runtime only:
 /// a remote server owns its own network policy, so the REST wire types carry no
 /// field for this and `sanitize_remote` rejects it.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -961,6 +964,26 @@ pub struct NetBandwidth {
 }
 
 impl NetBandwidth {
+    // The bridge caps bucket size at (1<<62)/1000 bytes. With a 100ms refill,
+    // size = floor(kbps * 125 / 10); this is the largest kbps that fits.
+    pub(crate) const MAX_KBPS: u64 = 368_934_881_474_191;
+
+    fn validate(&self) -> BoxliteResult<()> {
+        for (field, kbps) in [("tx_kbps", self.tx_kbps), ("rx_kbps", self.rx_kbps)] {
+            if let Some(kbps) = kbps
+                && kbps > Self::MAX_KBPS
+            {
+                return Err(boxlite_shared::errors::BoxliteError::InvalidArgument(
+                    format!(
+                        "net_bandwidth.{field} must be at most {} kbps (got {kbps})",
+                        Self::MAX_KBPS
+                    ),
+                ));
+            }
+        }
+        Ok(())
+    }
+
     /// True when neither direction is capped. A `Some(0)` counts as uncapped,
     /// so callers that pass a flag through unconditionally do not have to
     /// special-case zero.
@@ -1362,6 +1385,54 @@ mod tests {
 
         opts.sanitize()
             .expect("a cap with the default enabled network must be accepted");
+    }
+
+    #[test]
+    fn box_options_sanitize_accepts_bandwidth_up_to_bridge_maximum() {
+        for kbps in [None, Some(0), Some(NetBandwidth::MAX_KBPS)] {
+            let mut opts = BoxOptions {
+                net_bandwidth: NetBandwidth {
+                    tx_kbps: kbps,
+                    rx_kbps: kbps,
+                },
+                ..Default::default()
+            };
+
+            opts.sanitize_common().unwrap();
+            opts.sanitize_persisted().unwrap();
+            opts.sanitize().unwrap();
+        }
+    }
+
+    #[test]
+    fn box_options_sanitize_rejects_bandwidth_above_bridge_maximum() {
+        for field in ["tx_kbps", "rx_kbps"] {
+            for kbps in [NetBandwidth::MAX_KBPS + 1, u64::MAX] {
+                let mut opts = BoxOptions {
+                    net_bandwidth: NetBandwidth {
+                        tx_kbps: (field == "tx_kbps").then_some(kbps),
+                        rx_kbps: (field == "rx_kbps").then_some(kbps),
+                    },
+                    ..Default::default()
+                };
+
+                for result in [
+                    opts.sanitize_common(),
+                    opts.sanitize_persisted(),
+                    opts.sanitize(),
+                ] {
+                    let error = result.expect_err("oversized bandwidth must fail before startup");
+                    assert!(matches!(
+                        error,
+                        boxlite_shared::errors::BoxliteError::InvalidArgument(_)
+                    ));
+                    let message = error.to_string();
+                    assert!(message.contains(&format!("net_bandwidth.{field}")));
+                    assert!(message.contains(&kbps.to_string()));
+                    assert!(message.contains(&NetBandwidth::MAX_KBPS.to_string()));
+                }
+            }
+        }
     }
 
     #[test]

--- a/src/boxlite/src/runtime/options.rs
+++ b/src/boxlite/src/runtime/options.rs
@@ -343,15 +343,6 @@ pub struct BoxOptions {
     /// Remote runtimes reject port mappings; use a box network tunnel for
     /// portable local/remote access to a guest service.
     pub ports: Vec<PortSpec>,
-    /// Bandwidth cap for the box's network interface.
-    ///
-    /// A sibling of `network` rather than a field inside it, for the same
-    /// reason `ports` is: the object-shaped `NetworkConfig` types are the REST
-    /// wire form and deny unknown fields, while this is local-only. It is also
-    /// bidirectional, so it belongs to neither the outbound nor the inbound
-    /// half.
-    #[serde(default)]
-    pub net_bandwidth: NetBandwidth,
     /// Automatically remove the box when stopped.
     ///
     /// Deprecated: use [`BoxOptions::auto_delete`]. When `auto_delete` is set,
@@ -543,7 +534,6 @@ impl Default for BoxOptions {
             rootfs: RootfsSpec::default(),
             volumes: Vec::new(),
             network: NetworkSpec::default(),
-            net_bandwidth: NetBandwidth::default(),
             inbound_network: NetworkSpec::default(),
             ports: Vec::new(),
             auto_remove: default_auto_remove(),
@@ -612,11 +602,12 @@ impl BoxOptions {
             ));
         }
 
-        self.net_bandwidth.validate()?;
-        if matches!(self.network, NetworkSpec::Disabled) && !self.net_bandwidth.is_unlimited() {
+        let rate_limit = &self.advanced.network_rate_limit;
+        rate_limit.validate()?;
+        if matches!(self.network, NetworkSpec::Disabled) && !rate_limit.is_unlimited() {
             return Err(boxlite_shared::errors::BoxliteError::InvalidArgument(
-                "net_bandwidth requires network.outbound.mode=\"enabled\" — there is \
-                 no interface to shape when the network is disabled"
+                "advanced.network_rate_limit requires network.outbound.mode=\"enabled\" — \
+                 there is no interface to shape when the network is disabled"
                     .to_string(),
             ));
         }
@@ -936,62 +927,6 @@ impl NetworkConfig {
     }
 }
 
-/// Bandwidth cap for a box's network interface, in kilobits per second.
-///
-/// Directions are named from the box's point of view, matching Firecracker's
-/// net device: `tx` is what the box sends, `rx` is what reaches it. Which side
-/// opened the connection does not matter — an inbound port forward's traffic is
-/// charged the same as an outbound request's.
-///
-/// Shaping happens below IP in the gvproxy bridge, so one budget per direction
-/// covers TCP, UDP, ICMP and ARP together; there is no per-protocol split.
-///
-/// `None` or `0` in a direction leaves that direction unlimited, the same
-/// convention Firecracker, Kata and Cloud Hypervisor use. Each direction must
-/// fit within the bridge's token bucket limit; larger values are rejected.
-/// Local runtime only:
-/// a remote server owns its own network policy, so the REST wire types carry no
-/// field for this and `sanitize_remote` rejects it.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(default)]
-pub struct NetBandwidth {
-    /// Guest to internet, kilobits per second.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tx_kbps: Option<u64>,
-    /// Internet to guest, kilobits per second.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub rx_kbps: Option<u64>,
-}
-
-impl NetBandwidth {
-    // The bridge caps bucket size at (1<<62)/1000 bytes. With a 100ms refill,
-    // size = floor(kbps * 125 / 10); this is the largest kbps that fits.
-    pub(crate) const MAX_KBPS: u64 = 368_934_881_474_191;
-
-    fn validate(&self) -> BoxliteResult<()> {
-        for (field, kbps) in [("tx_kbps", self.tx_kbps), ("rx_kbps", self.rx_kbps)] {
-            if let Some(kbps) = kbps
-                && kbps > Self::MAX_KBPS
-            {
-                return Err(boxlite_shared::errors::BoxliteError::InvalidArgument(
-                    format!(
-                        "net_bandwidth.{field} must be at most {} kbps (got {kbps})",
-                        Self::MAX_KBPS
-                    ),
-                ));
-            }
-        }
-        Ok(())
-    }
-
-    /// True when neither direction is capped. A `Some(0)` counts as uncapped,
-    /// so callers that pass a flag through unconditionally do not have to
-    /// special-case zero.
-    pub fn is_unlimited(&self) -> bool {
-        matches!(self.tx_kbps, None | Some(0)) && matches!(self.rx_kbps, None | Some(0))
-    }
-}
-
 /// Internal Rust network configuration for a box.
 ///
 /// Separates outbound guest egress from inbound service access policy so future
@@ -1204,7 +1139,7 @@ mod tests {
     use super::*;
     use crate::experimental::custom_kernel::{KernelFormat, KernelOptions};
     use crate::runtime::advanced_options::{
-        ContainerCapabilities, SecurityOptions, SecurityOptionsBuilder,
+        ContainerCapabilities, NetworkRateLimit, SecurityOptions, SecurityOptionsBuilder,
     };
     use crate::runtime::types::Bytes;
 
@@ -1333,24 +1268,53 @@ mod tests {
         );
     }
 
+    fn rate_limited(tx_kbps: Option<u64>, rx_kbps: Option<u64>) -> AdvancedBoxOptions {
+        let mut advanced = AdvancedBoxOptions::default();
+        advanced.network_rate_limit = NetworkRateLimit { tx_kbps, rx_kbps };
+        advanced
+    }
+
+    /// Same premise as the capabilities test above: an uncapped box must not
+    /// grow a `network_rate_limit` key inside `advanced`, while a capped one
+    /// must round-trip through the persisted form.
+    #[test]
+    fn box_options_omits_network_rate_limit_key_when_unlimited() {
+        let json = serde_json::to_string(&BoxOptions::default()).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let advanced = parsed.get("advanced").unwrap();
+        assert!(
+            !advanced
+                .as_object()
+                .unwrap()
+                .contains_key("network_rate_limit"),
+            "an unlimited rate limit must omit the key: {advanced}"
+        );
+
+        let capped = BoxOptions {
+            advanced: rate_limited(Some(10_000), None),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&capped).unwrap();
+        let back: BoxOptions = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.advanced.network_rate_limit.tx_kbps, Some(10_000));
+        assert_eq!(back.advanced.network_rate_limit.rx_kbps, None);
+    }
+
     /// There is no interface to shape when the network is off, so the pair must
     /// be rejected rather than silently ignored — the same rule `ports` follows.
     #[test]
-    fn box_options_sanitize_rejects_bandwidth_without_a_network() {
+    fn box_options_sanitize_rejects_rate_limit_without_a_network() {
         let mut opts = BoxOptions {
             network: NetworkSpec::Disabled,
-            net_bandwidth: NetBandwidth {
-                tx_kbps: Some(10_000),
-                rx_kbps: None,
-            },
+            advanced: rate_limited(Some(10_000), None),
             ..Default::default()
         };
 
         let error = opts
             .sanitize()
-            .expect_err("a bandwidth cap with the network disabled must be rejected");
+            .expect_err("a rate limit with the network disabled must be rejected");
         assert!(
-            error.to_string().contains("net_bandwidth"),
+            error.to_string().contains("advanced.network_rate_limit"),
             "error should name the offending option, got: {error}"
         );
     }
@@ -1358,13 +1322,10 @@ mod tests {
     /// A zero is the documented spelling of "no cap", so it must not collide
     /// with `network: Disabled` the way a real cap does.
     #[test]
-    fn box_options_sanitize_allows_zero_bandwidth_without_a_network() {
+    fn box_options_sanitize_allows_zero_rate_limit_without_a_network() {
         let mut opts = BoxOptions {
             network: NetworkSpec::Disabled,
-            net_bandwidth: NetBandwidth {
-                tx_kbps: Some(0),
-                rx_kbps: Some(0),
-            },
+            advanced: rate_limited(Some(0), Some(0)),
             ..Default::default()
         };
 
@@ -1374,12 +1335,9 @@ mod tests {
 
     /// The common case still has to pass: a cap alongside an enabled network.
     #[test]
-    fn box_options_sanitize_accepts_bandwidth_with_a_network() {
+    fn box_options_sanitize_accepts_rate_limit_with_a_network() {
         let mut opts = BoxOptions {
-            net_bandwidth: NetBandwidth {
-                tx_kbps: Some(10_000),
-                rx_kbps: Some(20_000),
-            },
+            advanced: rate_limited(Some(10_000), Some(20_000)),
             ..Default::default()
         };
 
@@ -1388,13 +1346,10 @@ mod tests {
     }
 
     #[test]
-    fn box_options_sanitize_accepts_bandwidth_up_to_bridge_maximum() {
-        for kbps in [None, Some(0), Some(NetBandwidth::MAX_KBPS)] {
+    fn box_options_sanitize_accepts_rate_limit_up_to_bridge_maximum() {
+        for kbps in [None, Some(0), Some(NetworkRateLimit::MAX_KBPS)] {
             let mut opts = BoxOptions {
-                net_bandwidth: NetBandwidth {
-                    tx_kbps: kbps,
-                    rx_kbps: kbps,
-                },
+                advanced: rate_limited(kbps, kbps),
                 ..Default::default()
             };
 
@@ -1405,14 +1360,14 @@ mod tests {
     }
 
     #[test]
-    fn box_options_sanitize_rejects_bandwidth_above_bridge_maximum() {
+    fn box_options_sanitize_rejects_rate_limit_above_bridge_maximum() {
         for field in ["tx_kbps", "rx_kbps"] {
-            for kbps in [NetBandwidth::MAX_KBPS + 1, u64::MAX] {
+            for kbps in [NetworkRateLimit::MAX_KBPS + 1, u64::MAX] {
                 let mut opts = BoxOptions {
-                    net_bandwidth: NetBandwidth {
-                        tx_kbps: (field == "tx_kbps").then_some(kbps),
-                        rx_kbps: (field == "rx_kbps").then_some(kbps),
-                    },
+                    advanced: rate_limited(
+                        (field == "tx_kbps").then_some(kbps),
+                        (field == "rx_kbps").then_some(kbps),
+                    ),
                     ..Default::default()
                 };
 
@@ -1421,15 +1376,15 @@ mod tests {
                     opts.sanitize_persisted(),
                     opts.sanitize(),
                 ] {
-                    let error = result.expect_err("oversized bandwidth must fail before startup");
+                    let error = result.expect_err("oversized rate limit must fail before startup");
                     assert!(matches!(
                         error,
                         boxlite_shared::errors::BoxliteError::InvalidArgument(_)
                     ));
                     let message = error.to_string();
-                    assert!(message.contains(&format!("net_bandwidth.{field}")));
+                    assert!(message.contains(&format!("advanced.network_rate_limit.{field}")));
                     assert!(message.contains(&kbps.to_string()));
-                    assert!(message.contains(&NetBandwidth::MAX_KBPS.to_string()));
+                    assert!(message.contains(&NetworkRateLimit::MAX_KBPS.to_string()));
                 }
             }
         }

--- a/src/boxlite/tests/gvproxy_backend.rs
+++ b/src/boxlite/tests/gvproxy_backend.rs
@@ -35,6 +35,7 @@ fn backend_for(
         secrets: Vec::new(),
         ca_cert_pem: None,
         ca_key_pem: None,
+        net_bandwidth: Default::default(),
     };
     let (instance, endpoint) = GvproxyInstance::from_config(&spec).expect("create gvproxy");
     let config = NetworkBackendConfig {
@@ -42,6 +43,7 @@ fn backend_for(
         allow_net: Vec::new(),
         secrets: Vec::new(),
         ca_dir: dir.path().to_path_buf(),
+        net_bandwidth: Default::default(),
     };
     (
         instance,

--- a/src/boxlite/tests/gvproxy_backend.rs
+++ b/src/boxlite/tests/gvproxy_backend.rs
@@ -35,7 +35,7 @@ fn backend_for(
         secrets: Vec::new(),
         ca_cert_pem: None,
         ca_key_pem: None,
-        net_bandwidth: Default::default(),
+        rate_limit: Default::default(),
     };
     let (instance, endpoint) = GvproxyInstance::from_config(&spec).expect("create gvproxy");
     let config = NetworkBackendConfig {
@@ -43,7 +43,7 @@ fn backend_for(
         allow_net: Vec::new(),
         secrets: Vec::new(),
         ca_dir: dir.path().to_path_buf(),
-        net_bandwidth: Default::default(),
+        rate_limit: Default::default(),
     };
     (
         instance,

--- a/src/boxlite/tests/network.rs
+++ b/src/boxlite/tests/network.rs
@@ -10,6 +10,7 @@ fn test_config(socket_path: PathBuf) -> NetworkBackendConfig {
         allow_net: Vec::new(),
         secrets: Vec::new(),
         ca_dir: PathBuf::from("/tmp/test-ca"),
+        net_bandwidth: Default::default(),
     }
 }
 
@@ -24,6 +25,7 @@ fn spec_carries_unique_socket_path_across_serde() {
         secrets: Vec::new(),
         ca_cert_pem: None,
         ca_key_pem: None,
+        net_bandwidth: Default::default(),
     };
 
     // socket_path survives serde — this is how it crosses to the shim.

--- a/src/boxlite/tests/network.rs
+++ b/src/boxlite/tests/network.rs
@@ -10,7 +10,7 @@ fn test_config(socket_path: PathBuf) -> NetworkBackendConfig {
         allow_net: Vec::new(),
         secrets: Vec::new(),
         ca_dir: PathBuf::from("/tmp/test-ca"),
-        net_bandwidth: Default::default(),
+        rate_limit: Default::default(),
     }
 }
 
@@ -25,7 +25,7 @@ fn spec_carries_unique_socket_path_across_serde() {
         secrets: Vec::new(),
         ca_cert_pem: None,
         ca_key_pem: None,
-        net_bandwidth: Default::default(),
+        rate_limit: Default::default(),
     };
 
     // socket_path survives serde — this is how it crosses to the shim.

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -348,6 +348,8 @@ silently restarting it, because restarting would run the command a second time.
 | `--network <enabled\|disabled>` | | Outbound network mode (default `enabled`) |
 | `--allow-net HOST` | | Restrict egress to an exact host, wildcard domain, IP, or CIDR; repeatable and implies enabled networking |
 | `--inbound <enabled\|disabled>` | | Inbound network mode (default `enabled`) |
+| `--net-tx-kbps KBPS` | | Cap what the box sends, in kilobits/sec; `0` or unset is uncapped. Local runtime only; verified on Linux |
+| `--net-rx-kbps KBPS` | | Cap what reaches the box, in kilobits/sec; `0` or unset is uncapped. Local runtime only; verified on Linux |
 | `--name NAME` | | Name the box |
 | `--detach` | `-d` | Run in background, print box ID |
 | `--rm` | | Remove the box when it stops; conflicts with lifecycle deadlines and is ignored with `--detach` |
@@ -408,6 +410,8 @@ default, and `exec` still starts it on demand.
 | `--network <enabled\|disabled>` | | Outbound network mode (default `enabled`) |
 | `--allow-net HOST` | | Restrict egress to an exact host, wildcard domain, IP, or CIDR; repeatable and implies enabled networking |
 | `--inbound <enabled\|disabled>` | | Inbound network mode (default `enabled`) |
+| `--net-tx-kbps KBPS` | | Cap what the box sends, in kilobits/sec; `0` or unset is uncapped. Local runtime only; verified on Linux |
+| `--net-rx-kbps KBPS` | | Cap what reaches the box, in kilobits/sec; `0` or unset is uncapped. Local runtime only; verified on Linux |
 | `--auto-stop DURATION` | | Stop the box after this much inactivity; `0` disables; requires a REST server |
 | `--auto-delete DURATION` | | Delete the box this long after it stops; `0` disables; requires a REST server |
 | `--no-auto-resume` | | Ask a REST server to refuse implicit resume after a box has run; first boot is unaffected, and the embedded runtime records but does not enforce it |

--- a/src/cli/src/cli.rs
+++ b/src/cli/src/cli.rs
@@ -8,7 +8,8 @@ use boxlite::experimental::{
     EXPERIMENTAL_FEATURES_ENV, ExperimentalFeature, ExperimentalFeatures, RuntimeBuilder,
 };
 use boxlite::runtime::options::{
-    InboundNetworkConfig, NetworkMode, OutboundNetworkConfig, PortProtocol, PortSpec, VolumeSpec,
+    InboundNetworkConfig, NetBandwidth, NetworkMode, OutboundNetworkConfig, PortProtocol, PortSpec,
+    VolumeSpec,
 };
 use boxlite::{
     BoxCommand, BoxOptions, BoxliteOptions, BoxliteRestOptions, BoxliteRuntime,
@@ -1164,10 +1165,33 @@ pub struct NetworkFlags {
     /// the box).
     #[arg(long = "inbound", value_name = "MODE")]
     pub inbound: Option<String>,
+
+    /// Cap what the box sends, in kilobits/sec (guest to internet). Unset or 0
+    /// leaves it uncapped. Local runtime only. Verified on Linux; on macOS the
+    /// guest link is a datagram socket whose sender behaviour under
+    /// backpressure is unverified, so this may drop frames instead of slowing
+    /// the guest down.
+    #[arg(long = "net-tx-kbps", value_name = "KBPS")]
+    pub net_tx_kbps: Option<u64>,
+
+    /// Cap what reaches the box, in kilobits/sec (internet to guest). Unset or
+    /// 0 leaves it uncapped. Local runtime only. Paced the same way on Linux
+    /// and macOS.
+    #[arg(long = "net-rx-kbps", value_name = "KBPS")]
+    pub net_rx_kbps: Option<u64>,
 }
 
 impl NetworkFlags {
     pub fn apply_to(&self, opts: &mut BoxOptions) -> anyhow::Result<()> {
+        // Bandwidth is independent of mode and allowlist, so it is assigned
+        // before the early return below. Folding it into that condition instead
+        // would mean a lone --net-tx-kbps is silently dropped the day someone
+        // adds another flag and forgets to extend the guard.
+        opts.net_bandwidth = NetBandwidth {
+            tx_kbps: self.net_tx_kbps,
+            rx_kbps: self.net_rx_kbps,
+        };
+
         // Leave BoxOptions::default() (outbound Enabled/full access, inbound
         // Enabled/public) untouched when no flag is given, so a bare `run`
         // behaves as before.
@@ -2237,7 +2261,42 @@ mod tests {
             network: network.map(str::to_string),
             allow_net: allow_net.iter().map(|s| s.to_string()).collect(),
             inbound: None,
+            net_tx_kbps: None,
+            net_rx_kbps: None,
         }
+    }
+
+    /// apply_to returns early when no mode or allowlist flag is set. A bandwidth
+    /// cap must survive that path, or `--net-tx-kbps` on its own is dropped with
+    /// no error at all.
+    #[test]
+    fn bandwidth_flags_apply_without_any_other_network_flag() {
+        let mut opts = BoxOptions::default();
+        let mut flags = network_flags(None, &[]);
+        flags.net_tx_kbps = Some(10_000);
+
+        flags.apply_to(&mut opts).expect("apply_to");
+
+        assert_eq!(opts.net_bandwidth.tx_kbps, Some(10_000));
+        assert_eq!(opts.net_bandwidth.rx_kbps, None);
+        // The early return still protects the untouched network defaults.
+        assert!(matches!(
+            opts.network,
+            boxlite::NetworkSpec::Enabled { ref allow_net } if allow_net.is_empty()
+        ));
+    }
+
+    #[test]
+    fn bandwidth_flags_apply_alongside_an_allowlist() {
+        let mut opts = BoxOptions::default();
+        let mut flags = network_flags(None, &["example.com"]);
+        flags.net_tx_kbps = Some(1_000);
+        flags.net_rx_kbps = Some(2_000);
+
+        flags.apply_to(&mut opts).expect("apply_to");
+
+        assert_eq!(opts.net_bandwidth.tx_kbps, Some(1_000));
+        assert_eq!(opts.net_bandwidth.rx_kbps, Some(2_000));
     }
 
     #[test]

--- a/src/cli/src/cli.rs
+++ b/src/cli/src/cli.rs
@@ -8,12 +8,11 @@ use boxlite::experimental::{
     EXPERIMENTAL_FEATURES_ENV, ExperimentalFeature, ExperimentalFeatures, RuntimeBuilder,
 };
 use boxlite::runtime::options::{
-    InboundNetworkConfig, NetBandwidth, NetworkMode, OutboundNetworkConfig, PortProtocol, PortSpec,
-    VolumeSpec,
+    InboundNetworkConfig, NetworkMode, OutboundNetworkConfig, PortProtocol, PortSpec, VolumeSpec,
 };
 use boxlite::{
     BoxCommand, BoxOptions, BoxliteOptions, BoxliteRestOptions, BoxliteRuntime,
-    ContainerCapabilities, ImageRegistry, NetworkSpec,
+    ContainerCapabilities, ImageRegistry, NetworkRateLimit, NetworkSpec,
 };
 use clap::error::ErrorKind;
 use clap::parser::ValueSource;
@@ -1183,11 +1182,11 @@ pub struct NetworkFlags {
 
 impl NetworkFlags {
     pub fn apply_to(&self, opts: &mut BoxOptions) -> anyhow::Result<()> {
-        // Bandwidth is independent of mode and allowlist, so it is assigned
-        // before the early return below. Folding it into that condition instead
-        // would mean a lone --net-tx-kbps is silently dropped the day someone
-        // adds another flag and forgets to extend the guard.
-        opts.net_bandwidth = NetBandwidth {
+        // The rate limit is independent of mode and allowlist, so it is
+        // assigned before the early return below. Folding it into that
+        // condition instead would mean a lone --net-tx-kbps is silently dropped
+        // the day someone adds another flag and forgets to extend the guard.
+        opts.advanced.network_rate_limit = NetworkRateLimit {
             tx_kbps: self.net_tx_kbps,
             rx_kbps: self.net_rx_kbps,
         };
@@ -2266,19 +2265,19 @@ mod tests {
         }
     }
 
-    /// apply_to returns early when no mode or allowlist flag is set. A bandwidth
-    /// cap must survive that path, or `--net-tx-kbps` on its own is dropped with
-    /// no error at all.
+    /// apply_to returns early when no mode or allowlist flag is set. A rate
+    /// limit must survive that path, or `--net-tx-kbps` on its own is dropped
+    /// with no error at all.
     #[test]
-    fn bandwidth_flags_apply_without_any_other_network_flag() {
+    fn rate_limit_flags_apply_without_any_other_network_flag() {
         let mut opts = BoxOptions::default();
         let mut flags = network_flags(None, &[]);
         flags.net_tx_kbps = Some(10_000);
 
         flags.apply_to(&mut opts).expect("apply_to");
 
-        assert_eq!(opts.net_bandwidth.tx_kbps, Some(10_000));
-        assert_eq!(opts.net_bandwidth.rx_kbps, None);
+        assert_eq!(opts.advanced.network_rate_limit.tx_kbps, Some(10_000));
+        assert_eq!(opts.advanced.network_rate_limit.rx_kbps, None);
         // The early return still protects the untouched network defaults.
         assert!(matches!(
             opts.network,
@@ -2287,7 +2286,7 @@ mod tests {
     }
 
     #[test]
-    fn bandwidth_flags_apply_alongside_an_allowlist() {
+    fn rate_limit_flags_apply_alongside_an_allowlist() {
         let mut opts = BoxOptions::default();
         let mut flags = network_flags(None, &["example.com"]);
         flags.net_tx_kbps = Some(1_000);
@@ -2295,8 +2294,8 @@ mod tests {
 
         flags.apply_to(&mut opts).expect("apply_to");
 
-        assert_eq!(opts.net_bandwidth.tx_kbps, Some(1_000));
-        assert_eq!(opts.net_bandwidth.rx_kbps, Some(2_000));
+        assert_eq!(opts.advanced.network_rate_limit.tx_kbps, Some(1_000));
+        assert_eq!(opts.advanced.network_rate_limit.rx_kbps, Some(2_000));
     }
 
     #[test]

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/main.go
@@ -196,6 +196,10 @@ type GvproxyConfig struct {
 	// forwarding / DNS / DHCP leases / stats / cam) to a host unix socket the
 	// boxlite core dials. Empty => the services API is not exposed.
 	ControlSocketPath string `json:"control_socket_path,omitempty"`
+
+	// RateLimit, when set, shapes the guest link in both directions. Absent or
+	// zero-sized in a direction means that direction is unlimited. See shaper.go.
+	RateLimit *RateLimitConfig `json:"rate_limit,omitempty"`
 }
 
 // GvproxyInstance tracks a running gvisor-tap-vsock instance
@@ -312,6 +316,13 @@ func gvproxy_create(configJSON *C.char, errOut **C.char) C.longlong {
 	var config GvproxyConfig
 	if err := json.Unmarshal([]byte(goJSON), &config); err != nil {
 		logrus.WithError(err).Error("Failed to parse gvproxy config")
+		setErr(err)
+		return -1
+	}
+
+	// Reject a bad rate limit outright rather than letting part of it apply.
+	if err := config.RateLimit.Validate(); err != nil {
+		logrus.WithError(err).Error("Invalid gvproxy rate limit config")
 		setErr(err)
 		return -1
 	}
@@ -530,7 +541,7 @@ func gvproxy_create(configJSON *C.char, errOut **C.char) C.longlong {
 				logrus.WithFields(logrus.Fields{"id": id, "remote": wrappedConn.RemoteAddr().String()}).Info("VFKit connection accepted")
 
 				// Handle the VFKit protocol with the wrapped connection
-				if err := vn.AcceptVfkit(ctx, wrappedConn); err != nil {
+				if err := vn.AcceptVfkit(ctx, wrapConn(wrappedConn, 0, config.RateLimit)); err != nil {
 					if ctx.Err() == nil {
 						logrus.WithFields(logrus.Fields{"error": err, "id": id}).Error("AcceptVfkit error")
 					}
@@ -556,7 +567,7 @@ func gvproxy_create(configJSON *C.char, errOut **C.char) C.longlong {
 				listener.Close()
 
 				// Handle the Qemu protocol
-				if err := vn.AcceptQemu(ctx, acceptedConn); err != nil {
+				if err := vn.AcceptQemu(ctx, wrapConn(acceptedConn, 4, config.RateLimit)); err != nil {
 					if ctx.Err() == nil {
 						logrus.WithFields(logrus.Fields{"error": err, "id": id}).Error("AcceptQemu error")
 					}

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/mitm_proxy.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/mitm_proxy.go
@@ -33,7 +33,7 @@ func mitmAndForward(guestConn net.Conn, hostname string, destAddr string, ca *Bo
 
 	upstreamTransport := &http.Transport{
 		ForceAttemptHTTP2: true,
-		TLSClientConfig:  resolveUpstreamTLS(hostname, upstreamTLSConfig...),
+		TLSClientConfig:   resolveUpstreamTLS(hostname, upstreamTLSConfig...),
 		DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
 			return (&net.Dialer{Timeout: upstreamDialTimeout}).DialContext(ctx, network, destAddr)
 		},
@@ -134,4 +134,3 @@ func (t *secretTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 	return t.inner.RoundTrip(req)
 }
-

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/mitm_test_helpers_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/mitm_test_helpers_test.go
@@ -25,12 +25,12 @@ func newTestCA(t *testing.T) *BoxCA {
 	serial, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
 	now := time.Now()
 	template := &x509.Certificate{
-		SerialNumber: serial,
-		Subject:      pkix.Name{CommonName: "BoxLite Test CA"},
-		NotBefore:    now.Add(-1 * time.Minute),
-		NotAfter:     now.Add(24 * time.Hour),
-		IsCA:         true,
-		KeyUsage:     x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: "BoxLite Test CA"},
+		NotBefore:             now.Add(-1 * time.Minute),
+		NotAfter:              now.Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
 		BasicConstraintsValid: true,
 		MaxPathLen:            0,
 	}

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/shaper.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/shaper.go
@@ -1,0 +1,608 @@
+package main
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+)
+
+// Per-box bandwidth shaping for the guest link.
+//
+// The whole guest data plane is one AF_UNIX connection: libkrun's virtio-net
+// backend on one side, gvisor-tap-vsock's tap.Switch on the other. The bridge
+// owns that net.Conn right up until it hands it to vn.AcceptQemu/AcceptVfkit,
+// which makes it the one place a rate limit can sit that is per-box, applies to
+// both directions, and cannot be switched off from inside the guest. Shaping
+// here needs no libkrun change and no gvisor upgrade.
+//
+// Direction names follow Firecracker's net device and are relative to the box:
+// TX is what the box sends (guest -> internet), RX is what reaches it
+// (internet -> guest). Note RX corresponds to the switch's *Sent* counter,
+// because "sent" there means sent to the guest.
+//
+// Shaping below IP means one budget per direction covers TCP, UDP, ICMP and ARP
+// alike. There is no per-protocol accounting, and none is wanted.
+
+// maxFrameBytes is the largest single frame the shaper must be able to pass: the
+// IPv4 TotalLength ceiling (65535) plus a 14-byte Ethernet header.
+//
+// Bucket capacity is floored here. On the RX side a whole frame is charged at
+// once, so a smaller bucket could starve a maximum-size frame forever — the same
+// class of deadlock as firecracker-microvm/firecracker#259.
+//
+// It matters on TX too: tap.Switch reads through a bufio.Reader
+// (pkg/tap/switch.go:234), and bufio hands a read straight to the underlying
+// conn when the request is at least its own buffer size and that buffer is
+// empty, so a large frame body does arrive as a single Read.
+const maxFrameBytes = 65550
+
+// ---------------------------------------------------------------------------
+// configuration
+// ---------------------------------------------------------------------------
+
+// TokenBucketConfig is Firecracker's bucket shape: a capacity in bytes, the time
+// to refill it, and an optional one-shot burst spent before the sustained rate
+// applies and never refilled.
+//
+// Sustained rate is Size * 1000 / RefillTimeMs bytes per second.
+type TokenBucketConfig struct {
+	Size         int64 `json:"size"`
+	RefillTimeMs int64 `json:"refill_time_ms"`
+	OneTimeBurst int64 `json:"one_time_burst,omitempty"`
+}
+
+// RateLimitConfig carries one bucket per direction. A nil or zero-Size
+// direction is unlimited, matching Firecracker, Kata and Cloud Hypervisor.
+type RateLimitConfig struct {
+	RX *TokenBucketConfig `json:"rx,omitempty"`
+	TX *TokenBucketConfig `json:"tx,omitempty"`
+}
+
+func (t *TokenBucketConfig) unlimited() bool { return t == nil || t.Size == 0 }
+
+func (t *TokenBucketConfig) refillNs() int64 { return t.RefillTimeMs * int64(time.Millisecond) }
+
+// bytesPerSec is only used for sizing the RX queue; the buckets themselves work
+// straight off the (Size, RefillTimeMs) pair to avoid a rounding step.
+func (t *TokenBucketConfig) bytesPerSec() int64 { return t.Size * 1000 / t.RefillTimeMs }
+
+func (t *TokenBucketConfig) validate(dir string) error {
+	if t.unlimited() {
+		return nil
+	}
+	if t.Size < 0 {
+		return fmt.Errorf("rate_limit.%s.size must not be negative (got %d)", dir, t.Size)
+	}
+	if t.RefillTimeMs <= 0 {
+		return fmt.Errorf("rate_limit.%s.refill_time_ms must be positive (got %d)", dir, t.RefillTimeMs)
+	}
+	// Guards bytesPerSec and the refill arithmetic below.
+	if t.Size > (1<<62)/1000 {
+		return fmt.Errorf("rate_limit.%s.size is too large (got %d)", dir, t.Size)
+	}
+	if t.OneTimeBurst < 0 {
+		return fmt.Errorf("rate_limit.%s.one_time_burst must not be negative (got %d)", dir, t.OneTimeBurst)
+	}
+	return nil
+}
+
+// Validate rejects a partial or nonsensical configuration outright rather than
+// letting half of it take effect — the same all-or-nothing rule Firecracker and
+// E2B apply.
+func (c *RateLimitConfig) Validate() error {
+	if c == nil {
+		return nil
+	}
+	if err := c.RX.validate("rx"); err != nil {
+		return err
+	}
+	return c.TX.validate("tx")
+}
+
+func (c *RateLimitConfig) unlimited() bool {
+	return c == nil || (c.RX.unlimited() && c.TX.unlimited())
+}
+
+// ---------------------------------------------------------------------------
+// token bucket
+// ---------------------------------------------------------------------------
+
+// tokenBucket meters bytes against a configured rate.
+//
+// rateBytes and refillNs are the configured rate pair and are never adjusted;
+// capacity — the ceiling on accumulated tokens, i.e. the burst size — is floored
+// separately at maxFrameBytes. Keeping the two apart matters: raising capacity
+// to the floor while deriving the rate from it would silently speed the limit up
+// for any box configured below 64 KiB of burst.
+type tokenBucket struct {
+	mu        sync.Mutex
+	rateBytes int64
+	refillNs  int64
+	capacity  int64
+	tokens    int64
+	oneTime   int64
+	last      time.Time
+	now       func() time.Time
+}
+
+func newTokenBucket(cfg *TokenBucketConfig, now func() time.Time) *tokenBucket {
+	if now == nil {
+		now = time.Now
+	}
+	capacity := cfg.Size
+	if capacity < maxFrameBytes {
+		capacity = maxFrameBytes
+	}
+	return &tokenBucket{
+		rateBytes: cfg.Size,
+		refillNs:  cfg.refillNs(),
+		capacity:  capacity,
+		tokens:    capacity,
+		oneTime:   cfg.OneTimeBurst,
+		last:      now(),
+		now:       now,
+	}
+}
+
+// reserve refills from the clock, charges n bytes (letting the balance go
+// negative) and reports how long the caller must wait for it to reach zero.
+//
+// It is pure policy: it never sleeps and never starts a goroutine, so the whole
+// rate calculation is testable against an injected clock with exact equality
+// rather than wall-clock tolerances.
+func (b *tokenBucket) reserve(n int64) time.Duration {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.refillLocked()
+
+	if n > 0 {
+		if b.oneTime > 0 {
+			spend := n
+			if spend > b.oneTime {
+				spend = b.oneTime
+			}
+			b.oneTime -= spend
+			n -= spend
+		}
+		b.tokens -= n
+	}
+
+	if b.tokens >= 0 {
+		return 0
+	}
+	// The deficit is bounded by one frame (RX) or one Read (TX), so this
+	// product cannot overflow for any size Validate accepts.
+	return time.Duration(-b.tokens * b.refillNs / b.rateBytes)
+}
+
+// waitNonNegative reports the wait left on an existing deficit without charging
+// anything. This is the TX form: charge after reading, sleep off the overshoot
+// before the next read.
+func (b *tokenBucket) waitNonNegative() time.Duration { return b.reserve(0) }
+
+func (b *tokenBucket) refillLocked() {
+	now := b.now()
+	elapsed := now.Sub(b.last)
+	if elapsed <= 0 {
+		return
+	}
+	// Long idles are clamped first so the multiplication below stays bounded.
+	if elapsed.Nanoseconds() >= b.refillNs*b.capacity/b.rateBytes {
+		b.tokens = b.capacity
+		b.last = now
+		return
+	}
+	gained := elapsed.Nanoseconds() * b.rateBytes / b.refillNs
+	if gained <= 0 {
+		// Not a whole token yet. Leave `last` alone so repeated sub-token calls
+		// do not discard the remainder.
+		return
+	}
+	b.tokens += gained
+	if b.tokens > b.capacity {
+		b.tokens = b.capacity
+	}
+	// Advance `last` by exactly the time those tokens represent, keeping the
+	// sub-token remainder for next time.
+	b.last = b.last.Add(time.Duration(gained * b.refillNs / b.rateBytes))
+}
+
+// ---------------------------------------------------------------------------
+// frame boundary tracking
+// ---------------------------------------------------------------------------
+
+// framer follows frame boundaries in a byte stream without reframing or
+// buffering it. It answers one question: of these n bytes, how many were frame
+// body rather than length prefix.
+//
+// It exists so the buckets charge pure frame bytes, matching both the switch's
+// own counters (pkg/tap/switch.go:152,167 charge pkt.Size(); :291 charges
+// len(buf), neither including the prefix) and Firecracker/gVisor, which meter
+// below any transport framing. Charging raw socket bytes instead would bill
+// Linux four extra bytes per frame and macOS none: 0.26% on a 1514-byte frame,
+// but 5.7% on a stream of 66-byte ACKs, and inconsistent across platforms
+// either way.
+//
+// hdrLen comes from the caller and is never assumed: gvisor-tap-vsock's
+// pkg/tap/protocols.go uses four big-endian bytes for qemu, two little-endian
+// for hyperkit, and no prefix at all for the datagram protocols.
+type framer struct {
+	hdrLen int
+	hdrGot int
+	hdrBuf [4]byte
+	body   int
+}
+
+func (f *framer) consume(b []byte) (frameBytes, frames int) {
+	if len(b) == 0 {
+		return 0, 0
+	}
+	// Datagram protocols carry no prefix: one read is exactly one frame.
+	if f.hdrLen == 0 {
+		return len(b), 1
+	}
+
+	i := 0
+	for i < len(b) {
+		if f.body == 0 {
+			need := f.hdrLen - f.hdrGot
+			n := len(b) - i
+			if n > need {
+				n = need
+			}
+			copy(f.hdrBuf[f.hdrGot:], b[i:i+n])
+			f.hdrGot += n
+			i += n
+			if f.hdrGot == f.hdrLen {
+				f.body = f.decodeLen()
+				f.hdrGot = 0
+				if f.body == 0 {
+					frames++
+				}
+			}
+			continue
+		}
+		n := len(b) - i
+		if n > f.body {
+			n = f.body
+		}
+		f.body -= n
+		frameBytes += n
+		i += n
+		if f.body == 0 {
+			frames++
+		}
+	}
+	return frameBytes, frames
+}
+
+// decodeLen mirrors pkg/tap/protocols.go exactly: qemu writes a big-endian
+// uint32, hyperkit a little-endian uint16.
+func (f *framer) decodeLen() int {
+	if f.hdrLen == 2 {
+		return int(binary.LittleEndian.Uint16(f.hdrBuf[:2]))
+	}
+	return int(binary.BigEndian.Uint32(f.hdrBuf[:4]))
+}
+
+// ---------------------------------------------------------------------------
+// counters
+// ---------------------------------------------------------------------------
+
+// shaperStats stays internal to the bridge for now. The live stats path (GET
+// /stats over the control socket) serves vn.ServicesMux() directly, so there is
+// no bridge-owned mux to inject into, and the FFI stats path has no callers on
+// the Rust side. Surfacing these belongs with that plumbing, not here.
+type shaperStats struct {
+	txThrottledEvents atomic.Int64
+	txThrottledNs     atomic.Int64
+	rxThrottledEvents atomic.Int64
+	rxThrottledNs     atomic.Int64
+	rxDroppedFrames   atomic.Int64
+	rxDroppedBytes    atomic.Int64
+	rxDeliveredBytes  atomic.Int64
+	queueFrames       atomic.Int64
+	queueBytes        atomic.Int64
+}
+
+type shaperSnapshot struct {
+	TxThrottledEvents int64
+	TxThrottledNs     int64
+	RxThrottledEvents int64
+	RxThrottledNs     int64
+	RxDroppedFrames   int64
+	RxDroppedBytes    int64
+	RxDeliveredBytes  int64
+	QueueFrames       int64
+	QueueBytes        int64
+}
+
+func (s *shaperStats) snapshot() shaperSnapshot {
+	return shaperSnapshot{
+		TxThrottledEvents: s.txThrottledEvents.Load(),
+		TxThrottledNs:     s.txThrottledNs.Load(),
+		RxThrottledEvents: s.rxThrottledEvents.Load(),
+		RxThrottledNs:     s.rxThrottledNs.Load(),
+		RxDroppedFrames:   s.rxDroppedFrames.Load(),
+		RxDroppedBytes:    s.rxDroppedBytes.Load(),
+		RxDeliveredBytes:  s.rxDeliveredBytes.Load(),
+		QueueFrames:       s.queueFrames.Load(),
+		QueueBytes:        s.queueBytes.Load(),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// shaped connection
+// ---------------------------------------------------------------------------
+
+type shapedConn struct {
+	net.Conn
+
+	hdrLen int
+	tx     *tokenBucket
+	rx     *tokenBucket
+	framer framer // read side only; tap.Switch reads from a single goroutine
+
+	queue      chan []byte
+	queueBytes atomic.Int64
+	maxQueueB  int64
+
+	stop      chan struct{}
+	closeOnce sync.Once
+	stats     shaperStats
+}
+
+// wrapConn is the single place a connection becomes shaped; main.go and the test
+// harness both go through it so the two cannot drift.
+//
+// An unlimited configuration returns the connection untouched, so a box with no
+// limit pays nothing, not even an interface indirection.
+func wrapConn(conn net.Conn, hdrLen int, cfg *RateLimitConfig) net.Conn {
+	if cfg.unlimited() {
+		return conn
+	}
+	return newShapedConn(conn, hdrLen, cfg, nil)
+}
+
+func newShapedConn(conn net.Conn, hdrLen int, cfg *RateLimitConfig, now func() time.Time) *shapedConn {
+	c := &shapedConn{
+		Conn:   conn,
+		hdrLen: hdrLen,
+		framer: framer{hdrLen: hdrLen},
+		stop:   make(chan struct{}),
+	}
+	if !cfg.TX.unlimited() {
+		c.tx = newTokenBucket(cfg.TX, now)
+	}
+	if !cfg.RX.unlimited() {
+		c.rx = newTokenBucket(cfg.RX, now)
+		queueBytes, queueFrames := queueBounds(cfg.RX)
+		c.maxQueueB = queueBytes
+		c.queue = make(chan []byte, queueFrames)
+		go c.pace()
+	}
+	return c
+}
+
+// queueBounds sizes the RX queue from the configured rate: one hundred
+// milliseconds of buffering, the same time constant the bucket refill uses.
+//
+// The floor is deliberately small. Eight maximum frames would be 512 KiB, which
+// at 1 Mbit/s is over four seconds of standing queue — the box gets its
+// bandwidth but its latency becomes unusable and TCP never sees a congestion
+// signal. At low rates, dropping early is the correct behaviour. Real active
+// queue management (CoDel) would be the principled fix and is out of scope.
+func queueBounds(cfg *TokenBucketConfig) (queueBytes int64, queueFrames int) {
+	queueBytes = cfg.bytesPerSec() / 10
+	if min := int64(2 * maxFrameBytes); queueBytes < min {
+		queueBytes = min
+	}
+	if max := int64(4 << 20); queueBytes > max {
+		queueBytes = max
+	}
+	queueFrames = int(queueBytes / 1514)
+	if queueFrames < 16 {
+		queueFrames = 16
+	}
+	if queueFrames > 4096 {
+		queueFrames = 4096
+	}
+	return queueBytes, queueFrames
+}
+
+// sleep waits for d, or reports false if the connection was closed first. Every
+// wait in the shaper goes through here: a bare time.Sleep would strand Read or
+// the pacer for a full refill window after Close.
+func (c *shapedConn) sleep(d time.Duration) bool {
+	if d <= 0 {
+		return true
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-c.stop:
+		return false
+	case <-t.C:
+		return true
+	}
+}
+
+// Read shapes TX, what the box sends.
+//
+// The charge happens after the read, not before, so there is no need to guess
+// how many bytes the read will return: the balance simply goes negative and the
+// next call sleeps off the overshoot. That overshoot is bounded by one Read,
+// the same bound the capacity floor already assumes, so TX cannot starve at any
+// bucket size. RX is charged up front and therefore can, which is why the pacer
+// has an explicit oversized-frame path.
+//
+// Not reading is itself the backpressure: the AF_UNIX receive buffer fills, and
+// on Linux libkrun's unixstream backend then sees EAGAIN, defers the frame and
+// stops draining the virtio tx queue, so the guest's own TCP backs off. The
+// macOS unixgram backend has no equivalent mechanism and its behaviour under a
+// full receive buffer is unverified — do not assume it backpressures.
+func (c *shapedConn) Read(p []byte) (int, error) {
+	if c.tx != nil {
+		if d := c.tx.waitNonNegative(); d > 0 {
+			c.stats.txThrottledEvents.Add(1)
+			c.stats.txThrottledNs.Add(int64(d))
+			if !c.sleep(d) {
+				return 0, net.ErrClosed
+			}
+		}
+	}
+	n, err := c.Conn.Read(p)
+	if n > 0 && c.tx != nil {
+		frameBytes, _ := c.framer.consume(p[:n])
+		c.tx.reserve(int64(frameBytes))
+	}
+	return n, err
+}
+
+// Write shapes RX, what reaches the box, by queueing rather than blocking.
+//
+// Two upstream facts make queue-and-drop the only legal strategy here:
+//
+//   - tap.Switch.txPkt holds both writeLock and connLock across the whole
+//     conn.Write call (pkg/tap/switch.go:119-124), so blocking here wedges the
+//     entire switch, Accept and disconnect included.
+//   - tap.Switch.txBuf treats any error other than ENOBUFS as fatal and calls
+//     e.disconnect (pkg/tap/switch.go:186), tearing down the VM's connection, so
+//     returning an error here would kill networking outright.
+//
+// Cannot block, cannot fail: a full queue must drop and count.
+//
+// The frame must be copied. switch.go:126 hands over pkt.ToView().AsSlice(), and
+// rxBuf releases the packet as soon as tx returns; on the datagram path txBuf
+// does not reallocate (its append runs only for stream protocols, :173-177), so
+// the slice is gvisor-owned and may be recycled the moment this returns.
+// Queueing it uncopied would be a use-after-free-shaped race. Allocating per
+// frame is fine without a pool: the queue is bounded and drains at the
+// configured rate, so churn is capped by the limit the user asked for.
+func (c *shapedConn) Write(p []byte) (int, error) {
+	if c.rx == nil {
+		return c.Conn.Write(p)
+	}
+
+	size := int64(len(p))
+	if c.queueBytes.Load()+size > c.maxQueueB {
+		c.dropped(size)
+		return len(p), nil
+	}
+
+	frame := make([]byte, len(p))
+	copy(frame, p)
+
+	select {
+	case c.queue <- frame:
+		c.stats.queueFrames.Add(1)
+		c.stats.queueBytes.Store(c.queueBytes.Add(size))
+	default:
+		c.dropped(size)
+	}
+	return len(p), nil
+}
+
+func (c *shapedConn) dropped(size int64) {
+	c.stats.rxDroppedFrames.Add(1)
+	c.stats.rxDroppedBytes.Add(size)
+}
+
+func (c *shapedConn) dequeue(frame []byte) {
+	c.stats.queueFrames.Add(-1)
+	c.stats.queueBytes.Store(c.queueBytes.Add(-int64(len(frame))))
+}
+
+// pace drains the RX queue at the configured rate.
+func (c *shapedConn) pace() {
+	for {
+		select {
+		case <-c.stop:
+			c.drain()
+			return
+		case frame := <-c.queue:
+			c.dequeue(frame)
+
+			// The frame arrives whole, so the only adjustment needed is to
+			// leave the length prefix out of the charge.
+			charge := int64(len(frame))
+			if charge > int64(c.hdrLen) {
+				charge -= int64(c.hdrLen)
+			}
+			if d := c.rx.reserve(charge); d > 0 {
+				c.stats.rxThrottledEvents.Add(1)
+				c.stats.rxThrottledNs.Add(int64(d))
+				if !c.sleep(d) {
+					c.drain()
+					return
+				}
+			}
+			if !c.writeFrame(frame) {
+				return
+			}
+			c.stats.rxDeliveredBytes.Add(charge)
+		}
+	}
+}
+
+// writeFrame reports whether the pacer should keep running.
+func (c *shapedConn) writeFrame(frame []byte) bool {
+	for {
+		if _, err := c.Conn.Write(frame); err != nil {
+			if errors.Is(err, syscall.ENOBUFS) {
+				// The same retry upstream performs (gvisor-tap-vsock#367), but
+				// paced: a bare continue spins a core while the buffer drains.
+				if !c.sleep(200 * time.Microsecond) {
+					return false
+				}
+				continue
+			}
+			// Closing the inner conn makes rxStream's ReadFull fail, which
+			// returns Switch.Accept and lets the library run its own deferred
+			// disconnect. Reaching into the switch from here is neither possible
+			// (disconnect is unexported) nor desirable.
+			_ = c.Conn.Close()
+			return false
+		}
+		return true
+	}
+}
+
+func (c *shapedConn) drain() {
+	for {
+		select {
+		case frame := <-c.queue:
+			c.dequeue(frame)
+			c.dropped(int64(len(frame)))
+		default:
+			return
+		}
+	}
+}
+
+// Close must never wait for the pacer.
+//
+// tap.Switch.txBuf calls e.disconnect while txPkt already holds writeLock and
+// connLock (pkg/tap/switch.go:119-124, :186), and disconnect closes the
+// connection (:202); Accept's deferred cleanup reaches the same call under
+// connLock (:92-96). So this runs with the switch's global write lock held. If
+// it joined a pacer that happened to be blocked in Conn.Write on a full socket
+// buffer, the entire switch would deadlock behind that lock.
+//
+// Closing the inner conn is what actually unblocks an in-flight pacer write,
+// with net.ErrClosed; the pacer then observes stop, discards the queue and exits
+// on its own.
+func (c *shapedConn) Close() error {
+	var err error
+	c.closeOnce.Do(func() {
+		close(c.stop)
+		err = c.Conn.Close()
+	})
+	return err
+}

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/shaper.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/shaper.go
@@ -240,9 +240,9 @@ func (b *tokenBucket) refillLocked() {
 	elapsedNs := elapsed.Nanoseconds()
 
 	gained, ok := mulDiv(elapsedNs, b.rateBytes, b.refillNs)
-	if !ok || gained >= b.capacity {
-		// More than a bucket's worth of time has passed (or so much that the
-		// conversion does not fit); either way the bucket is full.
+	if !ok || (b.tokens >= 0 && gained >= b.capacity-b.tokens) {
+		// Clamp before adding to avoid overflow. A negative balance must
+		// first repay its debt, even when gained exceeds one full bucket.
 		b.tokens = b.capacity
 		b.last = now
 		return

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/shaper.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/shaper.go
@@ -4,11 +4,15 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"math"
+	"math/bits"
 	"net"
 	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
+
+	"github.com/sirupsen/logrus"
 )
 
 // Per-box bandwidth shaping for the guest link.
@@ -39,7 +43,7 @@ import (
 // (pkg/tap/switch.go:234), and bufio hands a read straight to the underlying
 // conn when the request is at least its own buffer size and that buffer is
 // empty, so a large frame body does arrive as a single Read.
-const maxFrameBytes = 65550
+const maxFrameBytes = 65549
 
 // ---------------------------------------------------------------------------
 // configuration
@@ -80,6 +84,12 @@ func (t *TokenBucketConfig) validate(dir string) error {
 	}
 	if t.RefillTimeMs <= 0 {
 		return fmt.Errorf("rate_limit.%s.refill_time_ms must be positive (got %d)", dir, t.RefillTimeMs)
+	}
+	// refillNs() multiplies by 1e6 and runs before any of the guards in
+	// refillLocked, so the bound has to live here. An hour is far beyond any
+	// useful averaging window; the Rust core pins this to 100ms.
+	if t.RefillTimeMs > 3_600_000 {
+		return fmt.Errorf("rate_limit.%s.refill_time_ms must be at most 3600000 (got %d)", dir, t.RefillTimeMs)
 	}
 	// Guards bytesPerSec and the refill arithmetic below.
 	if t.Size > (1<<62)/1000 {
@@ -130,6 +140,26 @@ type tokenBucket struct {
 	now       func() time.Time
 }
 
+// mulDiv returns a*b/d computed in 128 bits, and whether the result fits in
+// int64. All three inputs are non-negative here.
+//
+// The naive form overflows for buckets past a few tens of gigabytes per refill
+// period, and a wrapped intermediate is worse than an error: it silently turns
+// the limit off instead of failing. Sizes that large are accepted by Validate
+// and can come from a hand-written bridge config, so the arithmetic is made
+// exact rather than assumed to be in range.
+func mulDiv(a, b, d int64) (int64, bool) {
+	hi, lo := bits.Mul64(uint64(a), uint64(b))
+	if hi >= uint64(d) { // quotient would not fit in 64 bits
+		return 0, false
+	}
+	q, _ := bits.Div64(hi, lo, uint64(d))
+	if q > uint64(math.MaxInt64) {
+		return 0, false
+	}
+	return int64(q), true
+}
+
 func newTokenBucket(cfg *TokenBucketConfig, now func() time.Time) *tokenBucket {
 	if now == nil {
 		now = time.Now
@@ -176,9 +206,13 @@ func (b *tokenBucket) reserve(n int64) time.Duration {
 	if b.tokens >= 0 {
 		return 0
 	}
-	// The deficit is bounded by one frame (RX) or one Read (TX), so this
-	// product cannot overflow for any size Validate accepts.
-	return time.Duration(-b.tokens * b.refillNs / b.rateBytes)
+	// Guarded like refillLocked: the deficit is normally one frame, but the
+	// product is checked rather than assumed.
+	wait, ok := mulDiv(-b.tokens, b.refillNs, b.rateBytes)
+	if !ok {
+		return time.Duration(math.MaxInt64)
+	}
+	return time.Duration(wait)
 }
 
 // waitNonNegative reports the wait left on an existing deficit without charging
@@ -186,19 +220,33 @@ func (b *tokenBucket) reserve(n int64) time.Duration {
 // before the next read.
 func (b *tokenBucket) waitNonNegative() time.Duration { return b.reserve(0) }
 
+// refillLocked converts elapsed time into tokens.
+//
+// Every product here is guarded before it is evaluated rather than bounded by
+// what Validate happens to accept. refillNs*capacity overflows int64 once the
+// bucket passes ~92 GB per refill period, and a wrapped negative threshold makes
+// the "has a full period passed" test always true — which refills the bucket on
+// every call and silently stops the limit from applying at all.
+//
+// These guards cover the arithmetic in this function. refillNs() itself is a
+// separate multiplication that happens earlier, so its input is bounded in
+// Validate instead.
 func (b *tokenBucket) refillLocked() {
 	now := b.now()
 	elapsed := now.Sub(b.last)
 	if elapsed <= 0 {
 		return
 	}
-	// Long idles are clamped first so the multiplication below stays bounded.
-	if elapsed.Nanoseconds() >= b.refillNs*b.capacity/b.rateBytes {
+	elapsedNs := elapsed.Nanoseconds()
+
+	gained, ok := mulDiv(elapsedNs, b.rateBytes, b.refillNs)
+	if !ok || gained >= b.capacity {
+		// More than a bucket's worth of time has passed (or so much that the
+		// conversion does not fit); either way the bucket is full.
 		b.tokens = b.capacity
 		b.last = now
 		return
 	}
-	gained := elapsed.Nanoseconds() * b.rateBytes / b.refillNs
 	if gained <= 0 {
 		// Not a whole token yet. Leave `last` alone so repeated sub-token calls
 		// do not discard the remainder.
@@ -210,7 +258,12 @@ func (b *tokenBucket) refillLocked() {
 	}
 	// Advance `last` by exactly the time those tokens represent, keeping the
 	// sub-token remainder for next time.
-	b.last = b.last.Add(time.Duration(gained * b.refillNs / b.rateBytes))
+	usedNs, ok := mulDiv(gained, b.refillNs, b.rateBytes)
+	if !ok {
+		b.last = now
+		return
+	}
+	b.last = b.last.Add(time.Duration(usedNs))
 }
 
 // ---------------------------------------------------------------------------
@@ -307,8 +360,6 @@ type shaperStats struct {
 	rxDroppedFrames   atomic.Int64
 	rxDroppedBytes    atomic.Int64
 	rxDeliveredBytes  atomic.Int64
-	queueFrames       atomic.Int64
-	queueBytes        atomic.Int64
 }
 
 type shaperSnapshot struct {
@@ -319,8 +370,6 @@ type shaperSnapshot struct {
 	RxDroppedFrames   int64
 	RxDroppedBytes    int64
 	RxDeliveredBytes  int64
-	QueueFrames       int64
-	QueueBytes        int64
 }
 
 func (s *shaperStats) snapshot() shaperSnapshot {
@@ -332,8 +381,6 @@ func (s *shaperStats) snapshot() shaperSnapshot {
 		RxDroppedFrames:   s.rxDroppedFrames.Load(),
 		RxDroppedBytes:    s.rxDroppedBytes.Load(),
 		RxDeliveredBytes:  s.rxDeliveredBytes.Load(),
-		QueueFrames:       s.queueFrames.Load(),
-		QueueBytes:        s.queueBytes.Load(),
 	}
 }
 
@@ -393,11 +440,17 @@ func newShapedConn(conn net.Conn, hdrLen int, cfg *RateLimitConfig, now func() t
 // queueBounds sizes the RX queue from the configured rate: one hundred
 // milliseconds of buffering, the same time constant the bucket refill uses.
 //
-// The floor is deliberately small. Eight maximum frames would be 512 KiB, which
-// at 1 Mbit/s is over four seconds of standing queue — the box gets its
-// bandwidth but its latency becomes unusable and TCP never sees a congestion
-// signal. At low rates, dropping early is the correct behaviour. Real active
-// queue management (CoDel) would be the principled fix and is out of scope.
+// The floor is two maximum frames, and that is a capacity requirement, not a
+// latency target: a queue that cannot hold one maximum-size frame would drop it
+// unconditionally, so the floor is what makes a full-size frame deliverable at
+// any rate.
+//
+// It does cost latency at low rates — 2*maxFrameBytes is ~1s of standing queue
+// at 1 Mbit/s and ~16s at 64 kbit/s, so a slow box trades round-trip time for
+// the ability to carry large frames at all. A larger floor would be worse (eight
+// frames is ~4s at 1 Mbit/s) but no floor is not an option. Active queue
+// management (CoDel) is the principled fix for the latency half and is out of
+// scope here.
 func queueBounds(cfg *TokenBucketConfig) (queueBytes int64, queueFrames int) {
 	queueBytes = cfg.bytesPerSec() / 10
 	if min := int64(2 * maxFrameBytes); queueBytes < min {
@@ -439,8 +492,9 @@ func (c *shapedConn) sleep(d time.Duration) bool {
 // how many bytes the read will return: the balance simply goes negative and the
 // next call sleeps off the overshoot. That overshoot is bounded by one Read,
 // the same bound the capacity floor already assumes, so TX cannot starve at any
-// bucket size. RX is charged up front and therefore can, which is why the pacer
-// has an explicit oversized-frame path.
+// bucket size. RX is charged up front, so it could starve on a frame larger than
+// the bucket — that is what the maxFrameBytes capacity floor in newTokenBucket
+// prevents, and it is the only guard against that deadlock class.
 //
 // Not reading is itself the backpressure: the AF_UNIX receive buffer fills, and
 // on Linux libkrun's unixstream backend then sees EAGAIN, defers the frame and
@@ -501,8 +555,7 @@ func (c *shapedConn) Write(p []byte) (int, error) {
 
 	select {
 	case c.queue <- frame:
-		c.stats.queueFrames.Add(1)
-		c.stats.queueBytes.Store(c.queueBytes.Add(size))
+		c.queueBytes.Add(size)
 	default:
 		c.dropped(size)
 	}
@@ -515,8 +568,7 @@ func (c *shapedConn) dropped(size int64) {
 }
 
 func (c *shapedConn) dequeue(frame []byte) {
-	c.stats.queueFrames.Add(-1)
-	c.stats.queueBytes.Store(c.queueBytes.Add(-int64(len(frame))))
+	c.queueBytes.Add(-int64(len(frame)))
 }
 
 // pace drains the RX queue at the configured rate.
@@ -603,6 +655,22 @@ func (c *shapedConn) Close() error {
 	c.closeOnce.Do(func() {
 		close(c.stop)
 		err = c.Conn.Close()
+
+		// The only reader of these counters. There is no path from here to the
+		// control socket's /stats (it serves vn.ServicesMux directly, with no
+		// bridge-owned mux to inject into), so without this line an RX queue
+		// overflow would leave no trace anywhere.
+		s := c.stats.snapshot()
+		logrus.WithFields(logrus.Fields{
+			"tx_throttled_events": s.TxThrottledEvents,
+			"tx_throttled_ms":     s.TxThrottledNs / int64(time.Millisecond),
+			"rx_throttled_events": s.RxThrottledEvents,
+			"rx_throttled_ms":     s.RxThrottledNs / int64(time.Millisecond),
+			"rx_delivered_bytes":  s.RxDeliveredBytes,
+			"rx_dropped_frames":   s.RxDroppedFrames,
+			"rx_dropped_bytes":    s.RxDroppedBytes,
+			"rx_queue_bytes":      c.queueBytes.Load(),
+		}).Debug("shaped conn closed")
 	})
 	return err
 }

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/shaper.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/shaper.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"math/bits"
 	"net"
+	"os"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -400,6 +401,10 @@ type shapedConn struct {
 	queueBytes atomic.Int64
 	maxQueueB  int64
 
+	readDeadlineMu      sync.Mutex
+	readDeadline        time.Time
+	readDeadlineChanged chan struct{}
+
 	stop      chan struct{}
 	closeOnce sync.Once
 	stats     shaperStats
@@ -419,10 +424,11 @@ func wrapConn(conn net.Conn, hdrLen int, cfg *RateLimitConfig) net.Conn {
 
 func newShapedConn(conn net.Conn, hdrLen int, cfg *RateLimitConfig, now func() time.Time) *shapedConn {
 	c := &shapedConn{
-		Conn:   conn,
-		hdrLen: hdrLen,
-		framer: framer{hdrLen: hdrLen},
-		stop:   make(chan struct{}),
+		Conn:                conn,
+		hdrLen:              hdrLen,
+		framer:              framer{hdrLen: hdrLen},
+		stop:                make(chan struct{}),
+		readDeadlineChanged: make(chan struct{}),
 	}
 	if !cfg.TX.unlimited() {
 		c.tx = newTokenBucket(cfg.TX, now)
@@ -486,6 +492,81 @@ func (c *shapedConn) sleep(d time.Duration) bool {
 	}
 }
 
+// SetReadDeadline covers both the underlying read and the TX token wait.
+// Serialize forwarding and notification so concurrent setters cannot leave
+// the wrapper and the underlying connection with different read deadlines.
+func (c *shapedConn) SetReadDeadline(t time.Time) error {
+	c.readDeadlineMu.Lock()
+	defer c.readDeadlineMu.Unlock()
+	if err := c.Conn.SetReadDeadline(t); err != nil {
+		return err
+	}
+	c.setReadDeadlineLocked(t)
+	return nil
+}
+
+func (c *shapedConn) SetDeadline(t time.Time) error {
+	c.readDeadlineMu.Lock()
+	defer c.readDeadlineMu.Unlock()
+	if err := c.Conn.SetDeadline(t); err != nil {
+		return err
+	}
+	c.setReadDeadlineLocked(t)
+	return nil
+}
+
+func (c *shapedConn) setReadDeadlineLocked(t time.Time) {
+	c.readDeadline = t
+	close(c.readDeadlineChanged)
+	c.readDeadlineChanged = make(chan struct{})
+}
+
+func (c *shapedConn) waitForTX() error {
+	d := c.tx.waitNonNegative()
+	if d <= 0 {
+		return nil
+	}
+	c.stats.txThrottledEvents.Add(1)
+	c.stats.txThrottledNs.Add(int64(d))
+
+	// Deadline updates wake the waiter without restarting the token wait.
+	readyAt := time.Now().Add(d)
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	for {
+		select {
+		case <-c.stop:
+			return net.ErrClosed
+		default:
+		}
+		c.readDeadlineMu.Lock()
+		deadline, changed := c.readDeadline, c.readDeadlineChanged
+		c.readDeadlineMu.Unlock()
+
+		now := time.Now()
+		wait := readyAt.Sub(now)
+		if !deadline.IsZero() {
+			remaining := deadline.Sub(now)
+			if remaining <= 0 {
+				return &net.OpError{Op: "read", Err: os.ErrDeadlineExceeded}
+			}
+			if remaining < wait {
+				wait = remaining
+			}
+		}
+		if wait <= 0 {
+			return nil
+		}
+		timer.Reset(wait)
+		select {
+		case <-c.stop:
+			return net.ErrClosed
+		case <-changed:
+		case <-timer.C:
+		}
+	}
+}
+
 // Read shapes TX, what the box sends.
 //
 // The charge happens after the read, not before, so there is no need to guess
@@ -503,12 +584,8 @@ func (c *shapedConn) sleep(d time.Duration) bool {
 // full receive buffer is unverified — do not assume it backpressures.
 func (c *shapedConn) Read(p []byte) (int, error) {
 	if c.tx != nil {
-		if d := c.tx.waitNonNegative(); d > 0 {
-			c.stats.txThrottledEvents.Add(1)
-			c.stats.txThrottledNs.Add(int64(d))
-			if !c.sleep(d) {
-				return 0, net.ErrClosed
-			}
+		if err := c.waitForTX(); err != nil {
+			return 0, err
 		}
 	}
 	n, err := c.Conn.Read(p)

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/shaper.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/shaper.go
@@ -125,20 +125,20 @@ func (c *RateLimitConfig) unlimited() bool {
 
 // tokenBucket meters bytes against a configured rate.
 //
-// rateBytes and refillNs are the configured rate pair and are never adjusted;
+// bytesPerRefill and refillNs are the configured rate pair and are never adjusted;
 // capacity — the ceiling on accumulated tokens, i.e. the burst size — is floored
 // separately at maxFrameBytes. Keeping the two apart matters: raising capacity
 // to the floor while deriving the rate from it would silently speed the limit up
 // for any box configured below 64 KiB of burst.
 type tokenBucket struct {
-	mu        sync.Mutex
-	rateBytes int64
-	refillNs  int64
-	capacity  int64
-	tokens    int64
-	oneTime   int64
-	last      time.Time
-	now       func() time.Time
+	mu             sync.Mutex
+	bytesPerRefill int64 // tokens gained per refillNs; with refillNs this is the rate
+	refillNs       int64
+	capacity       int64 // ceiling on tokens, i.e. the burst size
+	tokens         int64 // may go negative: a debt the caller sleeps off
+	oneTimeBurst   int64 // spent before tokens, never refilled
+	lastRefill     time.Time
+	now            func() time.Time
 }
 
 // mulDiv returns a*b/d computed in 128 bits, and whether the result fits in
@@ -170,13 +170,13 @@ func newTokenBucket(cfg *TokenBucketConfig, now func() time.Time) *tokenBucket {
 		capacity = maxFrameBytes
 	}
 	return &tokenBucket{
-		rateBytes: cfg.Size,
-		refillNs:  cfg.refillNs(),
-		capacity:  capacity,
-		tokens:    capacity,
-		oneTime:   cfg.OneTimeBurst,
-		last:      now(),
-		now:       now,
+		bytesPerRefill: cfg.Size,
+		refillNs:       cfg.refillNs(),
+		capacity:       capacity,
+		tokens:         capacity,
+		oneTimeBurst:   cfg.OneTimeBurst,
+		lastRefill:     now(),
+		now:            now,
 	}
 }
 
@@ -193,12 +193,12 @@ func (b *tokenBucket) reserve(n int64) time.Duration {
 	b.refillLocked()
 
 	if n > 0 {
-		if b.oneTime > 0 {
+		if b.oneTimeBurst > 0 {
 			spend := n
-			if spend > b.oneTime {
-				spend = b.oneTime
+			if spend > b.oneTimeBurst {
+				spend = b.oneTimeBurst
 			}
-			b.oneTime -= spend
+			b.oneTimeBurst -= spend
 			n -= spend
 		}
 		b.tokens -= n
@@ -209,7 +209,7 @@ func (b *tokenBucket) reserve(n int64) time.Duration {
 	}
 	// Guarded like refillLocked: the deficit is normally one frame, but the
 	// product is checked rather than assumed.
-	wait, ok := mulDiv(-b.tokens, b.refillNs, b.rateBytes)
+	wait, ok := mulDiv(-b.tokens, b.refillNs, b.bytesPerRefill)
 	if !ok {
 		return time.Duration(math.MaxInt64)
 	}
@@ -234,22 +234,22 @@ func (b *tokenBucket) waitNonNegative() time.Duration { return b.reserve(0) }
 // Validate instead.
 func (b *tokenBucket) refillLocked() {
 	now := b.now()
-	elapsed := now.Sub(b.last)
+	elapsed := now.Sub(b.lastRefill)
 	if elapsed <= 0 {
 		return
 	}
 	elapsedNs := elapsed.Nanoseconds()
 
-	gained, ok := mulDiv(elapsedNs, b.rateBytes, b.refillNs)
+	gained, ok := mulDiv(elapsedNs, b.bytesPerRefill, b.refillNs)
 	if !ok || (b.tokens >= 0 && gained >= b.capacity-b.tokens) {
 		// Clamp before adding to avoid overflow. A negative balance must
 		// first repay its debt, even when gained exceeds one full bucket.
 		b.tokens = b.capacity
-		b.last = now
+		b.lastRefill = now
 		return
 	}
 	if gained <= 0 {
-		// Not a whole token yet. Leave `last` alone so repeated sub-token calls
+		// Not a whole token yet. Leave `lastRefill` alone so repeated sub-token calls
 		// do not discard the remainder.
 		return
 	}
@@ -257,14 +257,14 @@ func (b *tokenBucket) refillLocked() {
 	if b.tokens > b.capacity {
 		b.tokens = b.capacity
 	}
-	// Advance `last` by exactly the time those tokens represent, keeping the
+	// Advance `lastRefill` by exactly the time those tokens represent, keeping the
 	// sub-token remainder for next time.
-	usedNs, ok := mulDiv(gained, b.refillNs, b.rateBytes)
+	usedNs, ok := mulDiv(gained, b.refillNs, b.bytesPerRefill)
 	if !ok {
-		b.last = now
+		b.lastRefill = now
 		return
 	}
-	b.last = b.last.Add(time.Duration(usedNs))
+	b.lastRefill = b.lastRefill.Add(time.Duration(usedNs))
 }
 
 // ---------------------------------------------------------------------------
@@ -283,14 +283,14 @@ func (b *tokenBucket) refillLocked() {
 // but 5.7% on a stream of 66-byte ACKs, and inconsistent across platforms
 // either way.
 //
-// hdrLen comes from the caller and is never assumed: gvisor-tap-vsock's
+// prefixLen comes from the caller and is never assumed: gvisor-tap-vsock's
 // pkg/tap/protocols.go uses four big-endian bytes for qemu, two little-endian
 // for hyperkit, and no prefix at all for the datagram protocols.
 type framer struct {
-	hdrLen int
-	hdrGot int
-	hdrBuf [4]byte
-	body   int
+	prefixLen     int     // length-prefix bytes per frame: 4 for qemu, 2 for hyperkit, 0 for datagram
+	prefixGot     int     // prefix bytes collected so far for the current frame
+	prefixBuf     [4]byte // the partial prefix, decoded once prefixGot == prefixLen
+	bodyRemaining int     // body bytes still to come for the current frame
 }
 
 func (f *framer) consume(b []byte) (frameBytes, frames int) {
@@ -298,38 +298,38 @@ func (f *framer) consume(b []byte) (frameBytes, frames int) {
 		return 0, 0
 	}
 	// Datagram protocols carry no prefix: one read is exactly one frame.
-	if f.hdrLen == 0 {
+	if f.prefixLen == 0 {
 		return len(b), 1
 	}
 
 	i := 0
 	for i < len(b) {
-		if f.body == 0 {
-			need := f.hdrLen - f.hdrGot
+		if f.bodyRemaining == 0 {
+			need := f.prefixLen - f.prefixGot
 			n := len(b) - i
 			if n > need {
 				n = need
 			}
-			copy(f.hdrBuf[f.hdrGot:], b[i:i+n])
-			f.hdrGot += n
+			copy(f.prefixBuf[f.prefixGot:], b[i:i+n])
+			f.prefixGot += n
 			i += n
-			if f.hdrGot == f.hdrLen {
-				f.body = f.decodeLen()
-				f.hdrGot = 0
-				if f.body == 0 {
+			if f.prefixGot == f.prefixLen {
+				f.bodyRemaining = f.decodeLen()
+				f.prefixGot = 0
+				if f.bodyRemaining == 0 {
 					frames++
 				}
 			}
 			continue
 		}
 		n := len(b) - i
-		if n > f.body {
-			n = f.body
+		if n > f.bodyRemaining {
+			n = f.bodyRemaining
 		}
-		f.body -= n
+		f.bodyRemaining -= n
 		frameBytes += n
 		i += n
-		if f.body == 0 {
+		if f.bodyRemaining == 0 {
 			frames++
 		}
 	}
@@ -339,10 +339,10 @@ func (f *framer) consume(b []byte) (frameBytes, frames int) {
 // decodeLen mirrors pkg/tap/protocols.go exactly: qemu writes a big-endian
 // uint32, hyperkit a little-endian uint16.
 func (f *framer) decodeLen() int {
-	if f.hdrLen == 2 {
-		return int(binary.LittleEndian.Uint16(f.hdrBuf[:2]))
+	if f.prefixLen == 2 {
+		return int(binary.LittleEndian.Uint16(f.prefixBuf[:2]))
 	}
-	return int(binary.BigEndian.Uint32(f.hdrBuf[:4]))
+	return int(binary.BigEndian.Uint32(f.prefixBuf[:4]))
 }
 
 // ---------------------------------------------------------------------------
@@ -389,23 +389,38 @@ func (s *shaperStats) snapshot() shaperSnapshot {
 // shaped connection
 // ---------------------------------------------------------------------------
 
+// shapedConn wraps the guest link and meters both directions. The two sides
+// use different mechanisms because of how tap.Switch drives them: Read (TX) may
+// block, so it sleeps off the bucket debt in place; Write (RX) must never block
+// or fail, so it queues and a pacer goroutine delivers at the configured rate.
 type shapedConn struct {
 	net.Conn
 
-	hdrLen int
-	tx     *tokenBucket
-	rx     *tokenBucket
-	framer framer // read side only; tap.Switch reads from a single goroutine
+	// Nil in an unlimited direction; that side then passes through untouched.
+	txTokenBucket *tokenBucket // guest -> internet, charged in Read
+	rxTokenBucket *tokenBucket // internet -> guest, charged in pace
 
-	queue      chan []byte
-	queueBytes atomic.Int64
-	maxQueueB  int64
+	// Tracks frame boundaries on the read side so TX is charged for frame bytes
+	// only, not the length prefix. Its state is advanced by Read alone, and
+	// tap.Switch reads from a single goroutine, so it needs no lock; the pacer
+	// only consults the immutable prefixLen.
+	framer framer
 
+	// RX queue between Write and the pacer goroutine. Bounded both by frame
+	// count (the channel capacity) and by bytes (maxQueueBytes); a frame that
+	// would exceed either is dropped and counted rather than blocking Write.
+	queue         chan []byte
+	queueBytes    atomic.Int64 // bytes currently queued
+	maxQueueBytes int64
+
+	// Mirror of the read deadline set on Conn, so the TX token wait in Read can
+	// honor it too. readDeadlineChanged is closed and replaced on every update
+	// to wake a waiter without restarting its token wait.
 	readDeadlineMu      sync.Mutex
 	readDeadline        time.Time
 	readDeadlineChanged chan struct{}
 
-	stop      chan struct{}
+	stop      chan struct{} // closed once by Close; every wait in the shaper selects on it
 	closeOnce sync.Once
 	stats     shaperStats
 }
@@ -415,28 +430,27 @@ type shapedConn struct {
 //
 // An unlimited configuration returns the connection untouched, so a box with no
 // limit pays nothing, not even an interface indirection.
-func wrapConn(conn net.Conn, hdrLen int, cfg *RateLimitConfig) net.Conn {
+func wrapConn(conn net.Conn, prefixLen int, cfg *RateLimitConfig) net.Conn {
 	if cfg.unlimited() {
 		return conn
 	}
-	return newShapedConn(conn, hdrLen, cfg, nil)
+	return newShapedConn(conn, prefixLen, cfg, nil)
 }
 
-func newShapedConn(conn net.Conn, hdrLen int, cfg *RateLimitConfig, now func() time.Time) *shapedConn {
+func newShapedConn(conn net.Conn, prefixLen int, cfg *RateLimitConfig, now func() time.Time) *shapedConn {
 	c := &shapedConn{
 		Conn:                conn,
-		hdrLen:              hdrLen,
-		framer:              framer{hdrLen: hdrLen},
+		framer:              framer{prefixLen: prefixLen},
 		stop:                make(chan struct{}),
 		readDeadlineChanged: make(chan struct{}),
 	}
 	if !cfg.TX.unlimited() {
-		c.tx = newTokenBucket(cfg.TX, now)
+		c.txTokenBucket = newTokenBucket(cfg.TX, now)
 	}
 	if !cfg.RX.unlimited() {
-		c.rx = newTokenBucket(cfg.RX, now)
+		c.rxTokenBucket = newTokenBucket(cfg.RX, now)
 		queueBytes, queueFrames := queueBounds(cfg.RX)
-		c.maxQueueB = queueBytes
+		c.maxQueueBytes = queueBytes
 		c.queue = make(chan []byte, queueFrames)
 		go c.pace()
 	}
@@ -522,7 +536,7 @@ func (c *shapedConn) setReadDeadlineLocked(t time.Time) {
 }
 
 func (c *shapedConn) waitForTX() error {
-	d := c.tx.waitNonNegative()
+	d := c.txTokenBucket.waitNonNegative()
 	if d <= 0 {
 		return nil
 	}
@@ -583,15 +597,15 @@ func (c *shapedConn) waitForTX() error {
 // macOS unixgram backend has no equivalent mechanism and its behaviour under a
 // full receive buffer is unverified — do not assume it backpressures.
 func (c *shapedConn) Read(p []byte) (int, error) {
-	if c.tx != nil {
+	if c.txTokenBucket != nil {
 		if err := c.waitForTX(); err != nil {
 			return 0, err
 		}
 	}
 	n, err := c.Conn.Read(p)
-	if n > 0 && c.tx != nil {
+	if n > 0 && c.txTokenBucket != nil {
 		frameBytes, _ := c.framer.consume(p[:n])
-		c.tx.reserve(int64(frameBytes))
+		c.txTokenBucket.reserve(int64(frameBytes))
 	}
 	return n, err
 }
@@ -617,12 +631,12 @@ func (c *shapedConn) Read(p []byte) (int, error) {
 // frame is fine without a pool: the queue is bounded and drains at the
 // configured rate, so churn is capped by the limit the user asked for.
 func (c *shapedConn) Write(p []byte) (int, error) {
-	if c.rx == nil {
+	if c.rxTokenBucket == nil {
 		return c.Conn.Write(p)
 	}
 
 	size := int64(len(p))
-	if c.queueBytes.Load()+size > c.maxQueueB {
+	if c.queueBytes.Load()+size > c.maxQueueBytes {
 		c.dropped(size)
 		return len(p), nil
 	}
@@ -661,10 +675,10 @@ func (c *shapedConn) pace() {
 			// The frame arrives whole, so the only adjustment needed is to
 			// leave the length prefix out of the charge.
 			charge := int64(len(frame))
-			if charge > int64(c.hdrLen) {
-				charge -= int64(c.hdrLen)
+			if charge > int64(c.framer.prefixLen) {
+				charge -= int64(c.framer.prefixLen)
 			}
-			if d := c.rx.reserve(charge); d > 0 {
+			if d := c.rxTokenBucket.reserve(charge); d > 0 {
 				c.stats.rxThrottledEvents.Add(1)
 				c.stats.rxThrottledNs.Add(int64(d))
 				if !c.sleep(d) {

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/shaper_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/shaper_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/json"
+	"fmt"
 	"io"
 	"math/bits"
 	"net"
@@ -669,5 +670,48 @@ func TestRateLimitConfigUnmarshalsTheJSONTheCoreEmits(t *testing.T) {
 	}
 	if !bare.RateLimit.unlimited() {
 		t.Error("a config without rate_limit must read as unlimited")
+	}
+}
+
+// Refilling must repay outstanding reservations before granting another burst.
+func TestBucketRefillRepaysDebtBeforeFilling(t *testing.T) {
+	for _, debt := range []int64{1500, maxFrameBytes / 2, maxFrameBytes, maxFrameBytes + 1500} {
+		t.Run(fmt.Sprint(debt), func(t *testing.T) {
+			clk := newFakeClock()
+			b := newTokenBucket(bucketCfg(12500, 100), clk.now)
+			b.reserve(b.capacity)
+			b.reserve(debt)
+			clk.advance(time.Duration(b.capacity) * time.Second / 125000)
+			b.waitNonNegative()
+			if want := b.capacity - debt; b.tokens != want {
+				t.Fatalf("tokens = %d, want %d after refilling one capacity with %d bytes of debt", b.tokens, want, debt)
+			}
+		})
+	}
+}
+
+func TestRxMaximumFramesRespectSustainedRate(t *testing.T) {
+	delivered := make(chan struct{}, 4)
+	inner := newFakeConn(func(p []byte) (int, error) {
+		delivered <- struct{}{}
+		return len(p), nil
+	})
+	c := newShapedConn(inner, 4, &RateLimitConfig{RX: bucketCfg(12500, 100)}, nil)
+	defer c.Close()
+	frame := qemuFrame(bytes.Repeat([]byte{0x42}, maxFrameBytes))
+	start := time.Now()
+	for i := 0; i < 4; i++ {
+		if _, err := c.Write(frame); err != nil {
+			t.Fatal(err)
+		}
+		select {
+		case <-delivered:
+		case <-time.After(5 * time.Second):
+			t.Fatal("frame was not delivered")
+		}
+	}
+	// 4 frames minus the initial bucket: 196647 bytes / 125000 B/s = 1.573s.
+	if elapsed := time.Since(start); elapsed < 1400*time.Millisecond {
+		t.Fatalf("elapsed = %v, want at least 1.4s at 1000 kbps after the initial burst", elapsed)
 	}
 }

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/shaper_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/shaper_test.go
@@ -1,0 +1,574 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"net"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// A shaper can only ever be too slow, never too fast: CI load, GC pauses and
+// scheduler noise all push measured throughput down, never up. So no test here
+// asserts a two-sided band. Where the failure mode is "did not limit at all" we
+// assert the floor; where it is "let too much through" we assert the ceiling;
+// never both on the same measurement.
+//
+// Almost everything below avoids the clock entirely instead, by driving
+// tokenBucket through an injected `now` and asserting exact durations.
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{t: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+}
+
+func (c *fakeClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
+// fakeConn is a net.Conn whose Write behaviour each test dictates. net.Pipe
+// cannot stand in for it: a pipe never returns ENOBUFS, and its synchronous
+// Write cannot be made to block independently of a reader.
+type fakeConn struct {
+	net.Conn
+	writeFn   func(p []byte) (int, error)
+	closed    atomic.Bool
+	closeOnce sync.Once
+	closeCh   chan struct{}
+	mu        sync.Mutex
+	written   [][]byte
+}
+
+func newFakeConn(writeFn func(p []byte) (int, error)) *fakeConn {
+	return &fakeConn{writeFn: writeFn, closeCh: make(chan struct{})}
+}
+
+func (f *fakeConn) Write(p []byte) (int, error) {
+	if f.writeFn != nil {
+		n, err := f.writeFn(p)
+		if err == nil {
+			f.mu.Lock()
+			f.written = append(f.written, append([]byte(nil), p...))
+			f.mu.Unlock()
+		}
+		return n, err
+	}
+	f.mu.Lock()
+	f.written = append(f.written, append([]byte(nil), p...))
+	f.mu.Unlock()
+	return len(p), nil
+}
+
+func (f *fakeConn) Read(p []byte) (int, error) { <-f.closeCh; return 0, io.EOF }
+
+func (f *fakeConn) Close() error {
+	f.closeOnce.Do(func() {
+		f.closed.Store(true)
+		close(f.closeCh)
+	})
+	return nil
+}
+
+func (f *fakeConn) frames() [][]byte {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([][]byte(nil), f.written...)
+}
+
+// qemuFrame prefixes a body with the 4-byte big-endian length tap.Switch uses
+// for the qemu protocol.
+func qemuFrame(body []byte) []byte {
+	out := make([]byte, 4+len(body))
+	binary.BigEndian.PutUint32(out[:4], uint32(len(body)))
+	copy(out[4:], body)
+	return out
+}
+
+func bucketCfg(size, refillMs int64) *TokenBucketConfig {
+	return &TokenBucketConfig{Size: size, RefillTimeMs: refillMs}
+}
+
+// ---------------------------------------------------------------------------
+// tier 1: token bucket against an injected clock, exact equality
+// ---------------------------------------------------------------------------
+func TestBucketReserveReturnsExactDeficitWait(t *testing.T) {
+	clk := newFakeClock()
+	// Capacity is floored to maxFrameBytes, but the rate must stay the
+	// configured one: 100000 B per 1000 ms.
+	b := newTokenBucket(bucketCfg(100000, 1000), clk.now)
+	if got := b.reserve(b.capacity); got != 0 {
+		t.Fatalf("draining a full bucket should not wait, got %v", got)
+	}
+	// 50000 bytes of deficit at 100000 B/s is exactly 500ms.
+	if got := b.reserve(50000); got != 500*time.Millisecond {
+		t.Fatalf("reserve wait = %v, want 500ms", got)
+	}
+	clk.advance(500 * time.Millisecond)
+	if got := b.waitNonNegative(); got != 0 {
+		t.Fatalf("after sleeping off the deficit the wait should be 0, got %v", got)
+	}
+}
+
+// The capacity floor must not become a rate increase. A box configured well
+// below maxFrameBytes still gets its configured bytes per second; only its
+// burst is raised.
+func TestBucketCapacityFloorDoesNotChangeTheRate(t *testing.T) {
+	clk := newFakeClock()
+	b := newTokenBucket(bucketCfg(1000, 1000), clk.now) // 1000 B/s
+	if b.capacity != maxFrameBytes {
+		t.Fatalf("capacity = %d, want it floored to %d", b.capacity, maxFrameBytes)
+	}
+	b.reserve(b.capacity) // drain
+	// 2000 bytes at the configured 1000 B/s is 2s — not 2000/65550 s, which is
+	// what deriving the rate from the floored capacity would have produced.
+	if got := b.reserve(2000); got != 2*time.Second {
+		t.Fatalf("reserve wait = %v, want 2s (rate must come from the config, not the floor)", got)
+	}
+}
+
+func TestBucketOneTimeBurstIsSpentFirstAndNeverRefilled(t *testing.T) {
+	clk := newFakeClock()
+	cfg := bucketCfg(1000, 1000)
+	cfg.OneTimeBurst = 5000
+	b := newTokenBucket(cfg, clk.now)
+	// The burst absorbs the charge, leaving the sustained tokens untouched.
+	before := b.tokens
+	if got := b.reserve(5000); got != 0 {
+		t.Fatalf("one-time burst should absorb the charge, got wait %v", got)
+	}
+	if b.tokens != before {
+		t.Fatalf("sustained tokens = %d, want them untouched at %d", b.tokens, before)
+	}
+	if b.oneTime != 0 {
+		t.Fatalf("one-time burst = %d, want it fully spent", b.oneTime)
+	}
+	// Refilling never restores it.
+	clk.advance(time.Hour)
+	b.reserve(0)
+	if b.oneTime != 0 {
+		t.Fatalf("one-time burst = %d after refill, want it to stay spent", b.oneTime)
+	}
+}
+
+func TestBucketRefillClampsAtCapacity(t *testing.T) {
+	clk := newFakeClock()
+	b := newTokenBucket(bucketCfg(100000, 1000), clk.now)
+	b.reserve(b.capacity)
+	clk.advance(10 * time.Second) // ten refill periods
+	b.reserve(0)
+	if b.tokens != b.capacity {
+		t.Fatalf("tokens = %d after a long idle, want them clamped to capacity %d", b.tokens, b.capacity)
+	}
+}
+
+// Sub-token calls must not discard the elapsed remainder, or a fast caller
+// could starve the bucket forever.
+func TestBucketKeepsSubTokenRemainder(t *testing.T) {
+	clk := newFakeClock()
+	b := newTokenBucket(bucketCfg(1000, 1000), clk.now) // 1 token per ms
+	b.reserve(b.capacity)
+	for i := 0; i < 100; i++ {
+		clk.advance(100 * time.Microsecond) // a tenth of a token each
+		b.reserve(0)
+	}
+	// 100 * 100us = 10ms of accrual = 10 tokens.
+	if b.tokens != 10 {
+		t.Fatalf("tokens = %d, want 10 (sub-token remainders must accumulate)", b.tokens)
+	}
+}
+
+func TestRateLimitConfigValidateRejectsBadInput(t *testing.T) {
+	for name, cfg := range map[string]*RateLimitConfig{
+		"zero refill":     {TX: &TokenBucketConfig{Size: 1000, RefillTimeMs: 0}},
+		"negative refill": {TX: &TokenBucketConfig{Size: 1000, RefillTimeMs: -1}},
+		"negative burst":  {RX: &TokenBucketConfig{Size: 1000, RefillTimeMs: 100, OneTimeBurst: -1}},
+		"size overflow":   {RX: &TokenBucketConfig{Size: 1 << 62, RefillTimeMs: 100}},
+	} {
+		if err := cfg.Validate(); err == nil {
+			t.Errorf("%s: Validate() = nil, want an error", name)
+		}
+	}
+	// Unlimited in either shape is valid and must not be rejected.
+	for name, cfg := range map[string]*RateLimitConfig{
+		"nil config":    nil,
+		"both nil":      {},
+		"zero size":     {TX: &TokenBucketConfig{Size: 0}},
+		"one direction": {TX: bucketCfg(1000, 100)},
+	} {
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("%s: Validate() = %v, want nil", name, err)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// tier 2: framer, pure and exhaustive
+// ---------------------------------------------------------------------------
+// Splitting the same stream at every possible offset is the highest-value test
+// here: the accounting must not depend on how the reads happen to land.
+func TestFramerConsumeSplitAtEveryOffset(t *testing.T) {
+	bodies := [][]byte{
+		bytes.Repeat([]byte{0xAA}, 60),
+		bytes.Repeat([]byte{0xBB}, 1514),
+		bytes.Repeat([]byte{0xCC}, 65549),
+	}
+	var stream []byte
+	wantBytes := 0
+	for _, b := range bodies {
+		stream = append(stream, qemuFrame(b)...)
+		wantBytes += len(b)
+	}
+	for split := 1; split < len(stream); split++ {
+		f := &framer{hdrLen: 4}
+		gotBytes, gotFrames := 0, 0
+		for i := 0; i < len(stream); i += split {
+			end := i + split
+			if end > len(stream) {
+				end = len(stream)
+			}
+			fb, fr := f.consume(stream[i:end])
+			gotBytes += fb
+			gotFrames += fr
+		}
+		if gotBytes != wantBytes {
+			t.Fatalf("split %d: frameBytes = %d, want %d", split, gotBytes, wantBytes)
+		}
+		if gotFrames != len(bodies) {
+			t.Fatalf("split %d: frames = %d, want %d", split, gotFrames, len(bodies))
+		}
+	}
+}
+
+// The whole point of the framer: length prefixes are not billed. Charging raw
+// socket bytes would bill 4 extra per frame on Linux and none on macOS.
+func TestFramerExcludesTheLengthPrefixFromTheCharge(t *testing.T) {
+	body := bytes.Repeat([]byte{0x01}, 66) // a bare TCP ACK
+	f := &framer{hdrLen: 4}
+	frameBytes, frames := f.consume(qemuFrame(body))
+	if frameBytes != len(body) {
+		t.Fatalf("frameBytes = %d, want %d (the 4-byte prefix must not be charged)", frameBytes, len(body))
+	}
+	if frames != 1 {
+		t.Fatalf("frames = %d, want 1", frames)
+	}
+}
+
+func TestFramerZeroHeaderIsPassthrough(t *testing.T) {
+	f := &framer{hdrLen: 0}
+	buf := bytes.Repeat([]byte{0x02}, 1500)
+	frameBytes, frames := f.consume(buf)
+	if frameBytes != len(buf) || frames != 1 {
+		t.Fatalf("consume = (%d, %d), want (%d, 1)", frameBytes, frames, len(buf))
+	}
+}
+
+// hdrLen is a parameter, not a constant: hyperkit uses a 2-byte little-endian
+// prefix. A hardcoded 4 would decode garbage here.
+func TestFramerHandlesHyperkitTwoByteHeader(t *testing.T) {
+	body := bytes.Repeat([]byte{0x03}, 300)
+	frame := make([]byte, 2+len(body))
+	binary.LittleEndian.PutUint16(frame[:2], uint16(len(body)))
+	copy(frame[2:], body)
+	f := &framer{hdrLen: 2}
+	frameBytes, frames := f.consume(frame)
+	if frameBytes != len(body) || frames != 1 {
+		t.Fatalf("consume = (%d, %d), want (%d, 1)", frameBytes, frames, len(body))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// tier 3: shapedConn invariants
+// ---------------------------------------------------------------------------
+func TestUnlimitedConfigReturnsUnwrappedConn(t *testing.T) {
+	c := newFakeConn(nil)
+	for name, cfg := range map[string]*RateLimitConfig{
+		"nil":       nil,
+		"empty":     {},
+		"zero size": {TX: &TokenBucketConfig{Size: 0}, RX: &TokenBucketConfig{Size: 0}},
+	} {
+		if got := wrapConn(c, 4, cfg); got != net.Conn(c) {
+			t.Errorf("%s: wrapConn returned a wrapper, want the conn untouched", name)
+		}
+	}
+}
+
+// Guards pkg/tap/switch.go:119-124 (txPkt holds writeLock and connLock across
+// the write) and :186 (any non-ENOBUFS error disconnects the VM). Write must
+// therefore never block and never fail, whatever the inner conn does.
+func TestRxWriteNeverBlocksAndNeverErrors(t *testing.T) {
+	blocked := make(chan struct{})
+	inner := newFakeConn(func(p []byte) (int, error) {
+		<-blocked // never returns for the duration of the test
+		return len(p), nil
+	})
+	defer close(blocked)
+	cfg := &RateLimitConfig{RX: bucketCfg(1_000_000, 100)}
+	c := newShapedConn(inner, 4, cfg, nil)
+	defer c.Close()
+	frame := qemuFrame(bytes.Repeat([]byte{0x04}, 1500))
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 10000; i++ {
+			n, err := c.Write(frame)
+			if err != nil {
+				t.Errorf("Write returned error %v; txBuf would disconnect the VM", err)
+				return
+			}
+			if n != len(frame) {
+				t.Errorf("Write returned n = %d, want %d", n, len(frame))
+				return
+			}
+		}
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("10000 writes did not complete; Write must never block")
+	}
+}
+
+// The regression test for the deadlock described on Close: closing runs with the
+// switch's writeLock held, so it must not wait for a pacer that may be parked
+// inside Conn.Write.
+func TestCloseDoesNotBlockWhilePacerIsWriting(t *testing.T) {
+	var inner *fakeConn
+	inner = newFakeConn(func(p []byte) (int, error) {
+		<-inner.closeCh // unblocks only when the conn is closed
+		return 0, net.ErrClosed
+	})
+	cfg := &RateLimitConfig{RX: bucketCfg(1_000_000, 100)}
+	c := newShapedConn(inner, 4, cfg, nil)
+	if _, err := c.Write(qemuFrame(bytes.Repeat([]byte{0x05}, 1500))); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	// Give the pacer a moment to pick the frame up and park in Write.
+	time.Sleep(50 * time.Millisecond)
+	done := make(chan struct{})
+	go func() { _ = c.Close(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close blocked on the pacer; with the switch's writeLock held this deadlocks every TX path")
+	}
+}
+
+func TestRxQueueFullDropsAndCounts(t *testing.T) {
+	blocked := make(chan struct{})
+	inner := newFakeConn(func(p []byte) (int, error) {
+		<-blocked
+		return len(p), nil
+	})
+	defer close(blocked)
+	// Smallest queue the bounds allow: 2 * maxFrameBytes, 16 frames.
+	cfg := &RateLimitConfig{RX: bucketCfg(1000, 1000)}
+	c := newShapedConn(inner, 4, cfg, nil)
+	defer c.Close()
+	frame := qemuFrame(bytes.Repeat([]byte{0x06}, 1500))
+	for i := 0; i < 200; i++ {
+		if _, err := c.Write(frame); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+	got := c.stats.snapshot()
+	if got.RxDroppedFrames == 0 {
+		t.Fatal("no frames dropped; a bounded queue must shed load once full")
+	}
+	if got.RxDroppedBytes == 0 {
+		t.Fatal("dropped bytes not counted")
+	}
+}
+
+func TestRxPacerRetriesOnENOBUFS(t *testing.T) {
+	var attempts atomic.Int64
+	inner := newFakeConn(func(p []byte) (int, error) {
+		if attempts.Add(1) <= 3 {
+			return 0, syscall.ENOBUFS
+		}
+		return len(p), nil
+	})
+	cfg := &RateLimitConfig{RX: bucketCfg(1_000_000, 100)}
+	c := newShapedConn(inner, 4, cfg, nil)
+	defer c.Close()
+	body := bytes.Repeat([]byte{0x07}, 1500)
+	frame := qemuFrame(body)
+	if _, err := c.Write(frame); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	deadline := time.After(2 * time.Second)
+	for {
+		if written := inner.frames(); len(written) == 1 {
+			if !bytes.Equal(written[0], frame) {
+				t.Fatal("frame was altered across the ENOBUFS retries")
+			}
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("frame never delivered after ENOBUFS; attempts = %d", attempts.Load())
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+	if attempts.Load() < 4 {
+		t.Fatalf("attempts = %d, want the write retried past the ENOBUFS runs", attempts.Load())
+	}
+}
+
+func TestRxPacerClosesConnOnOtherWriteError(t *testing.T) {
+	inner := newFakeConn(func(p []byte) (int, error) { return 0, io.ErrClosedPipe })
+	cfg := &RateLimitConfig{RX: bucketCfg(1_000_000, 100)}
+	c := newShapedConn(inner, 4, cfg, nil)
+	defer c.Close()
+	if _, err := c.Write(qemuFrame(bytes.Repeat([]byte{0x08}, 1500))); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	deadline := time.After(2 * time.Second)
+	for !inner.closed.Load() {
+		select {
+		case <-deadline:
+			t.Fatal("pacer did not close the inner conn; rxStream would never unwind and the switch would leak the connection")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+}
+
+func TestFramesSurviveShapingIntactAndInOrder(t *testing.T) {
+	inner := newFakeConn(nil)
+	cfg := &RateLimitConfig{RX: bucketCfg(100_000_000, 100)} // generous
+	c := newShapedConn(inner, 4, cfg, nil)
+	defer c.Close()
+	const count = 100
+	want := make([][]byte, count)
+	for i := 0; i < count; i++ {
+		body := bytes.Repeat([]byte{byte(i)}, 100+i)
+		want[i] = qemuFrame(body)
+		if _, err := c.Write(want[i]); err != nil {
+			t.Fatalf("Write %d: %v", i, err)
+		}
+	}
+	deadline := time.After(5 * time.Second)
+	for len(inner.frames()) < count {
+		select {
+		case <-deadline:
+			t.Fatalf("only %d of %d frames delivered", len(inner.frames()), count)
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+	got := inner.frames()
+	for i := range want {
+		if !bytes.Equal(got[i], want[i]) {
+			t.Fatalf("frame %d differs; the shaper must not reframe or reorder", i)
+		}
+	}
+}
+
+// TX shaping: assert the floor only. Load can only make this slower.
+func TestTxShapingTakesAtLeastTheConfiguredTime(t *testing.T) {
+	const rate = 64 * 1024 // bytes/sec
+	const total = 256 * 1024
+	server, client := net.Pipe()
+	go func() {
+		buf := bytes.Repeat([]byte{0x09}, 4096)
+		for sent := 0; sent < total; sent += len(buf) {
+			if _, err := server.Write(buf); err != nil {
+				return
+			}
+		}
+	}()
+	defer server.Close()
+	cfg := &RateLimitConfig{TX: bucketCfg(rate, 1000)}
+	c := newShapedConn(client, 0, cfg, nil)
+	defer c.Close()
+	start := time.Now()
+	buf := make([]byte, 4096)
+	for read := 0; read < total; {
+		n, err := c.Read(buf)
+		if err != nil {
+			t.Fatalf("Read: %v", err)
+		}
+		read += n
+	}
+	elapsed := time.Since(start)
+	// Lower bound only. total/rate is 4s, minus a full bucket of free burst
+	// (~1s), minus the final read: deficit charging bills after the fact, so
+	// the last chunk's cost is never slept off. That puts the true minimum
+	// near 2.94s. Floor the assertion below it — the failure this guards is
+	// "not shaped at all", which would land near zero, so a wide margin costs
+	// nothing and load can only push the measurement up.
+	if min := 2500 * time.Millisecond; elapsed < min {
+		t.Fatalf("elapsed = %v, want at least %v — TX was not shaped", elapsed, min)
+	}
+}
+
+func TestQueueBoundsFloorAvoidsSecondsOfStandingQueue(t *testing.T) {
+	// 1 Mbit/s. An eight-frame floor would be 512KiB here, over four seconds of
+	// buffering; the small floor keeps latency usable and drops instead.
+	queueBytes, queueFrames := queueBounds(bucketCfg(125_000, 1000))
+	if queueBytes != 2*maxFrameBytes {
+		t.Fatalf("queueBytes = %d, want the %d floor", queueBytes, 2*maxFrameBytes)
+	}
+	if queueFrames < 16 {
+		t.Fatalf("queueFrames = %d, want at least 16", queueFrames)
+	}
+	// A fast link gets one refill period of buffering, capped at 4MiB.
+	queueBytes, _ = queueBounds(bucketCfg(12_500_000, 1000)) // 100 Mbit/s
+	if want := int64(1_250_000); queueBytes != want {
+		t.Fatalf("queueBytes = %d, want %d (100ms of buffering)", queueBytes, want)
+	}
+	queueBytes, _ = queueBounds(bucketCfg(1_250_000_000, 1000)) // 10 Gbit/s
+	if want := int64(4 << 20); queueBytes != want {
+		t.Fatalf("queueBytes = %d, want it capped at %d", queueBytes, want)
+	}
+}
+
+// End-to-end on the real switch: with a limit configured, wrapConn sits in the
+// data path gvproxy_create builds, and ordinary forwarding must still work.
+// This is an integration check, not a rate check — the pacing and drop
+// behaviour is covered deterministically above.
+func TestShapedConnDoesNotBreakForwarding(t *testing.T) {
+	cfg := testGvproxyConfig()
+	cfg.RateLimit = &RateLimitConfig{
+		TX: bucketCfg(10_000_000, 1000),
+		RX: bucketCfg(10_000_000, 1000),
+	}
+	tap := startNetworkWith(t, cfg)
+
+	conn, port := listenUDP(t)
+	defer conn.Close()
+
+	payload := []byte("shaped-but-still-forwarded")
+	tap.send(t, udpFrame(t, cfg.HostIP, port, payload))
+
+	buf := make([]byte, 1024)
+	if err := conn.SetReadDeadline(time.Now().Add(forwardWindow)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	n, _, err := conn.ReadFrom(buf)
+	if err != nil {
+		t.Fatalf("shaped conn broke UDP forwarding: %v", err)
+	}
+	if got := string(buf[:n]); got != string(payload) {
+		t.Fatalf("payload = %q, want %q", got, payload)
+	}
+}

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/shaper_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/shaper_test.go
@@ -3,7 +3,9 @@ package main
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/json"
 	"io"
+	"math/bits"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -201,6 +203,9 @@ func TestRateLimitConfigValidateRejectsBadInput(t *testing.T) {
 		"negative refill": {TX: &TokenBucketConfig{Size: 1000, RefillTimeMs: -1}},
 		"negative burst":  {RX: &TokenBucketConfig{Size: 1000, RefillTimeMs: 100, OneTimeBurst: -1}},
 		"size overflow":   {RX: &TokenBucketConfig{Size: 1 << 62, RefillTimeMs: 100}},
+		// refillNs() multiplies by 1e6 before any guard in refillLocked runs,
+		// so an unbounded period wraps there instead.
+		"refill overflow": {TX: &TokenBucketConfig{Size: 1000, RefillTimeMs: 1 << 40}},
 	} {
 		if err := cfg.Validate(); err == nil {
 			t.Errorf("%s: Validate() = nil, want an error", name)
@@ -521,10 +526,15 @@ func TestTxShapingTakesAtLeastTheConfiguredTime(t *testing.T) {
 	}
 }
 
-func TestQueueBoundsFloorAvoidsSecondsOfStandingQueue(t *testing.T) {
-	// 1 Mbit/s. An eight-frame floor would be 512KiB here, over four seconds of
-	// buffering; the small floor keeps latency usable and drops instead.
+func TestQueueBoundsFloorFitsAMaximumFrame(t *testing.T) {
+	// 1 Mbit/s. The floor is a capacity requirement — the queue must hold a
+	// maximum-size frame or such a frame could never be enqueued — and at this
+	// rate it is roughly a second of standing queue, which is the cost of that
+	// guarantee rather than something the floor avoids.
 	queueBytes, queueFrames := queueBounds(bucketCfg(125_000, 1000))
+	if queueBytes < maxFrameBytes {
+		t.Fatalf("queueBytes = %d, must hold at least one %d-byte frame", queueBytes, maxFrameBytes)
+	}
 	if queueBytes != 2*maxFrameBytes {
 		t.Fatalf("queueBytes = %d, want the %d floor", queueBytes, 2*maxFrameBytes)
 	}
@@ -570,5 +580,94 @@ func TestShapedConnDoesNotBreakForwarding(t *testing.T) {
 	}
 	if got := string(buf[:n]); got != string(payload) {
 		t.Fatalf("payload = %q, want %q", got, payload)
+	}
+}
+
+// A bucket large enough that refillNs*capacity overflows int64 must still meter.
+// Before the guards in refillLocked the wrapped product made the "a full period
+// has passed" test always true, so every call refilled the bucket completely and
+// the cap stopped applying — silently, with no error anywhere.
+func TestBucketDoesNotOverflowOnHugeCapacity(t *testing.T) {
+	clk := newFakeClock()
+	// 1e12 bytes per 100ms: refillNs(1e8) * capacity(1e12) is ~1e20, well past
+	// int64. Validate accepts sizes far larger still.
+	const size = 1_000_000_000_000
+	b := newTokenBucket(bucketCfg(size, 100), clk.now)
+
+	// Confirm the premise precisely: the true product does not fit in int64, so
+	// the old threshold was computed from a wrapped value. (1e20 wraps to a
+	// positive number here, which is exactly why a sign check would miss it.)
+	if hi, _ := bits.Mul64(uint64(b.refillNs), uint64(b.capacity)); hi == 0 {
+		t.Fatalf("test no longer exercises the overflow: refillNs*capacity fits in 64 bits")
+	}
+
+	// Drain, then let a fraction of a period pass. A correct bucket is still in
+	// deficit; an overflowing one has silently refilled to full.
+	b.reserve(b.capacity)
+	clk.advance(10 * time.Millisecond) // a tenth of the refill period
+	b.reserve(0)
+
+	if b.tokens == b.capacity {
+		t.Fatal("bucket refilled to capacity after a tenth of a period; the limit is not being applied")
+	}
+	if want := int64(size / 10); b.tokens != want {
+		t.Fatalf("tokens = %d, want %d (one tenth of a period's accrual)", b.tokens, want)
+	}
+}
+
+// The deficit-to-wait conversion carries the same product and the same risk.
+func TestBucketReserveDoesNotOverflowOnHugeDeficit(t *testing.T) {
+	clk := newFakeClock()
+	b := newTokenBucket(bucketCfg(1_000_000_000_000, 100), clk.now)
+
+	b.reserve(b.capacity)
+	if d := b.reserve(b.capacity); d <= 0 {
+		t.Fatalf("wait = %v, want a positive duration; a wrapped product reads as no wait at all", d)
+	}
+}
+
+// The Rust core serializes this config; a rename on either side would silently
+// disable shaping rather than fail, so the contract is pinned from both ends.
+// The Rust half lives in net/gvproxy/config.rs
+// (rate_limit_serializes_with_the_keys_the_bridge_reads) and asserts the same
+// literal shape this test unmarshals.
+func TestRateLimitConfigUnmarshalsTheJSONTheCoreEmits(t *testing.T) {
+	// Byte-for-byte what GvproxyRateLimit produces for
+	// NetBandwidth { tx_kbps: 10_000, rx_kbps: 20_000 }.
+	const payload = `{"rate_limit":{"rx":{"size":250000,"refill_time_ms":100},` +
+		`"tx":{"size":125000,"refill_time_ms":100}}}`
+
+	var cfg GvproxyConfig
+	if err := json.Unmarshal([]byte(payload), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if cfg.RateLimit == nil {
+		t.Fatal("rate_limit did not bind; the key the core emits is not the key this struct reads")
+	}
+	if err := cfg.RateLimit.Validate(); err != nil {
+		t.Fatalf("the core's own output must validate: %v", err)
+	}
+
+	rx, tx := cfg.RateLimit.RX, cfg.RateLimit.TX
+	if rx == nil || tx == nil {
+		t.Fatalf("rx/tx did not bind: rx=%v tx=%v", rx, tx)
+	}
+	// Both directions must come back out at the rate the core meant: kbps*125
+	// bytes/sec, i.e. size*1000/refill_time_ms.
+	if got, want := rx.bytesPerSec(), int64(20_000*125); got != want {
+		t.Errorf("rx rate = %d B/s, want %d", got, want)
+	}
+	if got, want := tx.bytesPerSec(), int64(10_000*125); got != want {
+		t.Errorf("tx rate = %d B/s, want %d", got, want)
+	}
+
+	// And an omitted rate_limit must stay nil rather than bind an empty struct,
+	// which is what makes wrapConn a no-op for an uncapped box.
+	var bare GvproxyConfig
+	if err := json.Unmarshal([]byte(`{"socket_path":"/tmp/x.sock"}`), &bare); err != nil {
+		t.Fatalf("unmarshal bare: %v", err)
+	}
+	if !bare.RateLimit.unlimited() {
+		t.Error("a config without rate_limit must read as unlimited")
 	}
 }

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/shaper_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/shaper_test.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/bits"
 	"net"
+	"os"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -486,6 +488,224 @@ func TestFramesSurviveShapingIntactAndInOrder(t *testing.T) {
 		if !bytes.Equal(got[i], want[i]) {
 			t.Fatalf("frame %d differs; the shaper must not reframe or reorder", i)
 		}
+	}
+}
+
+// Debt lasts longer than the test timeout, so a missed deadline wakeup fails
+// before tokens could become available on their own.
+const (
+	deadlineTestQEMUHeaderBytes       = 4
+	deadlineTestBucketBytes     int64 = 1000
+	deadlineTestRefillPeriod          = time.Second
+	deadlineTestTXDebtWait            = 30 * time.Second
+	deadlineTestTXDebtBytes           = deadlineTestBucketBytes * int64(deadlineTestTXDebtWait/deadlineTestRefillPeriod)
+	deadlineTestWaitTimeout           = 2 * time.Second
+	deadlineTestExpiredOffset         = -time.Second
+)
+
+// Keep the bucket clock frozen so deadline updates cannot repay or hide debt.
+// The clock notification synchronizes with Read entering the TX throttle.
+func newTXDebtConn(t *testing.T) (*shapedConn, <-chan struct{}) {
+	t.Helper()
+	inner, peer := net.Pipe()
+	clock := newFakeClock()
+	cfg := &RateLimitConfig{TX: bucketCfg(deadlineTestBucketBytes, deadlineTestRefillPeriod.Milliseconds())}
+	c := newShapedConn(inner, deadlineTestQEMUHeaderBytes, cfg, clock.now)
+	c.tx.reserve(c.tx.capacity + deadlineTestTXDebtBytes)
+	started := make(chan struct{}, 1)
+	c.tx.now = func() time.Time {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		return clock.now()
+	}
+	t.Cleanup(func() { _ = c.Close(); _ = peer.Close() })
+	return c, started
+}
+
+func startTXRead(t *testing.T, c *shapedConn, started <-chan struct{}) <-chan error {
+	t.Helper()
+	result := make(chan error, 1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		var buf [1]byte
+		n, err := c.Read(buf[:])
+		if n != 0 {
+			err = fmt.Errorf("Read returned %d bytes while TX was in debt", n)
+		}
+		result <- err
+	}()
+	t.Cleanup(func() {
+		_ = c.Close()
+		select {
+		case <-done:
+		case <-time.After(deadlineTestWaitTimeout):
+			t.Error("TX Read did not exit after Close")
+		}
+	})
+	select {
+	case <-started:
+	case <-time.After(deadlineTestWaitTimeout):
+		t.Fatal("Read did not enter the TX throttle")
+	}
+	return result
+}
+
+func TestTxReadDeadlineInterruptsThrottle(t *testing.T) {
+	const deadlineDelay = 50 * time.Millisecond
+
+	for _, method := range []string{"SetReadDeadline", "SetDeadline"} {
+		for _, preset := range []bool{false, true} {
+			for _, offset := range []time.Duration{deadlineTestExpiredOffset, deadlineDelay} {
+				t.Run(fmt.Sprintf("%s/preset=%t/offset=%s", method, preset, offset), func(t *testing.T) {
+					t.Parallel()
+					c, started := newTXDebtConn(t)
+					setDeadline := c.SetReadDeadline
+					if method == "SetDeadline" {
+						setDeadline = c.SetDeadline
+					}
+					set := func() {
+						if err := setDeadline(time.Now().Add(offset)); err != nil {
+							t.Fatal(err)
+						}
+					}
+					if preset {
+						set()
+					}
+					result := startTXRead(t, c, started)
+					if !preset {
+						set()
+					}
+					select {
+					case err := <-result:
+						var timeout net.Error
+						if !errors.Is(err, os.ErrDeadlineExceeded) || !errors.As(err, &timeout) || !timeout.Timeout() {
+							t.Fatalf("Read error = %v, want a deadline timeout", err)
+						}
+					case <-time.After(deadlineTestWaitTimeout):
+						t.Fatalf("read deadline did not interrupt TX throttle (%s debt)", deadlineTestTXDebtWait)
+					}
+					c.tx.mu.Lock()
+					tokens := c.tx.tokens
+					c.tx.mu.Unlock()
+					if tokens != -deadlineTestTXDebtBytes {
+						t.Fatalf("deadline changed TX debt: tokens = %d, want %d", tokens, -deadlineTestTXDebtBytes)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestTxReadDeadlineCanBeExtendedOrCleared(t *testing.T) {
+	const (
+		initialDeadlineDelay      = 500 * time.Millisecond
+		extendedDeadlineDelay     = time.Minute
+		deadlineObservationMargin = 50 * time.Millisecond
+	)
+
+	for _, method := range []string{"SetReadDeadline", "SetDeadline"} {
+		for _, clear := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/clear=%t", method, clear), func(t *testing.T) {
+				t.Parallel()
+				c, started := newTXDebtConn(t)
+				setDeadline := c.SetReadDeadline
+				if method == "SetDeadline" {
+					setDeadline = c.SetDeadline
+				}
+				deadline := time.Now().Add(initialDeadlineDelay)
+				if err := setDeadline(deadline); err != nil {
+					t.Fatal(err)
+				}
+				result := startTXRead(t, c, started)
+				updated := time.Now().Add(extendedDeadlineDelay)
+				if clear {
+					updated = time.Time{}
+				}
+				if err := setDeadline(updated); err != nil {
+					t.Fatal(err)
+				}
+				select {
+				case err := <-result:
+					t.Fatalf("Read returned after deadline update: %v", err)
+				case <-time.After(time.Until(deadline) + deadlineObservationMargin):
+				}
+				_ = c.Close()
+				select {
+				case err := <-result:
+					if !errors.Is(err, net.ErrClosed) {
+						t.Fatalf("Read error = %v, want net.ErrClosed", err)
+					}
+				case <-time.After(deadlineTestWaitTimeout):
+					t.Fatal("Close did not interrupt TX throttle")
+				}
+			})
+		}
+	}
+}
+
+func TestShapedConnDeadlineSettersPreserveUnderlyingErrors(t *testing.T) {
+	const observationWindow = 100 * time.Millisecond
+
+	for _, method := range []string{"SetReadDeadline", "SetDeadline"} {
+		t.Run(method, func(t *testing.T) {
+			t.Parallel()
+			c, started := newTXDebtConn(t)
+			_ = c.Conn.Close()
+			setDeadline := c.SetReadDeadline
+			if method == "SetDeadline" {
+				setDeadline = c.SetDeadline
+			}
+			if err := setDeadline(time.Now().Add(deadlineTestExpiredOffset)); !errors.Is(err, io.ErrClosedPipe) {
+				t.Fatalf("deadline setter error = %v, want io.ErrClosedPipe", err)
+			}
+			result := startTXRead(t, c, started)
+			select {
+			case err := <-result:
+				t.Fatalf("failed setter changed the TX deadline: %v", err)
+			case <-time.After(observationWindow):
+			}
+		})
+	}
+}
+
+func TestShapedConnSetDeadlineAlsoSetsWriteDeadline(t *testing.T) {
+	c, _ := newTXDebtConn(t)
+	if err := c.SetDeadline(time.Now().Add(deadlineTestExpiredOffset)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Write([]byte{1}); !errors.Is(err, os.ErrDeadlineExceeded) {
+		t.Fatalf("Write error = %v, want a deadline timeout", err)
+	}
+}
+
+func TestShapedConnReadDeadlineDoesNotStopRXPacer(t *testing.T) {
+	const payloadBytes = 100
+
+	inner, peer := net.Pipe()
+	cfg := &RateLimitConfig{RX: bucketCfg(deadlineTestBucketBytes, deadlineTestRefillPeriod.Milliseconds())}
+	c := newShapedConn(inner, deadlineTestQEMUHeaderBytes, cfg, newFakeClock().now)
+	defer c.Close()
+	defer peer.Close()
+	c.rx.reserve(c.rx.capacity)
+	if err := c.SetReadDeadline(time.Now().Add(deadlineTestExpiredOffset)); err != nil {
+		t.Fatal(err)
+	}
+	if err := peer.SetReadDeadline(time.Now().Add(deadlineTestWaitTimeout)); err != nil {
+		t.Fatal(err)
+	}
+	frame := qemuFrame(bytes.Repeat([]byte{1}, payloadBytes))
+	if _, err := c.Write(frame); err != nil {
+		t.Fatal(err)
+	}
+	got := make([]byte, len(frame))
+	if _, err := io.ReadFull(peer, got); err != nil {
+		t.Fatalf("RX pacer stopped at read deadline: %v", err)
+	}
+	if !bytes.Equal(got, frame) {
+		t.Fatal("RX frame changed")
 	}
 }
 

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/shaper_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/shaper_test.go
@@ -162,14 +162,14 @@ func TestBucketOneTimeBurstIsSpentFirstAndNeverRefilled(t *testing.T) {
 	if b.tokens != before {
 		t.Fatalf("sustained tokens = %d, want them untouched at %d", b.tokens, before)
 	}
-	if b.oneTime != 0 {
-		t.Fatalf("one-time burst = %d, want it fully spent", b.oneTime)
+	if b.oneTimeBurst != 0 {
+		t.Fatalf("one-time burst = %d, want it fully spent", b.oneTimeBurst)
 	}
 	// Refilling never restores it.
 	clk.advance(time.Hour)
 	b.reserve(0)
-	if b.oneTime != 0 {
-		t.Fatalf("one-time burst = %d after refill, want it to stay spent", b.oneTime)
+	if b.oneTimeBurst != 0 {
+		t.Fatalf("one-time burst = %d after refill, want it to stay spent", b.oneTimeBurst)
 	}
 }
 
@@ -245,7 +245,7 @@ func TestFramerConsumeSplitAtEveryOffset(t *testing.T) {
 		wantBytes += len(b)
 	}
 	for split := 1; split < len(stream); split++ {
-		f := &framer{hdrLen: 4}
+		f := &framer{prefixLen: 4}
 		gotBytes, gotFrames := 0, 0
 		for i := 0; i < len(stream); i += split {
 			end := i + split
@@ -269,7 +269,7 @@ func TestFramerConsumeSplitAtEveryOffset(t *testing.T) {
 // socket bytes would bill 4 extra per frame on Linux and none on macOS.
 func TestFramerExcludesTheLengthPrefixFromTheCharge(t *testing.T) {
 	body := bytes.Repeat([]byte{0x01}, 66) // a bare TCP ACK
-	f := &framer{hdrLen: 4}
+	f := &framer{prefixLen: 4}
 	frameBytes, frames := f.consume(qemuFrame(body))
 	if frameBytes != len(body) {
 		t.Fatalf("frameBytes = %d, want %d (the 4-byte prefix must not be charged)", frameBytes, len(body))
@@ -280,7 +280,7 @@ func TestFramerExcludesTheLengthPrefixFromTheCharge(t *testing.T) {
 }
 
 func TestFramerZeroHeaderIsPassthrough(t *testing.T) {
-	f := &framer{hdrLen: 0}
+	f := &framer{prefixLen: 0}
 	buf := bytes.Repeat([]byte{0x02}, 1500)
 	frameBytes, frames := f.consume(buf)
 	if frameBytes != len(buf) || frames != 1 {
@@ -288,14 +288,14 @@ func TestFramerZeroHeaderIsPassthrough(t *testing.T) {
 	}
 }
 
-// hdrLen is a parameter, not a constant: hyperkit uses a 2-byte little-endian
+// prefixLen is a parameter, not a constant: hyperkit uses a 2-byte little-endian
 // prefix. A hardcoded 4 would decode garbage here.
 func TestFramerHandlesHyperkitTwoByteHeader(t *testing.T) {
 	body := bytes.Repeat([]byte{0x03}, 300)
 	frame := make([]byte, 2+len(body))
 	binary.LittleEndian.PutUint16(frame[:2], uint16(len(body)))
 	copy(frame[2:], body)
-	f := &framer{hdrLen: 2}
+	f := &framer{prefixLen: 2}
 	frameBytes, frames := f.consume(frame)
 	if frameBytes != len(body) || frames != 1 {
 		t.Fatalf("consume = (%d, %d), want (%d, 1)", frameBytes, frames, len(body))
@@ -511,9 +511,9 @@ func newTXDebtConn(t *testing.T) (*shapedConn, <-chan struct{}) {
 	clock := newFakeClock()
 	cfg := &RateLimitConfig{TX: bucketCfg(deadlineTestBucketBytes, deadlineTestRefillPeriod.Milliseconds())}
 	c := newShapedConn(inner, deadlineTestQEMUHeaderBytes, cfg, clock.now)
-	c.tx.reserve(c.tx.capacity + deadlineTestTXDebtBytes)
+	c.txTokenBucket.reserve(c.txTokenBucket.capacity + deadlineTestTXDebtBytes)
 	started := make(chan struct{}, 1)
-	c.tx.now = func() time.Time {
+	c.txTokenBucket.now = func() time.Time {
 		select {
 		case started <- struct{}{}:
 		default:
@@ -587,9 +587,9 @@ func TestTxReadDeadlineInterruptsThrottle(t *testing.T) {
 					case <-time.After(deadlineTestWaitTimeout):
 						t.Fatalf("read deadline did not interrupt TX throttle (%s debt)", deadlineTestTXDebtWait)
 					}
-					c.tx.mu.Lock()
-					tokens := c.tx.tokens
-					c.tx.mu.Unlock()
+					c.txTokenBucket.mu.Lock()
+					tokens := c.txTokenBucket.tokens
+					c.txTokenBucket.mu.Unlock()
 					if tokens != -deadlineTestTXDebtBytes {
 						t.Fatalf("deadline changed TX debt: tokens = %d, want %d", tokens, -deadlineTestTXDebtBytes)
 					}
@@ -689,7 +689,7 @@ func TestShapedConnReadDeadlineDoesNotStopRXPacer(t *testing.T) {
 	c := newShapedConn(inner, deadlineTestQEMUHeaderBytes, cfg, newFakeClock().now)
 	defer c.Close()
 	defer peer.Close()
-	c.rx.reserve(c.rx.capacity)
+	c.rxTokenBucket.reserve(c.rxTokenBucket.capacity)
 	if err := c.SetReadDeadline(time.Now().Add(deadlineTestExpiredOffset)); err != nil {
 		t.Fatal(err)
 	}

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/shaper_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/shaper_test.go
@@ -854,7 +854,7 @@ func TestBucketReserveDoesNotOverflowOnHugeDeficit(t *testing.T) {
 // literal shape this test unmarshals.
 func TestRateLimitConfigUnmarshalsTheJSONTheCoreEmits(t *testing.T) {
 	// Byte-for-byte what GvproxyRateLimit produces for
-	// NetBandwidth { tx_kbps: 10_000, rx_kbps: 20_000 }.
+	// NetworkRateLimit { tx_kbps: 10_000, rx_kbps: 20_000 }.
 	const payload = `{"rate_limit":{"rx":{"size":250000,"refill_time_ms":100},` +
 		`"tx":{"size":125000,"refill_time_ms":100}}}`
 

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/udp_filter_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/udp_filter_test.go
@@ -57,6 +57,17 @@ func startNetwork(t *testing.T, allowNet []string) *guestTap {
 
 	cfg := testGvproxyConfig()
 	cfg.AllowNet = allowNet
+	return startNetworkWith(t, cfg)
+}
+
+// startNetworkWith is startNetwork's body, taking the whole config so a test can
+// set cfg.RateLimit and exercise the shaper on the same path gvproxy_create
+// uses. Note net.Pipe is synchronous and unbuffered: it can show pacing and RX
+// queueing, but it cannot show the TX socket-buffer backpressure chain, because
+// there is no buffer to fill.
+func startNetworkWith(t *testing.T, cfg GvproxyConfig) *guestTap {
+	t.Helper()
+
 	// Mirror gvproxy_create: only resolve hostname rules when an allow_net is
 	// present. An empty allow_net is the common case and needs no resolution;
 	// the nil zones/maps are safe because buildDNSZones and newAllowNetFilter
@@ -85,7 +96,7 @@ func startNetwork(t *testing.T, allowNet []string) *guestTap {
 
 	guestSide, stackSide := net.Pipe()
 	ctx, cancel := context.WithCancel(context.Background())
-	go func() { _ = vn.AcceptQemu(ctx, stackSide) }()
+	go func() { _ = vn.AcceptQemu(ctx, wrapConn(stackSide, 4, cfg.RateLimit)) }()
 	t.Cleanup(func() {
 		cancel()
 		_ = guestSide.Close()


### PR DESCRIPTION
## Call graph

```text
Before
  NetworkFlags::apply_to      (CLI · src/cli/src/cli.rs:1185)                     — mode + allowlist only
    └─ build_network_backend  (spawn · src/boxlite/src/litebox/init/tasks/vmm_spawn.rs:347)
         └─ GvproxyBackend::spec  (backend · src/boxlite/src/net/gvproxy/services.rs:336)
              └─ GvproxyInstance::from_config (shim · src/boxlite/src/net/gvproxy/instance.rs:86)
                   └─ create_instance (ffi · src/boxlite/src/net/gvproxy/ffi.rs:22)
                        └─ gvproxy_create (bridge · gvproxy-bridge/main.go:304)
                             └─ vn.AcceptQemu(ctx, acceptedConn)  (main.go:570)   — raw conn, unshaped

After
  NetworkFlags::apply_to      (CLI · src/cli/src/cli.rs:1184)                     — also sets advanced.network_rate_limit
    └─ build_network_backend  (spawn · vmm_spawn.rs:347)                          — carries it into NetworkBackendConfig
         └─ GvproxyBackend::spec  (backend · services.rs:336)                     — onto NetworkBackendSpec
              └─ GvproxyInstance::from_config (shim · instance.rs:86)             — GvproxyConfig::with_rate_limit
                   └─ bucket_from_kbps (config · config.rs:149)                   — kbit/s to a token bucket
                        └─ create_instance (ffi · ffi.rs:22)                      — rate_limit on the wire
                             └─ gvproxy_create (bridge · main.go:304)             — RateLimitConfig.Validate
                                  └─ wrapConn (shaper · gvproxy-bridge/shaper.go:413)   — NEW, nil config returns the conn as-is
                                       └─ vn.AcceptQemu(ctx, shapedConn)  (main.go:570)
                                            ├─ shapedConn.Read  (shaper.go:504)   — TX: charge after read, sleep off the deficit
                                            └─ shapedConn.Write (shaper.go:542)   — RX: bounded queue, paced by a goroutine
```

## Summary

Caps a box's network bandwidth per direction through `advanced.network_rate_limit` (`NetworkRateLimit`) and the `--net-tx-kbps`/`--net-rx-kbps` flags. The limit is enforced in the gvproxy bridge by shaping the guest's own link, so it covers TCP, UDP, ICMP and ARP with one budget per direction and cannot be turned off from inside the guest. The cap threads from the CLI to the bridge; before, nothing carried it and the guest link was handed to the switch unwrapped.

## Changes

- The cap is `advanced.network_rate_limit`, typed `NetworkRateLimit`, grouped with the other local-only expert knobs (`security`, `isolate_mounts`, `privileged`) rather than placed inside `NetworkConfig`: those object-shaped types are the REST wire form and deny unknown fields. `sanitize_remote` refuses it for remote runtimes and the wire type has no field to carry it, the same treatment `SecurityOptions` gets. An unlimited value is omitted from the serialized form, so an ordinary box's persisted options and exported manifest keep their previous shape.
- Internally the value travels as `rate_limit` on `NetworkBackendConfig` and `NetworkBackendSpec`, matching `GvproxyConfig::rate_limit`; validation errors name `advanced.network_rate_limit.<field>`.
- Directions follow Firecracker's net device and are named from the box's point of view — `tx` is what the box sends. The cap is on the interface, so inbound port-forward traffic counts against the same budget as a reply to an outbound request.
- TX is charged after the read, so the balance goes negative and the next read sleeps off the overshoot; declining to read is itself the backpressure. RX cannot do the same — `txPkt` holds `writeLock` and `connLock` across `conn.Write` and `txBuf` disconnects the VM on any non-`ENOBUFS` error — so it queues and drops instead, paced by a goroutine.
- A passive framer tracks frame boundaries so the buckets charge frame bytes rather than socket bytes. Billing the length prefix would cost Linux four bytes per frame and macOS none: 0.26% on a 1514-byte frame but 5.7% on a stream of ACKs, and inconsistent across platforms.
- `GvproxyInstance::new` took five positional arguments and would have taken six; it now takes the config it was assembling.

## How to verify

```bash
cd src/deps/libgvproxy-sys/gvproxy-bridge && go test -race ./...
cargo test -p boxlite --no-default-features --features rest --lib -- net::gvproxy runtime::options rest::
cargo test -p boxlite-cli --bins
cargo check --workspace --all-targets
```

End to end, against a host serving a 4 MiB file:

```bash
boxlite run --rm --net-rx-kbps 2000 alpine \
  sh -c 'wget -q -O /tmp/p http://host.boxlite.internal:PORT/payload.bin && wc -c < /tmp/p'
```

Measured 242 and 483 kB/s against 250 and 500 configured, and 253.6 kB/s on the tx side against 250 — measured at the receiver, since libkrun's 16 MiB `SO_SNDBUF` lets the guest finish writing long before the bytes are on the wire.

## Risks / rollout

- Default is uncapped, and an uncapped box gets the connection back unwrapped, so the shaper is not in the path at all.
- No automated test drives the CLI-to-bridge chain: a bandwidth assertion needs a real VM and tens of seconds of wall clock. The measurement above is manual.
- Shaper counters reach no operator surface. The live `/stats` path serves `vn.ServicesMux()` directly with no bridge-owned mux to inject into, so an RX queue overflow shows up only in a `Debug` log at close.
- macOS ships the tx cap enabled with no runtime guard. Its guest link is a datagram socket whose sender behaviour under a full receive buffer is unverified and may drop frames rather than shape them; the flag help and all three docs say so.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inbound and outbound network rate limits through `boxlite run` and `boxlite create`.
  * Limits cover TCP, UDP, ICMP, and ARP traffic; unset or `0` means unlimited.
  * Added rate-limited networking support on Linux and macOS, including connection deadline handling.

* **Bug Fixes**
  * Remote runtimes now reject unsupported non-unlimited network limits before connecting.
  * Improved traffic shaping under backpressure and read timeouts.

* **Documentation**
  * Updated CLI and Rust API references with rate-limit settings and platform limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->