### PR TITLE
ci(node): use npm 11 on the Node 22 legs

### DIFF
--- a/.github/workflows/build-node.yml
+++ b/.github/workflows/build-node.yml
@@ -138,6 +138,12 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      # See the matching note in test.yml: under Node 22, npm 10.x cannot
+      # resolve sdks/node's dependency graph.
+      - name: Pin npm (Node 22 only)
+        if: matrix.node-version == '22'
+        run: npm install -g npm@^11
+
       # Remove npm/* from git checkout to avoid platform mismatch
       # (git contains all platforms, but we only want the one from artifacts)
       - name: Clean npm workspaces

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -281,6 +281,16 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      # npm picks manifests by `engines`, so under Node 22 vitest's peer set
+      # resolves to vite 8 → @vitejs/devtools, a chain any npm 10.x crashes on
+      # ("Cannot read properties of null (reading 'edgesOut')") and npm 11
+      # walks fine. Node 18/20 resolve a different set and are unaffected.
+      # sdks/node keeps no lockfile, so every run re-resolves. npm 11 needs
+      # node ^20.17 || >=22.9, so this must not run on the 18 leg.
+      - name: Pin npm (Node 22 only)
+        if: matrix.node-version == '22'
+        run: npm install -g npm@^11
+
       - name: Install dependencies
         working-directory: sdks/node
         run: npm install


### PR DESCRIPTION
## Summary

The Node 22 legs of `Node.js Tests` and `build-node / Test` fail at `npm install` in `sdks/node` with `Cannot read properties of null (reading 'edgesOut')`. npm selects manifests by `engines`, so Node 22 resolves vitest → vite 8 → `@vitejs/devtools` 0.7.x (published 2026-09-03), a peer chain npm 10.x's arborist cannot walk. npm 11 walks it fine, so the Node 22 legs now install npm 11 before `npm install`. Node 18/20 resolve a different peer set and are untouched.

## Call graph

```text
Before
  node  (job · .github/workflows/test.yml:265)
    └─ actions/setup-node@v4   (step · test.yml:279)      — Node 22 + bundled npm 10.9
         └─ npm install          (step · test.yml:288)      ← BUG: arborist #loadPeerSet crashes on vitest → vite 8 → @vitejs/devtools
              └─ npm run test    (step · test.yml:292)      — never reached
  test  (job · .github/workflows/build-node.yml:122)
    └─ actions/setup-node@v4   (step · build-node.yml:136)
         └─ npm install --ignore-scripts  (step · build-node.yml:159)  ← BUG: same graph, same crash

After
  node  (job · .github/workflows/test.yml:265)
    └─ actions/setup-node@v4   (step · test.yml:279)
         └─ npm install -g npm@^11  (step · test.yml:290)   — NEW, `if: matrix.node-version == '22'`
              └─ npm install     (step · test.yml:296)      — resolves with npm 11
                   └─ npm run test  (step · test.yml:300)
  test  (job · .github/workflows/build-node.yml:122)
    └─ actions/setup-node@v4   (step · build-node.yml:136)
         └─ npm install -g npm@^11  (step · build-node.yml:143)  — NEW, same guard
              └─ npm install --ignore-scripts  (step · build-node.yml:165)
```

## Changes

- Both Node 22 legs run `npm install -g npm@^11` right after `setup-node`, guarded by `if: matrix.node-version == '22'`. npm 11 requires `node ^20.17 || >=22.9`, so the guard keeps the Node 18 leg on its bundled npm.
- The comments record why only Node 22 is affected: the trigger is Node 22's `engines`-driven peer resolution, not the bundled npm version. npm 10.8.2 crashes on the same graph under Node 22.

## How to verify

Clean install of `sdks/node/package.json` (no lockfile) under Node 22:

```bash
cd sdks/node && rm -rf node_modules package-lock.json
npm install                                   # npm 10.9.x: edgesOut crash
npx -y npm@^11 install && npm run test        # 6 files, 92 tests pass
```

Same install under Node 18 (bundled npm 10.8.2) and Node 20 succeeds without the pin, so the guard is safe on those legs.

## Risks / rollout

- `npm install -g npm` adds one registry fetch per Node 22 job.
- Unblocks #1435, whose three Node 22 legs fail on this. `pull_request` runs use the workflow from the merge commit, so a rerun after this merges picks it up without a rebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js 22 build and test workflows to use npm 11.
  * Improved dependency installation reliability for Node.js SDK checks on Node.js 22.
  * Existing Node.js 18 and 20 workflows remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->