### PR TITLE
test(jailer): pair host-grant test with network.mode=disabled

### DIFF
--- a/src/boxlite/tests/jailer.rs
+++ b/src/boxlite/tests/jailer.rs
@@ -9,7 +9,7 @@
 mod common;
 
 use boxlite::runtime::advanced_options::{AdvancedBoxOptions, SecurityOptions};
-use boxlite::runtime::options::BoxOptions;
+use boxlite::runtime::options::{BoxOptions, NetworkSpec};
 use common::box_test::BoxTestBase;
 use std::path::PathBuf;
 
@@ -240,6 +240,7 @@ async fn host_network_grants_off_box_starts_and_executes() {
     };
     let options = BoxOptions {
         advanced,
+        network: NetworkSpec::Disabled,
         ..common::alpine_opts()
     };
     let t = BoxTestBase::with_home(jh.home, options).await;


### PR DESCRIPTION
## Summary

The #1072 regression guard added in #1079 asks for a box configuration the same
PR taught `sanitize_common` to reject, so it panics in fixture setup instead of
reaching its assertion. Pair it with `network.mode="disabled"`, as its own doc
comment already states.

## Call graph

Before

    host_network_grants_off_box_starts_and_executes  (test · src/boxlite/tests/jailer.rs:233)
      └─ with_home        (BoxTestBase · src/test-utils/src/box_test.rs:66)
           └─ create      (BoxliteRuntime · src/boxlite/src/runtime/core.rs:298)
                └─ sanitize_common  (BoxOptions · src/boxlite/src/runtime/options.rs:625)  ← BUG: `network` inherited from `alpine_opts()` as `Enabled`, so `network_enabled=false` trips the guard → InvalidArgument → the fixture's `.expect` panics
                     └─ exec_stdout  (BoxTestBase · src/boxlite/tests/jailer.rs:249)  — never reached

After

    host_network_grants_off_box_starts_and_executes  (test · src/boxlite/tests/jailer.rs:233)
      └─ with_home        (BoxTestBase · src/test-utils/src/box_test.rs:66)
           └─ create      (BoxliteRuntime · src/boxlite/src/runtime/core.rs:298)
                └─ sanitize_common  (BoxOptions · src/boxlite/src/runtime/options.rs:625)  — accepts `network.mode="disabled"` + `network_enabled=false`
                     └─ exec_stdout  (BoxTestBase · src/boxlite/tests/jailer.rs:249)  — reached; box starts without the jailer's host network grants

## Changes

- `src/boxlite/tests/jailer.rs`: set `network: NetworkSpec::Disabled` on the
  host-grant test's options. The AF_UNIX control-plane coverage the test exists
  for is unaffected — the seatbelt/Landlock profile is built from
  `security.network_enabled`, independently of `NetworkSpec`.

## How to verify

    make test:integration:rust FILTER=host_network_grants_off

Reverting the one-line pairing reproduces the failure this fixes:
`create BoxTestBase box: InvalidArgument("advanced.security.network_enabled=false
does not disable guest networking …")` at `src/test-utils/src/box_test.rs:76`.

## Risks / rollout

- Test-only; no production path changes.
- Main's `E2E local` has been red on this test since #1079 landed (2026-08-27);
  it is the only failing case in that suite's recent runs.
- Out of scope, same root cause: `docs/guides/ai-agent-integration.md:60` and
  `:214-227` still show `security.network_enabled=False` with no paired network
  mode, which `sanitize_common` now rejects at create.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated coverage to verify that boxes start and execute correctly when networking is disabled.
  - Added documentation for the regression scenario covered by the test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->