### PR TITLE
ci: remove the CodeQL bootstrap gate

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -131,19 +131,6 @@ not analyze pull requests from forks — which makes the `code_scanning` ruleset
 scanning results") permanently block fork PRs. Advanced setup runs on `pull_request`, so fork PRs
 in this public repo are scanned and the gate is satisfiable without an admin bypass.
 
-GitHub rejects advanced CodeQL uploads while default setup is enabled, so the workflow is dormant
-until the repository variable `CODEQL_ADVANCED_SETUP_ENABLED` is `true` (`codeql.yml:35`).
-
-**Activation, in this order:**
-
-1. Merge the workflow while `CODEQL_ADVANCED_SETUP_ENABLED` is unset or `false`, so default setup
-   remains the active scanner.
-2. Disable CodeQL default setup.
-3. Set the repository variable `CODEQL_ADVANCED_SETUP_ENABLED=true`.
-4. Trigger a push, pull request update, or manual dispatch, and verify the analysis uploads.
-
-**Rollback:** set `CODEQL_ADVANCED_SETUP_ENABLED=false` and re-enable default setup.
-
 The `analyze` job is a matrix over `actions`, `c-cpp`, `go`, `javascript-typescript`, `python` and
 `rust`. All use `build-mode: none` (source only, no compile) except `go`, whose extractor has to
 observe a real build and therefore uses `autobuild`.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,10 +5,6 @@
 # "Require code scanning results" ruleset rule can be satisfied without an admin
 # bypass.
 #
-# GitHub rejects advanced CodeQL uploads while default setup is enabled, so keep
-# this workflow dormant until repository variable CODEQL_ADVANCED_SETUP_ENABLED
-# is set to "true" after default setup is disabled.
-#
 # Languages use `build-mode: none` (source-only analysis, no compile step) where
 # CodeQL supports it. Go does not support `none` — its extractor must observe a
 # build — so Go uses `autobuild` (the same mode default setup used successfully
@@ -32,7 +28,6 @@ concurrency:
 
 jobs:
   analyze:
-    if: vars.CODEQL_ADVANCED_SETUP_ENABLED == 'true'
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

Remove the bootstrap variable gate so fork pull requests can run advanced CodeQL analysis when repository variables are unavailable. Default setup is already disabled, so remove the obsolete activation and rollback instructions as well.

Refs #842, whose CodeQL job was skipped despite the repository variable being set to `true`.

## Call graph

```text
Before
pull_request                 (.github/workflows/codeql.yml:21)
└─ analyze                   (.github/workflows/codeql.yml:35)
   └─ require bootstrap var  ← BUG: unavailable fork-PR variable skips the matrix
      └─ CodeQL analysis     (.github/workflows/codeql.yml:73) — no scan results

After
pull_request                 (.github/workflows/codeql.yml:17)
└─ analyze                   (.github/workflows/codeql.yml:30) — no bootstrap gate
   └─ Initialize CodeQL      (.github/workflows/codeql.yml:62)
      └─ CodeQL analysis     (.github/workflows/codeql.yml:68) — analyze and upload
```

## How to verify

- `make lint fmt:check test`: infrastructure type-check and all 512 tests passed; format/lint targets skip these YAML/documentation-only changes.
- Parsed `.github/workflows/codeql.yml` with `js-yaml`; all six language entries and existing triggers are preserved.
- `git diff --check` passed.
- On GitHub, verify that the six CodeQL matrix jobs execute and upload analysis results. Fork-PR behavior needs verification on a fork PR after it picks up this workflow.

## Risks / rollout

CodeQL default setup must remain disabled when advanced analysis uploads run. The repository currently reports default setup as `not-configured`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CodeQL workflow documentation to reflect that advanced analysis is no longer controlled by a repository variable.
  * Retained guidance that pull request activity, including contributions from forks, is scanned.

* **Chores**
  * CodeQL analysis now runs automatically on its configured workflow triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->