### PR TITLE
feat(dashboard): surface a billing history of every charged document

### DIFF
--- a/apps/dashboard/src/billing-api/billingApiClient.test.ts
+++ b/apps/dashboard/src/billing-api/billingApiClient.test.ts
@@ -199,10 +199,106 @@ describe('PR 829 real-data parity: settlement invoices', () => {
     }
     const api = serve(response)
 
-    await expect(api.listInvoices('org-1', 2, 25)).resolves.toEqual(response)
+    // The three fields the billing history needs are absent here on purpose:
+    // this is the payload a Commerce predating that change still returns, and
+    // either side may deploy first. The client fills them rather than letting
+    // the page throw on undefined.toLowerCase() and print NaN.
+    await expect(api.listInvoices('org-1', 2, 25)).resolves.toEqual({
+      ...response,
+      items: [{ ...response.items[0], type: 'advance_charges', paymentStatus: 'succeeded', totalPaidCents: 250 }],
+    })
     expect(requestedUrl).toBe('http://billing.test/api/billing/organization/org-1/invoices?page=2&perPage=25')
     expect(api).not.toHaveProperty('createInvoicePaymentUrl')
     expect(api).not.toHaveProperty('voidInvoice')
+  })
+
+  it('leaves the fields alone once Commerce sends them', async () => {
+    const api = serve({
+      items: [
+        {
+          id: 'invoice-2',
+          number: 'BOX-2026-0002',
+          sequentialId: 2,
+          type: 'credit',
+          chargedAt: '2026-09-04T00:00:00.000Z',
+          totalAmountCents: 5_000,
+          totalPaidCents: 5_000,
+          quotaCoveredCents: 0,
+          paymentStatus: 'pending',
+          voided: false,
+        },
+      ],
+      totalItems: 1,
+      totalPages: 1,
+    })
+
+    const page = await api.listInvoices('org-1', 1, 25, 'all')
+    expect(page.items[0].type).toBe('credit')
+    expect(page.items[0].paymentStatus).toBe('pending')
+    expect(page.items[0].totalPaidCents).toBe(5_000)
+  })
+
+  it('never defaults a paid amount below zero', async () => {
+    // Quota covering more than the total should not turn into a negative charge.
+    const api = serve({
+      items: [
+        {
+          id: 'invoice-3',
+          number: 'INV-000003',
+          sequentialId: 3,
+          chargedAt: '2026-08-18T12:00:00.000Z',
+          totalAmountCents: 1_000,
+          quotaCoveredCents: 4_000,
+          voided: false,
+        },
+      ],
+      totalItems: 1,
+      totalPages: 1,
+    })
+
+    const page = await api.listInvoices('org-1')
+    expect(page.items[0].totalPaidCents).toBe(0)
+  })
+})
+
+describe('listInvoices type filter', () => {
+  const creditInvoice = {
+    id: 'invoice-1',
+    number: 'BOX-2026-0001',
+    sequentialId: 1,
+    type: 'credit',
+    chargedAt: '2026-09-04T00:00:00.000Z',
+    totalAmountCents: 5_000,
+    totalPaidCents: 5_000,
+    quotaCoveredCents: 0,
+    paymentStatus: 'succeeded',
+    voided: false,
+  }
+
+  it('omits the parameter entirely when no filter is given', async () => {
+    const api = serve({ items: [], totalItems: 0, totalPages: 0 })
+
+    await api.listInvoices('org-1')
+    // Commerce then serves settlement invoices only, which is what every
+    // caller predating the billing history already expects.
+    expect(requestedUrl).toBe('http://billing.test/api/billing/organization/org-1/invoices')
+  })
+
+  it("asks for every kind on 'all' so a later one is not silently dropped", async () => {
+    const api = serve({ items: [creditInvoice], totalItems: 1, totalPages: 1 })
+
+    const page = await api.listInvoices('org-1', 1, 50, 'all')
+    expect(requestedUrl).toBe('http://billing.test/api/billing/organization/org-1/invoices?page=1&perPage=50&type=all')
+    expect(page.items[0].type).toBe('credit')
+    expect(page.items[0].paymentStatus).toBe('succeeded')
+    expect(page.items[0].totalPaidCents).toBe(5_000)
+  })
+
+  it('comma-joins an explicit subset', async () => {
+    const api = serve({ items: [], totalItems: 0, totalPages: 0 })
+
+    await api.listInvoices('org-1', undefined, undefined, ['credit', 'one_off'])
+    expect(requestedUrl).toBe('http://billing.test/api/billing/organization/org-1/invoices?type=credit%2Cone_off')
   })
 })
 

--- a/apps/dashboard/src/billing-api/billingApiClient.ts
+++ b/apps/dashboard/src/billing-api/billingApiClient.ts
@@ -8,6 +8,9 @@ import { BoxliteError } from '@/api/errors'
 import axios, { AxiosInstance } from 'axios'
 import {
   AutomaticTopUp,
+  Invoice,
+  InvoiceTypeFilter,
+  LegacyInvoice,
   OrganizationEmail,
   OrganizationPlan,
   OrganizationWallet,
@@ -22,6 +25,24 @@ import {
   UsagePrices,
   WalletTopUpRequest,
 } from './types'
+
+/**
+ * Fill the three fields a Commerce predating the billing history does not send.
+ * Either side may deploy first, and without this the page throws on
+ * `undefined.toLowerCase()` and prints NaN in the money column.
+ *
+ * The defaults are what the older endpoint's payload means: it served
+ * settlements only, an issued settlement had already been charged, and the
+ * part that reached the card is the total the quota did not absorb.
+ */
+function settlementDefaults(invoice: LegacyInvoice): Invoice {
+  return {
+    ...invoice,
+    type: invoice.type ?? 'advance_charges',
+    paymentStatus: invoice.paymentStatus ?? 'succeeded',
+    totalPaidCents: invoice.totalPaidCents ?? Math.max(0, invoice.totalAmountCents - invoice.quotaCoveredCents),
+  }
+}
 
 export class BillingApiClient {
   private axiosInstance: AxiosInstance
@@ -173,7 +194,18 @@ export class BillingApiClient {
     await this.axiosInstance.post(`/organization/${organizationId}/email/resend`, { email })
   }
 
-  public async listInvoices(organizationId: string, page?: number, perPage?: number): Promise<PaginatedInvoices> {
+  /**
+   * Omitting `type` keeps Commerce's default of settlement invoices only, so
+   * existing callers are unaffected. Pass `'all'` for a billing history: a
+   * document kind added to Commerce later is then included without a dashboard
+   * deploy, where an explicit list would drop it silently.
+   */
+  public async listInvoices(
+    organizationId: string,
+    page?: number,
+    perPage?: number,
+    type?: InvoiceTypeFilter,
+  ): Promise<PaginatedInvoices> {
     const params = new URLSearchParams()
     if (page !== undefined) {
       params.append('page', page.toString())
@@ -181,10 +213,17 @@ export class BillingApiClient {
     if (perPage !== undefined) {
       params.append('perPage', perPage.toString())
     }
+    if (type !== undefined) {
+      // An empty list serialises to an empty name and Commerce answers 400.
+      // That is the intended outcome: asking for no kinds is a caller bug, and
+      // failing loudly beats quietly serving the default set instead.
+      params.append('type', typeof type === 'string' ? type : type.join(','))
+    }
     const queryString = params.toString()
     const url = `/organization/${organizationId}/invoices${queryString ? `?${queryString}` : ''}`
     const response = await this.axiosInstance.get(url)
-    return response.data
+    const body = response.data as { items: LegacyInvoice[]; totalItems: number; totalPages: number }
+    return { ...body, items: body.items.map(settlementDefaults) }
   }
 
   public async listWalletTransactions(

--- a/apps/dashboard/src/billing-api/types/Invoice.ts
+++ b/apps/dashboard/src/billing-api/types/Invoice.ts
@@ -4,16 +4,44 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-/** A usage settlement that was funded when Commerce recorded it. */
+/**
+ * The billing document kinds Commerce mints. Hand-copied from the service:
+ * the billing client is written by hand rather than generated, so this union
+ * has to be kept in step with Commerce's INVOICE_TYPES by eye.
+ */
+export type InvoiceType = 'advance_charges' | 'subscription' | 'one_off' | 'credit'
+
+/**
+ * Which documents a listing should return.
+ *
+ * `'all'` asks Commerce for every kind it currently mints, so a type added
+ * later shows up without a dashboard deploy — money is never silently missing
+ * from a billing history. Pass an explicit list only where excluding an
+ * unknown future kind is the point, such as a per-type filter.
+ */
+export type InvoiceTypeFilter = 'all' | InvoiceType[]
+
+/** A billing document: a usage settlement, a plan charge, or a credit purchase. */
 export interface Invoice {
   id: string
   number: string
   sequentialId: number
+  type: InvoiceType
   chargedAt: string
   totalAmountCents: number
+  totalPaidCents: number
   quotaCoveredCents: number
+  paymentStatus: 'pending' | 'succeeded' | 'failed'
   voided: boolean
 }
+
+/**
+ * What a Commerce that predates the billing-history change still serves: the
+ * three fields below arrived with the `type` filter, and either side may deploy
+ * first. The client fills them in so a settlement renders rather than throwing.
+ */
+export type LegacyInvoice = Omit<Invoice, 'type' | 'totalPaidCents' | 'paymentStatus'> &
+  Partial<Pick<Invoice, 'type' | 'totalPaidCents' | 'paymentStatus'>>
 
 export interface PaginatedInvoices {
   items: Invoice[]

--- a/apps/dashboard/src/components/Invoices/columns.test.ts
+++ b/apps/dashboard/src/components/Invoices/columns.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import type { Invoice } from '@/billing-api'
+import { describe, expect, it } from 'vitest'
+import { invoiceLabel, invoiceStatus } from './columns'
+
+const invoice: Invoice = {
+  id: 'invoice-1',
+  number: 'BOX-2026-0001',
+  sequentialId: 1,
+  type: 'advance_charges',
+  chargedAt: '2026-09-04T00:00:00.000Z',
+  totalAmountCents: 1_212,
+  totalPaidCents: 1_212,
+  quotaCoveredCents: 0,
+  paymentStatus: 'succeeded',
+  voided: false,
+}
+
+describe('invoiceLabel', () => {
+  it.each([
+    ['advance_charges', 'Usage'],
+    ['subscription', 'Renewal'],
+    ['one_off', 'Upgrade'],
+    ['credit', 'Credits'],
+  ] as const)('names %s on the billing page', (type, expected) => {
+    expect(invoiceLabel({ ...invoice, type })).toBe(expected)
+  })
+
+  it('never calls a credit document a top-up, which only the manual rail is', () => {
+    // An auto-reload rule issues this same document off-session. The wire has
+    // no `source`, so borrowing the credit ledger's word for the manual rail
+    // would put "top-up" on a charge nobody clicked.
+    expect(invoiceLabel({ ...invoice, type: 'credit' }).toLowerCase()).not.toContain('top-up')
+  })
+
+  it('falls back to the wire name for a kind Commerce added later', () => {
+    // The listing asks for every kind, so an unmapped one arrives before this
+    // map knows it. A raw name is visible enough to get fixed; `undefined` is not.
+    expect(invoiceLabel({ ...invoice, type: 'progressive_billing' as Invoice['type'] })).toBe('progressive_billing')
+  })
+})
+
+describe('invoiceStatus', () => {
+  it.each([
+    ['succeeded', 'succeeded'],
+    ['pending', 'pending'],
+    ['failed', 'failed'],
+  ] as const)('reports %s payment as-is', (paymentStatus, expected) => {
+    expect(invoiceStatus({ ...invoice, paymentStatus })).toBe(expected)
+  })
+
+  it('reports a voided document as voided even when its payment succeeded', () => {
+    expect(invoiceStatus({ ...invoice, paymentStatus: 'succeeded', voided: true })).toBe('voided')
+  })
+})

--- a/apps/dashboard/src/components/Invoices/columns.ts
+++ b/apps/dashboard/src/components/Invoices/columns.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import type { Invoice } from '@/billing-api'
+
+/**
+ * What each document kind is called on the billing page. Keyed loosely on
+ * purpose: the listing asks Commerce for every kind, so a kind added there
+ * arrives here before this map knows about it, and an unlabelled row is far
+ * better than a missing one.
+ */
+const INVOICE_LABEL: Record<string, string> = {
+  advance_charges: 'Usage',
+  subscription: 'Renewal',
+  one_off: 'Upgrade',
+  // Not "Top-up": a standing auto-reload rule issues the same document without
+  // anyone clicking, and the invoice carries no `source` to tell the two apart.
+  // Which rule fired is ledger provenance, and Credit activity already says it.
+  credit: 'Credits',
+}
+
+/** Falls back to the raw wire name so an unmapped kind still reads as something. */
+export function invoiceLabel(invoice: Invoice): string {
+  return INVOICE_LABEL[invoice.type] ?? invoice.type
+}
+
+export type InvoiceStatus = 'voided' | 'succeeded' | 'pending' | 'failed'
+
+/**
+ * A voided document was cancelled after issue, which outranks however its
+ * payment ended — a voided-but-succeeded row must not read as money kept.
+ */
+export function invoiceStatus(invoice: Invoice): InvoiceStatus {
+  return invoice.voided ? 'voided' : invoice.paymentStatus
+}

--- a/apps/dashboard/src/components/Invoices/columns.ts
+++ b/apps/dashboard/src/components/Invoices/columns.ts
@@ -22,7 +22,13 @@ const INVOICE_LABEL: Record<string, string> = {
   credit: 'Credits',
 }
 
-/** Falls back to the raw wire name so an unmapped kind still reads as something. */
+/**
+ * Returns the display label for an invoice type.
+ * Falls back to the raw wire name so an unmapped kind still reads as something.
+ *
+ * @param invoice - The invoice to get the label for
+ * @returns The human-readable label for the invoice type
+ */
 export function invoiceLabel(invoice: Invoice): string {
   return INVOICE_LABEL[invoice.type] ?? invoice.type
 }
@@ -30,8 +36,12 @@ export function invoiceLabel(invoice: Invoice): string {
 export type InvoiceStatus = 'voided' | 'succeeded' | 'pending' | 'failed'
 
 /**
+ * Determines the display status of an invoice.
  * A voided document was cancelled after issue, which outranks however its
  * payment ended — a voided-but-succeeded row must not read as money kept.
+ *
+ * @param invoice - The invoice to get the status for
+ * @returns The status to display: 'voided' if voided, otherwise the payment status
  */
 export function invoiceStatus(invoice: Invoice): InvoiceStatus {
   return invoice.voided ? 'voided' : invoice.paymentStatus

--- a/apps/dashboard/src/components/Invoices/index.test.tsx
+++ b/apps/dashboard/src/components/Invoices/index.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+/*
+ * Copyright 2025 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import type { Invoice } from '@/billing-api'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { InvoicesTable } from '.'
+
+const invoice: Invoice = {
+  id: 'invoice-1',
+  number: 'BOX-2026-0001',
+  sequentialId: 1,
+  type: 'one_off',
+  chargedAt: '2026-09-04T00:00:00.000Z',
+  totalAmountCents: 54_837,
+  totalPaidCents: 54_837,
+  quotaCoveredCents: 0,
+  paymentStatus: 'succeeded',
+  voided: false,
+}
+
+describe('InvoicesTable', () => {
+  let root: Root | null = null
+
+  beforeAll(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  })
+
+  afterEach(() => {
+    act(() => root?.unmount())
+    root = null
+    document.body.innerHTML = ''
+  })
+
+  /** Mount the table on a fresh host and hand back that host to assert against. */
+  function render(data: Invoice[]): HTMLDivElement {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const mounted = createRoot(host)
+    root = mounted
+    act(() => {
+      mounted.render(<InvoicesTable data={data} loading={false} />)
+    })
+    return host
+  }
+
+  it('lays the money history out on the credit ledger grid', () => {
+    const target = render([invoice])
+
+    expect(Array.from(target.querySelectorAll('[data-invoice-header]')).map((header) => header.textContent)).toEqual([
+      'Date',
+      'Type',
+      'Number',
+      'Amount',
+      'Status',
+    ])
+    expect(target.querySelector('[data-invoice-date]')?.textContent).toBe('2026-09-04')
+    expect(target.querySelector('[data-invoice-type]')?.textContent).toBe('upgrade')
+    expect(target.querySelector('[data-invoice-number]')?.textContent).toBe('BOX-2026-0001')
+    expect(target.querySelector('[data-invoice-status]')?.textContent).toBe('paid')
+  })
+
+  it('shows the price charged for an upgrade, not the quota it granted', () => {
+    const target = render([invoice])
+
+    // The wallet ledger's row for this same upgrade reads +548.37 of granted
+    // quota; the amount actually billed is a different number and belongs here.
+    expect(target.querySelector('[data-invoice-amount]')?.textContent).toBe('548.37')
+  })
+
+  it('shows what reached the card, not the gross total, when quota covered the usage', () => {
+    // The section promises "amounts charged to your payment method". A usage
+    // settlement fully absorbed by included quota charged nothing, so printing
+    // its 121.50 gross would be the same class of lie this page exists to end.
+    const target = render([
+      { ...invoice, type: 'advance_charges', totalAmountCents: 12_150, totalPaidCents: 0, quotaCoveredCents: 12_150 },
+    ])
+
+    expect(target.querySelector('[data-invoice-amount]')?.textContent).toBe('0.00')
+  })
+
+  it('shows a partly quota-covered settlement at the amount actually charged', () => {
+    const target = render([
+      { ...invoice, type: 'advance_charges', totalAmountCents: 9_847, totalPaidCents: 1_847, quotaCoveredCents: 8_000 },
+    ])
+
+    expect(target.querySelector('[data-invoice-amount]')?.textContent).toBe('18.47')
+  })
+
+  it('shows nothing charged for a failed payment, whatever the document totalled', () => {
+    // The column reports what reached the card. A failed charge moved no money,
+    // so echoing the document total here would read as a payment that happened.
+    const target = render([{ ...invoice, totalAmountCents: 8_900, totalPaidCents: 0, paymentStatus: 'failed' }])
+
+    expect(target.querySelector('[data-invoice-amount]')?.textContent).toBe('0.00')
+    expect(target.querySelector('[data-invoice-status]')?.textContent).toBe('failed')
+  })
+
+  it('renders a payment status Commerce added later instead of throwing', () => {
+    // Same hand-copied-union hazard as the type map: `STATUS` has four keys and
+    // an unmapped one used to reach `undefined.color` and take the page down.
+    const target = render([{ ...invoice, paymentStatus: 'disputed' as Invoice['paymentStatus'] }])
+
+    expect(target.querySelector('[data-invoice-status]')?.textContent).toBe('disputed')
+    expect(target.querySelectorAll('[data-invoice-date]')).toHaveLength(1)
+  })
+
+  it('strikes a voided document through and stops calling it paid', () => {
+    const target = render([{ ...invoice, voided: true }])
+
+    const amount = target.querySelector('[data-invoice-amount]')
+    expect(amount?.textContent).toBe('548.37')
+    expect(amount?.className).toContain('line-through')
+    expect(target.querySelector('[data-invoice-status]')?.textContent).toBe('voided')
+  })
+
+  it('says the history is empty rather than rendering a bare header', () => {
+    const target = render([])
+
+    expect(target.textContent).toContain('No billing documents yet.')
+    expect(target.querySelectorAll('[data-invoice-header]')).toHaveLength(0)
+  })
+})

--- a/apps/dashboard/src/components/Invoices/index.tsx
+++ b/apps/dashboard/src/components/Invoices/index.tsx
@@ -24,23 +24,49 @@ const STATUS: Record<string, { label: string; color: string } | undefined> = {
   voided: { label: 'voided', color: MUTED },
 }
 
+/**
+ * Returns the display label and color for an invoice status.
+ * Falls back to a muted color and the raw status name for unmapped values.
+ *
+ * @param status - The invoice status
+ * @returns Object with label text and HSL color string
+ */
 function statusMark(status: InvoiceStatus): { label: string; color: string } {
   return STATUS[status] ?? { label: status, color: MUTED }
 }
 
+/**
+ * Extracts the date portion from an invoice's charged timestamp.
+ *
+ * @param invoice - The invoice
+ * @returns Date string in YYYY-MM-DD format
+ */
 function invoiceDate(invoice: Invoice): string {
   return invoice.chargedAt.slice(0, 10)
 }
 
 /**
+ * Formats the amount actually charged to the payment method.
  * What reached the payment method, not what the document totalled. A usage
  * settlement covered by included quota is charged nothing, and showing its
  * gross total here would contradict the section's own note.
+ *
+ * @param invoice - The invoice
+ * @returns Formatted dollar amount with two decimal places
  */
 function invoiceAmount(invoice: Invoice): string {
   return (invoice.totalPaidCents / 100).toFixed(2)
 }
 
+/**
+ * Renders a table of billing invoices with columns for date, type, number, amount, and status.
+ * Shows a loading state or empty state when appropriate.
+ *
+ * @param props - Component props
+ * @param props.data - Array of invoices to display
+ * @param props.loading - Whether the data is currently loading
+ * @returns The invoices table component
+ */
 export function InvoicesTable({ data, loading }: InvoicesTableProps) {
   if (loading) {
     return <div className="border-b border-border/40 py-[13px] font-mono text-[13px]">Loading...</div>

--- a/apps/dashboard/src/components/Invoices/index.tsx
+++ b/apps/dashboard/src/components/Invoices/index.tsx
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import type { Invoice } from '@/billing-api'
+import type { InvoicesTableProps } from './types'
+import { invoiceLabel, invoiceStatus, type InvoiceStatus } from './columns'
+
+// The credit ledger's grid, so the two lists line up column for column when
+// they sit on the same page.
+const ROW = 'grid grid-cols-[100px_110px_1fr_90px_80px] items-center gap-x-4'
+
+const MUTED = 'hsl(var(--muted-foreground))'
+
+// Keyed loosely for the same reason INVOICE_LABEL is: `paymentStatus` is a
+// hand-copied union, so a value Commerce adds later arrives here before this
+// map knows it. A row that reads oddly beats a billing page that throws.
+const STATUS: Record<string, { label: string; color: string } | undefined> = {
+  succeeded: { label: 'paid', color: 'hsl(var(--success))' },
+  pending: { label: 'pending', color: 'hsl(var(--warning))' },
+  failed: { label: 'failed', color: 'hsl(var(--destructive))' },
+  voided: { label: 'voided', color: MUTED },
+}
+
+function statusMark(status: InvoiceStatus): { label: string; color: string } {
+  return STATUS[status] ?? { label: status, color: MUTED }
+}
+
+function invoiceDate(invoice: Invoice): string {
+  return invoice.chargedAt.slice(0, 10)
+}
+
+/**
+ * What reached the payment method, not what the document totalled. A usage
+ * settlement covered by included quota is charged nothing, and showing its
+ * gross total here would contradict the section's own note.
+ */
+function invoiceAmount(invoice: Invoice): string {
+  return (invoice.totalPaidCents / 100).toFixed(2)
+}
+
+export function InvoicesTable({ data, loading }: InvoicesTableProps) {
+  if (loading) {
+    return <div className="border-b border-border/40 py-[13px] font-mono text-[13px]">Loading...</div>
+  }
+
+  if (data.length === 0) {
+    return (
+      <div className="border-b border-border/40 py-[13px] font-mono text-[13px] text-muted-foreground">
+        No billing documents yet.
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <div
+        className={`${ROW} border-b border-border pb-2 font-mono text-[10px] uppercase tracking-[1px] text-muted-foreground`}
+      >
+        <span data-invoice-header>Date</span>
+        <span data-invoice-header>Type</span>
+        <span data-invoice-header>Number</span>
+        <span data-invoice-header className="text-right">
+          Amount
+        </span>
+        <span data-invoice-header className="text-right">
+          Status
+        </span>
+      </div>
+      {data.map((invoice) => {
+        const status = statusMark(invoiceStatus(invoice))
+        return (
+          <div
+            key={invoice.id}
+            className={`${ROW} border-b border-border/40 py-[13px] font-mono text-[13px] transition-colors hover:bg-muted/30`}
+          >
+            <span data-invoice-date className="text-foreground">
+              {invoiceDate(invoice)}
+            </span>
+            <span data-invoice-type className="uppercase tracking-[0.5px] text-muted-foreground">
+              {invoiceLabel(invoice).toLowerCase()}
+            </span>
+            <span data-invoice-number className="truncate text-muted-foreground">
+              {invoice.number}
+            </span>
+            <span
+              data-invoice-amount
+              className={`text-right tabular-nums ${invoice.voided ? 'text-muted-foreground line-through' : 'text-foreground'}`}
+            >
+              {invoiceAmount(invoice)}
+            </span>
+            <span className="text-right">
+              <span className="inline-flex items-center gap-1.5">
+                <span className="size-[9px]" style={{ background: status.color }} />
+                <span
+                  data-invoice-status
+                  className={
+                    invoice.paymentStatus === 'failed' && !invoice.voided ? 'text-destructive' : 'text-foreground'
+                  }
+                >
+                  {status.label}
+                </span>
+              </span>
+            </span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/Invoices/types.ts
+++ b/apps/dashboard/src/components/Invoices/types.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import type { Invoice } from '@/billing-api'
+
+export interface InvoicesTableProps {
+  data: Invoice[]
+  loading: boolean
+}

--- a/apps/dashboard/src/components/WalletTransactions/index.test.tsx
+++ b/apps/dashboard/src/components/WalletTransactions/index.test.tsx
@@ -65,4 +65,24 @@ describe('WalletTransactionsTable PR #829 surface', () => {
     expect(host.textContent).not.toContain('Details')
     expect(host.textContent).not.toContain('Page 1 of 1')
   })
+
+  it('renders a status Commerce added later instead of throwing', () => {
+    // `status` is hand-copied from the service, so an unmapped value reaches
+    // this table before the map knows it and used to hit `undefined.color`.
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    root = createRoot(host)
+
+    act(() => {
+      root?.render(
+        <WalletTransactionsTable
+          data={[{ ...transaction, status: 'reversed' as WalletTransaction['status'] }]}
+          loading={false}
+        />,
+      )
+    })
+
+    expect(host.querySelector('[data-transaction-status]')?.textContent).toBe('reversed')
+    expect(host.querySelectorAll('[data-transaction-date]')).toHaveLength(1)
+  })
 })

--- a/apps/dashboard/src/components/WalletTransactions/index.tsx
+++ b/apps/dashboard/src/components/WalletTransactions/index.tsx
@@ -10,11 +10,18 @@ import { walletTransactionLabel } from './columns'
 
 const ROW = 'grid grid-cols-[100px_110px_1fr_90px_80px] items-center gap-x-4'
 
-const STATUS = {
+// Keyed loosely on purpose: `status` is a hand-copied union, so a value
+// Commerce adds later arrives here before this map knows the key.
+const STATUS: Record<string, { label: string; color: string } | undefined> = {
   settled: { label: 'ok', color: 'hsl(var(--success))' },
   pending: { label: 'pending', color: 'hsl(var(--warning))' },
   failed: { label: 'failed', color: 'hsl(var(--destructive))' },
-} as const
+}
+
+/** Falls back to the raw name rather than throwing on `undefined.color`. */
+function statusMark(status: WalletTransaction['status']): { label: string; color: string } {
+  return STATUS[status] ?? { label: status, color: 'hsl(var(--muted-foreground))' }
+}
 
 function transactionDate(transaction: WalletTransaction): string {
   return transaction.createdAt.slice(0, 10)
@@ -46,7 +53,7 @@ export function WalletTransactionsTable({ data, loading }: WalletTransactionsTab
         </span>
       </div>
       {data.map((transaction) => {
-        const status = STATUS[transaction.status]
+        const status = statusMark(transaction.status)
         return (
           <div
             key={transaction.id}

--- a/apps/dashboard/src/components/WalletTransactions/index.tsx
+++ b/apps/dashboard/src/components/WalletTransactions/index.tsx
@@ -18,20 +18,47 @@ const STATUS: Record<string, { label: string; color: string } | undefined> = {
   failed: { label: 'failed', color: 'hsl(var(--destructive))' },
 }
 
-/** Falls back to the raw name rather than throwing on `undefined.color`. */
+/**
+ * Returns the display label and color for a transaction status.
+ * Falls back to the raw name rather than throwing on `undefined.color`.
+ *
+ * @param status - The wallet transaction status
+ * @returns Object with label text and HSL color string
+ */
 function statusMark(status: WalletTransaction['status']): { label: string; color: string } {
   return STATUS[status] ?? { label: status, color: 'hsl(var(--muted-foreground))' }
 }
 
+/**
+ * Extracts the date portion from a transaction's created timestamp.
+ *
+ * @param transaction - The wallet transaction
+ * @returns Date string in YYYY-MM-DD format
+ */
 function transactionDate(transaction: WalletTransaction): string {
   return transaction.createdAt.slice(0, 10)
 }
 
+/**
+ * Formats the transaction amount with a sign prefix indicating direction.
+ *
+ * @param transaction - The wallet transaction
+ * @returns Formatted amount with '+' prefix for inbound or '-' for outbound
+ */
 function transactionAmount(transaction: WalletTransaction): string {
   const prefix = transaction.direction === 'inbound' ? '+' : '-'
   return `${prefix}${(transaction.amountCents / 100).toFixed(2)}`
 }
 
+/**
+ * Renders a table of wallet credit transactions with columns for date, type, amount, and status.
+ * Shows a loading state when data is being fetched.
+ *
+ * @param props - Component props
+ * @param props.data - Array of wallet transactions to display
+ * @param props.loading - Whether the data is currently loading
+ * @returns The wallet transactions table component
+ */
 export function WalletTransactionsTable({ data, loading }: WalletTransactionsTableProps) {
   if (loading) {
     return <div className="border-b border-border/40 py-[13px] font-mono text-[13px]">Loading...</div>

--- a/apps/dashboard/src/components/billing/WalletSection.integration.test.tsx
+++ b/apps/dashboard/src/components/billing/WalletSection.integration.test.tsx
@@ -8,6 +8,7 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AutomaticTopUp } from '@/billing-api/types/OrganizationWallet'
+import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { WalletSection } from './WalletSection'
 
 const mocks = vi.hoisted(() => ({
@@ -219,7 +220,7 @@ describe('WalletSection top-up checkout', () => {
     })
     await flush()
 
-    expect(mocks.invoicesQuery).toHaveBeenCalledWith(1, 100)
+    expect(mocks.invoicesQuery).toHaveBeenCalledWith(1, DEFAULT_PAGE_SIZE)
     expect(document.body.textContent).toContain('2026-09-04')
 
     const nextPage = [...document.querySelectorAll<HTMLButtonElement>('button')].find(
@@ -230,7 +231,7 @@ describe('WalletSection top-up checkout', () => {
     await act(async () => nextPage?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
     await flush()
 
-    expect(mocks.invoicesQuery).toHaveBeenLastCalledWith(2, 100)
+    expect(mocks.invoicesQuery).toHaveBeenLastCalledWith(2, DEFAULT_PAGE_SIZE)
     expect(document.body.textContent).toContain('2026-08-30')
   })
 
@@ -250,7 +251,7 @@ describe('WalletSection top-up checkout', () => {
     await act(async () => fold?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
     await flush()
 
-    expect(mocks.walletTransactionsQuery).toHaveBeenCalledWith(1, 100)
+    expect(mocks.walletTransactionsQuery).toHaveBeenCalledWith(1, DEFAULT_PAGE_SIZE)
     expect(document.body.textContent).toContain('2026-07-18')
 
     const creditActivity = document.querySelector('#credit-activity')
@@ -262,7 +263,7 @@ describe('WalletSection top-up checkout', () => {
     await act(async () => nextPage?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
     await flush()
 
-    expect(mocks.walletTransactionsQuery).toHaveBeenLastCalledWith(2, 100)
+    expect(mocks.walletTransactionsQuery).toHaveBeenLastCalledWith(2, DEFAULT_PAGE_SIZE)
     expect(document.body.textContent).toContain('2026-07-15')
   })
 

--- a/apps/dashboard/src/components/billing/WalletSection.integration.test.tsx
+++ b/apps/dashboard/src/components/billing/WalletSection.integration.test.tsx
@@ -64,14 +64,18 @@ vi.mock('@/hooks/queries/billingQueries', () => ({
             voided: false,
           },
         ],
-        totalItems: 101,
+        totalItems: DEFAULT_PAGE_SIZE * 2,
         totalPages: 2,
       },
       isLoading: false,
     }
   },
-  useOwnerWalletTransactionsQuery: (page = 1, perPage?: number) => {
-    mocks.walletTransactionsQuery(page, perPage)
+  useOwnerWalletTransactionsQuery: (page = 1, perPage?: number, enabled = true) => {
+    if (!enabled) {
+      return { data: undefined, isLoading: false }
+    }
+
+    mocks.walletTransactionsQuery(page, perPage, enabled)
     return {
       data: {
         items: [
@@ -88,7 +92,7 @@ vi.mock('@/hooks/queries/billingQueries', () => ({
             settledAt: page === 1 ? '2026-07-18T00:00:00.000Z' : '2026-07-15T00:00:00.000Z',
           },
         ],
-        totalItems: 101,
+        totalItems: DEFAULT_PAGE_SIZE * 2,
         totalPages: 2,
       },
       isLoading: false,
@@ -245,13 +249,15 @@ describe('WalletSection top-up checkout', () => {
     })
     await flush()
 
+    expect(mocks.walletTransactionsQuery).not.toHaveBeenCalled()
+
     const fold = [...document.querySelectorAll<HTMLButtonElement>('button')].find((button) =>
       button.textContent?.includes('Credit activity'),
     )
     await act(async () => fold?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
     await flush()
 
-    expect(mocks.walletTransactionsQuery).toHaveBeenCalledWith(1, DEFAULT_PAGE_SIZE)
+    expect(mocks.walletTransactionsQuery).toHaveBeenCalledWith(1, DEFAULT_PAGE_SIZE, true)
     expect(document.body.textContent).toContain('2026-07-18')
 
     const creditActivity = document.querySelector('#credit-activity')
@@ -263,7 +269,7 @@ describe('WalletSection top-up checkout', () => {
     await act(async () => nextPage?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
     await flush()
 
-    expect(mocks.walletTransactionsQuery).toHaveBeenLastCalledWith(2, DEFAULT_PAGE_SIZE)
+    expect(mocks.walletTransactionsQuery).toHaveBeenLastCalledWith(2, DEFAULT_PAGE_SIZE, true)
     expect(document.body.textContent).toContain('2026-07-15')
   })
 

--- a/apps/dashboard/src/components/billing/WalletSection.integration.test.tsx
+++ b/apps/dashboard/src/components/billing/WalletSection.integration.test.tsx
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
   redeemCoupon: vi.fn(),
   setAutomaticTopUp: vi.fn(),
   topUpWallet: vi.fn(),
+  invoicesQuery: vi.fn(),
   walletTransactionsQuery: vi.fn(),
   wallet: {
     automaticTopUp: undefined as AutomaticTopUp | undefined,
@@ -44,6 +45,30 @@ vi.mock('@/hooks/queries/billingQueries', () => ({
   useFetchOwnerCheckoutUrlQuery: () => mocks.fetchCheckoutUrl,
   useIsOwnerCheckoutUrlFetching: () => false,
   useOwnerBillingPortalUrlQuery: () => ({ data: undefined, isLoading: false }),
+  useOwnerInvoicesQuery: (page = 1, perPage?: number) => {
+    mocks.invoicesQuery(page, perPage)
+    return {
+      data: {
+        items: [
+          {
+            id: `invoice-${page}`,
+            number: page === 1 ? 'BOX-2026-0002' : 'BOX-2026-0001',
+            sequentialId: page === 1 ? 2 : 1,
+            type: page === 1 ? 'one_off' : 'credit',
+            chargedAt: page === 1 ? '2026-09-04T00:00:00.000Z' : '2026-08-30T00:00:00.000Z',
+            totalAmountCents: page === 1 ? 1_212 : 5_000,
+            totalPaidCents: page === 1 ? 1_212 : 5_000,
+            quotaCoveredCents: 0,
+            paymentStatus: 'succeeded',
+            voided: false,
+          },
+        ],
+        totalItems: 101,
+        totalPages: 2,
+      },
+      isLoading: false,
+    }
+  },
   useOwnerWalletTransactionsQuery: (page = 1, perPage?: number) => {
     mocks.walletTransactionsQuery(page, perPage)
     return {
@@ -110,6 +135,7 @@ describe('WalletSection top-up checkout', () => {
     mocks.wallet.ongoingBalanceCents = 0
     mocks.wallet.creditCardConnected = false
     mocks.topUpWallet.mockClear()
+    mocks.invoicesQuery.mockClear()
     mocks.walletTransactionsQuery.mockClear()
     mocks.topUpWallet.mockResolvedValue({ url: 'https://checkout.stripe.com/pay/cs_top_up' })
   })
@@ -133,7 +159,8 @@ describe('WalletSection top-up checkout', () => {
     })
     await flush()
 
-    expect(document.body.textContent).toContain('Transactions')
+    expect(document.body.textContent).toContain('Billing history')
+    expect(document.body.textContent).toContain('Credit activity')
     expect(document.body.textContent).not.toContain('Usage Settlements')
 
     const topUpButton = [...document.querySelectorAll<HTMLButtonElement>('button')].find(
@@ -154,7 +181,7 @@ describe('WalletSection top-up checkout', () => {
     expect(checkoutWindow.location.href).toBe('https://checkout.stripe.com/pay/cs_top_up')
   })
 
-  it('loads older transactions when history exceeds the first page', async () => {
+  it('leads with the money history and folds the credit ledger away', async () => {
     const host = document.createElement('div')
     document.body.appendChild(host)
 
@@ -164,10 +191,70 @@ describe('WalletSection top-up checkout', () => {
     })
     await flush()
 
+    // The charge is on the page; the grant that shares its date is not, because
+    // showing both at equal weight is what made a grant read as an amount billed.
+    expect(document.body.textContent).toContain('BOX-2026-0002')
+    expect(document.body.textContent).toContain('2026-09-04')
+    expect(document.body.textContent).not.toContain('2026-07-18')
+
+    const fold = [...document.querySelectorAll<HTMLButtonElement>('button')].find((button) =>
+      button.textContent?.includes('Credit activity'),
+    )
+    expect(fold?.getAttribute('aria-expanded')).toBe('false')
+
+    await act(async () => fold?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+    await flush()
+
+    expect(fold?.getAttribute('aria-expanded')).toBe('true')
+    expect(document.body.textContent).toContain('2026-07-18')
+  })
+
+  it('loads older invoices when the billing history exceeds the first page', async () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+
+    await act(async () => {
+      root = createRoot(host)
+      root.render(<WalletSection />)
+    })
+    await flush()
+
+    expect(mocks.invoicesQuery).toHaveBeenCalledWith(1, 100)
+    expect(document.body.textContent).toContain('2026-09-04')
+
+    const nextPage = [...document.querySelectorAll<HTMLButtonElement>('button')].find(
+      (button) => button.textContent?.trim() === 'Next →',
+    )
+    expect(nextPage).toBeDefined()
+
+    await act(async () => nextPage?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+    await flush()
+
+    expect(mocks.invoicesQuery).toHaveBeenLastCalledWith(2, 100)
+    expect(document.body.textContent).toContain('2026-08-30')
+  })
+
+  it('loads older transactions when credit activity exceeds the first page', async () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+
+    await act(async () => {
+      root = createRoot(host)
+      root.render(<WalletSection />)
+    })
+    await flush()
+
+    const fold = [...document.querySelectorAll<HTMLButtonElement>('button')].find((button) =>
+      button.textContent?.includes('Credit activity'),
+    )
+    await act(async () => fold?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+    await flush()
+
     expect(mocks.walletTransactionsQuery).toHaveBeenCalledWith(1, 100)
     expect(document.body.textContent).toContain('2026-07-18')
 
-    const nextPage = [...document.querySelectorAll<HTMLButtonElement>('button')].find(
+    const creditActivity = document.querySelector('#credit-activity')
+    const nextPage = [...(creditActivity?.querySelectorAll<HTMLButtonElement>('button') ?? [])].find(
       (button) => button.textContent?.trim() === 'Next →',
     )
     expect(nextPage).toBeDefined()

--- a/apps/dashboard/src/components/billing/WalletSection.tsx
+++ b/apps/dashboard/src/components/billing/WalletSection.tsx
@@ -7,6 +7,7 @@
 import { AutomaticTopUp } from '@/billing-api/types/OrganizationWallet'
 import { AsciiButton, AsciiChip, BRAND, Panel, PanelNote, SectionTitle, SegmentedBar } from '@/components/ascii'
 import { BalanceThresholdBanner } from '@/components/billing/BalanceLowBanner'
+import { InvoicesTable } from '@/components/Invoices'
 import { WalletTransactionsTable } from '@/components/WalletTransactions'
 import { Input } from '@/components/ui/input'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -18,6 +19,7 @@ import {
   useFetchOwnerCheckoutUrlQuery,
   useIsOwnerCheckoutUrlFetching,
   useOwnerBillingPortalUrlQuery,
+  useOwnerInvoicesQuery,
   useOwnerPaymentMethodsQuery,
   useOwnerPlanQuery,
   useOwnerWalletTransactionsQuery,
@@ -33,6 +35,7 @@ import { toast } from 'sonner'
 import { PaymentMethodsPanel } from './PaymentMethodsPanel'
 
 const TRANSACTION_HISTORY_LIMIT = 100
+const INVOICE_HISTORY_LIMIT = 100
 
 /** Commerce rejects anything smaller, so the form says so before the round trip. */
 export const MIN_TOP_UP_DOLLARS = 10
@@ -54,42 +57,106 @@ export function topUpGate(amountDollars: number | undefined): { enabled: boolean
   return { enabled: true, reason: null }
 }
 
-/** Own the server page so the PR #829 grid can stay a presentation-only component. */
-function WalletTransactionsSection() {
-  const [page, setPage] = useState(1)
-  const transactionsQuery = useOwnerWalletTransactionsQuery(page, TRANSACTION_HISTORY_LIMIT)
-  const totalPages = transactionsQuery.data?.totalPages ?? 0
-
+/** Keep the requested page inside a total that shrinks under it. */
+function useClampPage(page: number, totalPages: number, setPage: (page: number) => void) {
   useEffect(() => {
     if (totalPages > 0 && page > totalPages) {
       setPage(totalPages)
     }
-  }, [page, totalPages])
+  }, [page, totalPages, setPage])
+}
+
+function Pager({
+  page,
+  totalPages,
+  onPage,
+}: {
+  page: number
+  totalPages: number
+  onPage: (next: (current: number) => number) => void
+}) {
+  if (totalPages <= 1) {
+    return null
+  }
+
+  return (
+    <div className="flex items-center justify-end gap-3 border-b border-border/40 py-3 font-mono text-[11px] text-muted-foreground">
+      <span>
+        Page {page} of {totalPages}
+      </span>
+      <AsciiButton onClick={() => onPage((current) => Math.max(1, current - 1))} disabled={page <= 1}>
+        ← Previous
+      </AsciiButton>
+      <AsciiButton onClick={() => onPage((current) => Math.min(totalPages, current + 1))} disabled={page >= totalPages}>
+        Next →
+      </AsciiButton>
+    </div>
+  )
+}
+
+/**
+ * The money history: what was actually charged, for usage, plan changes and
+ * credit purchases alike. This is the primary billing surface — a credit grant
+ * is quota rather than a payment, and reading both off one table is what let a
+ * prorated upgrade's granted quota be mistaken for the amount billed for it.
+ */
+function BillingHistorySection() {
+  const [page, setPage] = useState(1)
+  const invoicesQuery = useOwnerInvoicesQuery(page, INVOICE_HISTORY_LIMIT)
+  const totalPages = invoicesQuery.data?.totalPages ?? 0
+  useClampPage(page, totalPages, setPage)
 
   return (
     <section>
       <SectionTitle
-        title="Transactions"
-        count={transactionsQuery.data ? `${transactionsQuery.data.totalItems} records` : undefined}
+        title="Billing history"
+        count={invoicesQuery.data ? `${invoicesQuery.data.totalItems} documents` : undefined}
       />
-      <WalletTransactionsTable
-        data={transactionsQuery.data?.items ?? []}
-        loading={Boolean(transactionsQuery.isLoading || transactionsQuery.isFetching)}
+      <InvoicesTable
+        data={invoicesQuery.data?.items ?? []}
+        loading={Boolean(invoicesQuery.isLoading || invoicesQuery.isFetching)}
       />
-      {totalPages > 1 && (
-        <div className="flex items-center justify-end gap-3 border-b border-border/40 py-3 font-mono text-[11px] text-muted-foreground">
-          <span>
-            Page {page} of {totalPages}
-          </span>
-          <AsciiButton onClick={() => setPage((current) => Math.max(1, current - 1))} disabled={page <= 1}>
-            ← Previous
-          </AsciiButton>
-          <AsciiButton
-            onClick={() => setPage((current) => Math.min(totalPages, current + 1))}
-            disabled={page >= totalPages}
-          >
-            Next →
-          </AsciiButton>
+      <Pager page={page} totalPages={totalPages} onPage={setPage} />
+      <PanelNote>Amounts charged to your payment method. Credit grants are listed under Credit activity.</PanelNote>
+    </section>
+  )
+}
+
+/**
+ * Grants, expiries and void-restores are free quota with no invoice behind
+ * them, so they appear in no other feed and still need a home — but folded,
+ * because a top-up already shows in the billing history above as the money it
+ * cost, and showing it twice at equal weight is what caused the confusion.
+ */
+function WalletTransactionsSection() {
+  const [open, setOpen] = useState(false)
+  const [page, setPage] = useState(1)
+  const transactionsQuery = useOwnerWalletTransactionsQuery(page, TRANSACTION_HISTORY_LIMIT, open)
+  const totalPages = transactionsQuery.data?.totalPages ?? 0
+  useClampPage(page, totalPages, setPage)
+
+  return (
+    <section>
+      <button
+        type="button"
+        aria-expanded={open}
+        aria-controls="credit-activity"
+        onClick={() => setOpen((wasOpen) => !wasOpen)}
+        className="flex w-full items-center gap-2 border-b border-border pb-2 font-mono text-[10px] uppercase tracking-[1.5px] text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <span style={{ color: BRAND }}>{open ? '▾' : '▸'}</span>
+        Credit activity
+        <span className="ml-auto normal-case tracking-normal">
+          {transactionsQuery.data ? `${transactionsQuery.data.totalItems} records` : ''}
+        </span>
+      </button>
+      {open && (
+        <div id="credit-activity" className="mt-3">
+          <WalletTransactionsTable
+            data={transactionsQuery.data?.items ?? []}
+            loading={Boolean(transactionsQuery.isLoading || transactionsQuery.isFetching)}
+          />
+          <Pager page={page} totalPages={totalPages} onPage={setPage} />
         </div>
       )}
     </section>
@@ -553,7 +620,9 @@ export function WalletSection() {
             </Panel>
           </section>
 
-          <WalletTransactionsSection key={selectedOrganization?.id ?? 'no-organization'} />
+          <BillingHistorySection key={`invoices-${selectedOrganization?.id ?? 'no-organization'}`} />
+
+          <WalletTransactionsSection key={`credits-${selectedOrganization?.id ?? 'no-organization'}`} />
         </div>
       )}
     </div>

--- a/apps/dashboard/src/components/billing/WalletSection.tsx
+++ b/apps/dashboard/src/components/billing/WalletSection.tsx
@@ -7,6 +7,7 @@
 import { AutomaticTopUp } from '@/billing-api/types/OrganizationWallet'
 import { AsciiButton, AsciiChip, BRAND, Panel, PanelNote, SectionTitle, SegmentedBar } from '@/components/ascii'
 import { BalanceThresholdBanner } from '@/components/billing/BalanceLowBanner'
+import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { InvoicesTable } from '@/components/Invoices'
 import { WalletTransactionsTable } from '@/components/WalletTransactions'
 import { Input } from '@/components/ui/input'
@@ -33,9 +34,6 @@ import { NumericFormat } from 'react-number-format'
 import { useAuth } from 'react-oidc-context'
 import { toast } from 'sonner'
 import { PaymentMethodsPanel } from './PaymentMethodsPanel'
-
-const TRANSACTION_HISTORY_LIMIT = 100
-const INVOICE_HISTORY_LIMIT = 100
 
 /** Commerce rejects anything smaller, so the form says so before the round trip. */
 export const MIN_TOP_UP_DOLLARS = 10
@@ -128,7 +126,7 @@ function Pager({
  */
 function BillingHistorySection() {
   const [page, setPage] = useState(1)
-  const invoicesQuery = useOwnerInvoicesQuery(page, INVOICE_HISTORY_LIMIT)
+  const invoicesQuery = useOwnerInvoicesQuery(page, DEFAULT_PAGE_SIZE)
   const totalPages = invoicesQuery.data?.totalPages ?? 0
   useClampPage(page, totalPages, setPage)
 
@@ -160,7 +158,7 @@ function BillingHistorySection() {
 function WalletTransactionsSection() {
   const [open, setOpen] = useState(false)
   const [page, setPage] = useState(1)
-  const transactionsQuery = useOwnerWalletTransactionsQuery(page, TRANSACTION_HISTORY_LIMIT, open)
+  const transactionsQuery = useOwnerWalletTransactionsQuery(page, DEFAULT_PAGE_SIZE, open)
   const totalPages = transactionsQuery.data?.totalPages ?? 0
   useClampPage(page, totalPages, setPage)
 

--- a/apps/dashboard/src/components/billing/WalletSection.tsx
+++ b/apps/dashboard/src/components/billing/WalletSection.tsx
@@ -46,7 +46,13 @@ export const MIN_TOP_UP_DOLLARS = 10
  */
 const DEFAULT_AUTO_RELOAD: AutomaticTopUp = { thresholdAmount: 20, targetAmount: 100 }
 
-/** Whether Top up can run, and why not when it cannot. */
+/**
+ * Validates whether a top-up amount meets requirements.
+ * Whether Top up can run, and why not when it cannot.
+ *
+ * @param amountDollars - The amount in dollars to validate, or undefined
+ * @returns Object with enabled flag and optional reason string when disabled
+ */
 export function topUpGate(amountDollars: number | undefined): { enabled: boolean; reason: string | null } {
   if (!amountDollars) {
     return { enabled: false, reason: null }
@@ -57,7 +63,14 @@ export function topUpGate(amountDollars: number | undefined): { enabled: boolean
   return { enabled: true, reason: null }
 }
 
-/** Keep the requested page inside a total that shrinks under it. */
+/**
+ * Ensures the current page stays within valid bounds when total pages change.
+ * Keep the requested page inside a total that shrinks under it.
+ *
+ * @param page - Current page number
+ * @param totalPages - Total number of available pages
+ * @param setPage - Function to update the page number
+ */
 function useClampPage(page: number, totalPages: number, setPage: (page: number) => void) {
   useEffect(() => {
     if (totalPages > 0 && page > totalPages) {
@@ -66,6 +79,16 @@ function useClampPage(page: number, totalPages: number, setPage: (page: number) 
   }, [page, totalPages, setPage])
 }
 
+/**
+ * Renders pagination controls for navigating between pages.
+ * Hidden when there's only one page or no pages.
+ *
+ * @param props - Component props
+ * @param props.page - Current page number
+ * @param props.totalPages - Total number of pages
+ * @param props.onPage - Callback to update page number, receives updater function
+ * @returns Pagination controls or null if not needed
+ */
 function Pager({
   page,
   totalPages,
@@ -95,10 +118,13 @@ function Pager({
 }
 
 /**
+ * Displays the billing history section showing all charged invoices.
  * The money history: what was actually charged, for usage, plan changes and
  * credit purchases alike. This is the primary billing surface — a credit grant
  * is quota rather than a payment, and reading both off one table is what let a
  * prorated upgrade's granted quota be mistaken for the amount billed for it.
+ *
+ * @returns The billing history section component with invoice table and pagination
  */
 function BillingHistorySection() {
   const [page, setPage] = useState(1)
@@ -123,10 +149,13 @@ function BillingHistorySection() {
 }
 
 /**
+ * Displays the collapsible credit activity section showing wallet ledger transactions.
  * Grants, expiries and void-restores are free quota with no invoice behind
  * them, so they appear in no other feed and still need a home — but folded,
  * because a top-up already shows in the billing history above as the money it
  * cost, and showing it twice at equal weight is what caused the confusion.
+ *
+ * @returns The wallet transactions section component with collapsible content
  */
 function WalletTransactionsSection() {
   const [open, setOpen] = useState(false)
@@ -163,6 +192,12 @@ function WalletTransactionsSection() {
   )
 }
 
+/**
+ * Main wallet section component displaying balance, payment methods, billing history, and credit activity.
+ * Manages state for top-ups, auto-reload settings, and coupon redemption.
+ *
+ * @returns The complete wallet section component
+ */
 export function WalletSection() {
   const { selectedOrganization } = useSelectedOrganization()
   const { user } = useAuth()

--- a/apps/dashboard/src/hooks/mutations/useDowngradePlanMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useDowngradePlanMutation.ts
@@ -25,6 +25,7 @@ export const useDowngradePlanMutation = () => {
         queryClient.invalidateQueries({ queryKey: queryKeys.organization.plan(organizationId) }),
         queryClient.invalidateQueries({ queryKey: queryKeys.organization.usage.overview(organizationId) }),
         queryClient.invalidateQueries({ queryKey: queryKeys.billing.transactions(organizationId) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.billing.invoices(organizationId) }),
       ])
     },
   })

--- a/apps/dashboard/src/hooks/mutations/useKeepPlanMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useKeepPlanMutation.ts
@@ -41,6 +41,7 @@ export const useKeepPlanMutation = () => {
         queryClient.invalidateQueries({ queryKey: queryKeys.organization.plan(organizationId) }),
         queryClient.invalidateQueries({ queryKey: queryKeys.organization.usage.overview(organizationId) }),
         queryClient.invalidateQueries({ queryKey: queryKeys.billing.transactions(organizationId) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.billing.invoices(organizationId) }),
       ])
     },
   })

--- a/apps/dashboard/src/hooks/mutations/useRedeemCouponMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useRedeemCouponMutation.ts
@@ -23,6 +23,7 @@ export const useRedeemCouponMutation = () => {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: queryKeys.organization.wallet(organizationId) }),
         queryClient.invalidateQueries({ queryKey: queryKeys.billing.transactions(organizationId) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.billing.invoices(organizationId) }),
         // a coupon can upgrade the plan
         queryClient.invalidateQueries({ queryKey: queryKeys.organization.plan(organizationId) }),
         queryClient.invalidateQueries({ queryKey: queryKeys.organization.usage.overview(organizationId) }),

--- a/apps/dashboard/src/hooks/mutations/useTopUpWalletMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useTopUpWalletMutation.ts
@@ -24,6 +24,7 @@ export const useTopUpWalletMutation = () => {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: queryKeys.organization.wallet(organizationId) }),
         queryClient.invalidateQueries({ queryKey: queryKeys.billing.transactions(organizationId) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.billing.invoices(organizationId) }),
       ])
     },
   })

--- a/apps/dashboard/src/hooks/mutations/useUpgradePlanMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useUpgradePlanMutation.ts
@@ -25,6 +25,7 @@ export const useUpgradePlanMutation = () => {
         queryClient.invalidateQueries({ queryKey: queryKeys.organization.plan(organizationId) }),
         queryClient.invalidateQueries({ queryKey: queryKeys.organization.usage.overview(organizationId) }),
         queryClient.invalidateQueries({ queryKey: queryKeys.billing.transactions(organizationId) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.billing.invoices(organizationId) }),
       ])
     },
   })

--- a/apps/dashboard/src/hooks/mutations/useWalletTransactionInvalidation.test.tsx
+++ b/apps/dashboard/src/hooks/mutations/useWalletTransactionInvalidation.test.tsx
@@ -82,4 +82,32 @@ describe('wallet transaction invalidation', () => {
 
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: queryKeys.billing.transactions('org-1') })
   })
+
+  it('refreshes the billing history after a top-up, not only the credit ledger', async () => {
+    // A top-up now mints its own document. Leaving the invoice key out would
+    // hold the primary section on stale data for the 5-minute staleTime while
+    // the ledger folded beneath it refreshed immediately.
+    await act(async () => {
+      await topUpWallet?.mutateAsync({ organizationId: 'org-1', amountCents: 500 })
+    })
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: queryKeys.billing.invoices('org-1') })
+  })
+
+  it('refreshes the billing history after a coupon redemption', async () => {
+    await act(async () => {
+      await redeemCoupon?.mutateAsync({ organizationId: 'org-1', couponCode: 'SAVE10' })
+    })
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: queryKeys.billing.invoices('org-1') })
+  })
+
+  it('shares one prefix between the filtered listing and the invalidation key', () => {
+    // Invalidation only reaches the listing if its key is a prefix of it; a
+    // separate shape would silently no-op.
+    const prefix = queryKeys.billing.invoices('org-1')
+    const listing = queryKeys.billing.invoices('org-1', 'all', 1, 100)
+
+    expect(listing.slice(0, prefix.length)).toEqual([...prefix])
+  })
 })

--- a/apps/dashboard/src/hooks/queries/billingQueries.ts
+++ b/apps/dashboard/src/hooks/queries/billingQueries.ts
@@ -14,6 +14,7 @@ import {
   useFetchOrganizationCheckoutUrlQuery,
   useIsOrganizationCheckoutUrlFetching,
 } from './useOrganizationCheckoutUrlQuery'
+import { useOrganizationInvoicesQuery } from './useOrganizationInvoicesQuery'
 import { useOrganizationWalletTransactionsQuery } from './useOrganizationWalletTransactionsQuery'
 import { useOrganizationPaymentMethodsQuery } from './useOrganizationPaymentMethodsQuery'
 import { useOrganizationPlanQuery } from './useOrganizationPlanQuery'
@@ -68,12 +69,27 @@ export function useIsOwnerCheckoutUrlFetching() {
   return useIsOrganizationCheckoutUrlFetching(organizationId)
 }
 
-export function useOwnerWalletTransactionsQuery(page?: number, perPage?: number) {
+/**
+ * The billing history: every document kind Commerce mints, so a kind added
+ * later appears here without a dashboard deploy.
+ */
+export function useOwnerInvoicesQuery(page?: number, perPage?: number) {
   const scope = useSelectedOrgBillingScope()
-  return useOrganizationWalletTransactionsQuery({
+  return useOrganizationInvoicesQuery({
     ...scope,
+    type: 'all',
     page,
     perPage,
+  })
+}
+
+export function useOwnerWalletTransactionsQuery(page?: number, perPage?: number, enabled = true) {
+  const scope = useSelectedOrgBillingScope()
+  return useOrganizationWalletTransactionsQuery({
+    organizationId: scope.organizationId,
+    page,
+    perPage,
+    enabled: scope.enabled && enabled,
   })
 }
 

--- a/apps/dashboard/src/hooks/queries/billingQueries.ts
+++ b/apps/dashboard/src/hooks/queries/billingQueries.ts
@@ -83,6 +83,15 @@ export function useOwnerInvoicesQuery(page?: number, perPage?: number) {
   })
 }
 
+/**
+ * Fetches wallet credit transactions for the selected organization owner.
+ * Returns grants, expiries, purchases, and usage charges affecting the wallet balance.
+ *
+ * @param page - Page number for pagination
+ * @param perPage - Number of items per page
+ * @param enabled - Whether the query should run, defaults to true
+ * @returns React Query result with paginated wallet transactions
+ */
 export function useOwnerWalletTransactionsQuery(page?: number, perPage?: number, enabled = true) {
   const scope = useSelectedOrgBillingScope()
   return useOrganizationWalletTransactionsQuery({

--- a/apps/dashboard/src/hooks/queries/queryKeys.ts
+++ b/apps/dashboard/src/hooks/queries/queryKeys.ts
@@ -51,6 +51,16 @@ export const queryKeys = {
     portalUrl: (organizationId: string) => [...queryKeys.billing.all, organizationId, 'portal-url'] as const,
     checkoutUrl: (organizationId: string) => [...queryKeys.billing.all, organizationId, 'checkout-url'] as const,
     paymentMethods: (organizationId: string) => [...queryKeys.billing.all, organizationId, 'payment-methods'] as const,
+    // Called with the organization alone this is the prefix every invoice
+    // listing shares, which is what the money mutations invalidate.
+    invoices: (organizationId: string, type?: string, page?: number, perPage?: number) =>
+      [
+        ...queryKeys.billing.all,
+        organizationId,
+        'invoices',
+        ...(type !== undefined ? [type] : []),
+        ...(page !== undefined && perPage !== undefined ? [{ page, perPage }] : []),
+      ] as const,
     transactions: (organizationId: string, page?: number, perPage?: number) =>
       [
         ...queryKeys.billing.all,

--- a/apps/dashboard/src/hooks/queries/queryKeys.ts
+++ b/apps/dashboard/src/hooks/queries/queryKeys.ts
@@ -51,8 +51,11 @@ export const queryKeys = {
     portalUrl: (organizationId: string) => [...queryKeys.billing.all, organizationId, 'portal-url'] as const,
     checkoutUrl: (organizationId: string) => [...queryKeys.billing.all, organizationId, 'checkout-url'] as const,
     paymentMethods: (organizationId: string) => [...queryKeys.billing.all, organizationId, 'payment-methods'] as const,
-    // Called with the organization alone this is the prefix every invoice
-    // listing shares, which is what the money mutations invalidate.
+    /**
+     * Query key factory for invoice listings.
+     * Called with the organization alone this is the prefix every invoice
+     * listing shares, which is what the money mutations invalidate.
+     */
     invoices: (organizationId: string, type?: string, page?: number, perPage?: number) =>
       [
         ...queryKeys.billing.all,

--- a/apps/dashboard/src/hooks/queries/useOrganizationInvoicesQuery.ts
+++ b/apps/dashboard/src/hooks/queries/useOrganizationInvoicesQuery.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import type { InvoiceTypeFilter, PaginatedInvoices } from '@/billing-api/types/Invoice'
+import { useQuery } from '@tanstack/react-query'
+import { useApi } from '../useApi'
+import { useConfig } from '../useConfig'
+import { queryKeys } from './queryKeys'
+
+/** Serialise the filter the same way the request does, so it can key the cache. */
+function invoiceTypeKey(type: InvoiceTypeFilter): string {
+  return typeof type === 'string' ? type : type.join(',')
+}
+
+export function useOrganizationInvoicesQuery({
+  organizationId,
+  type,
+  page,
+  perPage,
+  enabled = true,
+}: {
+  organizationId: string
+  type: InvoiceTypeFilter
+  page?: number
+  perPage?: number
+  enabled?: boolean
+}) {
+  const { billingApi } = useApi()
+  const config = useConfig()
+
+  return useQuery<PaginatedInvoices>({
+    // Two filters are two different listings, so the filter belongs in the key.
+    queryKey: queryKeys.billing.invoices(organizationId, invoiceTypeKey(type), page, perPage),
+    queryFn: () => billingApi.listInvoices(organizationId, page, perPage, type),
+    enabled: Boolean(enabled && config.billingApiUrl && organizationId),
+  })
+}

--- a/apps/dashboard/src/hooks/queries/useOrganizationInvoicesQuery.ts
+++ b/apps/dashboard/src/hooks/queries/useOrganizationInvoicesQuery.ts
@@ -10,11 +10,29 @@ import { useApi } from '../useApi'
 import { useConfig } from '../useConfig'
 import { queryKeys } from './queryKeys'
 
-/** Serialise the filter the same way the request does, so it can key the cache. */
+/**
+ * Converts an invoice type filter to a cache key string.
+ * Serialise the filter the same way the request does, so it can key the cache.
+ *
+ * @param type - The invoice type filter ('all' or array of types)
+ * @returns String representation for cache key
+ */
 function invoiceTypeKey(type: InvoiceTypeFilter): string {
   return typeof type === 'string' ? type : type.join(',')
 }
 
+/**
+ * Fetches a paginated list of invoices for an organization.
+ * Filters by invoice type and supports pagination.
+ *
+ * @param params - Query parameters
+ * @param params.organizationId - The organization ID
+ * @param params.type - Filter for invoice types ('all' or specific types)
+ * @param params.page - Page number for pagination
+ * @param params.perPage - Number of items per page
+ * @param params.enabled - Whether the query should run
+ * @returns React Query result with paginated invoices
+ */
 export function useOrganizationInvoicesQuery({
   organizationId,
   type,

--- a/apps/dashboard/src/mocks/fixtures.ts
+++ b/apps/dashboard/src/mocks/fixtures.ts
@@ -263,6 +263,12 @@ const HISTORY_END = new Date('2026-01-22T00:00:00.000Z')
 
 const DAY_MS = 86_400_000
 
+/**
+ * Calculates a date string counting back from the mock "today".
+ *
+ * @param days - Number of days to count back from HISTORY_END
+ * @returns ISO 8601 date string
+ */
 function daysBefore(days: number): string {
   return new Date(HISTORY_END.getTime() - days * DAY_MS).toISOString()
 }

--- a/apps/dashboard/src/mocks/fixtures.ts
+++ b/apps/dashboard/src/mocks/fixtures.ts
@@ -9,6 +9,8 @@
 // boxes) with no backend and no login, so local UI work doesn't depend on a
 // reachable dev API. Shapes follow the generated API client types.
 
+import type { Invoice } from '@/billing-api/types/Invoice'
+import type { WalletTransaction } from '@/billing-api/types/WalletTransaction'
 import {
   type Box,
   BoxClassEnum,
@@ -243,4 +245,135 @@ export const MOCK_VOLUME_USAGE: Record<string, { boxId: string; boxName: string;
     { boxId: 'mock-box-stopped', boxName: 'batch-worker', mountPath: '/models' },
   ],
   'vol-e5f6g7h8': [{ boxId: 'mock-box-running', boxName: 'web-api', mountPath: '/data' }],
+}
+
+// --- Billing history depth -------------------------------------------------
+//
+// The hand-written invoice and wallet rows in handlers.ts are a *coverage*
+// fixture: one of every type, status and label variant, so nothing renders as
+// `undefined`. They are deliberately few, which means the billing page in mock
+// never fills, never paginates, and never shows what a year of documents looks
+// like. These generators supply the *depth* the curated rows sit on top of.
+//
+// Everything below is arithmetic, no RNG: the same reload gives the same
+// history, so a screenshot is reproducible and a change in the UI is a real one.
+
+/** The mock "today". Every generated date is counted back from here. */
+const HISTORY_END = new Date('2026-01-22T00:00:00.000Z')
+
+const DAY_MS = 86_400_000
+
+function daysBefore(days: number): string {
+  return new Date(HISTORY_END.getTime() - days * DAY_MS).toISOString()
+}
+
+/**
+ * Usage settles every third day and the plan renews monthly, so a year reaches
+ * ~150 documents — past the page size the billing history requests, which is
+ * the only way the pager is reachable in mock at all.
+ */
+export function buildInvoiceHistory(): Invoice[] {
+  const rows: Invoice[] = []
+
+  for (let day = 3; day <= 365; day += 3) {
+    // A sawtooth between roughly $6 and $46, so the amount column has shape
+    // instead of one repeated number. Quota absorbs the first $20 of each.
+    const amountCents = 640 + ((day * 37) % 4_000)
+    rows.push({
+      id: `inv-usage-${day}`,
+      number: `BOX-2025-${String(2_000 - day).padStart(4, '0')}`,
+      sequentialId: 2_000 - day,
+      type: 'advance_charges',
+      chargedAt: daysBefore(day),
+      totalAmountCents: amountCents,
+      totalPaidCents: Math.max(0, amountCents - 2_000),
+      quotaCoveredCents: Math.min(amountCents, 2_000),
+      paymentStatus: 'succeeded',
+      voided: false,
+    })
+  }
+
+  for (let month = 1; month <= 12; month += 1) {
+    rows.push({
+      id: `inv-renewal-${month}`,
+      number: `BOX-2025-${String(2_100 + month).padStart(4, '0')}`,
+      sequentialId: 2_100 + month,
+      type: 'subscription',
+      chargedAt: daysBefore(month * 30),
+      totalAmountCents: 25_000,
+      totalPaidCents: 25_000,
+      quotaCoveredCents: 0,
+      paymentStatus: 'succeeded',
+      voided: false,
+    })
+  }
+
+  // Roughly every six weeks the balance ran low and credits were bought. Some
+  // of these were a person clicking Top up and some were a standing auto-reload
+  // rule firing off-session; the invoice wire carries no `source`, so they are
+  // indistinguishable here on purpose — which is why the label is "Credits".
+  for (let index = 1; index <= 8; index += 1) {
+    rows.push({
+      id: `inv-credit-${index}`,
+      number: `BOX-2025-${String(2_200 + index).padStart(4, '0')}`,
+      sequentialId: 2_200 + index,
+      type: 'credit',
+      chargedAt: daysBefore(index * 42),
+      totalAmountCents: index % 2 === 0 ? 5_000 : 10_000,
+      totalPaidCents: index % 2 === 0 ? 5_000 : 10_000,
+      quotaCoveredCents: 0,
+      paymentStatus: 'succeeded',
+      voided: false,
+    })
+  }
+
+  return rows
+}
+
+/**
+ * The credit ledger over the same span: the monthly cycle grant that funds the
+ * plan, and the usage that draws it back down.
+ */
+export function buildWalletHistory(): WalletTransaction[] {
+  const rows: WalletTransaction[] = []
+
+  for (let month = 1; month <= 12; month += 1) {
+    const createdAt = daysBefore(month * 30)
+    rows.push({
+      id: `txn-cycle-${month}`,
+      direction: 'inbound',
+      kind: 'granted',
+      status: 'settled',
+      source: 'interval',
+      amountCents: 25_000,
+      name: 'Pro monthly quota',
+      subscriptionCreditKind: 'cycle',
+      createdAt,
+      settledAt: createdAt,
+    })
+  }
+
+  for (let day = 3; day <= 365; day += 3) {
+    const createdAt = daysBefore(day)
+    rows.push({
+      id: `txn-usage-${day}`,
+      direction: 'outbound',
+      kind: 'invoiced',
+      status: 'settled',
+      source: 'interval',
+      amountCents: 640 + ((day * 37) % 4_000),
+      name: null,
+      subscriptionCreditKind: null,
+      createdAt,
+      settledAt: createdAt,
+    })
+  }
+
+  return rows
+}
+
+/** Newest first — the order both feeds are served in. */
+export function newestFirst<T extends Invoice | WalletTransaction>(rows: T[]): T[] {
+  const chargedOrCreated = (row: T) => ('chargedAt' in row ? row.chargedAt : row.createdAt)
+  return [...rows].sort((left, right) => chargedOrCreated(right).localeCompare(chargedOrCreated(left)))
 }

--- a/apps/dashboard/src/mocks/handlers.ts
+++ b/apps/dashboard/src/mocks/handlers.ts
@@ -26,7 +26,10 @@ import {
   MOCK_PAGINATED_BOXES,
   MOCK_VOLUMES,
   MOCK_VOLUME_USAGE,
+  buildInvoiceHistory,
   buildMockConfig,
+  buildWalletHistory,
+  newestFirst,
 } from './fixtures'
 
 const BILLING_API_URL = 'http://localhost:3000/api/billing'
@@ -347,47 +350,126 @@ export const handlers = [
 
     const mockInvoices: Invoice[] = [
       {
+        // A standing auto-reload rule bought these off-session — the charge the
+        // customer did not initiate, and the one hardest to place on a card
+        // statement. The wire carries no `source`, so it is deliberately
+        // indistinguishable here from the manual purchase below; that is why
+        // the label is "Credits" and not "Top-up".
+        id: 'inv-013',
+        number: 'BOX-2026-0012',
+        sequentialId: 12,
+        type: 'credit',
+        chargedAt: new Date('2026-01-22').toISOString(),
+        totalAmountCents: 5_000,
+        totalPaidCents: 5_000,
+        quotaCoveredCents: 0,
+        paymentStatus: 'succeeded',
+        voided: false,
+      },
+      {
+        id: 'inv-010',
+        number: 'BOX-2026-0011',
+        sequentialId: 11,
+        type: 'credit',
+        chargedAt: new Date('2026-01-14').toISOString(),
+        totalAmountCents: 10_000,
+        totalPaidCents: 10_000,
+        quotaCoveredCents: 0,
+        paymentStatus: 'succeeded',
+        voided: false,
+      },
+      {
+        id: 'inv-011',
+        number: 'BOX-2026-0010',
+        sequentialId: 10,
+        type: 'one_off',
+        // The upgrade that granted 548.37 of quota cost this much to buy.
+        chargedAt: new Date('2026-01-09').toISOString(),
+        totalAmountCents: 4_231,
+        totalPaidCents: 4_231,
+        quotaCoveredCents: 0,
+        paymentStatus: 'succeeded',
+        voided: false,
+      },
+      {
+        id: 'inv-012',
+        number: 'BOX-2026-0009',
+        sequentialId: 9,
+        type: 'subscription',
+        chargedAt: new Date('2026-01-05').toISOString(),
+        totalAmountCents: 25_000,
+        totalPaidCents: 0,
+        quotaCoveredCents: 0,
+        paymentStatus: 'pending',
+        voided: false,
+      },
+      {
         id: 'inv-001',
         number: 'INV-2026-001',
         sequentialId: 1,
+        type: 'advance_charges',
         chargedAt: new Date('2026-01-01').toISOString(),
         totalAmountCents: 9847,
+        totalPaidCents: 1_847,
         quotaCoveredCents: 8_000,
+        paymentStatus: 'succeeded',
         voided: false,
       },
       {
         id: 'inv-004',
         number: 'INV-2025-010',
         sequentialId: 10,
+        type: 'advance_charges',
         chargedAt: new Date('2025-10-01').toISOString(),
         totalAmountCents: 12150,
+        totalPaidCents: 0,
         quotaCoveredCents: 12_150,
+        paymentStatus: 'succeeded',
         voided: false,
       },
       {
         id: 'inv-009',
         number: 'INV-2030-010',
         sequentialId: 10,
+        type: 'advance_charges',
         chargedAt: new Date('2025-10-01').toISOString(),
         totalAmountCents: 12150,
+        totalPaidCents: 2_150,
         quotaCoveredCents: 10_000,
+        paymentStatus: 'succeeded',
         voided: true,
       },
       {
         id: 'inv-005',
         number: 'INV-2025-009',
         sequentialId: 9,
+        type: 'advance_charges',
         chargedAt: new Date('2025-09-01').toISOString(),
         totalAmountCents: 8900,
+        // Nothing reached the card, which is what the Amount column reports.
+        totalPaidCents: 0,
         quotaCoveredCents: 0,
+        paymentStatus: 'failed',
         voided: false,
       },
+      // A year of ordinary months underneath, so the page fills and pages.
+      ...buildInvoiceHistory(),
     ]
+
+    // Mirror Commerce: no `type` means settlements only, `all` means every
+    // kind, otherwise the named subset. Without this the mock cannot show the
+    // difference the billing history exists to make visible.
+    const requestedTypes = url.searchParams.get('type')
+    const visibleInvoices = newestFirst(
+      requestedTypes === 'all'
+        ? mockInvoices
+        : mockInvoices.filter((invoice) => (requestedTypes?.split(',') ?? ['advance_charges']).includes(invoice.type)),
+    )
 
     const startIndex = (page - 1) * perPage
     const endIndex = startIndex + perPage
-    const paginatedItems = mockInvoices.slice(startIndex, endIndex)
-    const totalItems = mockInvoices.length
+    const paginatedItems = visibleInvoices.slice(startIndex, endIndex)
+    const totalItems = visibleInvoices.length
     const totalPages = Math.ceil(totalItems / perPage)
 
     return HttpResponse.json<PaginatedInvoices>({
@@ -558,13 +640,17 @@ export const handlers = [
         createdAt: '2026-08-23T10:00:00.000Z',
         settledAt: null,
       },
+      // The same year of ordinary months as the invoice feed: the cycle grant
+      // that funds the plan and the usage that draws it back down.
+      ...buildWalletHistory(),
     ]
+    const ledger = newestFirst(transactions)
     const start = (page - 1) * perPage
 
     return HttpResponse.json<PaginatedWalletTransactions>({
-      items: transactions.slice(start, start + perPage),
-      totalItems: transactions.length,
-      totalPages: Math.ceil(transactions.length / perPage),
+      items: ledger.slice(start, start + perPage),
+      totalItems: ledger.length,
+      totalPages: Math.ceil(ledger.length / perPage),
     })
   }),
   http.post(`${BILLING_API_URL}/organization/:organizationId/wallet/top-up`, async () => {


### PR DESCRIPTION
## Summary

The billing page's only list was the wallet ledger, which records granted quota rather than money. A mid-cycle upgrade showed the prorated included-usage it granted while the amount actually charged for it appeared on no customer-facing surface. This adds a Billing history of every charged document and demotes the credit ledger to a fold beneath it.

## Call graph

Before
```
WalletSection              (apps/dashboard/src/components/billing/WalletSection.tsx:166)
  └─ WalletTransactionsSection                                          — the only list
       └─ useOwnerWalletTransactionsQuery (hooks/queries/billingQueries.ts:86)
            └─ listWalletTransactions     (BillingApiClient · billing-api/billingApiClient.ts:229)
                 └─ WalletTransactionsTable (components/WalletTransactions/index.tsx:35)
                      └─ STATUS[transaction.status]  ← BUG: unmapped status → undefined.color, page throws

  (no invoice path — listInvoices had no caller, and plan-fee
   invoices and top-up documents reached no surface at all)
```

After
```
WalletSection              (apps/dashboard/src/components/billing/WalletSection.tsx:166)
  ├─ BillingHistorySection                       (WalletSection.tsx:103)  — primary
  │    └─ useOwnerInvoicesQuery                  (billingQueries.ts:76)   — asks type 'all'
  │         └─ useOrganizationInvoicesQuery      (hooks/queries/useOrganizationInvoicesQuery.ts:18)
  │              └─ listInvoices                 (BillingApiClient · billingApiClient.ts:203)
  │                   └─ settlementDefaults      (billingApiClient.ts:38)  — fills fields an older service omits
  │                        └─ InvoicesTable      (components/Invoices/index.tsx:44)
  │                             └─ invoiceAmount (components/Invoices/index.tsx:40)  — reads totalPaidCents
  │
  └─ WalletTransactionsSection                   (WalletSection.tsx:131)  — folded, lazy
       └─ useOwnerWalletTransactionsQuery        (billingQueries.ts:86)   — gated on the fold
            └─ WalletTransactionsTable           (components/WalletTransactions/index.tsx:35)
                 └─ statusMark                   — falls back to the raw name instead of throwing
```

## Changes

- **Billing history is the primary list; credit activity is a fold.** A top-up appears in both feeds, so one has to lead. Grants, expiries and void-restores carry no invoice, so the ledger stays — collapsed, and its query deferred until opened.
- **`listInvoices` takes an optional `'all' | InvoiceType[]` filter.** The history asks for `'all'`, so a document kind the service adds later is included without a dashboard deploy; an explicit list would drop it silently, and money missing from a billing history is worse than an unlabelled row.
- **The client fills `type`, `paymentStatus` and `totalPaidCents` when absent.** They arrive with the `type` filter and either side may deploy first; without defaults a settlement from an older service throws on `undefined.toLowerCase()` and prints `NaN` in the money column.
- **The Amount column reads `totalPaidCents`, not the document total.** A usage settlement absorbed by included quota is charged nothing, and its gross total would contradict the note printed under the table.
- **`credit` documents are labelled "Credits", not "Top-up".** A standing auto-reload rule issues the same document off-session, and the invoice wire carries no `source` to tell the two apart. Provenance stays in the credit ledger, which does have `source` and already splits Top-up from Auto top-up.
- **Both status maps fall back to the raw wire name.** `paymentStatus` and the wallet's `status` are hand-copied unions; an unmapped value previously reached `undefined.color` and took the page down.
- **Every money mutation now invalidates the invoice listing** alongside the credit ledger, so the promoted section does not sit on stale data for the 5-minute `staleTime` while the demoted one refreshes.
- **Mock fixtures gained deterministic generators** for a year of documents, and the handler honours the `type` parameter, so the billing page in mock fills and paginates.

## How to verify

```
cd apps && yarn vitest run --config dashboard/vite.config.mts --dir dashboard/src
cd apps && yarn tsc -p dashboard/tsconfig.app.json --noEmit
```

For the page itself, `yarn start:mock` needs no backend and no login — the Wallet tab shows 149 documents across two pages, with the credit ledger folded beneath.

## Risks / rollout

- Ordering with the service is safe in both directions: omitting `type` preserves the current settlements-only response, and `settlementDefaults` covers a service that predates the three new fields. The defaults assume an issued settlement was collected, which is true of the payload shipping today but is an assumption about a service outside this repo.
- No CI job runs dashboard tests — `.github/workflows/test.yml` invokes only `api:test` — so the suite here is local-only coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate **Billing history** and collapsible **Credit activity** sections to the wallet.
  * Billing history displays invoice dates, types, numbers, paid amounts, and payment statuses.
  * Added pagination for both billing history and credit activity.
  * Added filtering of invoices by type.
  * Added a helpful empty state when no billing documents are available.
* **Bug Fixes**
  * Older invoice formats continue to display with sensible defaults.
  * Unknown transaction or payment statuses render safely.
  * Voided invoices are clearly marked and styled appropriately.
  * Billing history refreshes after billing-related actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->