### PR TITLE
build: show guest e2fsprogs output only on failure

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -308,6 +308,15 @@ test\:guest-perms:
 		exit 1; \
 	fi
 
+# Run a guest build contract case without the full artifact qualification suite.
+PHONY_TARGETS += test\:guest-build-contracts
+test\:guest-build-contracts: export _BOXLITE_GUEST_TARGET_ARG := $(value GUEST_TARGET)
+test\:guest-build-contracts: export _BOXLITE_PROFILE_ARG := $(value PROFILE)
+test\:guest-build-contracts:
+	@target="$${_BOXLITE_GUEST_TARGET_ARG:-$$(bash "$$PWD/scripts/util.sh" --target)}"; \
+	profile="$${_BOXLITE_PROFILE_ARG:-release}"; \
+	bash "$$PWD/scripts/test/test-guest-build-contracts.sh" --target "$$target" --profile "$$profile" --case "$${FILTER:-all}"
+
 # Build and qualify the standalone guest artifacts. Native x86_64 release also
 # exercises verifier rejection paths; matching native Linux runs tool smoke tests.
 test\:guest-artifacts: export _BOXLITE_GUEST_TARGET_ARG := $(value GUEST_TARGET)

--- a/make/test.mk
+++ b/make/test.mk
@@ -308,15 +308,6 @@ test\:guest-perms:
 		exit 1; \
 	fi
 
-# Run a guest build contract case without the full artifact qualification suite.
-PHONY_TARGETS += test\:guest-build-contracts
-test\:guest-build-contracts: export _BOXLITE_GUEST_TARGET_ARG := $(value GUEST_TARGET)
-test\:guest-build-contracts: export _BOXLITE_PROFILE_ARG := $(value PROFILE)
-test\:guest-build-contracts:
-	@target="$${_BOXLITE_GUEST_TARGET_ARG:-$$(bash "$$PWD/scripts/util.sh" --target)}"; \
-	profile="$${_BOXLITE_PROFILE_ARG:-release}"; \
-	bash "$$PWD/scripts/test/test-guest-build-contracts.sh" --target "$$target" --profile "$$profile" --case "$${FILTER:-all}"
-
 # Build and qualify the standalone guest artifacts. Native x86_64 release also
 # exercises verifier rejection paths; matching native Linux runs tool smoke tests.
 test\:guest-artifacts: export _BOXLITE_GUEST_TARGET_ARG := $(value GUEST_TARGET)

--- a/scripts/build/build-guest-deps.sh
+++ b/scripts/build/build-guest-deps.sh
@@ -66,6 +66,10 @@ cleanup() {
     local status=$? cleanup_failed=0
     trap - EXIT HUP INT TERM
     set +e
+    if [ "$status" -ne 0 ] && [ -n "$work" ] && [ -s "$work/build.log" ]; then
+        echo "ERROR: guest e2fsprogs build failed; build output follows:" >&2
+        cat "$work/build.log" >&2
+    fi
     remove_tree "$work" "temporary guest tools work directory" || cleanup_failed=1
     remove_tree "$stage" "guest tools staging directory" || cleanup_failed=1
     if [ "$status" -eq 0 ] && [ "$cleanup_failed" -ne 0 ]; then
@@ -233,7 +237,7 @@ build_tools() {
         make -j"$jobs" libs
         make -C misc -j"$jobs" mke2fs.static
         make -C resize -j"$jobs" resize2fs.static
-    )
+    ) >"$work/build.log" 2>&1
 
     stage=$(mktemp -d "$output_parent/.guest-tools-stage.XXXXXX")
     install -m 0755 "$work/build/misc/mke2fs.static" "$stage/mke2fs"

--- a/scripts/test/test-guest-build-contracts.sh
+++ b/scripts/test/test-guest-build-contracts.sh
@@ -20,7 +20,7 @@ while [ "$#" -gt 0 ]; do
 done
 case "$profile" in release|debug) ;; *) echo "ERROR: unsupported profile: $profile" >&2; exit 2 ;; esac
 case "$test_case" in
-    all|cleanup|failure-leaves-history-untouched|guest-mode|historical-content|missing-readelf|unsafe-guest-symlink) ;;
+    all|build-output|cleanup|failure-leaves-history-untouched|guest-mode|historical-content|missing-readelf|unsafe-guest-symlink) ;;
     *) echo "ERROR: unsupported guest build contract case: $test_case" >&2; exit 2 ;;
 esac
 if [ -z "$target" ]; then target=$(bash "$root/scripts/util.sh" --target); fi
@@ -208,11 +208,7 @@ check_unsafe_guest_symlink() {
     saved_guest=""
 }
 
-check_cleanup_failure() {
-    local fixture_root="$tmp/cleanup-repo" fixture_bin="$tmp/cleanup-bin"
-    local headers="$tmp/cleanup-headers" cleanup_env="$tmp/fail-cleanup.bash"
-    local fixture_target
-
+prepare_guest_tools_fixture() {
     mkdir -p "$fixture_root/scripts/build" \
         "$fixture_root/src/deps/e2fsprogs-sys/vendor/e2fsprogs/config" \
         "$fixture_bin" "$headers/asm" "$headers/linux"
@@ -245,6 +241,68 @@ check_cleanup_failure() {
         "$fixture_bin/make" "$fixture_bin/${target%%-*}-linux-musl-gcc" "$fixture_bin/cc"
     : > "$headers/asm/unistd.h"
     : > "$headers/linux/audit.h"
+}
+
+check_build_output() {
+    local fixture_root="$tmp/output-repo" fixture_bin="$tmp/output-bin"
+    local headers="$tmp/output-headers" fixture_target phase status expected
+    prepare_guest_tools_fixture
+    cat >> "$fixture_root/src/deps/e2fsprogs-sys/vendor/e2fsprogs/configure" <<'EOF'
+echo 'configure stdout'
+echo 'configure stderr' >&2
+if [ "$FAIL_PHASE" = configure ]; then exit 41; fi
+EOF
+    cat > "$fixture_bin/make" <<'EOF'
+#!/bin/bash
+case "$*" in
+    *mke2fs.static*) phase=mke2fs ;;
+    *resize2fs.static*) phase=resize2fs ;;
+    *) phase=libs ;;
+esac
+echo "$phase stdout"
+echo "$phase stderr" >&2
+if [ "$FAIL_PHASE" = "$phase" ]; then exit 42; fi
+EOF
+    for phase in success configure libs mke2fs resize2fs; do
+        rm -rf -- "$fixture_target"
+        status=0
+        FAIL_PHASE="$phase" CLEANUP_TEST_HEADERS="$headers" BUILD_CC=cc TMPDIR="$tmp" \
+            PATH="$fixture_bin:$PATH" bash "$fixture_root/scripts/build/build-guest-deps.sh" \
+            --target "$target" --profile "$profile" >"$tmp/build.out" 2>"$tmp/build.err" || status=$?
+        if [ "$phase" = success ]; then
+            [ "$status" -eq 0 ] || fail "successful build returned $status"
+            if grep -Eq '(configure|libs|mke2fs|resize2fs) (stdout|stderr)' "$tmp/build.out" "$tmp/build.err"; then
+                fail "successful guest tools build leaked configure or make output"
+            fi
+            grep -Fq 'Guest e2fsprogs tools built:' "$tmp/build.out" || fail "missing success summary"
+            [ -s "$fixture_target/mke2fs" ] && [ -s "$fixture_target/resize2fs" ] || fail "tools were not published"
+            continue
+        fi
+        expected=42
+        if [ "$phase" = configure ]; then expected=41; fi
+        [ "$status" -eq "$expected" ] || fail "$phase failure returned $status instead of $expected"
+        for expected in configure "$phase"; do
+            grep -Fxq "$expected stdout" "$tmp/build.err" || fail "$phase failure lost $expected stdout"
+            grep -Fxq "$expected stderr" "$tmp/build.err" || fail "$phase failure lost $expected stderr"
+        done
+        case "$phase" in
+            configure) expected=libs ;;
+            libs) expected=mke2fs ;;
+            mke2fs) expected=resize2fs ;;
+            resize2fs) expected='Guest e2fsprogs tools built:' ;;
+        esac
+        if grep -Fq "$expected" "$tmp/build.out" "$tmp/build.err"; then
+            fail "build continued after $phase failed"
+        fi
+        [ ! -e "$fixture_target/mke2fs" ] && [ ! -e "$fixture_target/resize2fs" ] || fail "failed build published tools"
+    done
+}
+
+check_cleanup_failure() {
+    local fixture_root="$tmp/cleanup-repo" fixture_bin="$tmp/cleanup-bin"
+    local headers="$tmp/cleanup-headers" cleanup_env="$tmp/fail-cleanup.bash"
+    local fixture_target
+    prepare_guest_tools_fixture
     printf '%s\n' \
         'rm() {' \
         '  case "$*" in' \
@@ -277,6 +335,7 @@ case "$test_case" in
     missing-readelf) check_missing_readelf ;;
     unsafe-guest-symlink) check_unsafe_guest_symlink ;;
     cleanup) check_cleanup_failure ;;
+    build-output) check_build_output ;;
     all)
         check_historical_content
         check_failure_leaves_history_untouched
@@ -284,6 +343,7 @@ case "$test_case" in
         check_missing_readelf
         check_unsafe_guest_symlink
         check_cleanup_failure
+        check_build_output
         ;;
 esac
 


### PR DESCRIPTION
## Summary

Guest e2fsprogs builds stream every configure check and compiler message into the runtime build output, obscuring progress on successful builds. Capture configure and make stdout/stderr in the existing temporary work directory, retain the short progress and completion messages, and print the captured log to stderr when the build fails.

## Call graph

Before
```text
build_guest_deps (scripts/build/build-runtime.sh:192) — starts the tools builder
  → build_tools (scripts/build/build-guest-deps.sh:163) — streams configure and make output
  → cleanup (scripts/build/build-guest-deps.sh:65) — removes temporary files and preserves status
```

After
```text
build_guest_deps (scripts/build/build-runtime.sh:192) — starts the tools builder
  → build_tools (scripts/build/build-guest-deps.sh:167) — captures configure and make output in build.log
  → cleanup (scripts/build/build-guest-deps.sh:65) — prints the log on failure, then removes temporary files and preserves status
```

## Changes

The configure/build subshell remains outside conditional execution, preserving Bash stop-on-error behavior. The existing cleanup trap prints diagnostics before deleting the temporary log. A focused Make target exposes the guest build contract cases; the output case exercises the production builder with stubbed build tools.

## How to verify

- `make test:guest-build-contracts FILTER=build-output GUEST_TARGET=aarch64-unknown-linux-musl PROFILE=debug`
- `make test:guest-build-contracts FILTER=cleanup GUEST_TARGET=aarch64-unknown-linux-musl PROFILE=debug`
- `bash -n scripts/build/build-guest-deps.sh scripts/test/test-guest-build-contracts.sh`
- `git diff --check`

These checks passed locally. The output regression failed against the original production script before the change, then passed with it. It covers quiet success, stdout/stderr recovery, original exit codes, and stopping before subsequent phases or publication when configure, libraries, mke2fs, or resize2fs fails. Full cross-compilation was not rerun.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a targeted test command for running individual guest build contract cases with configurable targets, profiles, and filters.
  - Added coverage for guest-tools build output handling, failure propagation, and prevention of partial artifacts.

- **Bug Fixes**
  - Build failures now provide captured configuration and compilation output, improving diagnostic visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->