### PR TITLE
fix(dashboard): state the upgrade's cycle restart and refresh the wallet

### DIFF
--- a/apps/dashboard/src/components/billing/planChange.test.ts
+++ b/apps/dashboard/src/components/billing/planChange.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { OrganizationPlan, Plan } from '@/billing-api'
+import { format } from 'date-fns'
 import { describe, expect, it } from 'vitest'
 import { isUpgradeTo, planCardCta, planChangeSummary, queuedChange, scheduledChange } from './planChange'
 
@@ -156,11 +157,19 @@ describe('effect', () => {
     expect(summary.effect).toContain('leave the dashboard')
   })
 
-  it('charges an upgrade on a live subscription immediately and prorated', () => {
+  it('states that an upgrade restarts the cycle rather than charging a price difference', () => {
     const summary = summarize('max', LIVE_PRO)
 
     expect(summary.effect).toContain('immediately')
-    expect(summary.effect).toContain('prorated')
+    expect(summary.effect).toContain('restarts your billing cycle today')
+    expect(summary.effect).toContain('a full period of Max less the unused part of your current cycle')
+    expect(summary.effect).toContain('next renewal is one month from today')
+    expect(summary.effect).not.toContain('prorated')
+    // Read off the fixture so moving it cannot make this pass vacuously. The
+    // old cycle end is the renewal date the upgrade no longer keeps, so the
+    // copy must never print it. (This guard did not discriminate against the
+    // old string either — that carried no date at all.)
+    expect(summary.effect).not.toContain(format(LIVE_PRO.cycleTo, 'MMM d, yyyy'))
   })
 
   it('names the day a downgrade lands and says nothing is charged', () => {
@@ -223,6 +232,29 @@ describe('caveats', () => {
     const canceling: OrganizationPlan = { ...LIVE_PRO, pendingPlanId: 'starter', cancelAtPeriodEnd: true }
 
     expect(summarize('max', canceling).caveats[0].text).toContain('set to end')
+  })
+
+  // A plan change never clears a scheduled cancellation; the upgrade only
+  // moves it onto the period it opens today.
+  it('says an upgrade moves a scheduled cancellation rather than replacing it', () => {
+    const canceling: OrganizationPlan = { ...LIVE_PRO, cancelAtPeriodEnd: true }
+    const caveat = summarize('max', canceling).caveats[0]
+
+    expect(caveat.text).toContain('starts a new billing period today')
+    expect(caveat.text).toContain('the cancellation moves to the end of it')
+    expect(caveat.text).toContain('"Keep Pro"')
+    expect(caveat.text).not.toContain('replaces that with this change')
+  })
+
+  // A downgrade drops the cancellation and takes over at the boundary, so this
+  // branch keeps the wording it always had. Pinned because the upgrade branch
+  // now sits beside it and must not leak into it.
+  it('says a downgrade replaces a scheduled cancellation', () => {
+    const canceling: OrganizationPlan = { ...LIVE_PRO, cancelAtPeriodEnd: true }
+    const caveat = summarize('starter', canceling).caveats[0]
+
+    expect(caveat.text).toContain('Confirming replaces that with this change')
+    expect(caveat.text).not.toContain('new billing period')
   })
 
   it('stays quiet on an ordinary switch', () => {

--- a/apps/dashboard/src/components/billing/planChange.ts
+++ b/apps/dashboard/src/components/billing/planChange.ts
@@ -174,7 +174,7 @@ export function planChangeSummary({
     walletNote: wallet
       ? `Usage beyond the included quota draws on the wallet, which holds ${formatAmount(wallet.balanceCents)}.`
       : null,
-    caveats: caveatsFor({ planId, plan, current, catalog, rollDay }),
+    caveats: caveatsFor({ planId, direction, plan, current, catalog, rollDay }),
     blocked: blockFor({ planId, target, plan, ended, rollDay }),
   }
 }
@@ -228,7 +228,18 @@ function effectFor({
     return `Switches you to ${targetName}. Because your current plan is negotiated, the terms and any charge are settled by billing rather than shown here.`
   }
   if (direction === 'upgrade') {
-    return `Applies immediately. Your subscription is charged the prorated difference today, and ${targetName}'s quota is available right away.`
+    // An in-place upgrade restarts the billing cycle at the upgrade instant:
+    // the charge is a whole period of the new plan less the unused share of the
+    // old one, and the renewal moves with it.
+    //
+    // NOT YET TRUE OF THE DEPLOYED SERVICE. That contract arrives with
+    // boxlite-commerce's `feat/upgrade-opens-fresh-cycle`
+    // (docs/boxlite-client-contract.md there; write-upgrade.ts anchors the
+    // successor at the upgrade instant, cycle.ts prices the credit as
+    // unusedPeriodCents). Until it merges, Commerce still charges the price
+    // difference and keeps the billing day — and this is the sentence read
+    // immediately before money moves, so it must not ship ahead of it.
+    return `Applies immediately and restarts your billing cycle today: you are charged a full period of ${targetName} less the unused part of your current cycle. ${targetName}'s full quota is available right away, and the next renewal is one month from today.`
   }
   return rollDay
     ? `Applies on ${rollDay}, when the current cycle rolls. Nothing is charged today.`
@@ -237,12 +248,14 @@ function effectFor({
 
 function caveatsFor({
   planId,
+  direction,
   plan,
   current,
   catalog,
   rollDay,
 }: {
   planId: string
+  direction: PlanChangeDirection
   plan: OrganizationPlan | null
   current: Plan | undefined
   catalog: Plan[]
@@ -259,10 +272,21 @@ function caveatsFor({
     })
   }
   const queued = queuedChange(plan)
-  if (queued?.kind === 'cancel') {
+  if (plan && queued?.kind === 'cancel') {
+    // A downgrade clears the scheduled end and takes over at the boundary; an
+    // upgrade keeps it, re-derived as the end of the period just bought
+    // (boxlite-commerce subscription.repository.ts, queueDowngrade and
+    // replaceActivePlan — same unmerged change as `effectFor`'s upgrade
+    // branch). That end arrives as the plan block's next `cycleTo`, which does
+    // not exist until the change applies, so this states an offset from today
+    // rather than a date.
+    const ends = `Your subscription is set to end${rollDay ? ` on ${rollDay}` : ''}.`
     caveats.push({
       tone: 'warn',
-      text: `Your subscription is set to end${rollDay ? ` on ${rollDay}` : ''}. Confirming replaces that with this change.`,
+      text:
+        direction === 'upgrade'
+          ? `${ends} This change starts a new billing period today and the cancellation moves to the end of it, one month from today. Use "Keep ${plan.planName}" on the billing page if you want to stay subscribed.`
+          : `${ends} Confirming replaces that with this change.`,
     })
     // When the queued plan IS the one being viewed, `blocked` already says there
     // is nothing to confirm — "confirming replaces it" beside that contradicts it.

--- a/apps/dashboard/src/hooks/mutations/useUpgradePlanMutation.test.tsx
+++ b/apps/dashboard/src/hooks/mutations/useUpgradePlanMutation.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { queryKeys } from '../queries/queryKeys'
+import { useUpgradePlanMutation } from './useUpgradePlanMutation'
+
+const mocks = vi.hoisted(() => ({
+  upgradePlan: vi.fn(),
+}))
+
+vi.mock('@/hooks/useApi', () => ({
+  useApi: () => ({ billingApi: mocks }),
+}))
+
+let upgradePlan: ReturnType<typeof useUpgradePlanMutation> | undefined
+
+function UpgradePlanProbe() {
+  upgradePlan = useUpgradePlanMutation()
+  return null
+}
+
+/**
+ * An in-place upgrade restarts the billing cycle, so the cycle window and the
+ * included allowance both move at the moment it applies. The plan block and
+ * the wallet are rendered side by side (ThisCycleCard, CycleOverview), so a
+ * wallet left cached states a stale balance beside the new quota.
+ */
+describe('useUpgradePlanMutation', () => {
+  let queryClient: QueryClient
+  let invalidateQueries: ReturnType<typeof vi.spyOn>
+  let root: Root | null = null
+
+  beforeAll(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  })
+
+  beforeEach(() => {
+    queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } })
+    invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
+    mocks.upgradePlan.mockResolvedValue(undefined)
+
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    root = createRoot(host)
+    act(() => {
+      root?.render(
+        <QueryClientProvider client={queryClient}>
+          <UpgradePlanProbe />
+        </QueryClientProvider>,
+      )
+    })
+  })
+
+  afterEach(() => {
+    act(() => root?.unmount())
+    root = null
+    upgradePlan = undefined
+    queryClient.clear()
+    document.body.innerHTML = ''
+    vi.clearAllMocks()
+  })
+
+  it('refreshes the plan block and the wallet after an upgrade applies in place', async () => {
+    await act(async () => {
+      await upgradePlan?.mutateAsync({ organizationId: 'org-1', planId: 'max' })
+    })
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: queryKeys.organization.plan('org-1') })
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: queryKeys.organization.wallet('org-1') })
+  })
+})

--- a/apps/dashboard/src/hooks/mutations/useUpgradePlanMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useUpgradePlanMutation.ts
@@ -23,6 +23,11 @@ export const useUpgradePlanMutation = () => {
     onSuccess: async (_data, { organizationId }) => {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: queryKeys.organization.plan(organizationId) }),
+        // The upgrade path reconciles subscription credit and invalidates the
+        // available balance (boxlite-commerce upgrade-subscription.ts,
+        // finish-upgrade.ts), so the wallet moves with the plan block — and the
+        // two are read side by side (ThisCycleCard, CycleOverview).
+        queryClient.invalidateQueries({ queryKey: queryKeys.organization.wallet(organizationId) }),
         queryClient.invalidateQueries({ queryKey: queryKeys.organization.usage.overview(organizationId) }),
         queryClient.invalidateQueries({ queryKey: queryKeys.billing.transactions(organizationId) }),
       ])


### PR DESCRIPTION
## Summary

The billing service's in-place upgrade restarts the cycle at the upgrade instant, so the confirmation page stated the wrong charge basis and the wrong renewal date, and the wallet was left cached beside a refreshed plan block.

## Call graph

```text
Before
  BillingPlanChange     (page · apps/dashboard/src/pages/BillingPlanChange.tsx:154)  — renders summary.effect
    └─ effectFor        (planChange.ts:230)  ← BUG: "charged the prorated difference today" — the charge is a whole
                                                   period of the new plan less the unused share of the old, and the
                                                   sentence implies the renewal date survives when it moves to today
    └─ caveatsFor       (planChange.ts:267)  ← BUG: "Confirming replaces that with this change" — an upgrade does not
                                                   clear a scheduled cancellation; it carries it to the new period end
  useUpgradePlanMutation (hook · useUpgradePlanMutation.ts:23)
                                             ← BUG: invalidates plan/usage/transactions only, so the wallet renders
                                                   a stale balance next to the new cycle's quota

After
  BillingPlanChange     (page · apps/dashboard/src/pages/BillingPlanChange.tsx:154)  — unchanged
    └─ effectFor        (planChange.ts:230)  — states the cycle restart, the full-period-less-unused-share charge,
                                               and the renewal moving to today
    └─ caveatsFor       (planChange.ts:275)  — takes `direction`; upgrade says the cancellation moves to the new
                                               period end, downgrade keeps the wording it had (it does clear it)
  useUpgradePlanMutation (hook · useUpgradePlanMutation.ts:23)
                                             — additionally invalidates `queryKeys.organization.wallet`
```

## Changes

- `effectFor`'s upgrade branch describes a cycle restart rather than a price difference, and carries a `NOT YET TRUE OF THE DEPLOYED SERVICE` note naming the upstream change it depends on.
- `caveatsFor` takes `direction`: an upgrade keeps a scheduled cancellation (re-derived to the new period end) and points at the `Keep <plan>` control; a downgrade clears it, so that branch keeps its original wording.
- `useUpgradePlanMutation` also invalidates the wallet query — the upgrade path reconciles subscription credit and invalidates the available balance server-side.
- `useKeepPlanMutation` and `useDowngradePlanMutation` are deliberately untouched: reactivation grants and expires no credit lots, and a queued downgrade moves no money.

## How to verify

```
cd apps/dashboard
../node_modules/.bin/vitest run src/components/billing/planChange.test.ts \
  src/hooks/mutations/useUpgradePlanMutation.test.tsx
```

Reverting `planChange.ts` and `useUpgradePlanMutation.ts` to their parent blobs makes three of the assertions fail against the old copy and the old invalidation set; the downgrade-cancel test is a characterization pin that passes on both sides, and says so in its own comment.

## Risks / rollout

- **Do not merge before boxlite-commerce `feat/upgrade-opens-fresh-cycle`.** Until that lands, the service still charges the price difference and keeps the billing day, and this copy is read immediately before money moves. The constraint is also in the commit body and in the code comment, but a squash-merge can drop the body.
- The copy says "one month from today", which holds for anniversary billing (what every subscription row is written with today). A calendar-billed subscription would end the re-anchored period at the next month start, and a month-end anchor clamps (a Jan 31 upgrade renews Feb 28).

Fixes #1446


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Billing**
  - Updated upgrade confirmations to clarify that the billing cycle restarts immediately, with the next renewal one month later.
  - Clarified that upgrades charge for the full new period minus the unused portion of the current cycle.
  - Improved messaging when upgrading a plan with a scheduled cancellation.

- **Bug Fixes**
  - Available wallet balances now refresh automatically after an in-place plan upgrade.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->