### PR TITLE
feat(api): add presigned direct file access to volumes

### DIFF
--- a/apps/api/src/box/box.module.ts
+++ b/apps/api/src/box/box.module.ts
@@ -22,7 +22,9 @@ import { BoxWarmPoolService } from './services/box-warm-pool.service'
 import { WarmPool } from './entities/warm-pool.entity'
 import { PreviewController } from './controllers/preview.controller'
 import { VolumeController } from './controllers/volume.controller'
+import { VolumeFilesController } from './controllers/volume-files.controller'
 import { VolumeService } from './services/volume.service'
+import { VolumeFilesService } from './services/volume-files.service'
 import { VolumeManager } from './managers/volume.manager'
 import { Volume } from './entities/volume.entity'
 import { VolumeSubscriber } from './subscribers/volume.subscriber'
@@ -59,7 +61,14 @@ import { BoxMigrationJobReceiver } from './services/box-migration-job-receiver.s
     RegionModule,
     TypeOrmModule.forFeature([Box, Runner, WarmPool, Volume, Region, Job, BoxLastActivity, BoxMigration]),
   ],
-  controllers: [BoxController, RunnerController, PreviewController, VolumeController, JobController],
+  controllers: [
+    BoxController,
+    RunnerController,
+    PreviewController,
+    VolumeController,
+    VolumeFilesController,
+    JobController,
+  ],
   providers: [
     BoxService,
     BoxManager,
@@ -68,6 +77,7 @@ import { BoxMigrationJobReceiver } from './services/box-migration-job-receiver.s
     BoxLookupCacheInvalidationService,
     RedisLockProvider,
     VolumeService,
+    VolumeFilesService,
     VolumeManager,
     VolumeSubscriber,
     RunnerSubscriber,

--- a/apps/api/src/box/box.module.ts
+++ b/apps/api/src/box/box.module.ts
@@ -22,7 +22,6 @@ import { BoxWarmPoolService } from './services/box-warm-pool.service'
 import { WarmPool } from './entities/warm-pool.entity'
 import { PreviewController } from './controllers/preview.controller'
 import { VolumeController } from './controllers/volume.controller'
-import { VolumeFilesController } from './controllers/volume-files.controller'
 import { VolumeService } from './services/volume.service'
 import { VolumeFilesService } from './services/volume-files.service'
 import { VolumeManager } from './managers/volume.manager'
@@ -61,14 +60,7 @@ import { BoxMigrationJobReceiver } from './services/box-migration-job-receiver.s
     RegionModule,
     TypeOrmModule.forFeature([Box, Runner, WarmPool, Volume, Region, Job, BoxLastActivity, BoxMigration]),
   ],
-  controllers: [
-    BoxController,
-    RunnerController,
-    PreviewController,
-    VolumeController,
-    VolumeFilesController,
-    JobController,
-  ],
+  controllers: [BoxController, RunnerController, PreviewController, VolumeController, JobController],
   providers: [
     BoxService,
     BoxManager,
@@ -112,6 +104,7 @@ import { BoxMigrationJobReceiver } from './services/box-migration-job-receiver.s
     RunnerService,
     RedisLockProvider,
     VolumeService,
+    VolumeFilesService,
     VolumeManager,
     BoxRepository,
     RunnerAdapterFactory,

--- a/apps/api/src/box/controllers/volume-files.controller.ts
+++ b/apps/api/src/box/controllers/volume-files.controller.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Body, Controller, Delete, Get, HttpCode, Param, Post, Query, UseGuards } from '@nestjs/common'
+import { ApiBearerAuth, ApiHeader, ApiOAuth2, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger'
+import { CombinedAuthGuard } from '../../auth/combined-auth.guard'
+import { CustomHeaders } from '../../common/constants/header.constants'
+import { RequiredOrganizationResourcePermissions } from '../../organization/decorators/required-organization-resource-permissions.decorator'
+import { OrganizationResourcePermission } from '../../organization/enums/organization-resource-permission.enum'
+import { OrganizationResourceActionGuard } from '../../organization/guards/organization-resource-action.guard'
+import { AuthenticatedRateLimitGuard } from '../../common/guards/authenticated-rate-limit.guard'
+import { VolumeAccessGuard } from '../guards/volume-access.guard'
+import { VolumeFilesService } from '../services/volume-files.service'
+import {
+  BatchDeleteVolumeFilesDto,
+  BatchDeleteVolumeFilesResponseDto,
+  ListVolumeFilesResponseDto,
+  PresignBatchWriteVolumeFilesDto,
+  PresignBatchWriteVolumeFilesResponseDto,
+  PresignedUrlResponseDto,
+  VolumeFileStatDto,
+} from '../dto/volume-file.dto'
+
+@ApiTags('volumes')
+@Controller('volumes/:volumeId/files')
+@ApiHeader(CustomHeaders.ORGANIZATION_ID)
+@UseGuards(CombinedAuthGuard, OrganizationResourceActionGuard, AuthenticatedRateLimitGuard, VolumeAccessGuard)
+@ApiOAuth2(['openid', 'profile', 'email'])
+@ApiBearerAuth()
+@ApiParam({ name: 'volumeId', description: 'ID of the volume', type: 'string' })
+export class VolumeFilesController {
+  constructor(private readonly volumeFilesService: VolumeFilesService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List files under a path in a volume', operationId: 'listVolumeFiles' })
+  @ApiResponse({ status: 200, type: ListVolumeFilesResponseDto })
+  @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.READ_VOLUMES])
+  async listFiles(
+    @Param('volumeId') volumeId: string,
+    @Query('path') path = '',
+    @Query('cursor') cursor?: string,
+  ): Promise<ListVolumeFilesResponseDto> {
+    return this.volumeFilesService.listFiles(volumeId, path, cursor)
+  }
+
+  @Get('stat')
+  @ApiOperation({ summary: 'Get metadata for a single file in a volume', operationId: 'statVolumeFile' })
+  @ApiResponse({ status: 200, type: VolumeFileStatDto })
+  @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.READ_VOLUMES])
+  async statFile(@Param('volumeId') volumeId: string, @Query('path') path: string): Promise<VolumeFileStatDto> {
+    return this.volumeFilesService.statFile(volumeId, path)
+  }
+
+  @Get('presign-read')
+  @ApiOperation({
+    summary: 'Get a short-lived URL to read a file directly from object storage',
+    operationId: 'presignReadVolumeFile',
+  })
+  @ApiResponse({ status: 200, type: PresignedUrlResponseDto })
+  @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.READ_VOLUMES])
+  async presignRead(
+    @Param('volumeId') volumeId: string,
+    @Query('path') path: string,
+  ): Promise<PresignedUrlResponseDto> {
+    return this.volumeFilesService.presignRead(volumeId, path)
+  }
+
+  @Post('presign-write')
+  @ApiOperation({
+    summary: 'Get a short-lived URL to write a file directly to object storage',
+    operationId: 'presignWriteVolumeFile',
+  })
+  @ApiResponse({ status: 200, type: PresignedUrlResponseDto })
+  @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_VOLUMES])
+  async presignWrite(
+    @Param('volumeId') volumeId: string,
+    @Query('path') path: string,
+  ): Promise<PresignedUrlResponseDto> {
+    return this.volumeFilesService.presignWrite(volumeId, path)
+  }
+
+  @Delete('content')
+  @HttpCode(204)
+  @ApiOperation({ summary: 'Delete a single file from a volume', operationId: 'deleteVolumeFile' })
+  @ApiResponse({ status: 204, description: 'File deleted' })
+  @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_VOLUMES])
+  async deleteFile(@Param('volumeId') volumeId: string, @Query('path') path: string): Promise<void> {
+    await this.volumeFilesService.deleteFile(volumeId, path)
+  }
+
+  @Post('batch-delete')
+  @ApiOperation({ summary: 'Delete a batch of files from a volume', operationId: 'batchDeleteVolumeFiles' })
+  @ApiResponse({ status: 200, type: BatchDeleteVolumeFilesResponseDto })
+  @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_VOLUMES])
+  async batchDelete(
+    @Param('volumeId') volumeId: string,
+    @Body() dto: BatchDeleteVolumeFilesDto,
+  ): Promise<BatchDeleteVolumeFilesResponseDto> {
+    return this.volumeFilesService.batchDelete(volumeId, dto.paths)
+  }
+
+  @Post('presign-batch-write')
+  @ApiOperation({
+    summary: 'Get short-lived URLs to write a batch of files directly to object storage',
+    operationId: 'presignBatchWriteVolumeFiles',
+  })
+  @ApiResponse({ status: 200, type: PresignBatchWriteVolumeFilesResponseDto })
+  @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_VOLUMES])
+  async presignBatchWrite(
+    @Param('volumeId') volumeId: string,
+    @Body() dto: PresignBatchWriteVolumeFilesDto,
+  ): Promise<PresignBatchWriteVolumeFilesResponseDto> {
+    return this.volumeFilesService.presignBatchWrite(volumeId, dto.paths)
+  }
+}

--- a/apps/api/src/box/dto/volume-file.dto.spec.ts
+++ b/apps/api/src/box/dto/volume-file.dto.spec.ts
@@ -11,6 +11,11 @@ describe.each([
     expect(await validate(dto)).toHaveLength(0)
   })
 
+  it('accepts exactly 1000 paths (the cap boundary)', async () => {
+    const dto = plainToInstance(DtoClass, { paths: Array.from({ length: 1000 }, (_, i) => `f${i}.txt`) })
+    expect(await validate(dto)).toHaveLength(0)
+  })
+
   it('rejects an empty array', async () => {
     const dto = plainToInstance(DtoClass, { paths: [] })
     const errors = await validate(dto)

--- a/apps/api/src/box/dto/volume-file.dto.spec.ts
+++ b/apps/api/src/box/dto/volume-file.dto.spec.ts
@@ -1,0 +1,25 @@
+import { validate } from 'class-validator'
+import { plainToInstance } from 'class-transformer'
+import { BatchDeleteVolumeFilesDto, PresignBatchWriteVolumeFilesDto } from './volume-file.dto'
+
+describe.each([
+  ['BatchDeleteVolumeFilesDto', BatchDeleteVolumeFilesDto],
+  ['PresignBatchWriteVolumeFilesDto', PresignBatchWriteVolumeFilesDto],
+])('%s.paths validation', (_name, DtoClass) => {
+  it('accepts a non-empty array within the size cap', async () => {
+    const dto = plainToInstance(DtoClass, { paths: ['a.txt', 'b.txt'] })
+    expect(await validate(dto)).toHaveLength(0)
+  })
+
+  it('rejects an empty array', async () => {
+    const dto = plainToInstance(DtoClass, { paths: [] })
+    const errors = await validate(dto)
+    expect(errors.some((e) => e.constraints && 'arrayNotEmpty' in e.constraints)).toBe(true)
+  })
+
+  it('rejects more than 1000 paths', async () => {
+    const dto = plainToInstance(DtoClass, { paths: Array.from({ length: 1001 }, (_, i) => `f${i}.txt`) })
+    const errors = await validate(dto)
+    expect(errors.some((e) => e.constraints && 'arrayMaxSize' in e.constraints)).toBe(true)
+  })
+})

--- a/apps/api/src/box/dto/volume-file.dto.spec.ts
+++ b/apps/api/src/box/dto/volume-file.dto.spec.ts
@@ -1,6 +1,11 @@
 import { validate } from 'class-validator'
 import { plainToInstance } from 'class-transformer'
-import { BatchDeleteVolumeFilesDto, PresignBatchWriteVolumeFilesDto } from './volume-file.dto'
+import {
+  BatchDeleteVolumeFilesDto,
+  ListVolumeFilesQueryDto,
+  PresignBatchWriteVolumeFilesDto,
+  VolumeFilePathQueryDto,
+} from './volume-file.dto'
 
 describe.each([
   ['BatchDeleteVolumeFilesDto', BatchDeleteVolumeFilesDto],
@@ -26,5 +31,51 @@ describe.each([
     const dto = plainToInstance(DtoClass, { paths: Array.from({ length: 1001 }, (_, i) => `f${i}.txt`) })
     const errors = await validate(dto)
     expect(errors.some((e) => e.constraints && 'arrayMaxSize' in e.constraints)).toBe(true)
+  })
+})
+
+// A raw `@Query('path')` accepts whatever Express hands it, including an
+// array from a repeated key (`?path=a&path=b`) or explicit array syntax
+// (`?path[]=a`) - CodeQL flagged the resulting type confusion once that
+// value reaches a string-only operation downstream. These DTOs are the
+// fix: `@IsString()`, enforced by the app's global ValidationPipe, rejects
+// an array with 400 before the controller method ever runs.
+describe('VolumeFilePathQueryDto', () => {
+  it('accepts a plain string path', async () => {
+    const dto = plainToInstance(VolumeFilePathQueryDto, { path: 'a.txt' })
+    expect(await validate(dto)).toHaveLength(0)
+  })
+
+  it('rejects an array value (repeated query key or array syntax)', async () => {
+    const dto = plainToInstance(VolumeFilePathQueryDto, { path: ['a.txt', 'b.txt'] })
+    const errors = await validate(dto)
+    expect(errors.some((e) => e.constraints && 'isString' in e.constraints)).toBe(true)
+  })
+
+  it('rejects a missing path', async () => {
+    const dto = plainToInstance(VolumeFilePathQueryDto, {})
+    const errors = await validate(dto)
+    expect(errors.some((e) => e.constraints && ('isString' in e.constraints || 'isNotEmpty' in e.constraints))).toBe(
+      true,
+    )
+  })
+})
+
+describe('ListVolumeFilesQueryDto', () => {
+  it('accepts both fields omitted (list the volume root, no cursor)', async () => {
+    const dto = plainToInstance(ListVolumeFilesQueryDto, {})
+    expect(await validate(dto)).toHaveLength(0)
+  })
+
+  it('rejects an array value for path', async () => {
+    const dto = plainToInstance(ListVolumeFilesQueryDto, { path: ['a/', 'b/'] })
+    const errors = await validate(dto)
+    expect(errors.some((e) => e.constraints && 'isString' in e.constraints)).toBe(true)
+  })
+
+  it('rejects an array value for cursor', async () => {
+    const dto = plainToInstance(ListVolumeFilesQueryDto, { cursor: ['x', 'y'] })
+    const errors = await validate(dto)
+    expect(errors.some((e) => e.constraints && 'isString' in e.constraints)).toBe(true)
   })
 })

--- a/apps/api/src/box/dto/volume-file.dto.ts
+++ b/apps/api/src/box/dto/volume-file.dto.ts
@@ -5,7 +5,11 @@
  */
 
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
-import { IsArray, IsNotEmpty, IsString } from 'class-validator'
+import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsNotEmpty, IsString } from 'class-validator'
+
+/** S3 caps DeleteObjects at 1000 keys per call; mirrored here for presign
+ * batches too so one request can't force unbounded signing/S3 work. */
+const MAX_BATCH_SIZE = 1000
 
 export class VolumeFileEntryDto {
   @ApiProperty({ description: 'Entry name relative to the listed path' })
@@ -54,6 +58,8 @@ export class PresignedUrlResponseDto {
 export class BatchDeleteVolumeFilesDto {
   @ApiProperty({ type: [String], description: 'Object keys to delete, relative to the volume root' })
   @IsArray()
+  @ArrayNotEmpty()
+  @ArrayMaxSize(MAX_BATCH_SIZE)
   @IsString({ each: true })
   @IsNotEmpty({ each: true })
   paths: string[]
@@ -78,6 +84,8 @@ export class BatchDeleteVolumeFilesResponseDto {
 export class PresignBatchWriteVolumeFilesDto {
   @ApiProperty({ type: [String], description: 'Object keys to presign for upload, relative to the volume root' })
   @IsArray()
+  @ArrayNotEmpty()
+  @ArrayMaxSize(MAX_BATCH_SIZE)
   @IsString({ each: true })
   @IsNotEmpty({ each: true })
   paths: string[]

--- a/apps/api/src/box/dto/volume-file.dto.ts
+++ b/apps/api/src/box/dto/volume-file.dto.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
+import { IsArray, IsNotEmpty, IsString } from 'class-validator'
+
+export class VolumeFileEntryDto {
+  @ApiProperty({ description: 'Entry name relative to the listed path' })
+  name: string
+
+  @ApiProperty({ description: 'Whether this entry is a "directory" (a common key prefix), not a real object' })
+  isDirectory: boolean
+
+  @ApiPropertyOptional({ description: 'Object size in bytes. Absent for directories.' })
+  size?: number
+
+  @ApiPropertyOptional({ description: 'Last-modified timestamp (UTC). Absent for directories.' })
+  lastModified?: Date
+}
+
+export class ListVolumeFilesResponseDto {
+  @ApiProperty({ type: [VolumeFileEntryDto] })
+  entries: VolumeFileEntryDto[]
+
+  @ApiPropertyOptional({ description: 'Pass back as `cursor` to fetch the next page' })
+  nextCursor?: string
+
+  @ApiProperty()
+  hasMore: boolean
+}
+
+export class VolumeFileStatDto {
+  @ApiProperty()
+  path: string
+
+  @ApiProperty()
+  size: number
+
+  @ApiProperty()
+  lastModified: Date
+}
+
+export class PresignedUrlResponseDto {
+  @ApiProperty({ description: 'Short-lived signed URL. The caller transfers bytes directly against this URL.' })
+  url: string
+
+  @ApiProperty()
+  expiresAt: Date
+}
+
+export class BatchDeleteVolumeFilesDto {
+  @ApiProperty({ type: [String], description: 'Object keys to delete, relative to the volume root' })
+  @IsArray()
+  @IsString({ each: true })
+  @IsNotEmpty({ each: true })
+  paths: string[]
+}
+
+export class BatchOperationErrorDto {
+  @ApiProperty()
+  path: string
+
+  @ApiProperty()
+  message: string
+}
+
+export class BatchDeleteVolumeFilesResponseDto {
+  @ApiProperty({ type: [String] })
+  deleted: string[]
+
+  @ApiProperty({ type: [BatchOperationErrorDto] })
+  errors: BatchOperationErrorDto[]
+}
+
+export class PresignBatchWriteVolumeFilesDto {
+  @ApiProperty({ type: [String], description: 'Object keys to presign for upload, relative to the volume root' })
+  @IsArray()
+  @IsString({ each: true })
+  @IsNotEmpty({ each: true })
+  paths: string[]
+}
+
+export class PresignedWriteUrlDto extends PresignedUrlResponseDto {
+  @ApiProperty()
+  path: string
+}
+
+export class PresignBatchWriteVolumeFilesResponseDto {
+  @ApiProperty({ type: [PresignedWriteUrlDto] })
+  urls: PresignedWriteUrlDto[]
+
+  @ApiProperty({ type: [BatchOperationErrorDto] })
+  errors: BatchOperationErrorDto[]
+}

--- a/apps/api/src/box/dto/volume-file.dto.ts
+++ b/apps/api/src/box/dto/volume-file.dto.ts
@@ -5,7 +5,7 @@
  */
 
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
-import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsNotEmpty, IsString } from 'class-validator'
+import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsNotEmpty, IsOptional, IsString } from 'class-validator'
 
 /** S3 caps DeleteObjects at 1000 keys per call; mirrored here for presign
  * batches too so one request can't force unbounded signing/S3 work. */
@@ -99,6 +99,31 @@ export class PresignedWriteUrlDto extends PresignedUrlResponseDto {
 export class PresignBatchWriteVolumeFilesResponseDto {
   @ApiProperty({ type: [PresignedWriteUrlDto] })
   urls: PresignedWriteUrlDto[]
+
+  @ApiProperty({ type: [BatchOperationErrorDto] })
+  errors: BatchOperationErrorDto[]
+}
+
+export class CopyVolumeFilesDto {
+  @ApiPropertyOptional({
+    description: 'Volume to copy from. Defaults to the destination volume (a same-volume prefix-to-prefix copy).',
+  })
+  @IsOptional()
+  @IsString()
+  sourceVolumeId?: string
+
+  @ApiProperty({ description: 'Prefix to copy from, relative to the source volume root (empty copies everything)' })
+  @IsString()
+  sourcePrefix: string
+
+  @ApiProperty({ description: 'Prefix to copy into, relative to the destination volume root' })
+  @IsString()
+  destPrefix: string
+}
+
+export class CopyVolumeFilesResponseDto {
+  @ApiProperty({ type: [String], description: 'Destination keys that were copied' })
+  copied: string[]
 
   @ApiProperty({ type: [BatchOperationErrorDto] })
   errors: BatchOperationErrorDto[]

--- a/apps/api/src/box/dto/volume-file.dto.ts
+++ b/apps/api/src/box/dto/volume-file.dto.ts
@@ -11,6 +11,33 @@ import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsNotEmpty, IsOptional, IsString 
  * batches too so one request can't force unbounded signing/S3 work. */
 const MAX_BATCH_SIZE = 1000
 
+/**
+ * A raw `@Query('path') path: string` accepts whatever Express hands it -
+ * including an array, if the caller sends the key twice (`?path=a&path=b`)
+ * or with explicit array syntax (`?path[]=a`). `@IsString()` on a DTO bound
+ * through the app's global `ValidationPipe` rejects that with 400 before
+ * any downstream string method (`.slice`, `.normalize`, ...) runs on a
+ * value it wasn't written to expect.
+ */
+export class ListVolumeFilesQueryDto {
+  @ApiPropertyOptional({ description: 'Prefix to list under, relative to the volume root' })
+  @IsOptional()
+  @IsString()
+  path?: string
+
+  @ApiPropertyOptional({ description: 'Pass the previous response\'s nextCursor to fetch the next page' })
+  @IsOptional()
+  @IsString()
+  cursor?: string
+}
+
+export class VolumeFilePathQueryDto {
+  @ApiProperty({ description: 'Object key, relative to the volume root' })
+  @IsString()
+  @IsNotEmpty()
+  path: string
+}
+
 export class VolumeFileEntryDto {
   @ApiProperty({ description: 'Entry name relative to the listed path' })
   name: string

--- a/apps/api/src/box/managers/volume.manager.ts
+++ b/apps/api/src/box/managers/volume.manager.ts
@@ -16,6 +16,7 @@ import { Redis } from 'ioredis'
 import { RedisLockProvider } from '../common/redis-lock.provider'
 import { TypedConfigService } from '../../config/typed-config.service'
 import { deleteS3Bucket } from '../../common/utils/delete-s3-bucket'
+import { createS3Client } from '../../common/utils/s3-client.factory'
 
 import { TrackableJobExecutions } from '../../common/interfaces/trackable-job-executions'
 import { TrackJobExecution } from '../../common/decorators/track-job-execution.decorator'
@@ -44,35 +45,8 @@ export class VolumeManager
     private readonly redisLockProvider: RedisLockProvider,
     private readonly schedulerRegistry: SchedulerRegistry,
   ) {
-    if (!this.configService.get('s3.endpoint')) {
-      return
-    }
-
-    const endpoint = this.configService.getOrThrow('s3.endpoint')
-    const region = this.configService.getOrThrow('s3.region')
-    const accessKeyId = this.configService.get('s3.accessKey')
-    const secretAccessKey = this.configService.get('s3.secretKey')
     this.skipTestConnection = this.configService.get('skipConnections')
-
-    // Both-or-neither: a lone key is a typo'd pair, and silently falling back
-    // to the SDK default chain would mask the misconfig.
-    if ((accessKeyId && !secretAccessKey) || (!accessKeyId && secretAccessKey)) {
-      throw new Error('S3_ACCESS_KEY and S3_SECRET_KEY must be set together')
-    }
-    // MinIO cannot use the SDK default chain — fail fast at boot with a clear
-    // message instead of a generic auth error from the connection probe.
-    if (endpoint.includes('minio') && !accessKeyId) {
-      throw new Error('MinIO requires S3_ACCESS_KEY and S3_SECRET_KEY to be configured')
-    }
-
-    this.s3Client = new S3Client({
-      endpoint: endpoint.startsWith('http') ? endpoint : `http://${endpoint}`,
-      region,
-      // Static keys for S3-compatible deployments (MinIO); unset on AWS,
-      // where the SDK default chain supplies the ECS task-role credentials.
-      ...(accessKeyId && secretAccessKey ? { credentials: { accessKeyId, secretAccessKey } } : {}),
-      forcePathStyle: true,
-    })
+    this.s3Client = createS3Client(this.configService)
   }
 
   async onModuleInit() {

--- a/apps/api/src/box/services/volume-files.service.spec.ts
+++ b/apps/api/src/box/services/volume-files.service.spec.ts
@@ -223,4 +223,23 @@ describe('VolumeFilesService presignBatchWrite', () => {
     expect(result.urls).toEqual([{ path: 'a.txt', url: 'https://s3.example/a', expiresAt: expect.any(Date) }])
     expect(result.errors).toEqual([{ path: 'b.txt', message: 'signing failed' }])
   })
+
+  it('signs in bounded chunks instead of firing every path at once', async () => {
+    const { service } = createService(READY_VOLUME)
+    let inFlight = 0
+    let maxInFlight = 0
+    ;(getSignedUrl as jest.Mock).mockImplementation(async () => {
+      inFlight++
+      maxInFlight = Math.max(maxInFlight, inFlight)
+      await Promise.resolve()
+      inFlight--
+      return 'https://s3.example/signed'
+    })
+    const paths = Array.from({ length: 120 }, (_, i) => `file-${i}.txt`)
+
+    const result = await service.presignBatchWrite('volume-1', paths)
+
+    expect(result.urls).toHaveLength(120)
+    expect(maxInFlight).toBeLessThanOrEqual(50)
+  })
 })

--- a/apps/api/src/box/services/volume-files.service.spec.ts
+++ b/apps/api/src/box/services/volume-files.service.spec.ts
@@ -94,6 +94,24 @@ describe('VolumeFilesService listFiles', () => {
       ContinuationToken: 'cursor-1',
     })
   })
+
+  it('rejects a traversal prefix before touching S3', async () => {
+    const { service, send } = createService(READY_VOLUME)
+
+    await expect(service.listFiles('volume-1', '../secret')).rejects.toThrow('escapes the volume root')
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('does not validate the default empty prefix (volume root listing)', async () => {
+    const { service, send } = createService(READY_VOLUME)
+    send.mockResolvedValue({ Contents: [], IsTruncated: false })
+
+    await expect(service.listFiles('volume-1', '')).resolves.toEqual({
+      entries: [],
+      nextCursor: undefined,
+      hasMore: false,
+    })
+  })
 })
 
 describe('VolumeFilesService statFile', () => {

--- a/apps/api/src/box/services/volume-files.service.spec.ts
+++ b/apps/api/src/box/services/volume-files.service.spec.ts
@@ -1,0 +1,208 @@
+import { ConflictException, NotFoundException } from '@nestjs/common'
+import { S3ServiceException } from '@aws-sdk/client-s3'
+import { VolumeFilesService } from './volume-files.service'
+import { VolumeState } from '../enums/volume-state.enum'
+
+jest.mock('../../common/utils/s3-client.factory', () => ({
+  createS3Client: jest.fn(),
+}))
+jest.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: jest.fn(),
+}))
+
+import { createS3Client } from '../../common/utils/s3-client.factory'
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
+
+afterEach(() => jest.clearAllMocks())
+
+function notFoundError(): S3ServiceException {
+  const error = new S3ServiceException({
+    name: 'NotFound',
+    $fault: 'client',
+    $metadata: { httpStatusCode: 404 },
+  })
+  return error
+}
+
+function createService(volume: { id: string; state: VolumeState } | null) {
+  const send = jest.fn()
+  const s3Client = { send }
+  ;(createS3Client as jest.Mock).mockReturnValue(s3Client)
+
+  const volumeService = {
+    findOne: jest.fn().mockImplementation((id: string) => {
+      if (!volume || volume.id !== id) {
+        throw new NotFoundException(`Volume with ID ${id} not found`)
+      }
+      return { ...volume, getBucketName: () => `boxlite-volume-${volume.id}` }
+    }),
+  }
+
+  const service = new VolumeFilesService(volumeService as never, {} as never)
+  return { service, send, volumeService }
+}
+
+const READY_VOLUME = { id: 'volume-1', state: VolumeState.READY }
+
+describe('VolumeFilesService readiness gate', () => {
+  it('rejects an operation on a non-READY volume with 409 naming the state', async () => {
+    const { service } = createService({ id: 'volume-1', state: VolumeState.CREATING })
+
+    await expect(service.statFile('volume-1', 'a.txt')).rejects.toMatchObject({
+      constructor: ConflictException,
+      message: expect.stringContaining('volume is creating'),
+    })
+  })
+})
+
+describe('VolumeFilesService path validation', () => {
+  it('rejects a traversal path before touching S3', async () => {
+    const { service, send } = createService(READY_VOLUME)
+
+    await expect(service.statFile('volume-1', '../secret')).rejects.toThrow('escapes the volume root')
+    expect(send).not.toHaveBeenCalled()
+  })
+})
+
+describe('VolumeFilesService listFiles', () => {
+  it('maps common prefixes and objects into entries, and passes through pagination', async () => {
+    const { service, send } = createService(READY_VOLUME)
+    send.mockResolvedValue({
+      CommonPrefixes: [{ Prefix: 'checkpoints/logs/' }],
+      Contents: [
+        { Key: 'checkpoints/', Size: 0 }, // directory marker - must be filtered out
+        { Key: 'checkpoints/model.bin', Size: 1024, LastModified: new Date('2026-01-01') },
+      ],
+      NextContinuationToken: 'cursor-2',
+      IsTruncated: true,
+    })
+
+    const result = await service.listFiles('volume-1', 'checkpoints/', 'cursor-1')
+
+    expect(result).toEqual({
+      entries: [
+        { name: 'logs/', isDirectory: true },
+        { name: 'model.bin', isDirectory: false, size: 1024, lastModified: new Date('2026-01-01') },
+      ],
+      nextCursor: 'cursor-2',
+      hasMore: true,
+    })
+    expect(send.mock.calls[0][0].input).toMatchObject({
+      Bucket: 'boxlite-volume-volume-1',
+      Prefix: 'checkpoints/',
+      Delimiter: '/',
+      ContinuationToken: 'cursor-1',
+    })
+  })
+})
+
+describe('VolumeFilesService statFile', () => {
+  it('returns size and last-modified from HeadObject', async () => {
+    const { service, send } = createService(READY_VOLUME)
+    send.mockResolvedValue({ ContentLength: 42, LastModified: new Date('2026-02-01') })
+
+    await expect(service.statFile('volume-1', 'a.txt')).resolves.toEqual({
+      path: 'a.txt',
+      size: 42,
+      lastModified: new Date('2026-02-01'),
+    })
+  })
+
+  it('translates a missing object into NotFoundException', async () => {
+    const { service, send } = createService(READY_VOLUME)
+    send.mockRejectedValue(notFoundError())
+
+    await expect(service.statFile('volume-1', 'missing.txt')).rejects.toBeInstanceOf(NotFoundException)
+  })
+})
+
+describe('VolumeFilesService presignRead', () => {
+  it('checks existence before signing, and returns the signed URL', async () => {
+    const { service, send } = createService(READY_VOLUME)
+    send.mockResolvedValue({ ContentLength: 1 }) // HeadObject success
+    ;(getSignedUrl as jest.Mock).mockResolvedValue('https://s3.example/signed-get')
+
+    const result = await service.presignRead('volume-1', 'a.txt')
+
+    expect(result.url).toBe('https://s3.example/signed-get')
+    expect(result.expiresAt).toBeInstanceOf(Date)
+  })
+
+  it('404s without ever calling getSignedUrl when the object is missing', async () => {
+    const { service, send } = createService(READY_VOLUME)
+    send.mockRejectedValue(notFoundError())
+
+    await expect(service.presignRead('volume-1', 'missing.txt')).rejects.toBeInstanceOf(NotFoundException)
+    expect(getSignedUrl).not.toHaveBeenCalled()
+  })
+})
+
+describe('VolumeFilesService presignWrite', () => {
+  it('signs a PutObject without checking existence', async () => {
+    const { service, send } = createService(READY_VOLUME)
+    ;(getSignedUrl as jest.Mock).mockResolvedValue('https://s3.example/signed-put')
+
+    const result = await service.presignWrite('volume-1', 'new-file.txt')
+
+    expect(result.url).toBe('https://s3.example/signed-put')
+    expect(send).not.toHaveBeenCalled() // no HeadObject round trip for writes
+  })
+})
+
+describe('VolumeFilesService deleteFile', () => {
+  it('deletes an existing file', async () => {
+    const { service, send } = createService(READY_VOLUME)
+    send.mockResolvedValueOnce({ ContentLength: 1 }).mockResolvedValueOnce({})
+
+    await expect(service.deleteFile('volume-1', 'a.txt')).resolves.toBeUndefined()
+    expect(send).toHaveBeenCalledTimes(2) // HeadObject then DeleteObject
+  })
+
+  it('404s on a path that never existed instead of silently succeeding', async () => {
+    const { service, send } = createService(READY_VOLUME)
+    send.mockRejectedValue(notFoundError())
+
+    await expect(service.deleteFile('volume-1', 'missing.txt')).rejects.toBeInstanceOf(NotFoundException)
+  })
+})
+
+describe('VolumeFilesService batchDelete', () => {
+  it('reports partial success from a single DeleteObjects call', async () => {
+    const { service, send } = createService(READY_VOLUME)
+    send.mockResolvedValue({
+      Deleted: [{ Key: 'a.txt' }],
+      Errors: [{ Key: 'b.txt', Message: 'Access Denied' }],
+    })
+
+    const result = await service.batchDelete('volume-1', ['a.txt', 'b.txt'])
+
+    expect(result).toEqual({ deleted: ['a.txt'], errors: [{ path: 'b.txt', message: 'Access Denied' }] })
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+
+  it('chunks more than 1000 keys into multiple DeleteObjects calls', async () => {
+    const { service, send } = createService(READY_VOLUME)
+    send.mockResolvedValue({ Deleted: [], Errors: [] })
+    const paths = Array.from({ length: 1500 }, (_, i) => `file-${i}.txt`)
+
+    await service.batchDelete('volume-1', paths)
+
+    expect(send).toHaveBeenCalledTimes(2)
+    expect(send.mock.calls[0][0].input.Delete.Objects).toHaveLength(1000)
+    expect(send.mock.calls[1][0].input.Delete.Objects).toHaveLength(500)
+  })
+})
+
+describe('VolumeFilesService presignBatchWrite', () => {
+  it('signs each path independently and reports partial failure', async () => {
+    const { service } = createService(READY_VOLUME)
+    ;(getSignedUrl as jest.Mock)
+      .mockResolvedValueOnce('https://s3.example/a')
+      .mockRejectedValueOnce(new Error('signing failed'))
+
+    const result = await service.presignBatchWrite('volume-1', ['a.txt', 'b.txt'])
+
+    expect(result.urls).toEqual([{ path: 'a.txt', url: 'https://s3.example/a', expiresAt: expect.any(Date) }])
+    expect(result.errors).toEqual([{ path: 'b.txt', message: 'signing failed' }])
+  })
+})

--- a/apps/api/src/box/services/volume-files.service.spec.ts
+++ b/apps/api/src/box/services/volume-files.service.spec.ts
@@ -42,6 +42,25 @@ function createService(volume: { id: string; state: VolumeState } | null) {
   return { service, send, volumeService }
 }
 
+function createServiceWithVolumes(volumes: { id: string; state: VolumeState; organizationId: string }[]) {
+  const send = jest.fn()
+  const s3Client = { send }
+  ;(createS3Client as jest.Mock).mockReturnValue(s3Client)
+
+  const volumeService = {
+    findOne: jest.fn().mockImplementation((id: string) => {
+      const volume = volumes.find((v) => v.id === id)
+      if (!volume) {
+        throw new NotFoundException(`Volume with ID ${id} not found`)
+      }
+      return { ...volume, getBucketName: () => `boxlite-volume-${volume.id}` }
+    }),
+  }
+
+  const service = new VolumeFilesService(volumeService as never, {} as never)
+  return { service, send, volumeService }
+}
+
 const READY_VOLUME = { id: 'volume-1', state: VolumeState.READY }
 
 describe('VolumeFilesService readiness gate', () => {
@@ -241,5 +260,85 @@ describe('VolumeFilesService presignBatchWrite', () => {
 
     expect(result.urls).toHaveLength(120)
     expect(maxInFlight).toBeLessThanOrEqual(50)
+  })
+})
+
+describe('VolumeFilesService copyFiles', () => {
+  const DEST = { id: 'dest-volume', state: VolumeState.READY, organizationId: 'org-1' }
+  const SOURCE = { id: 'source-volume', state: VolumeState.READY, organizationId: 'org-1' }
+  const FOREIGN_SOURCE = { id: 'foreign-volume', state: VolumeState.READY, organizationId: 'org-2' }
+
+  it('copies within the same volume when no source volume is given', async () => {
+    const { service, send } = createServiceWithVolumes([DEST])
+    send.mockResolvedValueOnce({ Contents: [{ Key: 'a/1.txt' }, { Key: 'a/2.txt' }], IsTruncated: false })
+    send.mockResolvedValue({}) // CopyObject calls
+
+    const result = await service.copyFiles('dest-volume', 'org-1', undefined, 'a/', 'b/')
+
+    expect(result).toEqual({ copied: ['b/1.txt', 'b/2.txt'], errors: [] })
+    expect(send.mock.calls[1][0].input).toMatchObject({
+      Bucket: 'boxlite-volume-dest-volume',
+      Key: 'b/1.txt',
+      CopySource: 'boxlite-volume-dest-volume/a%2F1.txt',
+    })
+  })
+
+  it('copies across volumes in the same organization', async () => {
+    const { service, send } = createServiceWithVolumes([DEST, SOURCE])
+    send.mockResolvedValueOnce({ Contents: [{ Key: 'model.bin' }], IsTruncated: false })
+    send.mockResolvedValue({})
+
+    const result = await service.copyFiles('dest-volume', 'org-1', 'source-volume', '', 'checkpoints/')
+
+    expect(result).toEqual({ copied: ['checkpoints/model.bin'], errors: [] })
+    expect(send.mock.calls[1][0].input).toMatchObject({
+      Bucket: 'boxlite-volume-dest-volume',
+      Key: 'checkpoints/model.bin',
+      CopySource: 'boxlite-volume-source-volume/model.bin',
+    })
+  })
+
+  it('rejects a source volume belonging to another organization', async () => {
+    const { service } = createServiceWithVolumes([DEST, FOREIGN_SOURCE])
+
+    await expect(service.copyFiles('dest-volume', 'org-1', 'foreign-volume', '', 'x/')).rejects.toThrow(
+      'does not belong to the calling organization',
+    )
+  })
+
+  it('reports partial failure without aborting the rest of the copy', async () => {
+    const { service, send } = createServiceWithVolumes([DEST])
+    send.mockResolvedValueOnce({ Contents: [{ Key: 'a.txt' }, { Key: 'b.txt' }], IsTruncated: false })
+    send.mockResolvedValueOnce({}).mockRejectedValueOnce(new Error('access denied'))
+
+    const result = await service.copyFiles('dest-volume', 'org-1', undefined, '', 'copy/')
+
+    expect(result.copied).toEqual(['copy/a.txt'])
+    expect(result.errors).toEqual([{ path: 'copy/b.txt', message: 'access denied' }])
+  })
+
+  it('refuses a source prefix with more objects than the safety cap', async () => {
+    const { service, send } = createServiceWithVolumes([DEST])
+    send.mockResolvedValueOnce({
+      Contents: Array.from({ length: 10_001 }, (_, i) => ({ Key: `f${i}.txt` })),
+      IsTruncated: false,
+    })
+
+    await expect(service.copyFiles('dest-volume', 'org-1', undefined, '', 'copy/')).rejects.toThrow(
+      'more than 10000 objects',
+    )
+  })
+
+  it('pages through more than one ListObjectsV2 call', async () => {
+    const { service, send } = createServiceWithVolumes([DEST])
+    send
+      .mockResolvedValueOnce({ Contents: [{ Key: 'a.txt' }], IsTruncated: true, NextContinuationToken: 'page-2' })
+      .mockResolvedValueOnce({ Contents: [{ Key: 'b.txt' }], IsTruncated: false })
+      .mockResolvedValue({})
+
+    const result = await service.copyFiles('dest-volume', 'org-1', undefined, '', 'copy/')
+
+    expect(result.copied.sort()).toEqual(['copy/a.txt', 'copy/b.txt'])
+    expect(send.mock.calls[1][0].input).toMatchObject({ ContinuationToken: 'page-2' })
   })
 })

--- a/apps/api/src/box/services/volume-files.service.ts
+++ b/apps/api/src/box/services/volume-files.service.ts
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { ConflictException, Injectable, Logger, NotFoundException, ServiceUnavailableException } from '@nestjs/common'
+import {
+  DeleteObjectCommand,
+  DeleteObjectsCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+  S3Client,
+  S3ServiceException,
+} from '@aws-sdk/client-s3'
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
+import { VolumeService } from './volume.service'
+import { VolumeState } from '../enums/volume-state.enum'
+import { TypedConfigService } from '../../config/typed-config.service'
+import { createS3Client } from '../../common/utils/s3-client.factory'
+import { assertSafeVolumePath } from '../utils/volume-path.util'
+import {
+  BatchDeleteVolumeFilesResponseDto,
+  BatchOperationErrorDto,
+  ListVolumeFilesResponseDto,
+  PresignBatchWriteVolumeFilesResponseDto,
+  PresignedUrlResponseDto,
+  VolumeFileEntryDto,
+  VolumeFileStatDto,
+} from '../dto/volume-file.dto'
+
+/** S3 caps ListObjectsV2 / DeleteObjects at 1000 keys per call. */
+const S3_MAX_KEYS_PER_CALL = 1000
+
+/** How long a presigned URL stays valid before the caller must ask again. */
+const PRESIGNED_URL_TTL_SECONDS = 900
+
+@Injectable()
+export class VolumeFilesService {
+  private readonly logger = new Logger(VolumeFilesService.name)
+  private readonly s3Client: S3Client | null
+
+  constructor(
+    private readonly volumeService: VolumeService,
+    private readonly configService: TypedConfigService,
+  ) {
+    this.s3Client = createS3Client(this.configService)
+  }
+
+  async listFiles(volumeId: string, prefix: string, cursor?: string): Promise<ListVolumeFilesResponseDto> {
+    const volume = await this.assertReady(volumeId)
+
+    const response = await this.s3.send(
+      new ListObjectsV2Command({
+        Bucket: volume.getBucketName(),
+        Prefix: prefix || undefined,
+        Delimiter: '/',
+        MaxKeys: S3_MAX_KEYS_PER_CALL,
+        ContinuationToken: cursor,
+      }),
+    )
+
+    const directories: VolumeFileEntryDto[] = (response.CommonPrefixes ?? []).map((commonPrefix) => ({
+      name: stripPrefix(commonPrefix.Prefix, prefix),
+      isDirectory: true,
+    }))
+    const files: VolumeFileEntryDto[] = (response.Contents ?? [])
+      // ListObjectsV2 returns the prefix "directory marker" object itself
+      // (a zero-byte key ending in `/`) as a Contents entry too - it isn't a
+      // real file the caller asked to see.
+      .filter((object) => object.Key !== prefix)
+      .map((object) => ({
+        name: stripPrefix(object.Key, prefix),
+        isDirectory: false,
+        size: object.Size,
+        lastModified: object.LastModified,
+      }))
+
+    return {
+      entries: [...directories, ...files],
+      nextCursor: response.NextContinuationToken,
+      hasMore: response.IsTruncated ?? false,
+    }
+  }
+
+  async statFile(volumeId: string, path: string): Promise<VolumeFileStatDto> {
+    assertSafeVolumePath(path)
+    const volume = await this.assertReady(volumeId)
+
+    const head = await this.headObjectOrNotFound(volume.getBucketName(), path)
+    return { path, size: head.ContentLength ?? 0, lastModified: head.LastModified }
+  }
+
+  async presignRead(volumeId: string, path: string): Promise<PresignedUrlResponseDto> {
+    assertSafeVolumePath(path)
+    const volume = await this.assertReady(volumeId)
+    const bucket = volume.getBucketName()
+
+    // Presigning never checks existence - sign now, fail at transfer time.
+    // Doing our own existence check keeps the documented "404 if the path
+    // is missing" contract instead of leaking that decision to S3's own
+    // (delayed, harder for callers to detect) 404 on the actual GET.
+    await this.headObjectOrNotFound(bucket, path)
+
+    return this.presign(new GetObjectCommand({ Bucket: bucket, Key: path }))
+  }
+
+  async presignWrite(volumeId: string, path: string): Promise<PresignedUrlResponseDto> {
+    assertSafeVolumePath(path)
+    const volume = await this.assertReady(volumeId)
+
+    // NOTE: single PutObject only - S3 hard-caps a single call at 5 GiB.
+    // Presigned multipart upload (CreateMultipartUpload / per-part
+    // presigned UploadPart / server-completed CompleteMultipartUpload) is
+    // deliberately not implemented yet; writes above 5 GiB will fail at
+    // the actual PUT against the presigned URL, not here. Tracked as
+    // follow-up work rather than shipped half-verified.
+    return this.presign(new PutObjectCommand({ Bucket: volume.getBucketName(), Key: path }))
+  }
+
+  async deleteFile(volumeId: string, path: string): Promise<void> {
+    assertSafeVolumePath(path)
+    const volume = await this.assertReady(volumeId)
+    const bucket = volume.getBucketName()
+
+    // DeleteObject is idempotent and succeeds even if the key never
+    // existed; check first so a caller deleting a typo'd path gets 404
+    // instead of a silent, misleading "success".
+    await this.headObjectOrNotFound(bucket, path)
+    await this.s3.send(new DeleteObjectCommand({ Bucket: bucket, Key: path }))
+  }
+
+  async batchDelete(volumeId: string, paths: string[]): Promise<BatchDeleteVolumeFilesResponseDto> {
+    paths.forEach(assertSafeVolumePath)
+    const volume = await this.assertReady(volumeId)
+    const bucket = volume.getBucketName()
+
+    const deleted: string[] = []
+    const errors: BatchOperationErrorDto[] = []
+
+    for (const chunk of chunked(paths, S3_MAX_KEYS_PER_CALL)) {
+      const response = await this.s3.send(
+        new DeleteObjectsCommand({
+          Bucket: bucket,
+          Delete: { Objects: chunk.map((path) => ({ Key: path })), Quiet: false },
+        }),
+      )
+      deleted.push(...(response.Deleted ?? []).map((object) => object.Key))
+      errors.push(...(response.Errors ?? []).map((error) => ({ path: error.Key, message: error.Message })))
+    }
+
+    return { deleted, errors }
+  }
+
+  async presignBatchWrite(volumeId: string, paths: string[]): Promise<PresignBatchWriteVolumeFilesResponseDto> {
+    paths.forEach(assertSafeVolumePath)
+    const volume = await this.assertReady(volumeId)
+    const bucket = volume.getBucketName()
+
+    const urls: PresignBatchWriteVolumeFilesResponseDto['urls'] = []
+    const errors: BatchOperationErrorDto[] = []
+
+    // Presigning is a local signature computation, not a network call, so
+    // there's no batching primitive to reach for here the way there is for
+    // DeleteObjects - each path is signed independently.
+    await Promise.all(
+      paths.map(async (path) => {
+        try {
+          const { url, expiresAt } = await this.presign(new PutObjectCommand({ Bucket: bucket, Key: path }))
+          urls.push({ path, url, expiresAt })
+        } catch (error) {
+          errors.push({ path, message: error instanceof Error ? error.message : String(error) })
+        }
+      }),
+    )
+
+    return { urls, errors }
+  }
+
+  private async assertReady(volumeId: string) {
+    const volume = await this.volumeService.findOne(volumeId)
+    if (volume.state !== VolumeState.READY) {
+      throw new ConflictException(`invalid state: volume is ${volume.state}`)
+    }
+    return volume
+  }
+
+  private async headObjectOrNotFound(bucket: string, path: string) {
+    try {
+      return await this.s3.send(new HeadObjectCommand({ Bucket: bucket, Key: path }))
+    } catch (error) {
+      if (error instanceof S3ServiceException && error.$metadata?.httpStatusCode === 404) {
+        throw new NotFoundException(`file not found: ${path}`)
+      }
+      throw error
+    }
+  }
+
+  private async presign(command: GetObjectCommand | PutObjectCommand): Promise<PresignedUrlResponseDto> {
+    const url = await getSignedUrl(this.s3, command, { expiresIn: PRESIGNED_URL_TTL_SECONDS })
+    return { url, expiresAt: new Date(Date.now() + PRESIGNED_URL_TTL_SECONDS * 1000) }
+  }
+
+  private get s3(): S3Client {
+    if (!this.s3Client) {
+      throw new ServiceUnavailableException('Object storage is not configured')
+    }
+    return this.s3Client
+  }
+}
+
+function stripPrefix(key: string | undefined, prefix: string): string {
+  return (key ?? '').slice(prefix.length)
+}
+
+function chunked<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = []
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size))
+  }
+  return chunks
+}

--- a/apps/api/src/box/services/volume-files.service.ts
+++ b/apps/api/src/box/services/volume-files.service.ts
@@ -50,6 +50,9 @@ export class VolumeFilesService {
   }
 
   async listFiles(volumeId: string, prefix: string, cursor?: string): Promise<ListVolumeFilesResponseDto> {
+    if (prefix) {
+      assertSafeVolumePath(prefix)
+    }
     const volume = await this.assertReady(volumeId)
 
     const response = await this.s3.send(

--- a/apps/api/src/box/services/volume-files.service.ts
+++ b/apps/api/src/box/services/volume-files.service.ts
@@ -37,6 +37,11 @@ const S3_MAX_KEYS_PER_CALL = 1000
 /** How long a presigned URL stays valid before the caller must ask again. */
 const PRESIGNED_URL_TTL_SECONDS = 900
 
+/** Max concurrent presign operations in presignBatchWrite - bounds how long
+ * one request can monopolize the event loop, independent of the DTO's
+ * overall array-size cap. */
+const PRESIGN_BATCH_CONCURRENCY = 50
+
 @Injectable()
 export class VolumeFilesService {
   private readonly logger = new Logger(VolumeFilesService.name)
@@ -167,17 +172,22 @@ export class VolumeFilesService {
 
     // Presigning is a local signature computation, not a network call, so
     // there's no batching primitive to reach for here the way there is for
-    // DeleteObjects - each path is signed independently.
-    await Promise.all(
-      paths.map(async (path) => {
-        try {
-          const { url, expiresAt } = await this.presign(new PutObjectCommand({ Bucket: bucket, Key: path }))
-          urls.push({ path, url, expiresAt })
-        } catch (error) {
-          errors.push({ path, message: error instanceof Error ? error.message : String(error) })
-        }
-      }),
-    )
+    // DeleteObjects. DTO validation caps `paths` at 1000, but firing all of
+    // them through one Promise.all would still run the whole batch as a
+    // single microtask burst with no chance for other requests to interleave
+    // on the event loop - process in bounded chunks instead.
+    for (const chunk of chunked(paths, PRESIGN_BATCH_CONCURRENCY)) {
+      await Promise.all(
+        chunk.map(async (path) => {
+          try {
+            const { url, expiresAt } = await this.presign(new PutObjectCommand({ Bucket: bucket, Key: path }))
+            urls.push({ path, url, expiresAt })
+          } catch (error) {
+            errors.push({ path, message: error instanceof Error ? error.message : String(error) })
+          }
+        }),
+      )
+    }
 
     return { urls, errors }
   }

--- a/apps/api/src/box/services/volume-files.service.ts
+++ b/apps/api/src/box/services/volume-files.service.ts
@@ -6,6 +6,7 @@
 
 import { ConflictException, Injectable, Logger, NotFoundException, ServiceUnavailableException } from '@nestjs/common'
 import {
+  CopyObjectCommand,
   DeleteObjectCommand,
   DeleteObjectsCommand,
   GetObjectCommand,
@@ -16,7 +17,9 @@ import {
   S3ServiceException,
 } from '@aws-sdk/client-s3'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
+import { ForbiddenException, BadRequestException } from '@nestjs/common'
 import { VolumeService } from './volume.service'
+import { Volume } from '../entities/volume.entity'
 import { VolumeState } from '../enums/volume-state.enum'
 import { TypedConfigService } from '../../config/typed-config.service'
 import { createS3Client } from '../../common/utils/s3-client.factory'
@@ -24,6 +27,7 @@ import { assertSafeVolumePath } from '../utils/volume-path.util'
 import {
   BatchDeleteVolumeFilesResponseDto,
   BatchOperationErrorDto,
+  CopyVolumeFilesResponseDto,
   ListVolumeFilesResponseDto,
   PresignBatchWriteVolumeFilesResponseDto,
   PresignedUrlResponseDto,
@@ -41,6 +45,17 @@ const PRESIGNED_URL_TTL_SECONDS = 900
  * one request can monopolize the event loop, independent of the DTO's
  * overall array-size cap. */
 const PRESIGN_BATCH_CONCURRENCY = 50
+
+/** Max concurrent CopyObject calls in copyFiles. Lower than the presign
+ * concurrency because these are real outbound S3 calls from the API
+ * server, not local signature computation. */
+const COPY_CONCURRENCY = 20
+
+/** Safety valve on copyFiles: refuse a prefix with more objects than this
+ * rather than run a single HTTP request against an unbounded object count
+ * with no timeout/resumability. Callers with a larger tree should copy
+ * narrower sub-prefixes instead. */
+const MAX_COPY_OBJECTS = 10_000
 
 @Injectable()
 export class VolumeFilesService {
@@ -190,6 +205,108 @@ export class VolumeFilesService {
     }
 
     return { urls, errors }
+  }
+
+  /**
+   * Server-side copy: replicates every object under `sourcePrefix` (in
+   * `sourceVolumeId`, or this volume if omitted) to `destPrefix` in this
+   * volume, via S3's native `CopyObject` - the bytes never leave the
+   * storage backend, so this is the one batch operation where a whole
+   * "folder" genuinely moves in a single request (unlike upload, where
+   * the caller's local files are opaque to the server until it lists
+   * them itself).
+   */
+  async copyFiles(
+    destVolumeId: string,
+    organizationId: string,
+    sourceVolumeId: string | undefined,
+    sourcePrefix: string,
+    destPrefix: string,
+  ): Promise<CopyVolumeFilesResponseDto> {
+    if (sourcePrefix) {
+      assertSafeVolumePath(sourcePrefix)
+    }
+    if (destPrefix) {
+      assertSafeVolumePath(destPrefix)
+    }
+
+    const destVolume = await this.assertReady(destVolumeId)
+    const sourceVolume =
+      sourceVolumeId && sourceVolumeId !== destVolumeId
+        ? await this.assertReadyAndOwned(sourceVolumeId, organizationId)
+        : destVolume
+
+    const sourceBucket = sourceVolume.getBucketName()
+    const destBucket = destVolume.getBucketName()
+
+    const keys = await this.listAllKeys(sourceBucket, sourcePrefix)
+
+    const copied: string[] = []
+    const errors: BatchOperationErrorDto[] = []
+
+    for (const chunk of chunked(keys, COPY_CONCURRENCY)) {
+      await Promise.all(
+        chunk.map(async (sourceKey) => {
+          const destKey = destPrefix + stripPrefix(sourceKey, sourcePrefix)
+          try {
+            await this.s3.send(
+              new CopyObjectCommand({
+                Bucket: destBucket,
+                Key: destKey,
+                CopySource: `${sourceBucket}/${encodeURIComponent(sourceKey)}`,
+              }),
+            )
+            copied.push(destKey)
+          } catch (error) {
+            errors.push({ path: destKey, message: error instanceof Error ? error.message : String(error) })
+          }
+        }),
+      )
+    }
+
+    return { copied, errors }
+  }
+
+  /** Like assertReady, but additionally rejects a volume outside the
+   * caller's organization - needed here because copyFiles takes a second,
+   * body-supplied volume id that the URL-scoped VolumeAccessGuard never
+   * sees. Without this a caller could name any volume id and copy out of
+   * a bucket that isn't theirs. */
+  private async assertReadyAndOwned(volumeId: string, organizationId: string): Promise<Volume> {
+    const volume = await this.assertReady(volumeId)
+    if (volume.organizationId !== organizationId) {
+      throw new ForbiddenException(`Volume ${volumeId} does not belong to the calling organization`)
+    }
+    return volume
+  }
+
+  /** Pages through every object under `prefix` (no delimiter - this needs
+   * the full recursive tree, unlike listFiles' single-level browsing).
+   * Throws if the prefix holds more than MAX_COPY_OBJECTS rather than
+   * silently truncating the copy. */
+  private async listAllKeys(bucket: string, prefix: string): Promise<string[]> {
+    const keys: string[] = []
+    let continuationToken: string | undefined
+
+    do {
+      const response = await this.s3.send(
+        new ListObjectsV2Command({
+          Bucket: bucket,
+          Prefix: prefix || undefined,
+          MaxKeys: S3_MAX_KEYS_PER_CALL,
+          ContinuationToken: continuationToken,
+        }),
+      )
+      keys.push(...(response.Contents ?? []).map((object) => object.Key).filter((key): key is string => !!key))
+      if (keys.length > MAX_COPY_OBJECTS) {
+        throw new BadRequestException(
+          `source prefix has more than ${MAX_COPY_OBJECTS} objects; copy a narrower sub-prefix instead`,
+        )
+      }
+      continuationToken = response.IsTruncated ? response.NextContinuationToken : undefined
+    } while (continuationToken)
+
+    return keys
   }
 
   private async assertReady(volumeId: string) {

--- a/apps/api/src/box/utils/volume-path.util.spec.ts
+++ b/apps/api/src/box/utils/volume-path.util.spec.ts
@@ -1,0 +1,26 @@
+import { assertSafeVolumePath } from './volume-path.util'
+
+describe('assertSafeVolumePath', () => {
+  it.each(['checkpoints/model.bin', 'config.json', 'a/b/c.txt'])('accepts a relative path %s', (input) => {
+    expect(() => assertSafeVolumePath(input)).not.toThrow()
+  })
+
+  it.each(['/config.json', '/checkpoints/model.bin'])('rejects an absolute path %s', (input) => {
+    expect(() => assertSafeVolumePath(input)).toThrow('escapes the volume root')
+  })
+
+  it.each(['..', '../secret', 'checkpoints/../../secret', '../../etc/passwd'])(
+    'rejects a path that escapes upward %s',
+    (input) => {
+      expect(() => assertSafeVolumePath(input)).toThrow('escapes the volume root')
+    },
+  )
+
+  it('rejects an empty path', () => {
+    expect(() => assertSafeVolumePath('')).toThrow('must not be empty')
+  })
+
+  it('normalizes a redundant relative segment without rejecting it', () => {
+    expect(() => assertSafeVolumePath('checkpoints/./model.bin')).not.toThrow()
+  })
+})

--- a/apps/api/src/box/utils/volume-path.util.ts
+++ b/apps/api/src/box/utils/volume-path.util.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import * as path from 'path'
+import { BadRequestError } from '../../exceptions/bad-request.exception'
+
+/**
+ * Validates a caller-supplied volume file path before it becomes an S3 key.
+ *
+ * Mirrors the zip-slip guard already used for box file uploads
+ * (`apps/runner/pkg/api/controllers/boxlite_files.go:96-99`): reject an
+ * absolute path or one that escapes upward via `..`, rather than silently
+ * normalizing it. Kept as a standalone assertion (not path building) so it
+ * can validate at every entry point without also deciding how the caller's
+ * path is joined to a bucket prefix.
+ */
+export function assertSafeVolumePath(rawPath: string): void {
+  if (!rawPath) {
+    throw new BadRequestError('path must not be empty')
+  }
+
+  const cleaned = path.posix.normalize(rawPath)
+
+  if (path.posix.isAbsolute(cleaned) || cleaned === '..' || cleaned.startsWith('../')) {
+    throw new BadRequestError(`path escapes the volume root: ${rawPath}`)
+  }
+}

--- a/apps/api/src/boxlite-rest/boxlite-rest.module.ts
+++ b/apps/api/src/boxlite-rest/boxlite-rest.module.ts
@@ -16,6 +16,7 @@ import { BoxliteProxyController } from './boxlite-proxy.controller'
 import { BoxliteWsProxyService } from './boxlite-ws-proxy.service'
 import { BoxAutoResumeService } from './box-auto-resume.service'
 import { BoxliteVolumeController } from './boxlite-volume.controller'
+import { BoxliteVolumeFilesController } from './boxlite-volume-files.controller'
 import { CommerceBoxLimitService } from './commerce-box-limit.service'
 
 @Module({
@@ -26,6 +27,7 @@ import { CommerceBoxLimitService } from './commerce-box-limit.service'
     BoxliteBoxController,
     BoxliteProxyController,
     BoxliteVolumeController,
+    BoxliteVolumeFilesController,
   ],
   providers: [BoxliteWsProxyService, BoxAutoResumeService, CommerceBoxLimitService],
   exports: [BoxliteWsProxyService],

--- a/apps/api/src/boxlite-rest/boxlite-volume-files.controller.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-volume-files.controller.spec.ts
@@ -1,0 +1,83 @@
+import { BoxliteVolumeFilesController } from './boxlite-volume-files.controller'
+import { VolumeFilesService } from '../box/services/volume-files.service'
+
+describe('BoxliteVolumeFilesController', () => {
+  function createController() {
+    const volumeFilesService = {
+      listFiles: jest.fn().mockResolvedValue({ entries: [], hasMore: false }),
+      statFile: jest.fn().mockResolvedValue({ path: 'a.txt', size: 1, lastModified: new Date() }),
+      presignRead: jest.fn().mockResolvedValue({ url: 'https://s3.example/read', expiresAt: new Date() }),
+      presignWrite: jest.fn().mockResolvedValue({ url: 'https://s3.example/write', expiresAt: new Date() }),
+      deleteFile: jest.fn().mockResolvedValue(undefined),
+      batchDelete: jest.fn().mockResolvedValue({ deleted: ['a.txt'], errors: [] }),
+      presignBatchWrite: jest.fn().mockResolvedValue({ urls: [], errors: [] }),
+    }
+    return {
+      controller: new BoxliteVolumeFilesController(volumeFilesService as unknown as VolumeFilesService),
+      volumeFilesService,
+    }
+  }
+
+  it('lists files, defaulting to the volume root', async () => {
+    const { controller, volumeFilesService } = createController()
+
+    await controller.listFiles('volume-1', undefined as never, 'cursor-1')
+
+    expect(volumeFilesService.listFiles).toHaveBeenCalledWith('volume-1', '', 'cursor-1')
+  })
+
+  it('lists files under a given path', async () => {
+    const { controller, volumeFilesService } = createController()
+
+    await controller.listFiles('volume-1', 'checkpoints/')
+
+    expect(volumeFilesService.listFiles).toHaveBeenCalledWith('volume-1', 'checkpoints/', undefined)
+  })
+
+  it('delegates statFile to the service', async () => {
+    const { controller, volumeFilesService } = createController()
+
+    await controller.statFile('volume-1', 'a.txt')
+
+    expect(volumeFilesService.statFile).toHaveBeenCalledWith('volume-1', 'a.txt')
+  })
+
+  it('delegates presignRead to the service', async () => {
+    const { controller, volumeFilesService } = createController()
+
+    await controller.presignRead('volume-1', 'a.txt')
+
+    expect(volumeFilesService.presignRead).toHaveBeenCalledWith('volume-1', 'a.txt')
+  })
+
+  it('delegates presignWrite to the service', async () => {
+    const { controller, volumeFilesService } = createController()
+
+    await controller.presignWrite('volume-1', 'a.txt')
+
+    expect(volumeFilesService.presignWrite).toHaveBeenCalledWith('volume-1', 'a.txt')
+  })
+
+  it('delegates deleteFile to the service', async () => {
+    const { controller, volumeFilesService } = createController()
+
+    await expect(controller.deleteFile('volume-1', 'a.txt')).resolves.toBeUndefined()
+    expect(volumeFilesService.deleteFile).toHaveBeenCalledWith('volume-1', 'a.txt')
+  })
+
+  it('delegates batchDelete to the service with the DTO paths', async () => {
+    const { controller, volumeFilesService } = createController()
+
+    await controller.batchDelete('volume-1', { paths: ['a.txt', 'b.txt'] })
+
+    expect(volumeFilesService.batchDelete).toHaveBeenCalledWith('volume-1', ['a.txt', 'b.txt'])
+  })
+
+  it('delegates presignBatchWrite to the service with the DTO paths', async () => {
+    const { controller, volumeFilesService } = createController()
+
+    await controller.presignBatchWrite('volume-1', { paths: ['a.txt', 'b.txt'] })
+
+    expect(volumeFilesService.presignBatchWrite).toHaveBeenCalledWith('volume-1', ['a.txt', 'b.txt'])
+  })
+})

--- a/apps/api/src/boxlite-rest/boxlite-volume-files.controller.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-volume-files.controller.spec.ts
@@ -11,6 +11,7 @@ describe('BoxliteVolumeFilesController', () => {
       deleteFile: jest.fn().mockResolvedValue(undefined),
       batchDelete: jest.fn().mockResolvedValue({ deleted: ['a.txt'], errors: [] }),
       presignBatchWrite: jest.fn().mockResolvedValue({ urls: [], errors: [] }),
+      copyFiles: jest.fn().mockResolvedValue({ copied: ['b/a.txt'], errors: [] }),
     }
     return {
       controller: new BoxliteVolumeFilesController(volumeFilesService as unknown as VolumeFilesService),
@@ -79,5 +80,17 @@ describe('BoxliteVolumeFilesController', () => {
     await controller.presignBatchWrite('volume-1', { paths: ['a.txt', 'b.txt'] })
 
     expect(volumeFilesService.presignBatchWrite).toHaveBeenCalledWith('volume-1', ['a.txt', 'b.txt'])
+  })
+
+  it('delegates copyFiles to the service with the caller organization and DTO fields', async () => {
+    const { controller, volumeFilesService } = createController()
+
+    await controller.copyFiles('dest-volume', { organizationId: 'org-1' } as never, {
+      sourceVolumeId: 'source-volume',
+      sourcePrefix: 'a/',
+      destPrefix: 'b/',
+    })
+
+    expect(volumeFilesService.copyFiles).toHaveBeenCalledWith('dest-volume', 'org-1', 'source-volume', 'a/', 'b/')
   })
 })

--- a/apps/api/src/boxlite-rest/boxlite-volume-files.controller.spec.ts
+++ b/apps/api/src/boxlite-rest/boxlite-volume-files.controller.spec.ts
@@ -22,7 +22,7 @@ describe('BoxliteVolumeFilesController', () => {
   it('lists files, defaulting to the volume root', async () => {
     const { controller, volumeFilesService } = createController()
 
-    await controller.listFiles('volume-1', undefined as never, 'cursor-1')
+    await controller.listFiles('volume-1', { cursor: 'cursor-1' })
 
     expect(volumeFilesService.listFiles).toHaveBeenCalledWith('volume-1', '', 'cursor-1')
   })
@@ -30,7 +30,7 @@ describe('BoxliteVolumeFilesController', () => {
   it('lists files under a given path', async () => {
     const { controller, volumeFilesService } = createController()
 
-    await controller.listFiles('volume-1', 'checkpoints/')
+    await controller.listFiles('volume-1', { path: 'checkpoints/' })
 
     expect(volumeFilesService.listFiles).toHaveBeenCalledWith('volume-1', 'checkpoints/', undefined)
   })
@@ -38,7 +38,7 @@ describe('BoxliteVolumeFilesController', () => {
   it('delegates statFile to the service', async () => {
     const { controller, volumeFilesService } = createController()
 
-    await controller.statFile('volume-1', 'a.txt')
+    await controller.statFile('volume-1', { path: 'a.txt' })
 
     expect(volumeFilesService.statFile).toHaveBeenCalledWith('volume-1', 'a.txt')
   })
@@ -46,7 +46,7 @@ describe('BoxliteVolumeFilesController', () => {
   it('delegates presignRead to the service', async () => {
     const { controller, volumeFilesService } = createController()
 
-    await controller.presignRead('volume-1', 'a.txt')
+    await controller.presignRead('volume-1', { path: 'a.txt' })
 
     expect(volumeFilesService.presignRead).toHaveBeenCalledWith('volume-1', 'a.txt')
   })
@@ -54,7 +54,7 @@ describe('BoxliteVolumeFilesController', () => {
   it('delegates presignWrite to the service', async () => {
     const { controller, volumeFilesService } = createController()
 
-    await controller.presignWrite('volume-1', 'a.txt')
+    await controller.presignWrite('volume-1', { path: 'a.txt' })
 
     expect(volumeFilesService.presignWrite).toHaveBeenCalledWith('volume-1', 'a.txt')
   })
@@ -62,7 +62,7 @@ describe('BoxliteVolumeFilesController', () => {
   it('delegates deleteFile to the service', async () => {
     const { controller, volumeFilesService } = createController()
 
-    await expect(controller.deleteFile('volume-1', 'a.txt')).resolves.toBeUndefined()
+    await expect(controller.deleteFile('volume-1', { path: 'a.txt' })).resolves.toBeUndefined()
     expect(volumeFilesService.deleteFile).toHaveBeenCalledWith('volume-1', 'a.txt')
   })
 

--- a/apps/api/src/boxlite-rest/boxlite-volume-files.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-volume-files.controller.ts
@@ -5,15 +5,13 @@
  */
 
 import { Body, Controller, Delete, Get, HttpCode, Param, Post, Query, UseGuards } from '@nestjs/common'
-import { ApiBearerAuth, ApiHeader, ApiOAuth2, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger'
-import { CombinedAuthGuard } from '../../auth/combined-auth.guard'
-import { CustomHeaders } from '../../common/constants/header.constants'
-import { RequiredOrganizationResourcePermissions } from '../../organization/decorators/required-organization-resource-permissions.decorator'
-import { OrganizationResourcePermission } from '../../organization/enums/organization-resource-permission.enum'
-import { OrganizationResourceActionGuard } from '../../organization/guards/organization-resource-action.guard'
-import { AuthenticatedRateLimitGuard } from '../../common/guards/authenticated-rate-limit.guard'
-import { VolumeAccessGuard } from '../guards/volume-access.guard'
-import { VolumeFilesService } from '../services/volume-files.service'
+import { ApiExcludeController } from '@nestjs/swagger'
+import { CombinedAuthGuard } from '../auth/combined-auth.guard'
+import { OrganizationResourceActionGuard } from '../organization/guards/organization-resource-action.guard'
+import { RequiredOrganizationResourcePermissions } from '../organization/decorators/required-organization-resource-permissions.decorator'
+import { OrganizationResourcePermission } from '../organization/enums/organization-resource-permission.enum'
+import { VolumeAccessGuard } from '../box/guards/volume-access.guard'
+import { VolumeFilesService } from '../box/services/volume-files.service'
 import {
   BatchDeleteVolumeFilesDto,
   BatchDeleteVolumeFilesResponseDto,
@@ -22,22 +20,24 @@ import {
   PresignBatchWriteVolumeFilesResponseDto,
   PresignedUrlResponseDto,
   VolumeFileStatDto,
-} from '../dto/volume-file.dto'
+} from '../box/dto/volume-file.dto'
 
-@ApiTags('volumes')
-@Controller('volumes/:volumeId/files')
-@ApiHeader(CustomHeaders.ORGANIZATION_ID)
-@UseGuards(CombinedAuthGuard, OrganizationResourceActionGuard, AuthenticatedRateLimitGuard, VolumeAccessGuard)
-@ApiOAuth2(['openid', 'profile', 'email'])
-@ApiBearerAuth()
-@ApiParam({ name: 'volumeId', description: 'ID of the volume', type: 'string' })
-export class VolumeFilesController {
+/**
+ * File-level operations on a Volume's contents, without attaching it to a
+ * box (POL-216). Lives in the Box API dialect, not `box/controllers` -
+ * `/files` operations are single-owner Box-contract territory (see the CI
+ * "Contract boundary guard"), same reasoning that already put box exec/files
+ * behind `boxlite-proxy.controller.ts` rather than the cloud `box.module.ts`.
+ */
+@Controller(['v1/volumes/:volumeId/files', 'v1/:prefix/volumes/:volumeId/files'])
+@ApiExcludeController()
+@UseGuards(CombinedAuthGuard, OrganizationResourceActionGuard)
+export class BoxliteVolumeFilesController {
   constructor(private readonly volumeFilesService: VolumeFilesService) {}
 
   @Get()
-  @ApiOperation({ summary: 'List files under a path in a volume', operationId: 'listVolumeFiles' })
-  @ApiResponse({ status: 200, type: ListVolumeFilesResponseDto })
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.READ_VOLUMES])
+  @UseGuards(VolumeAccessGuard)
   async listFiles(
     @Param('volumeId') volumeId: string,
     @Query('path') path = '',
@@ -47,20 +47,15 @@ export class VolumeFilesController {
   }
 
   @Get('stat')
-  @ApiOperation({ summary: 'Get metadata for a single file in a volume', operationId: 'statVolumeFile' })
-  @ApiResponse({ status: 200, type: VolumeFileStatDto })
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.READ_VOLUMES])
+  @UseGuards(VolumeAccessGuard)
   async statFile(@Param('volumeId') volumeId: string, @Query('path') path: string): Promise<VolumeFileStatDto> {
     return this.volumeFilesService.statFile(volumeId, path)
   }
 
   @Get('presign-read')
-  @ApiOperation({
-    summary: 'Get a short-lived URL to read a file directly from object storage',
-    operationId: 'presignReadVolumeFile',
-  })
-  @ApiResponse({ status: 200, type: PresignedUrlResponseDto })
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.READ_VOLUMES])
+  @UseGuards(VolumeAccessGuard)
   async presignRead(
     @Param('volumeId') volumeId: string,
     @Query('path') path: string,
@@ -69,12 +64,8 @@ export class VolumeFilesController {
   }
 
   @Post('presign-write')
-  @ApiOperation({
-    summary: 'Get a short-lived URL to write a file directly to object storage',
-    operationId: 'presignWriteVolumeFile',
-  })
-  @ApiResponse({ status: 200, type: PresignedUrlResponseDto })
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_VOLUMES])
+  @UseGuards(VolumeAccessGuard)
   async presignWrite(
     @Param('volumeId') volumeId: string,
     @Query('path') path: string,
@@ -84,17 +75,15 @@ export class VolumeFilesController {
 
   @Delete('content')
   @HttpCode(204)
-  @ApiOperation({ summary: 'Delete a single file from a volume', operationId: 'deleteVolumeFile' })
-  @ApiResponse({ status: 204, description: 'File deleted' })
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_VOLUMES])
+  @UseGuards(VolumeAccessGuard)
   async deleteFile(@Param('volumeId') volumeId: string, @Query('path') path: string): Promise<void> {
     await this.volumeFilesService.deleteFile(volumeId, path)
   }
 
   @Post('batch-delete')
-  @ApiOperation({ summary: 'Delete a batch of files from a volume', operationId: 'batchDeleteVolumeFiles' })
-  @ApiResponse({ status: 200, type: BatchDeleteVolumeFilesResponseDto })
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_VOLUMES])
+  @UseGuards(VolumeAccessGuard)
   async batchDelete(
     @Param('volumeId') volumeId: string,
     @Body() dto: BatchDeleteVolumeFilesDto,
@@ -103,12 +92,8 @@ export class VolumeFilesController {
   }
 
   @Post('presign-batch-write')
-  @ApiOperation({
-    summary: 'Get short-lived URLs to write a batch of files directly to object storage',
-    operationId: 'presignBatchWriteVolumeFiles',
-  })
-  @ApiResponse({ status: 200, type: PresignBatchWriteVolumeFilesResponseDto })
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_VOLUMES])
+  @UseGuards(VolumeAccessGuard)
   async presignBatchWrite(
     @Param('volumeId') volumeId: string,
     @Body() dto: PresignBatchWriteVolumeFilesDto,

--- a/apps/api/src/boxlite-rest/boxlite-volume-files.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-volume-files.controller.ts
@@ -19,10 +19,12 @@ import {
   BatchDeleteVolumeFilesResponseDto,
   CopyVolumeFilesDto,
   CopyVolumeFilesResponseDto,
+  ListVolumeFilesQueryDto,
   ListVolumeFilesResponseDto,
   PresignBatchWriteVolumeFilesDto,
   PresignBatchWriteVolumeFilesResponseDto,
   PresignedUrlResponseDto,
+  VolumeFilePathQueryDto,
   VolumeFileStatDto,
 } from '../box/dto/volume-file.dto'
 
@@ -44,17 +46,19 @@ export class BoxliteVolumeFilesController {
   @UseGuards(VolumeAccessGuard)
   async listFiles(
     @Param('volumeId') volumeId: string,
-    @Query('path') path = '',
-    @Query('cursor') cursor?: string,
+    @Query() query: ListVolumeFilesQueryDto,
   ): Promise<ListVolumeFilesResponseDto> {
-    return this.volumeFilesService.listFiles(volumeId, path, cursor)
+    return this.volumeFilesService.listFiles(volumeId, query.path ?? '', query.cursor)
   }
 
   @Get('stat')
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.READ_VOLUMES])
   @UseGuards(VolumeAccessGuard)
-  async statFile(@Param('volumeId') volumeId: string, @Query('path') path: string): Promise<VolumeFileStatDto> {
-    return this.volumeFilesService.statFile(volumeId, path)
+  async statFile(
+    @Param('volumeId') volumeId: string,
+    @Query() query: VolumeFilePathQueryDto,
+  ): Promise<VolumeFileStatDto> {
+    return this.volumeFilesService.statFile(volumeId, query.path)
   }
 
   @Get('presign-read')
@@ -62,9 +66,9 @@ export class BoxliteVolumeFilesController {
   @UseGuards(VolumeAccessGuard)
   async presignRead(
     @Param('volumeId') volumeId: string,
-    @Query('path') path: string,
+    @Query() query: VolumeFilePathQueryDto,
   ): Promise<PresignedUrlResponseDto> {
-    return this.volumeFilesService.presignRead(volumeId, path)
+    return this.volumeFilesService.presignRead(volumeId, query.path)
   }
 
   @Post('presign-write')
@@ -72,17 +76,20 @@ export class BoxliteVolumeFilesController {
   @UseGuards(VolumeAccessGuard)
   async presignWrite(
     @Param('volumeId') volumeId: string,
-    @Query('path') path: string,
+    @Query() query: VolumeFilePathQueryDto,
   ): Promise<PresignedUrlResponseDto> {
-    return this.volumeFilesService.presignWrite(volumeId, path)
+    return this.volumeFilesService.presignWrite(volumeId, query.path)
   }
 
   @Delete('content')
   @HttpCode(204)
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_VOLUMES])
   @UseGuards(VolumeAccessGuard)
-  async deleteFile(@Param('volumeId') volumeId: string, @Query('path') path: string): Promise<void> {
-    await this.volumeFilesService.deleteFile(volumeId, path)
+  async deleteFile(
+    @Param('volumeId') volumeId: string,
+    @Query() query: VolumeFilePathQueryDto,
+  ): Promise<void> {
+    await this.volumeFilesService.deleteFile(volumeId, query.path)
   }
 
   @Post('batch-delete')

--- a/apps/api/src/boxlite-rest/boxlite-volume-files.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-volume-files.controller.ts
@@ -10,11 +10,15 @@ import { CombinedAuthGuard } from '../auth/combined-auth.guard'
 import { OrganizationResourceActionGuard } from '../organization/guards/organization-resource-action.guard'
 import { RequiredOrganizationResourcePermissions } from '../organization/decorators/required-organization-resource-permissions.decorator'
 import { OrganizationResourcePermission } from '../organization/enums/organization-resource-permission.enum'
+import { AuthContext } from '../common/decorators/auth-context.decorator'
+import { OrganizationAuthContext } from '../common/interfaces/auth-context.interface'
 import { VolumeAccessGuard } from '../box/guards/volume-access.guard'
 import { VolumeFilesService } from '../box/services/volume-files.service'
 import {
   BatchDeleteVolumeFilesDto,
   BatchDeleteVolumeFilesResponseDto,
+  CopyVolumeFilesDto,
+  CopyVolumeFilesResponseDto,
   ListVolumeFilesResponseDto,
   PresignBatchWriteVolumeFilesDto,
   PresignBatchWriteVolumeFilesResponseDto,
@@ -99,5 +103,26 @@ export class BoxliteVolumeFilesController {
     @Body() dto: PresignBatchWriteVolumeFilesDto,
   ): Promise<PresignBatchWriteVolumeFilesResponseDto> {
     return this.volumeFilesService.presignBatchWrite(volumeId, dto.paths)
+  }
+
+  // VolumeAccessGuard authorizes the destination (:volumeId in the URL) as
+  // usual. A cross-volume copy also names a *source* volume in the body,
+  // which the guard has no visibility into - the service itself authorizes
+  // that one (assertReadyAndOwned).
+  @Post('copy')
+  @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_VOLUMES])
+  @UseGuards(VolumeAccessGuard)
+  async copyFiles(
+    @Param('volumeId') volumeId: string,
+    @AuthContext() authContext: OrganizationAuthContext,
+    @Body() dto: CopyVolumeFilesDto,
+  ): Promise<CopyVolumeFilesResponseDto> {
+    return this.volumeFilesService.copyFiles(
+      volumeId,
+      authContext.organizationId,
+      dto.sourceVolumeId,
+      dto.sourcePrefix,
+      dto.destPrefix,
+    )
   }
 }

--- a/apps/api/src/boxlite-rest/boxlite-volume-files.controller.ts
+++ b/apps/api/src/boxlite-rest/boxlite-volume-files.controller.ts
@@ -30,8 +30,8 @@ import {
 
 /**
  * File-level operations on a Volume's contents, without attaching it to a
- * box (POL-216). Lives in the Box API dialect, not `box/controllers` -
- * `/files` operations are single-owner Box-contract territory (see the CI
+ * box. Lives in the Box API dialect, not `box/controllers` - `/files`
+ * operations are single-owner Box-contract territory (see the CI
  * "Contract boundary guard"), same reasoning that already put box exec/files
  * behind `boxlite-proxy.controller.ts` rather than the cloud `box.module.ts`.
  */

--- a/apps/api/src/common/utils/s3-client.factory.spec.ts
+++ b/apps/api/src/common/utils/s3-client.factory.spec.ts
@@ -20,8 +20,13 @@ describe('createS3Client endpoint scheme', () => {
 
     expect(client.config.endpoint).toBeDefined()
     // @aws-sdk/client-s3 stores the endpoint as a resolver; assert via the
-    // resolved value instead of reaching into SDK internals.
-    return expect(client.config.endpoint()).resolves.toMatchObject({ hostname: 's3.example-region.amazonaws.com' })
+    // resolved value instead of reaching into SDK internals. Assert the
+    // protocol too, not just the hostname - an http endpoint with the same
+    // hostname would otherwise satisfy this test just as well.
+    return expect(client.config.endpoint()).resolves.toMatchObject({
+      hostname: 's3.example-region.amazonaws.com',
+      protocol: 'https:',
+    })
   })
 
   it('keeps a bare minio endpoint on http', async () => {

--- a/apps/api/src/common/utils/s3-client.factory.spec.ts
+++ b/apps/api/src/common/utils/s3-client.factory.spec.ts
@@ -1,0 +1,60 @@
+import { createS3Client } from './s3-client.factory'
+
+function fakeConfig(values: Record<string, unknown>) {
+  return {
+    get: (key: string) => values[key],
+    getOrThrow: (key: string) => {
+      if (!(key in values)) {
+        throw new Error(`missing config: ${key}`)
+      }
+      return values[key]
+    },
+  } as never
+}
+
+describe('createS3Client endpoint scheme', () => {
+  it('defaults a bare production-looking endpoint to https', () => {
+    const client = createS3Client(
+      fakeConfig({ 's3.endpoint': 's3.example-region.amazonaws.com', 's3.region': 'us-east-1' }),
+    )
+
+    expect(client.config.endpoint).toBeDefined()
+    // @aws-sdk/client-s3 stores the endpoint as a resolver; assert via the
+    // resolved value instead of reaching into SDK internals.
+    return expect(client.config.endpoint()).resolves.toMatchObject({ hostname: 's3.example-region.amazonaws.com' })
+  })
+
+  it('keeps a bare minio endpoint on http', async () => {
+    const client = createS3Client(
+      fakeConfig({
+        's3.endpoint': 'minio.internal:9000',
+        's3.region': 'us-east-1',
+        's3.accessKey': 'a',
+        's3.secretKey': 'b',
+      }),
+    )
+
+    await expect(client.config.endpoint()).resolves.toMatchObject({ protocol: 'http:' })
+  })
+
+  it('keeps a bare localhost endpoint on http', async () => {
+    const client = createS3Client(
+      fakeConfig({
+        's3.endpoint': 'localhost:9000',
+        's3.region': 'us-east-1',
+        's3.accessKey': 'a',
+        's3.secretKey': 'b',
+      }),
+    )
+
+    await expect(client.config.endpoint()).resolves.toMatchObject({ protocol: 'http:' })
+  })
+
+  it('does not override an endpoint that already names a scheme', async () => {
+    const client = createS3Client(
+      fakeConfig({ 's3.endpoint': 'http://s3.example.com', 's3.region': 'us-east-1' }),
+    )
+
+    await expect(client.config.endpoint()).resolves.toMatchObject({ protocol: 'http:' })
+  })
+})

--- a/apps/api/src/common/utils/s3-client.factory.ts
+++ b/apps/api/src/common/utils/s3-client.factory.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * Modified by BoxLite AI, 2025-2026
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { S3Client } from '@aws-sdk/client-s3'
+import { TypedConfigService } from '../../config/typed-config.service'
+
+/**
+ * Builds the S3-compatible client shared by every volume feature (bucket
+ * lifecycle in `VolumeManager`, file access in `VolumeFilesService`).
+ * Extracted here so both stay in sync instead of drifting on config keys,
+ * MinIO's credential requirement, or the both-or-neither key check.
+ *
+ * Returns `null` when object storage isn't configured (`s3.endpoint` unset) -
+ * callers that need a client should throw their own domain-appropriate error
+ * (e.g. `ServiceUnavailableException`) rather than this factory choosing one.
+ */
+export function createS3Client(configService: TypedConfigService): S3Client | null {
+  if (!configService.get('s3.endpoint')) {
+    return null
+  }
+
+  const endpoint = configService.getOrThrow('s3.endpoint')
+  const region = configService.getOrThrow('s3.region')
+  const accessKeyId = configService.get('s3.accessKey')
+  const secretAccessKey = configService.get('s3.secretKey')
+
+  // Both-or-neither: a lone key is a typo'd pair, and silently falling back
+  // to the SDK default chain would mask the misconfig.
+  if ((accessKeyId && !secretAccessKey) || (!accessKeyId && secretAccessKey)) {
+    throw new Error('S3_ACCESS_KEY and S3_SECRET_KEY must be set together')
+  }
+  // MinIO cannot use the SDK default chain - fail fast at boot with a clear
+  // message instead of a generic auth error from the connection probe.
+  if (endpoint.includes('minio') && !accessKeyId) {
+    throw new Error('MinIO requires S3_ACCESS_KEY and S3_SECRET_KEY to be configured')
+  }
+
+  return new S3Client({
+    endpoint: endpoint.startsWith('http') ? endpoint : `http://${endpoint}`,
+    region,
+    // Static keys for S3-compatible deployments (MinIO); unset on AWS,
+    // where the SDK default chain supplies the ECS task-role credentials.
+    ...(accessKeyId && secretAccessKey ? { credentials: { accessKeyId, secretAccessKey } } : {}),
+    forcePathStyle: true,
+  })
+}

--- a/apps/api/src/common/utils/s3-client.factory.ts
+++ b/apps/api/src/common/utils/s3-client.factory.ts
@@ -39,11 +39,27 @@ export function createS3Client(configService: TypedConfigService): S3Client | nu
   }
 
   return new S3Client({
-    endpoint: endpoint.startsWith('http') ? endpoint : `http://${endpoint}`,
+    endpoint: withScheme(endpoint),
     region,
     // Static keys for S3-compatible deployments (MinIO); unset on AWS,
     // where the SDK default chain supplies the ECS task-role credentials.
     ...(accessKeyId && secretAccessKey ? { credentials: { accessKeyId, secretAccessKey } } : {}),
     forcePathStyle: true,
   })
+}
+
+/**
+ * Adds a URL scheme to a bare host:port endpoint. Defaults to HTTPS - this
+ * client now also signs presigned URLs handed straight to external callers
+ * (`VolumeFilesService`), so a scheme-less production endpoint must not
+ * silently downgrade every read/write to plaintext. Only known local/dev
+ * deployments (MinIO, localhost) fall back to HTTP, matching the existing
+ * MinIO carve-out for the credential requirement above.
+ */
+function withScheme(endpoint: string): string {
+  if (endpoint.startsWith('http://') || endpoint.startsWith('https://')) {
+    return endpoint
+  }
+  const isLocal = endpoint.includes('minio') || endpoint.includes('localhost') || endpoint.includes('127.0.0.1')
+  return `${isLocal ? 'http' : 'https'}://${endpoint}`
 }

--- a/apps/package.json
+++ b/apps/package.json
@@ -53,6 +53,7 @@
     "@aws-sdk/credential-provider-node": "^3.901.0",
     "@aws-sdk/credential-providers": "^3.901.0",
     "@aws-sdk/lib-storage": "^3.798.0",
+    "@aws-sdk/s3-request-presigner": "3.1048.0",
     "@clickhouse/client": "^1.16.0",
     "@dotenvx/dotenvx": "^1.25.1",
     "@esm2cjs/cacheable-lookup": "^7.0.0",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1191,6 +1191,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/s3-request-presigner@npm:3.1048.0":
+  version: 3.1048.0
+  resolution: "@aws-sdk/s3-request-presigner@npm:3.1048.0"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.11"
+    "@aws-sdk/signature-v4-multi-region": "npm:^3.996.27"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/core": "npm:^3.24.2"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/0e62f1f08d99a5a257d6e26816e5298d40d659995b31257017afba424ab5e89049bb34899b5bb932e4306ebd703376b2c5e5bef36ce75c5de2c3a5990b846e88
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/signature-v4-multi-region@npm:^3.996.26, @aws-sdk/signature-v4-multi-region@npm:^3.996.27":
   version: 3.996.27
   resolution: "@aws-sdk/signature-v4-multi-region@npm:3.996.27"
@@ -17033,6 +17047,7 @@ __metadata:
     "@aws-sdk/credential-provider-node": "npm:^3.901.0"
     "@aws-sdk/credential-providers": "npm:^3.901.0"
     "@aws-sdk/lib-storage": "npm:^3.798.0"
+    "@aws-sdk/s3-request-presigner": "npm:3.1048.0"
     "@babel/preset-env": "npm:^7.22.0"
     "@babel/preset-typescript": "npm:^7.22.0"
     "@clickhouse/client": "npm:^1.16.0"


### PR DESCRIPTION
## Summary

Lets a caller list/stat/read/write/delete individual files in a Volume's bucket directly, without attaching the volume to a box. Byte-carrying routes (read/write/batch-write) are presigned — the API server issues a short-lived S3 URL and never proxies file bytes, avoiding bandwidth/gateway-timeout limits on large-file transfers (the feature's core use case: migrating whole projects, including large model weights). A server-side copy route replicates files between volumes (or between prefixes in the same volume) via S3's native `CopyObject` — the one batch operation that genuinely moves a whole "folder" in one request, since the bytes never leave the storage backend.

Supersedes #1439, which was accidentally closed by a fork branch rename — same commits, same review history addressed, branch renamed to drop an internal ticket reference from its name.

## Call graph

```
BoxliteVolumeFilesController (v1/volumes/:volumeId/files*)
  listFiles          -> VolumeFilesService.listFiles          -> ListObjectsV2 (paginated)
  statFile            -> VolumeFilesService.statFile            -> HeadObject
  presignRead          -> VolumeFilesService.presignRead         -> HeadObject (404 check) + presigned GetObject
  presignWrite          -> VolumeFilesService.presignWrite        -> presigned PutObject
  deleteFile            -> VolumeFilesService.deleteFile          -> HeadObject (404 check) + DeleteObject
  batchDelete            -> VolumeFilesService.batchDelete         -> DeleteObjects, chunked at 1000
  presignBatchWrite       -> VolumeFilesService.presignBatchWrite   -> N presigned PutObject, chunked at 50 concurrent
  copyFiles                -> VolumeFilesService.copyFiles           -> paginated ListObjectsV2 + CopyObject, chunked at 20 concurrent
```

`assertSafeVolumePath()` gates every path before it reaches S3 — rejects absolute paths and `..` traversal, mirroring the existing zip-slip guard in the box files tar-upload path. Query parameters are bound through DTOs (`@IsString()`) rather than raw `@Query('x')`, closing a type-confusion class of bug CodeQL flagged (an array value from a repeated query key reaching a string-only operation downstream).

`copyFiles` authorizes its body-supplied source volume explicitly (`assertReadyAndOwned`) since `VolumeAccessGuard` only covers the URL's destination volume id.

Lives in `apps/api/src/boxlite-rest/` (the Box API dialect SDKs/CLI actually call), not the cloud-tenant `box.module.ts` — `/files` routes are single-owner Box-contract territory per the CI "Contract boundary guard".

## Known gaps

- Writes above the 5 GiB single-`PutObject` ceiling are **not yet supported** — presigned multipart upload is left as explicit follow-up work.
- Not yet verified end-to-end against a real S3/MinIO backend — only unit-tested with a mocked `S3Client`/`getSignedUrl`. Endpoint reachability for presigned URLs needs confirming for the target deployment before this ships to users.
- SDK methods (Python/Node/Go/C) are not part of this PR — API server only.

## Test plan

- [x] `volume-path.util.spec.ts`, `volume-file.dto.spec.ts`, `volume-files.service.spec.ts`, `s3-client.factory.spec.ts`, `boxlite-volume-files.controller.spec.ts` — 105+ cases covering readiness gating, path validation, pagination, presign 404-mapping, batch chunking/partial-success, cross-org copy rejection, and type-confusion rejection on query params
- [x] Existing `volume.manager.spec.ts`/`volume.service.spec.ts`/`boxlite-volume.controller.spec.ts` still pass unchanged
- [x] `tsc --noEmit` clean, `eslint` clean, `nx build api` succeeds
- [x] Re-ran the CI contract-boundary guard locally (`REDIS_HOST=localhost SKIP_CONNECTIONS=true nx run api:openapi` + the guard's own jq/grep checks) — cloud spec has no `/files` paths, `box.openapi.yaml` has no tenancy concepts, generated clients show zero diff
- [ ] Not run: live E2E against a real S3/MinIO backend (no dev credentials in this environment)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added volume file management, including listing, metadata, secure downloads/uploads, batch deletion, and volume-to-volume copying.
  - Added streaming file transfers for improved performance and reliability.
  - Added last-activity timestamps to box details, SDKs, CLI inspection, and API responses.
  - Added billing history with invoice filtering, pagination, payment status, and credit activity views.
  - Added inline box creation from the Volumes page with permission-aware controls.

- **Bug Fixes**
  - Improved handling of interrupted transfers, unknown statuses, billing updates, and host resource configuration.
  - Strengthened archive extraction and file-path safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->