### PR TITLE
fix(setup): repair submodules whose checkout never ran

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@
 - High-cohesion facade (the shared Design rule's exemplar here): [`ImageManager`](src/boxlite/src/images/manager.rs) exposes `new`/`pull`/`list`/`load_from_local` and hides `Arc<ImageStore>`, blob sources, and manifest handling.
 - Facade exception — stateless utilities: [`jailer/common/`](src/boxlite/src/jailer/common/) async-signal-safe helpers.
 
-<!-- agent-tooling:guidance:begin rev=fce8dd28f95b sha256=0fc04f5da52b -->
+<!-- agent-tooling:guidance:begin rev=29d39e5b157b sha256=2728d86a743f -->
 
 > Managed by **boxlite-ai/agent-tooling** — do not edit between the markers. Change `plugins/boxlite-agent-tooling/guidance/workflow.md` there, then rerun `./.agent-tooling/install.sh` here.
 
@@ -92,8 +92,8 @@ Every change goes: understand → research → design → implement → test →
 **Test**
 
 - Two-side verification for reproducer tests. When you add a test alongside a fix, demonstrate it in this order, both manually run:
-  1. You must revert **every** production change — every non-test file back to its pre-fix state, only the test remains. Run the test. It must fail, with the failure pointing at the bug — log the observed failure signal (assertion text, hang, panic). **Partial reverts, mental simulation, or "it would obviously fail without the fix" are treated as cheating.** If a full revert is genuinely impractical, stop and surface that — do not paper over it.
-  2. Restore the production change in full. Run the test. It must pass.
+  1. You must revert **every** production change — every non-test file back to its pre-fix state, only the test remains. If that revert changes an API, signature, or schema so the test cannot compile or reach its defect check, keep production fully reverted and add only the smallest temporary test-only compatibility adapter needed to exercise the old contract. A test-only compatibility adapter may adapt setup or invocation only; it must not implement the fix, alter the defect check, or become the failure signal. Run the test. It must reach the defect check and fail for the original bug — log the observed failure signal (assertion text, hang, panic). **Partial reverts, mental simulation, or "it would obviously fail without the fix" are treated as cheating.** If no such adapter can preserve that signal, stop and surface the blocker.
+  2. Remove any temporary compatibility adapter, restore the production change in full, and run the test. It must pass.
      Without a complete step 1 you've only proved your code works, not that the fix was necessary or that this test would have caught the bug. Don't accept "it passes now" as evidence the test guards the right thing.
 - A test is only meaningful when there's something that could go wrong between the data being produced and the assertion being made. If the test builds the value it then asserts on (e.g., formatting a string and then asserting that the same string contains a substring it just put in), the assertion is tautological — nothing crossed a boundary, so nothing is being tested. The data must come from production code under test, not from the test body itself.
 - Add or update tests when behavior changes around branching, parsing, retries, security checks, or boundaries.

--- a/scripts/setup/setup-submodules.sh
+++ b/scripts/setup/setup-submodules.sh
@@ -67,6 +67,26 @@ validate_submodules() {
         "https://github.com/containers/bubblewrap.git"
 }
 
+# `git submodule status` prefixes a submodule with "-" only while its gitlink is
+# absent. A clone interrupted between fetch and checkout keeps the gitlink and the
+# fetched objects but leaves an empty index and no worktree files, so it reports "+"
+# or " " and reads as healthy. Emit those paths too, or the broken checkout is never
+# repaired.
+unchecked_paths() {
+    local repo_root="$1"
+    local path
+
+    # Fields are "<status><sha> <path> [(describe)]"; only the path is needed.
+    while read -r _ path _; do
+        [[ -n "$path" ]] || continue
+        if [[ ! -e "$repo_root/$path/.git" ]]; then
+            printf '%s\n' "$path"
+        elif [[ -z "$(git -C "$repo_root/$path" ls-files --cached 2>/dev/null | head -n 1)" ]]; then
+            printf '%s\n' "$path"
+        fi
+    done
+}
+
 validate_jobs() {
     local jobs="$1"
 
@@ -80,6 +100,8 @@ main() {
     local repo_root="${1:-$PROJECT_ROOT}"
     local jobs="${BOXLITE_SUBMODULE_JOBS:-4}"
     local submodule_status
+    local path
+    local unchecked=()
 
     validate_submodules "$repo_root"
     validate_jobs "$jobs"
@@ -91,14 +113,23 @@ main() {
     fi
 
     print_step "Checking git submodules... "
-    if ! grep -q '^-' <<<"$submodule_status"; then
+    while IFS= read -r path; do
+        [[ -n "$path" ]] || continue
+        unchecked+=("$path")
+    done < <(unchecked_paths "$repo_root" <<<"$submodule_status")
+
+    if ((${#unchecked[@]} == 0)); then
         print_success "Already initialized"
         return 0
     fi
 
     echo -e "${YELLOW}Initializing with $jobs jobs...${NC}"
     git -C "$repo_root" submodule sync
-    git -C "$repo_root" submodule update --init --depth 1 --jobs "$jobs"
+    # --force is what re-runs the checkout when the recorded commit already matches
+    # the submodule's HEAD — the interrupted-clone case. It is confined to the paths
+    # with no checkout, so a healthy submodule's local changes are never discarded.
+    git -C "$repo_root" submodule update --init --force --depth 1 --jobs "$jobs" \
+        -- "${unchecked[@]}"
     print_success "Submodules initialized"
 }
 

--- a/scripts/test/test-setup-submodules.sh
+++ b/scripts/test/test-setup-submodules.sh
@@ -149,4 +149,27 @@ GIT_CONFIG_GLOBAL="$scratch/gitconfig" GIT_ALLOW_PROTOCOL=file:https \
     "$subject" "$fixture" >"$scratch/second-run.log"
 grep -qi 'already initialized' "$scratch/second-run.log" || fail "second run was not idempotent"
 
+# A clone interrupted between fetch and checkout keeps its gitlink and objects but
+# loses the index and every worktree file. Git still reports such a submodule as
+# present, so the script has to recognise the empty checkout on its own.
+interrupted="src/deps/bubblewrap-sys/vendor/bubblewrap"
+interrupted_gitdir="$fixture/.git/modules/$interrupted"
+[[ -f "$interrupted_gitdir/index" ]] || fail "fixture submodule has no index to remove"
+rm -f "$interrupted_gitdir/index"
+find "$fixture/$interrupted" -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
+[[ ! -e "$fixture/$interrupted/README.md" ]] || fail "interrupted-clone fixture kept its checkout"
+if git -C "$fixture" submodule status | grep -q "^-.*$interrupted"; then
+    fail "interrupted-clone fixture reads as missing; it must read as present"
+fi
+
+GIT_CONFIG_GLOBAL="$scratch/gitconfig" GIT_ALLOW_PROTOCOL=file:https \
+    "$subject" "$fixture" >"$scratch/repair-run.log" 2>&1 || \
+    fail "repair run failed: $(cat "$scratch/repair-run.log")"
+[[ -f "$fixture/$interrupted/README.md" ]] || \
+    fail "interrupted clone was not repaired: $interrupted has no checkout"
+verify_oid "$interrupted"
+if git -C "$fixture" submodule status --recursive | grep -q '^[+-U]'; then
+    fail "repaired submodule status was not clean"
+fi
+
 printf 'test-setup-submodules: all checks passed\n'


### PR DESCRIPTION
## Summary

A clone interrupted between fetch and checkout leaves a submodule with its gitlink and
objects in place but no index and no worktree files. `setup:submodules` read that state
as healthy and skipped the repair, so every vendored dependency directory stayed empty
and no amount of re-running the setup would fix it.

## Call graph

Before

```
main                  (setup-submodules.sh:94)   — gate: grep -q '^-'   ← BUG: an interrupted clone reports "+" or " ", never "-"
  └─ print_success    (setup-submodules.sh:95)   — "Already initialized", returns 0
       └─ submodule update --init                — never reached; vendored dirs stay empty
```

After

```
main                  (setup-submodules.sh:116)  — collects the paths that have no checkout
  └─ unchecked_paths  (setup-submodules.sh:70)   — gitlink absent, or index lists no files
       └─ submodule update --init --force -- <paths>  (setup-submodules.sh:131)  — re-runs the checkout, scoped
```

Fixes #1450

## Changes

- `unchecked_paths` decides what needs initializing from the submodule itself — gitlink
  missing, or an index that lists no files — instead of trusting the `-` prefix of
  `git submodule status`, which only ever marks a submodule that was never registered.
- The repair passes `--force`, which is what makes git re-run a checkout when the pinned
  commit already equals the submodule's HEAD. It is scoped to the paths with no checkout,
  so a healthy submodule's local changes are never discarded.
- `test:setup:submodules` gains a case that wipes a submodule's index and worktree while
  keeping its gitlink, then asserts the script restores the checkout.
- Separate commit: regenerates the agent-tooling managed block in `AGENTS.md` at tooling
  rev `29d39e5b157b`.

## How to verify

- `make test:setup:submodules`
- Against a real checkout: delete `.git/modules/<submodule>/index` and every worktree entry
  under that submodule except `.git`, then run `make setup:submodules` — it now repairs the
  checkout instead of reporting "Already initialized".

## Risks / rollout

- `--force` discards local changes in the submodules it touches. It is passed only for
  paths that have no checkout at all, so there is nothing there to discard.

https://claude.ai/code/session_0123wcFzxezAbyHLev5PiqZn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved setup reliability by detecting and repairing partially completed submodule checkouts.
  - Limits recovery operations to only the affected submodules, avoiding unnecessary updates elsewhere.
  - Ensures repaired checkouts are fully restored and ready for use.

- **Tests**
  - Added coverage for interrupted submodule clone recovery and verification of a clean recursive checkout.

- **Documentation**
  - Updated workflow guidance for safely testing changes that affect compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->