### PR TITLE
fix(dashboard): open the create-box form on the volumes page

### DIFF
--- a/apps/dashboard/src/components/Box/CreateBoxDialog.test.tsx
+++ b/apps/dashboard/src/components/Box/CreateBoxDialog.test.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { act } from 'react'
+import { act, type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { CreateBoxDialog, resolvePerBoxLimits } from './CreateBoxDialog'
@@ -492,11 +492,9 @@ describe('CreateBoxDialog per-org resource cap', () => {
     )
   })
 
-  // Data-loss guard, not a preference. The API validates a mount by id OR name
-  // but persists the string verbatim, while its delete guard matches
-  // `box.volumes @> [{volumeId: <uuid>}]`. Submitting the name would store a
-  // value that guard cannot see, letting a mounted volume be deleted with no
-  // 409 — so picking from the list must yield the id.
+  // The API takes a mount by id or by name and resolves either to the volume's
+  // id, but a name is only unique within one organization — the picker holds
+  // the id, so that is what a click must submit.
   it('submits the volume id, never the display name', async () => {
     await rerenderOpen()
 
@@ -675,5 +673,66 @@ describe('CreateBoxDialog hourly price', () => {
     await renderOpen()
 
     expect(document.body.textContent).toContain('Unavailable')
+  })
+})
+
+// The trigger used to be built in and styled through `triggerClassName`. It is
+// now a children slot, so both halves of that contract need holding: a page
+// that passes a control gets a working opener, and a page that passes none —
+// the Volumes list, which opens the dialog from a table row — gets no stray
+// button of its own.
+describe('CreateBoxDialog trigger slot', () => {
+  let root: Root | null = null
+
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    state.org = makeOrg({})
+    state.config = { billingApiUrl: 'http://billing.test' }
+    state.pricesQuery = { data: LIVE_PRICES, isLoading: false }
+  })
+
+  afterEach(() => {
+    act(() => root?.unmount())
+    root = null
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  async function renderWithTrigger(children?: ReactNode) {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    await act(async () => {
+      root ??= createRoot(host)
+      root.render(<CreateBoxDialog>{children}</CreateBoxDialog>)
+    })
+    await flush()
+  }
+
+  function dialogIsOpen() {
+    return [...document.querySelectorAll('*')].some((el) => el.textContent === 'Create a box for your agent')
+  }
+
+  it('opens on the control the caller passes in', async () => {
+    await renderWithTrigger(<button type="button">Launch a box</button>)
+
+    const buttons = [...document.querySelectorAll<HTMLButtonElement>('button')]
+    const trigger = buttons.find((b) => b.textContent?.trim() === 'Launch a box')
+    expect(trigger).toBeDefined()
+    // Nothing but the caller's own control: the built-in "New Box" trigger this
+    // slot replaced must not still be rendered alongside it.
+    expect(buttons).toHaveLength(1)
+    expect(dialogIsOpen()).toBe(false)
+
+    await act(async () => trigger?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+    await flush()
+
+    expect(dialogIsOpen()).toBe(true)
+  })
+
+  it('renders no button of its own when the caller passes none', async () => {
+    await renderWithTrigger()
+
+    expect(document.querySelectorAll('button')).toHaveLength(0)
+    expect(dialogIsOpen()).toBe(false)
   })
 })

--- a/apps/dashboard/src/components/Box/CreateBoxDialog.test.tsx
+++ b/apps/dashboard/src/components/Box/CreateBoxDialog.test.tsx
@@ -698,6 +698,9 @@ describe('CreateBoxDialog trigger slot', () => {
     vi.restoreAllMocks()
   })
 
+  /**
+   * Renders CreateBoxDialog with an optional trigger control to verify the children slot.
+   */
   async function renderWithTrigger(children?: ReactNode) {
     const host = document.createElement('div')
     document.body.appendChild(host)
@@ -708,6 +711,9 @@ describe('CreateBoxDialog trigger slot', () => {
     await flush()
   }
 
+  /**
+   * Checks whether the dialog is currently open by looking for its title text.
+   */
   function dialogIsOpen() {
     return [...document.querySelectorAll('*')].some((el) => el.textContent === 'Create a box for your agent')
   }

--- a/apps/dashboard/src/components/Box/CreateBoxDialog.tsx
+++ b/apps/dashboard/src/components/Box/CreateBoxDialog.tsx
@@ -20,8 +20,8 @@ import { useVolumesQuery } from '@/hooks/queries/useVolumesQuery'
 import { VolumeState } from '@boxlite-ai/api-client'
 import { cn } from '@/lib/utils'
 import type { Box } from '@boxlite-ai/api-client'
-import { ChevronDown, Plus } from '@/components/ui/icon'
-import { useEffect, useRef, useState } from 'react'
+import { ChevronDown } from '@/components/ui/icon'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { generatePath, useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 
@@ -519,12 +519,10 @@ function MountRow({
                   key={v.id}
                   disabled={!ready}
                   className={cn('cursor-pointer', v.id === mount.volumeId && 'text-brand')}
-                  // Submit the id, never the name. The API accepts either for
-                  // validation, but it persists whatever it is given verbatim
-                  // (box.service.ts resolveVolumes), while the delete guard
-                  // matches `box.volumes @> [{volumeId: <uuid>}]`. A name stored
-                  // here is invisible to that guard, so the volume could be
-                  // deleted out from under this box with no 409.
+                  // Submit the id. The API takes a name too and resolves
+                  // either to the volume's id, but a name is only unique
+                  // within one organization and this picker already holds the
+                  // id, so there is nothing to gain by sending the weaker one.
                   onClick={() => ready && onChange({ ...mount, volumeId: v.id })}
                 >
                   {v.name}
@@ -560,18 +558,28 @@ function MountRow({
 
 export const CreateBoxDialog = ({
   className,
-  triggerClassName,
+  children,
   open: controlledOpen,
   onOpenChange,
   onCreated,
   prefillVolume,
 }: {
   className?: string
-  triggerClassName?: string
+  /**
+   * The control that opens the dialog. Omit it where the page already owns one
+   * — a table row's action, say — and drive `open` instead; the dialog then
+   * mounts without a button of its own.
+   */
+  children?: ReactNode
   open?: boolean
   onOpenChange?: (open: boolean) => void
   onCreated?: (box: Box) => void
-  /** Volume name to pre-mount, set when arriving from the Volumes page. */
+  /**
+   * Volume id to pre-mount at /data. The API takes a name too and resolves
+   * either to the canonical id, but a name is only unique within one
+   * organization (volume.service.ts validateVolumes), so the id is the
+   * selector to hand it — see MountRow above.
+   */
   prefillVolume?: string
 }) => {
   const navigate = useNavigate()
@@ -630,8 +638,8 @@ export const CreateBoxDialog = ({
     setStopSeconds(DEFAULTS.autoStopIntervalSeconds)
     setDeleteDelaySeconds(0)
     setAutoResumeEnabled(true)
-    // A volume passed in from the Volumes page arrives as navigation state, so
-    // "Create a box with this volume" lands on a form already holding it.
+    // The Volumes page mounts this dialog with a volume already chosen, so its
+    // "+ Box" row action lands on a form that is holding it.
     setMounts(prefillVolume ? [{ volumeId: prefillVolume, mountPath: '/data' }] : [])
     setSizePreset('small')
     setSubmitting(false)
@@ -731,19 +739,7 @@ export const CreateBoxDialog = ({
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>
-        <button
-          type="button"
-          title="New Box"
-          className={cn(
-            'inline-flex h-9 items-center gap-[7px] bg-primary px-[15px] text-[12.5px] font-semibold text-primary-foreground transition-opacity hover:opacity-85',
-            triggerClassName,
-          )}
-        >
-          <Plus className="size-3.5" strokeWidth={2.4} />
-          New Box
-        </button>
-      </DialogTrigger>
+      {children && <DialogTrigger asChild>{children}</DialogTrigger>}
 
       <DialogContent
         className={cn(

--- a/apps/dashboard/src/pages/Boxes.tsx
+++ b/apps/dashboard/src/pages/Boxes.tsx
@@ -9,7 +9,7 @@ import { StatCard } from '@/components/ascii'
 import { OnboardingGuideDialog } from '@/components/OnboardingGuideDialog'
 import { CreateBoxDialog } from '@/components/Box/CreateBoxDialog'
 import { BoxTable } from '@/components/BoxTable'
-import { Search } from '@/components/ui/icon'
+import { Plus, Search } from '@/components/ui/icon'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -62,14 +62,8 @@ import {
 import { QueryKey, useQuery, useQueryClient } from '@tanstack/react-query'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useAuth } from 'react-oidc-context'
-import { generatePath, useLocation, useNavigate, useSearchParams } from 'react-router-dom'
+import { generatePath, useNavigate, useSearchParams } from 'react-router-dom'
 import { toast } from 'sonner'
-
-interface BoxesLocationState {
-  openCreateBox?: boolean
-  /** Volume name to pre-mount, set when arriving from the Volumes page. */
-  mountVolume?: string
-}
 
 const Boxes: React.FC = () => {
   const api = useApi()
@@ -77,7 +71,6 @@ const Boxes: React.FC = () => {
   const { user } = useAuth()
   const userId = user?.profile.sub
   const navigate = useNavigate()
-  const location = useLocation()
   const [searchParams, setSearchParams] = useSearchParams()
   const { notificationSocket } = useNotificationSocket()
   const config = useConfig()
@@ -85,7 +78,6 @@ const Boxes: React.FC = () => {
   const { selectedOrganization, authenticatedUserOrganizationMember, authenticatedUserHasPermission } =
     useSelectedOrganization()
   const [createBoxOpen, setCreateBoxOpen] = useState(false)
-  const [prefillVolume, setPrefillVolume] = useState<string | undefined>(undefined)
   const [showOnboardingDialog, setShowOnboardingDialog] = useState(false)
   const [onboardingProgress, setOnboardingProgress] = useState<OnboardingProgress>(() => readOnboardingProgress(userId))
 
@@ -655,31 +647,6 @@ const Boxes: React.FC = () => {
     }, 220)
   }, [clearOnboardingUrlParam, userId])
 
-  // Two channels open this dialog: router state for a same-tab navigation, and
-  // query params for anything that has to survive being opened in a new tab
-  // (router state does not cross a tab boundary) — e.g. the Volumes page's
-  // "create a box with this volume".
-  useEffect(() => {
-    const state = location.state as BoxesLocationState | null
-    const fromUrl = searchParams.get('createBox') === '1'
-    if (!state?.openCreateBox && !fromUrl) {
-      return
-    }
-
-    setShowOnboardingDialog(false)
-    setPrefillVolume(state?.mountVolume ?? searchParams.get('volume') ?? undefined)
-    setCreateBoxOpen(true)
-
-    if (fromUrl) {
-      const nextParams = new URLSearchParams(searchParams)
-      nextParams.delete('createBox')
-      nextParams.delete('volume')
-      setSearchParams(nextParams, { replace: true })
-      return
-    }
-    navigate({ pathname: location.pathname, search: location.search }, { replace: true, state: null })
-  }, [location.pathname, location.search, location.state, navigate, searchParams, setSearchParams])
-
   // Fleet stat cards — real data, independent of the table's current filter/page.
   const orgId = selectedOrganization?.id
 
@@ -793,15 +760,22 @@ const Boxes: React.FC = () => {
         <div className="flex-1" />
         {authenticatedUserHasPermission(OrganizationRolePermissionsEnum.WRITE_BOXES) && (
           <CreateBoxDialog
-            triggerClassName="h-11 justify-center sm:h-9"
             open={createBoxOpen}
             onOpenChange={setCreateBoxOpen}
-            prefillVolume={prefillVolume}
             onCreated={() => {
               updateOnboardingProgress({ boxCreated: true })
               setShowOnboardingDialog(false)
             }}
-          />
+          >
+            <button
+              type="button"
+              title="New Box"
+              className="inline-flex h-11 items-center justify-center gap-[7px] bg-primary px-[15px] text-[12.5px] font-semibold text-primary-foreground transition-opacity hover:opacity-85 sm:h-9"
+            >
+              <Plus className="size-3.5" strokeWidth={2.4} />
+              New Box
+            </button>
+          </CreateBoxDialog>
         )}
       </div>
 

--- a/apps/dashboard/src/pages/Volumes.test.tsx
+++ b/apps/dashboard/src/pages/Volumes.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+/*
+ * Modified by BoxLite AI, 2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { OrganizationRolePermissionsEnum } from '@boxlite-ai/api-client'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import Volumes from './Volumes'
+
+const READY_VOLUME = {
+  id: 'f0f2f2b6-0b1e-4a1a-9c0a-1c2f3a4b5c6d',
+  name: 'subtitle-models',
+  state: 'ready',
+  createdAt: new Date().toISOString(),
+  lastUsedAt: null,
+}
+
+// Stands in for the real form so the assertions can read what the page decided
+// to hand it — whether it is open, and which volume it was told to mount.
+vi.mock('@/components/Box/CreateBoxDialog', () => ({
+  CreateBoxDialog: ({ open, prefillVolume }: { open?: boolean; prefillVolume?: string }) => (
+    <div data-testid="create-box-dialog" data-open={String(!!open)} data-prefill-volume={prefillVolume} />
+  ),
+}))
+
+// Each test sets the permissions its member holds.
+const state = vi.hoisted(() => ({ permissions: [] as string[] }))
+
+vi.mock('@/hooks/useSelectedOrganization', () => ({
+  useSelectedOrganization: () => ({
+    selectedOrganization: { id: 'org-1' },
+    authenticatedUserHasPermission: (permission: string) => state.permissions.includes(permission),
+  }),
+}))
+vi.mock('@/hooks/queries/useVolumesQuery', () => ({
+  useVolumesQuery: () => ({ data: [READY_VOLUME], isLoading: false, error: undefined }),
+}))
+vi.mock('@/hooks/mutations/useCreateVolumeMutation', () => ({
+  useCreateVolumeMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}))
+vi.mock('@/hooks/mutations/useDeleteVolumeMutation', () => ({
+  useDeleteVolumeMutation: () => ({ mutateAsync: vi.fn() }),
+}))
+vi.mock('@/hooks/useVolumeWsSync', () => ({ useVolumeWsSync: () => undefined }))
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ setQueriesData: vi.fn(), invalidateQueries: vi.fn() }),
+}))
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+
+// Matches links as well as buttons on purpose. The control this page used to
+// render for "+ Box" was an `<a target="_blank">`, so a button-only query would
+// report "no control" against that code and let a permission assertion pass for
+// the wrong reason.
+function rowAction(label: string): HTMLElement | undefined {
+  return Array.from(document.querySelectorAll<HTMLElement>('button, a')).find(
+    (element) => element.textContent?.trim() === label,
+  )
+}
+
+describe('Volumes row action "+ Box"', () => {
+  let root: Root | null = null
+
+  beforeAll(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  })
+
+  beforeEach(() => {
+    state.permissions = [OrganizationRolePermissionsEnum.WRITE_VOLUMES, OrganizationRolePermissionsEnum.WRITE_BOXES]
+  })
+
+  afterEach(() => {
+    act(() => root?.unmount())
+    root = null
+    document.body.innerHTML = ''
+  })
+
+  function renderPage() {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    act(() => {
+      root = createRoot(host)
+      root.render(<Volumes />)
+    })
+  }
+
+  it('opens the create-box form on this page rather than linking away to a new tab', () => {
+    renderPage()
+
+    expect(document.querySelector('[data-testid="create-box-dialog"]')).toBeNull()
+    // The regression this guards: the action used to be an anchor into
+    // /boxes?createBox=1 with target="_blank", which threw away the list the
+    // user was reading and started a second copy of the app.
+    expect(document.querySelector('a[target="_blank"]')).toBeNull()
+
+    const action = rowAction('+ Box')
+    expect(action).toBeDefined()
+
+    act(() => {
+      action?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    const dialog = document.querySelector('[data-testid="create-box-dialog"]')
+    expect(dialog).not.toBeNull()
+    expect(dialog?.getAttribute('data-open')).toBe('true')
+  })
+
+  it('hands the form the volume id, never the display name', () => {
+    renderPage()
+
+    act(() => {
+      rowAction('+ Box')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    // A name is only unique inside one organization; the id is the selector
+    // that cannot resolve to a different volume.
+    const prefill = document.querySelector('[data-testid="create-box-dialog"]')?.getAttribute('data-prefill-volume')
+    expect(prefill).toBe(READY_VOLUME.id)
+    expect(prefill).not.toBe(READY_VOLUME.name)
+  })
+
+  // Creating a box takes WRITE_BOXES, not WRITE_VOLUMES. While this action was
+  // a link to /boxes the dialog there was behind that check, so a
+  // volumes-only member never reached a form; opening it in place must not
+  // hand them one that 403s on submit.
+  it('hides the action from a member who may write volumes but not boxes', () => {
+    state.permissions = [OrganizationRolePermissionsEnum.WRITE_VOLUMES]
+    renderPage()
+
+    expect(rowAction('+ Box')).toBeUndefined()
+    expect(document.querySelector('[data-testid="create-box-dialog"]')).toBeNull()
+    // The volume-scoped controls are still there — the row was not hidden
+    // wholesale.
+    expect(rowAction('New Volume')).toBeDefined()
+  })
+})

--- a/apps/dashboard/src/pages/Volumes.test.tsx
+++ b/apps/dashboard/src/pages/Volumes.test.tsx
@@ -50,10 +50,10 @@ vi.mock('@tanstack/react-query', () => ({
 }))
 vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
 
-// Matches links as well as buttons on purpose. The control this page used to
-// render for "+ Box" was an `<a target="_blank">`, so a button-only query would
-// report "no control" against that code and let a permission assertion pass for
-// the wrong reason.
+/**
+ * Finds a row action by its text label, matching both buttons and links.
+ * Searches both element types because the "+ Box" action was previously a link.
+ */
 function rowAction(label: string): HTMLElement | undefined {
   return Array.from(document.querySelectorAll<HTMLElement>('button, a')).find(
     (element) => element.textContent?.trim() === label,

--- a/apps/dashboard/src/pages/Volumes.tsx
+++ b/apps/dashboard/src/pages/Volumes.tsx
@@ -5,6 +5,7 @@
  */
 
 import { PanelNote, StatusMark } from '@/components/ascii'
+import { CreateBoxDialog } from '@/components/Box/CreateBoxDialog'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -17,7 +18,6 @@ import {
 } from '@/components/ui/alert-dialog'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Database, Plus, Search, Trash } from '@/components/ui/icon'
-import { RoutePath } from '@/enums/RoutePath'
 import { useCreateVolumeMutation } from '@/hooks/mutations/useCreateVolumeMutation'
 import { useDeleteVolumeMutation } from '@/hooks/mutations/useDeleteVolumeMutation'
 import { queryKeys } from '@/hooks/queries/queryKeys'
@@ -82,8 +82,8 @@ const STATE_TONE: Record<string, 'ok' | 'warn' | 'bad' | 'idle'> = {
 // meant a "used by 0 boxes" that was confidently wrong against a real API.
 // Showing nothing beats showing a wrong zero. If it comes back, the honest
 // source is either a new endpoint or aggregating `BoxDto.volumes` over the
-// full box list — matching on id *or* name, since the API persists whichever
-// the caller sent.
+// full box list, matching on the stored `volumeId` — the API resolves a name
+// to the volume's id before persisting it (box.service.ts).
 const Volumes: React.FC = () => {
   const queryClient = useQueryClient()
   const { selectedOrganization, authenticatedUserHasPermission } = useSelectedOrganization()
@@ -97,12 +97,14 @@ const Volumes: React.FC = () => {
   const deleteVolume = useDeleteVolumeMutation({ invalidateOnSuccess: false })
 
   const canWrite = authenticatedUserHasPermission(OrganizationRolePermissionsEnum.WRITE_VOLUMES)
+  const canCreateBox = authenticatedUserHasPermission(OrganizationRolePermissionsEnum.WRITE_BOXES)
   const canDelete = authenticatedUserHasPermission(OrganizationRolePermissionsEnum.DELETE_VOLUMES)
 
   const [filter, setFilter] = useState('')
   const [createOpen, setCreateOpen] = useState(false)
   const [newName, setNewName] = useState('')
   const [pendingDelete, setPendingDelete] = useState<VolumeDto | null>(null)
+  const [boxVolumeId, setBoxVolumeId] = useState<string | null>(null)
   const [deleteConfirmText, setDeleteConfirmText] = useState('')
   const [busy, setBusy] = useState<Record<string, boolean>>({})
 
@@ -272,19 +274,17 @@ const Volumes: React.FC = () => {
                         label; destroy is the app's established icon treatment
                         (and a little harder to hit by accident that way). */}
                     <div className="flex items-center justify-end gap-[6px]">
-                      {canWrite && volume.state === VolumeState.READY && (
-                        <a
+                      {canCreateBox && volume.state === VolumeState.READY && (
+                        <button
+                          type="button"
                           // The id, not the name — see the mount-row comment in
-                          // CreateBoxDialog: a name persisted into box.volumes
-                          // is invisible to the server's delete guard.
-                          href={`${RoutePath.BOXES}?createBox=1&volume=${encodeURIComponent(volume.id)}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          title={`Create a box with ${volume.name} mounted (opens a new tab)`}
+                          // CreateBoxDialog.
+                          onClick={() => setBoxVolumeId(volume.id)}
+                          title={`Create a box with ${volume.name} mounted`}
                           className="whitespace-nowrap border border-border px-[9px] py-[5px] font-mono text-[11px] text-muted-foreground transition-colors hover:border-brand hover:text-foreground"
                         >
                           + Box
-                        </a>
+                        </button>
                       )}
                       {canDelete && (
                         <button
@@ -369,6 +369,19 @@ const Volumes: React.FC = () => {
           </div>
         </DialogContent>
       </Dialog>
+
+      {/* Opened here rather than at /boxes: the trip loses the list the user
+          was reading, and the row is the only thing that knows which volume
+          they meant. */}
+      {boxVolumeId && (
+        <CreateBoxDialog
+          open
+          onOpenChange={(open) => {
+            if (!open) setBoxVolumeId(null)
+          }}
+          prefillVolume={boxVolumeId}
+        />
+      )}
 
       <AlertDialog
         open={!!pendingDelete}


### PR DESCRIPTION
## Summary

A volume row's "+ Box" action was an anchor into `/boxes?createBox=1&volume=<id>` with `target="_blank"` — the dashboard's only in-app new-tab link. It now opens `CreateBoxDialog` on the Volumes page, prefilled with that volume, and gates on the permission a box create actually needs.

## Call graph

Before

```
+ Box row action        (Volumes · apps/dashboard/src/pages/Volumes.tsx:275)  ← BUG: gated on WRITE_VOLUMES, but creating a box needs WRITE_BOXES
  └─ <a target=_blank>  (Volumes · apps/dashboard/src/pages/Volumes.tsx:281)  ← BUG: new tab drops the volume list and puts Back out of reach
       └─ openFromUrl   (Boxes · apps/dashboard/src/pages/Boxes.tsx:664)  — reads ?createBox=1, opens the dialog, scrubs the URL
            └─ setPrefillVolume  (Boxes · apps/dashboard/src/pages/Boxes.tsx:670)  — carries the volume across the tab boundary
                 └─ DialogTrigger  (CreateBoxDialog · apps/dashboard/src/components/Box/CreateBoxDialog.tsx:734)  — always renders its own "New Box" button
```

After

```
+ Box row action        (Volumes · apps/dashboard/src/pages/Volumes.tsx:277)  — gated on canCreateBox (WRITE_BOXES, Volumes.tsx:100)
  └─ setBoxVolumeId     (Volumes · apps/dashboard/src/pages/Volumes.tsx:282)  — the row records which volume was meant
       └─ CreateBoxDialog  (Volumes · apps/dashboard/src/pages/Volumes.tsx:377)  — mounted on this page, open, prefillVolume={boxVolumeId}
            └─ DialogTrigger  (CreateBoxDialog · apps/dashboard/src/components/Box/CreateBoxDialog.tsx:742)  — rendered only when a caller passes one
                 └─ New Box button  (Boxes · apps/dashboard/src/pages/Boxes.tsx:762)  — Boxes passes its own trigger in
```

Fixes #1448

## Changes

- The row action is a `<button>` that opens the create-box form in place; no navigation, no second app instance.
- It gates on `WRITE_BOXES`, matching `Boxes.tsx:761`, `BoxTable/index.tsx:157` and `BoxDetails.tsx:194`. Previously `WRITE_VOLUMES` guarded it and the destination page's own check did the real work.
- `CreateBoxDialog`'s built-in trigger becomes a `children` slot, so a page that already owns its control mounts the dialog without a second button. `triggerClassName` is gone.
- Both cross-page open channels on the Boxes side retire with the link: the `?createBox=1&volume=` reader and the `BoxesLocationState` router-state one, which had no producer anywhere in the repo.
- The comments around volume selection claimed the API persists the caller's selector verbatim, so a name would be invisible to the delete guard. `box.service.ts:214-231` resolves a name or an id to the volume's id before persisting and throws when it cannot, so every copy of that rationale now gives the reason that survives: a name is only unique within one organization (`volume.service.ts:238-239`).

## How to verify

```
cd apps && npx vitest run --root dashboard
```

248 tests over 38 files. The five new cases are two-side verified: with the three production files restored to the parent commit they fail on `expected <a …> to be null`, `expected undefined to be '<volume id>'`, `expected <a …> to be undefined`, `expected undefined to be defined`, and `expected <button …> to have a length of +0 but got 1`.

To see it by hand: `cd apps && yarn start:mock`, open Volumes, and press "+ Box" on a ready volume.

## Risks / rollout

- `apps/dashboard` has no CI job — `.github/workflows/test.yml`'s path filters match only `apps/api/**` and `apps/infra/**` — so these suites run locally but not in CI. Pre-existing gap, not addressed here.
- The test helper matches `button, a` rather than `button` alone, so the permission case fails against the pre-fix `<a>` instead of passing vacuously.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Create boxes directly from the Volumes page without opening a separate page.
  - The selected volume is prefilled automatically when creating a box.
  - The create-box dialog now supports custom trigger controls and can be embedded in different page layouts.

- **Access and Availability**
  - The “+ Box” action is available only to users with box-creation permission and for volumes in a ready state.
  - Removed URL-based and router-driven methods for opening the create-box dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->