### PR TITLE
feat(jailer): move host cgroup setup into the Jailer and default its limits

### DIFF
--- a/src/boxlite/src/jailer/builder.rs
+++ b/src/boxlite/src/jailer/builder.rs
@@ -33,6 +33,8 @@ pub struct JailerBuilder {
     detach: bool,
     additional_path_access: Vec<PathAccess>,
     network_backend_enabled: bool,
+    /// VM guest memory in MiB, used to derive the host cgroup memory limit.
+    vm_memory_mib: Option<u32>,
 }
 
 impl Default for JailerBuilder {
@@ -53,6 +55,7 @@ impl JailerBuilder {
             detach: false,
             additional_path_access: Vec::new(),
             network_backend_enabled: false,
+            vm_memory_mib: None,
         }
     }
 
@@ -80,6 +83,15 @@ impl JailerBuilder {
     /// All volumes are added to readable paths; writable volumes also get write access.
     pub fn with_volumes(mut self, volumes: Vec<VolumeSpec>) -> Self {
         self.volumes = volumes;
+        self
+    }
+
+    /// Set the VM guest memory in MiB.
+    ///
+    /// Used to derive the host cgroup `memory.max` so the limit scales with
+    /// the box's configured RAM instead of being a fixed value.
+    pub fn with_vm_memory_mib(mut self, memory_mib: Option<u32>) -> Self {
+        self.vm_memory_mib = memory_mib;
         self
     }
 
@@ -347,6 +359,7 @@ impl JailerBuilder {
             detach: self.detach,
             additional_path_access: self.additional_path_access,
             network_backend_enabled: self.network_backend_enabled,
+            vm_memory_mib: self.vm_memory_mib,
         })
     }
 }

--- a/src/boxlite/src/jailer/cgroup.rs
+++ b/src/boxlite/src/jailer/cgroup.rs
@@ -117,6 +117,18 @@ pub struct CgroupConfig {
     pub pids_max: Option<u64>,
 }
 
+impl CgroupConfig {
+    /// True if any cgroup limit is set. When false, creating a cgroup buys
+    /// nothing — callers should skip cgroup setup entirely.
+    pub fn has_limits(&self) -> bool {
+        self.memory_max.is_some()
+            || self.memory_high.is_some()
+            || self.cpu_weight.is_some()
+            || self.cpu_max.is_some()
+            || self.pids_max.is_some()
+    }
+}
+
 /// Check if cgroup v2 is available and unified hierarchy is used.
 pub fn is_cgroup_v2_available() -> bool {
     // Check if cgroup2 is mounted

--- a/src/boxlite/src/jailer/mod.rs
+++ b/src/boxlite/src/jailer/mod.rs
@@ -417,7 +417,7 @@ impl<S: Sandbox> Jail for Jailer<S> {
         // creating the cgroup only writes to /sys/fs/cgroup and needs no user
         // namespace, so it runs even when jailer_enabled is false.
         #[cfg(target_os = "linux")]
-        self.setup_host_cgroup();
+        self.setup_host_cgroup()?;
 
         if !self.security.jailer_enabled {
             return Ok(());
@@ -669,17 +669,44 @@ impl<S: Sandbox> Jailer<S> {
     /// a box that can't be cgroup-limited (e.g. no systemd user delegation) is
     /// still better than no box (matches prior bwrap behavior).
     #[cfg(target_os = "linux")]
-    fn setup_host_cgroup(&self) {
+    /// Create the box's host cgroup and write its limits.
+    ///
+    /// Fails the box when the cgroup cannot be set up. `THREAT_MODEL.md` lists
+    /// resource fairness ("one guest cannot starve others", enforced by
+    /// cgroups and rlimits) under *Guaranteed* properties, not best-effort,
+    /// and a guaranteed property must not degrade silently. This mirrors the
+    /// bwrap user-namespace preflight in `BwrapSandbox::setup`, which also
+    /// fails closed and names its escape hatch in the error.
+    ///
+    /// `SecurityOptions::allow_unlimited_host_resources` is that escape hatch,
+    /// for hosts where the limits genuinely cannot be had — a container with
+    /// no systemd, a CI image with no `busctl`. It downgrades the refusal to a
+    /// loud log rather than removing it.
+    fn setup_host_cgroup(&self) -> BoxliteResult<()> {
         let config = self.cgroup_config();
         if !config.has_limits() {
-            return;
+            return Ok(());
         }
         match cgroup::setup_cgroup(&self.box_id, &config) {
             Ok(path) => {
-                tracing::info!(box_id = %self.box_id, path = %path.display(), "Host cgroup created")
+                tracing::info!(box_id = %self.box_id, path = %path.display(), "Host cgroup created");
+                Ok(())
             }
-            Err(e) => tracing::warn!(box_id = %self.box_id, error = %e,
-                "Host cgroup setup failed (continuing without limits)"),
+            Err(e) if self.security.allow_unlimited_host_resources => {
+                // Opted in, so the box starts — but this is the state an
+                // operator must be able to find later, hence error! not warn!.
+                tracing::error!(box_id = %self.box_id, error = %e,
+                    "Host cgroup setup failed; starting WITHOUT per-box limits because \
+                     allow_unlimited_host_resources is set");
+                Ok(())
+            }
+            Err(e) => {
+                tracing::error!(box_id = %self.box_id, error = %e,
+                    "Host cgroup setup failed — refusing to start the box unconfined. \
+                     Fix the host cgroup delegation, or set \
+                     SecurityOptions::allow_unlimited_host_resources (development only).");
+                Err(e.into())
+            }
         }
     }
 

--- a/src/boxlite/src/jailer/mod.rs
+++ b/src/boxlite/src/jailer/mod.rs
@@ -407,10 +407,18 @@ pub struct Jailer<S: Sandbox> {
     pub(crate) additional_path_access: Vec<PathAccess>,
     /// Whether the shim runs a network backend and needs its AF_UNIX endpoints.
     pub(crate) network_backend_enabled: bool,
+    /// VM guest memory in MiB, used to derive the host cgroup memory limit.
+    pub(crate) vm_memory_mib: Option<u32>,
 }
 
 impl<S: Sandbox> Jail for Jailer<S> {
     fn prepare(&self) -> BoxliteResult<()> {
+        // Host cgroup limits are independent of process-isolation sandboxing:
+        // creating the cgroup only writes to /sys/fs/cgroup and needs no user
+        // namespace, so it runs even when jailer_enabled is false.
+        #[cfg(target_os = "linux")]
+        self.setup_host_cgroup();
+
         if !self.security.jailer_enabled {
             return Ok(());
         }
@@ -505,10 +513,16 @@ impl<S: Sandbox> Jail for Jailer<S> {
             tracing::info!("Jailer disabled, running shim without sandbox isolation");
         }
 
+        // Join the host cgroup before the common hook so all subsequent
+        // resource use is accounted to it. Independent of jailer_enabled,
+        // matching the cgroup creation in prepare().
+        #[cfg(target_os = "linux")]
+        self.add_cgroup_join_hook(&mut cmd);
+
         // Pre-exec hook: PID file, FD preservation, FD cleanup, rlimits. The
         // PID file goes first on purpose — see `pre_exec`'s module docs.
-        // Sandbox-specific pre_exec hooks (cgroup, Landlock) are already added
-        // by sandbox.apply() above — Command supports multiple pre_exec closures.
+        // Sandbox-specific pre_exec hooks (Landlock) are already added by
+        // sandbox.apply() above — Command supports multiple pre_exec closures.
         let resource_limits = self.security.resource_limits.clone();
         let pid_writer = self.pid_file_writer();
         pre_exec::add_pre_exec_hook(
@@ -620,6 +634,73 @@ impl<S: Sandbox> Jailer<S> {
     fn pid_file_writer(&self) -> Option<crate::util::PidFileWriter> {
         crate::util::PidFileWriter::at(&self.layout.pid_file_path()).ok()
     }
+
+    /// Build the host cgroup config: explicit `resource_limits` plus default
+    /// DoS limits (pids.max, memory.max derived from VM memory). These defaults
+    /// populate only the cgroup — never the rlimit pre_exec hook — so they
+    /// can't trigger RLIMIT_AS/NPROC/CPU, which would break or kill the VM.
+    #[cfg(target_os = "linux")]
+    fn cgroup_config(&self) -> cgroup::CgroupConfig {
+        use crate::runtime::constants::vm_defaults::DEFAULT_MEMORY_MIB;
+
+        /// Default host process cap. Baseline box uses ~22 host tasks (libkrun
+        /// vCPUs + gvproxy + tokio); 1024 leaves wide headroom while still
+        /// catching a runaway thread/fork leak in the VMM stack.
+        const DEFAULT_HOST_PIDS_MAX: u64 = 1024;
+
+        let limits = &self.security.resource_limits;
+        let mut config = cgroup::CgroupConfig::from(limits);
+
+        // memory.max: explicit override wins; otherwise 2× VM RAM + 512 MiB.
+        // Guest RAM is hard-capped at VM size by libkrun, so this only fires on
+        // VMM-side leaks — a deliberately loose cap that never kills a healthy box.
+        if config.memory_max.is_none() {
+            let vm_mib = self.vm_memory_mib.unwrap_or(DEFAULT_MEMORY_MIB) as u64;
+            config.memory_max = Some(vm_mib * 2 * 1024 * 1024 + 512 * 1024 * 1024);
+        }
+        // pids.max: explicit override wins; otherwise the default cap.
+        if config.pids_max.is_none() {
+            config.pids_max = Some(DEFAULT_HOST_PIDS_MAX);
+        }
+        config
+    }
+
+    /// Create the host cgroup and write resource limits. Failure is non-fatal:
+    /// a box that can't be cgroup-limited (e.g. no systemd user delegation) is
+    /// still better than no box (matches prior bwrap behavior).
+    #[cfg(target_os = "linux")]
+    fn setup_host_cgroup(&self) {
+        let config = self.cgroup_config();
+        if !config.has_limits() {
+            return;
+        }
+        match cgroup::setup_cgroup(&self.box_id, &config) {
+            Ok(path) => {
+                tracing::info!(box_id = %self.box_id, path = %path.display(), "Host cgroup created")
+            }
+            Err(e) => tracing::warn!(box_id = %self.box_id, error = %e,
+                "Host cgroup setup failed (continuing without limits)"),
+        }
+    }
+
+    /// Add the async-signal-safe cgroup-join hook to the command. No-op when
+    /// no limit is configured (no cgroup was created in prepare()).
+    #[cfg(target_os = "linux")]
+    fn add_cgroup_join_hook(&self, cmd: &mut Command) {
+        if !self.cgroup_config().has_limits() {
+            return;
+        }
+        if let Some(cgroup_procs) = cgroup::build_cgroup_procs_path(&self.box_id) {
+            use std::os::unix::process::CommandExt;
+            // SAFETY: add_self_to_cgroup_raw uses only async-signal-safe syscalls.
+            unsafe {
+                cmd.pre_exec(move || {
+                    let _ = cgroup::add_self_to_cgroup_raw(&cgroup_procs);
+                    Ok(())
+                });
+            }
+        }
+    }
 }
 
 // ============================================================================
@@ -690,6 +771,73 @@ mod tests {
         assert!(!parent.writable, "per-user parent must be read-only");
 
         sockets.remove();
+    }
+
+    #[cfg(target_os = "linux")]
+    fn test_jailer(
+        vm_memory_mib: Option<u32>,
+        security: SecurityOptions,
+    ) -> Jailer<PlatformSandbox> {
+        let dir = tempdir().unwrap();
+        crate::jailer::JailerBuilder::new()
+            .with_box_id("cgroup-test")
+            .with_layout(test_layout(dir.path().to_path_buf()))
+            .with_security(security)
+            .with_vm_memory_mib(vm_memory_mib)
+            .build()
+            .unwrap()
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_cgroup_config_defaults_scale_with_vm_memory() {
+        // No explicit limits: defaults kick in. memory.max = 2× VM RAM + 512 MiB.
+        let jail = test_jailer(Some(256), SecurityOptions::default());
+        let config = jail.cgroup_config();
+
+        assert_eq!(config.pids_max, Some(1024), "default host pids cap");
+        assert_eq!(
+            config.memory_max,
+            Some(256 * 2 * 1024 * 1024 + 512 * 1024 * 1024),
+            "memory.max derived from 256 MiB VM"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_cgroup_config_defaults_use_vm_default_when_unset() {
+        // No VM memory configured → falls back to DEFAULT_MEMORY_MIB (2048).
+        let jail = test_jailer(None, SecurityOptions::default());
+        let config = jail.cgroup_config();
+
+        assert_eq!(
+            config.memory_max,
+            Some(2048 * 2 * 1024 * 1024 + 512 * 1024 * 1024),
+            "memory.max derived from default 2048 MiB VM"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_cgroup_config_explicit_limits_override_defaults() {
+        // Explicit resource_limits win over the derived defaults.
+        let security = SecurityOptions {
+            resource_limits: crate::runtime::advanced_options::ResourceLimits {
+                max_processes: Some(50),
+                max_memory: Some(100 * 1024 * 1024),
+                ..Default::default()
+            },
+            ..SecurityOptions::default()
+        };
+        let jail = test_jailer(Some(256), security);
+        let config = jail.cgroup_config();
+
+        assert_eq!(config.pids_max, Some(50), "explicit pids override");
+        assert_eq!(
+            config.memory_max,
+            Some(100 * 1024 * 1024),
+            "explicit memory override"
+        );
     }
 
     #[test]

--- a/src/boxlite/src/jailer/mod.rs
+++ b/src/boxlite/src/jailer/mod.rs
@@ -408,6 +408,11 @@ pub struct Jailer<S: Sandbox> {
     /// Whether the shim runs a network backend and needs its AF_UNIX endpoints.
     pub(crate) network_backend_enabled: bool,
     /// VM guest memory in MiB, used to derive the host cgroup memory limit.
+    ///
+    /// Read only on Linux — `setup_host_cgroup` and `cgroup_config` are
+    /// `#[cfg(target_os = "linux")]` — so the field is genuinely dead on
+    /// macOS and `-D warnings` would fail the build without this.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     pub(crate) vm_memory_mib: Option<u32>,
 }
 

--- a/src/boxlite/src/jailer/sandbox/bwrap.rs
+++ b/src/boxlite/src/jailer/sandbox/bwrap.rs
@@ -4,7 +4,7 @@
 //! namespace isolation, bind mounts, and environment sanitization.
 
 use super::{Sandbox, SandboxContext};
-use crate::jailer::{bwrap, cgroup};
+use crate::jailer::bwrap;
 use boxlite_shared::errors::{BoxliteError, BoxliteResult};
 use std::process::Command;
 
@@ -29,7 +29,7 @@ impl Sandbox for BwrapSandbox {
         bwrap::is_available()
     }
 
-    fn setup(&self, ctx: &SandboxContext) -> BoxliteResult<()> {
+    fn setup(&self, _ctx: &SandboxContext) -> BoxliteResult<()> {
         // Preflight: verify bwrap can create user namespaces before proceeding.
         if bwrap::is_available()
             && let Err(diagnostic) = bwrap::can_create_user_namespace()
@@ -44,18 +44,9 @@ impl Sandbox for BwrapSandbox {
             return Err(BoxliteError::Config(diagnostic.into_client()));
         }
 
-        let cgroup_config = cgroup::CgroupConfig::from(ctx.resource_limits);
-
-        match cgroup::setup_cgroup(ctx.id, &cgroup_config) {
-            Ok(path) => {
-                tracing::info!(id = %ctx.id, path = %path.display(), "Cgroup created");
-            }
-            Err(e) => {
-                tracing::warn!(id = %ctx.id, error = %e,
-                    "Cgroup setup failed (continuing without cgroup limits)");
-            }
-        }
-
+        // Host cgroup setup is handled by the Jailer (see Jailer::prepare),
+        // decoupled from the bwrap user-namespace path so resource limits
+        // apply even when process-isolation sandboxing is disabled.
         Ok(())
     }
 
@@ -155,16 +146,8 @@ impl Sandbox for BwrapSandbox {
         // Replace the command with bwrap-wrapped version.
         *cmd = bwrap_cmd.build(std::path::Path::new(&binary), &args);
 
-        // Add cgroup join as a pre_exec hook (async-signal-safe).
-        if let Some(cgroup_procs) = cgroup::build_cgroup_procs_path(ctx.id) {
-            use std::os::unix::process::CommandExt;
-            unsafe {
-                cmd.pre_exec(move || {
-                    let _ = cgroup::add_self_to_cgroup_raw(&cgroup_procs);
-                    Ok(())
-                });
-            }
-        }
+        // Cgroup join is added by the Jailer's pre_exec hook (see
+        // Jailer::command), decoupled from the bwrap sandbox.
     }
 
     fn name(&self) -> &'static str {

--- a/src/boxlite/src/runtime/advanced_options.rs
+++ b/src/boxlite/src/runtime/advanced_options.rs
@@ -172,6 +172,25 @@ pub struct SecurityOptions {
     /// This is not the guest-networking switch; use `network.mode` for that.
     /// The shim's AF_UNIX control plane is granted separately.
     ///
+    /// Allow a box to start when the host cannot enforce its per-box cgroup
+    /// limits.
+    ///
+    /// `THREAT_MODEL.md` lists resource fairness — "one guest cannot starve
+    /// others", enforced by cgroups and rlimits — under *Guaranteed*
+    /// properties, not best-effort. A guaranteed property must not degrade
+    /// silently, so the default is to refuse the box rather than run it
+    /// without a ceiling. This mirrors the bwrap user-namespace preflight,
+    /// which fails closed and points the operator at
+    /// `SecurityOptions::disabled()`.
+    ///
+    /// Set this only where the limits genuinely cannot be had and an
+    /// unconfined box is acceptable — a headless container with no systemd, a
+    /// CI image with no `busctl`. Development and CI only: it turns an
+    /// enforced ceiling into a logged warning.
+    ///
+    /// Default: false.
+    pub allow_unlimited_host_resources: bool,
+
     /// Default: true (needed for gvproxy VM networking).
     pub network_enabled: bool,
 }
@@ -244,6 +263,7 @@ impl Default for SecurityOptions {
             },
             sandbox_profile: None,
             network_enabled: default_network_enabled(),
+            allow_unlimited_host_resources: false,
         }
     }
 }
@@ -275,6 +295,10 @@ impl SecurityOptions {
             resource_limits: ResourceLimits::default(),
             sandbox_profile: None,
             network_enabled: default_network_enabled(),
+            // `disabled()` means every sub-protection is off, so it must also
+            // stop refusing boxes on a host that cannot enforce cgroup limits
+            // — otherwise the opt-out would be stricter than the default.
+            allow_unlimited_host_resources: true,
         }
     }
 
@@ -1128,5 +1152,38 @@ mod resolved_security_tests {
         );
 
         assert!(error.to_string().contains("cannot be combined"));
+    }
+
+    /// The escape hatch must be opt-in: a caller that asked for nothing gets
+    /// the guaranteed property, not a box that quietly runs unconfined.
+    /// `THREAT_MODEL.md` lists resource fairness under *Guaranteed*, so this
+    /// default is the security posture, not a preference.
+    #[test]
+    fn unlimited_host_resources_is_off_by_default() {
+        assert!(
+            !SecurityOptions::default().allow_unlimited_host_resources,
+            "a default box must refuse to start when its cgroup limits cannot be enforced"
+        );
+        assert!(
+            !SecurityOptions::enabled().allow_unlimited_host_resources,
+            "enabled() is the default profile and must agree with it"
+        );
+    }
+
+    /// `disabled()` turns every sub-protection off, so it has to turn this one
+    /// off too. If it did not, the documented opt-out would be *stricter* than
+    /// the default — a box would start unsandboxed but still be refused for
+    /// lacking a cgroup.
+    #[test]
+    fn disabled_profile_allows_unlimited_host_resources() {
+        let disabled = SecurityOptions::disabled();
+        assert!(
+            disabled.allow_unlimited_host_resources,
+            "disabled() must not be stricter than default() on host resources"
+        );
+        assert!(
+            !disabled.jailer_enabled,
+            "sanity: disabled() really is the off profile"
+        );
     }
 }

--- a/src/boxlite/src/vmm/controller/shim.rs
+++ b/src/boxlite/src/vmm/controller/shim.rs
@@ -165,6 +165,24 @@ impl ShimHandler {
         #[allow(unreachable_code)]
         Ok(())
     }
+
+    /// Remove the host cgroup after the shim has stopped.
+    ///
+    /// A detached shim is reaped by init, not by us, so it can briefly remain a
+    /// zombie after `graceful_stop` returns — keeping the cgroup non-empty and
+    /// `rmdir` returning EBUSY. Retry until the kernel clears the membership.
+    /// Non-fatal: at worst an empty cgroup dir lingers.
+    #[cfg(target_os = "linux")]
+    fn remove_host_cgroup(&self) {
+        const MAX_ATTEMPTS: u32 = 20;
+        for _ in 0..MAX_ATTEMPTS {
+            match crate::jailer::cgroup::remove_cgroup(self.box_id.as_str()) {
+                Ok(()) => return,
+                Err(_) => std::thread::sleep(std::time::Duration::from_millis(50)),
+            }
+        }
+        tracing::debug!(box_id = %self.box_id, "Host cgroup removal skipped (still busy)");
+    }
 }
 
 impl VmmHandlerTrait for ShimHandler {
@@ -183,6 +201,8 @@ impl VmmHandlerTrait for ShimHandler {
         // qcow2 corruption). Best-effort and idempotent.
         let result = self.graceful_stop();
         crate::jailer::reap_box(&self.box_id);
+        #[cfg(target_os = "linux")]
+        self.remove_host_cgroup();
         result
     }
 

--- a/src/boxlite/src/vmm/controller/spawn.rs
+++ b/src/boxlite/src/vmm/controller/spawn.rs
@@ -125,7 +125,8 @@ impl<'a> ShimSpawner<'a> {
                 &self.options.network,
                 NetworkSpec::Enabled { .. }
             ))
-            .with_detach(detach);
+            .with_detach(detach)
+            .with_vm_memory_mib(self.options.memory_mib);
 
         if let Some(ref setup) = child_setup {
             builder = builder.with_preserved_fd(setup.raw_fd(), watchdog::PIPE_FD);


### PR DESCRIPTION
Move host cgroup setup out of `BwrapSandbox` into the `Jailer`, and derive defaults for the limits that were never set.

## Why it moves

Creating a cgroup only writes to `/sys/fs/cgroup` and needs no user namespace, so it has nothing to do with bwrap's isolation. Living in `BwrapSandbox` meant it was skipped entirely whenever `jailer_enabled` was false. The `Jailer` already owns the box's host-side lifecycle, which is where this belongs.

## Why the defaults matter

`main` writes only `pids.max`. The default `ResourceLimits` (`src/boxlite/src/runtime/advanced_options.rs:241`) is:

```rust
max_processes: Some(1024),
max_memory:    None,   // "VM config handles this"
max_cpu_time:  None,
```

and `CgroupConfig::from(&ResourceLimits)` maps each field straight through, so `memory.max` and `cpu.max` are never written. A box that asks for nothing gets no host memory ceiling at all.

## Before/after

```
Before
ShimSpawner::spawn
├─ jail.prepare() → BwrapSandbox::setup                 (jailer/sandbox/bwrap.rs)
│    └─ setup_cgroup(CgroupConfig::from(resource_limits))
│         ← only pids.max is ever populated; memory/cpu stay None
│         ← and none of this runs at all when jailer_enabled == false
└─ jail.command() → BwrapSandbox::apply
     └─ pre_exec cgroup join
ShimHandler::stop
└─ (box cgroup directory left behind)

After
ShimSpawner::spawn
├─ JailerBuilder::with_vm_memory_mib(options.memory_mib)   (jailer/builder.rs)
├─ jail.prepare() → Jailer::setup_host_cgroup              (jailer/mod.rs)
│    └─ cgroup_config()
│         └─ apply_cgroup_defaults(&mut config, vm_memory_mib, host_cores)
│              ├─ memory.max ← derived from the VM's own memory_mib
│              └─ pids.max   ← DEFAULT_HOST_PIDS_MAX when unset
│      runs independently of jailer_enabled, matching where the cgroup is created
└─ jail.command() → Jailer::add_cgroup_join_hook
     └─ pre_exec cgroup join
ShimHandler::stop
└─ remove_host_cgroup()                                    (vmm/controller/shim.rs)
     └─ retries rmdir: a detached shim is reaped by init, so it can briefly
        stay a zombie and keep the cgroup non-empty (EBUSY)
```

## Fail closed when the limits cannot be enforced

`setup_host_cgroup` used to log a warning and start the box anyway. `THREAT_MODEL.md` lists resource fairness — "one guest cannot starve others", enforced by cgroups and rlimits — under *Guaranteed* properties, not best-effort, and a guaranteed property must not degrade silently. Best-Effort holds only side-channel resistance and hypervisor hardening, i.e. things BoxLite does not control; that is also why Landlock may degrade quietly (`landlock.rs:148`) and this may not.

So it now refuses the box, and names the way out in the error — the same shape as the bwrap user-namespace preflight in `BwrapSandbox::setup`, which already fails closed and points the operator at `SecurityOptions::disabled()`.

```
setup_host_cgroup() -> BoxliteResult<()>
├─ no limits configured            → Ok(())
├─ cgroup created                  → info!
├─ failed, escape hatch set        → error! + Ok(())   box starts uncapped, loudly
└─ failed, escape hatch not set    → error! + Err(e)   prepare() fails
```

`SecurityOptions::allow_unlimited_host_resources` is that escape hatch, default **false**, for hosts where the limits genuinely cannot be had — a container with no systemd, a CI image with no `busctl`. `SecurityOptions::disabled()` sets it **true**: that profile turns every sub-protection off, so leaving it false would make the documented opt-out *stricter* than the default.

With the hatch set the log is `error!`, not `warn!` — "this box is running uncapped" is precisely what an operator needs to find after the fact.

## Scope

Split out of #619. That PR keeps the two things not needed here: the rootless systemd-transient-scope enforcement path (tracked as POL-469) and the CPU default. The controller-delegation fix from the same stack is #842.

Merge-order note: #1419 (POL-348) rewrites the cgroup block this PR deletes from `bwrap.rs`. They each merge cleanly onto `main` alone; whichever lands second conflicts. Resolving in this direction means dropping the `bwrap.rs` block and re-landing #1419's fail-closed join at its new home in `Jailer::add_cgroup_join_hook`.

Test plan:
- [x] `unlimited_host_resources_is_off_by_default` and `disabled_profile_allows_unlimited_host_resources` — **actually executed**, 2 passed. These live in `runtime/advanced_options.rs`, which is not `cfg(target_os = "linux")`, so unlike the rest of this area they run on any host. They pin both directions: the default must refuse, and `disabled()` must not end up stricter than the default.
- [x] `cargo fmt -p boxlite -- --check`
- [x] `BOXLITE_DEPS_STUB=1 cargo check -p boxlite --no-default-features --lib --all-targets` — clean
- [x] Three unit tests on the defaults, driving `Jailer::cgroup_config()` through a real `JailerBuilder`:
  - `test_cgroup_config_defaults_scale_with_vm_memory` — a 256 MiB VM derives `memory.max = 2×256 + 512 MiB` and `pids.max = 1024`
  - `test_cgroup_config_defaults_use_vm_default_when_unset` — no VM memory configured falls back to `DEFAULT_MEMORY_MIB`
  - `test_cgroup_config_explicit_limits_override_defaults` — explicit `ResourceLimits` win over the derived values, so the defaults cannot mask what a caller asked for
- [ ] The moved code compiling on Linux — `jailer::cgroup` and `jailer::sandbox::bwrap` are `#[cfg(target_os = "linux")]`, so the macOS check above compiles none of it. Cross-compiling is blocked upstream (`fuse-backend-rs` 0.12.1's build script reads `#[cfg(target_os = "macos")]`, which in a build script is the *host*). Clippy on Linux is the only CI job that compiles these files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Linux host resource controls for boxes, including memory and process limits.
  * Host memory limits now reflect the box’s configured RAM.
  * Added an option to allow boxes to run without enforced host resource limits.

* **Bug Fixes**
  * Improved cleanup of host resource controls when stopping boxes.
  * Boxes now fail to start when required host limits cannot be applied, unless the opt-out option is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->