### PR TITLE
fix(guest): bound exec kills by process group, not just the leader

### DIFF
--- a/docs/investigations/exec-timeout-orphan.md
+++ b/docs/investigations/exec-timeout-orphan.md
@@ -1,0 +1,662 @@
+# Exec Timeout Orphan: Root Cause Analysis
+
+**Date:** 2026-09-07
+**Branch:** `main`
+**Severity:** High — a documented hard deadline does not bound the workload; orphans retain guest CPU/memory, and REST callers hang indefinitely
+**Reproduction rate:** 100% whenever the exec leader forks instead of exec'ing
+
+---
+
+## Conclusion
+
+### Root Cause: the timeout watcher signals the captured leader PID, not its process group
+
+`start_timeout_watcher` terminates an over-deadline exec through
+`TimeoutTarget::signal_if_live`, which called
+`ProcessInstance::signal(signal, /* process_group */ false)`. That argument
+restricts the signal to the single PID captured at spawn.
+
+When the workload is a shell that forks — `sh -c "sleep 300"` on a `dash`-family
+`/bin/sh`, or anything written as `cmd &` — the captured leader is the *shell*
+and the real work runs in its child. SIGTERM then reaps the shell only. The
+child is reparented to init and runs on, unbounded.
+
+The SIGKILL escalation cannot recover, and fails **silently**:
+
+- `ProcessInstance::signal` opens with a start-time guard,
+  `if !self.is_current() { return Ok(false); }`. Once the leader is reaped that
+  guard is false forever, so the escalation never reaches `kill()`.
+- The watcher logs only on the `Ok(true)` arm. `Ok(false)` was routed to
+  `info!("exited within grace after SIGTERM")` — which reads as success. A
+  failed escalation and a clean exit are indistinguishable in the guest log.
+
+The orphan also inherits the exec's stdout/stderr **pipe write ends**. Those
+pipes therefore never reach EOF, the runner's stream pump never observes
+closure, the exit frame is never delivered, and `Execution::wait()` never
+resolves. One defect, two symptoms.
+
+### Deadlock Call Graph
+
+```
+BEFORE (defective)
+
+guest: spawn_execution()                      container: PID 2 = `sh`, PGID 2
+  ↓                                                      PID 3 = `sleep 300`
+ProcessInstance::capture(leader_pid = 2)  ── captures PID 2 + its start_time
+  ↓
+start_timeout_watcher(target, 2s)
+  ↓
+sleep(2s)
+  ↓
+signal_if_live(SIGTERM)
+  → ProcessInstance::signal(SIGTERM, process_group = false)   ← BUG: leader only
+      → is_current() = true
+      → kill(2, SIGTERM)                       ✔ shell dies
+                                               ✘ PID 3 survives, reparented to init
+  ↓
+sleep(TIMEOUT_GRACE = 2s)
+  ↓
+signal_if_live(SIGKILL)
+  → ProcessInstance::signal(SIGKILL, false)
+      → is_current() = false                   ← leader already reaped
+      → return Ok(false)                       ← no kill(), and no log
+  ↓
+watcher task ends
+
+  PID 3 `sleep 300` alive past its deadline, PPID = 1,
+  still holding fd 1 → pipe:[83], fd 2 → pipe:[84]
+      ↓
+  runner stream pump never sees EOF
+      ↓
+  exit frame never sent over WS
+      ↓
+  SDK Execution::wait() hangs forever
+
+
+AFTER (fixed)
+
+guest: spawn_execution()                      container: PID 2 = `sh`, PGID 2
+  ↓                                                      PID 3 = `sleep 300`
+ProcessInstance::capture(2)   ← start_time AND pgid read together, here
+  → getpgid(2) == 2  ⇒  group = Some(Pid(2))
+        ↑ the only point that runs before the reaper can win. Re-deriving
+          the group later — at TimeoutTarget::new, or at signal time —
+          reports "no group" for a leader already reaped, silently
+          restoring leader-only delivery
+  ↓
+TimeoutTarget::new(process)   → group carried over, no /proc lookup
+  ↓
+start_timeout_watcher(target, 2s)
+  ↓
+sleep(2s)
+  ↓
+signal_job(SIGTERM)
+  → signal_process_group(2, SIGTERM) ⇒ kill(-2, SIGTERM)   ✔ shell AND child
+  ↓
+sleep(TIMEOUT_GRACE = 2s)
+  ↓
+signal_job(SIGKILL)                        ← same captured group, no re-lookup
+  → signal_process_group(2, SIGKILL) ⇒ kill(-2, SIGKILL)
+      → survivors killed even though the leader is gone
+      → ESRCH ⇒ Ok(false) when the group is already empty
+```
+
+### Why the escalation was silent
+
+| Watcher arm | Meaning before the fix                              | Logged as                            |
+|-------------|-----------------------------------------------------|--------------------------------------|
+| `Ok(true)`  | SIGKILL delivered                                   | `warn!` "SIGKILL after grace expired" |
+| `Ok(false)` | **either** everything exited **or** the guard refused | `info!` "exited within grace"        |
+| `Err(_)`    | `kill()` itself failed                              | `warn!` "timeout SIGKILL failed"      |
+
+The `Ok(false)` arm conflates a clean exit with a refused escalation. In every
+reproduction the guest log showed `SIGTERM on timeout` at +2.004s and then
+nothing at all — the failure left no trace.
+
+### Why the existing tests never caught it
+
+| Test | Workload | Forks? | Verdict |
+|------|----------|--------|---------|
+| `exec_options.rs::test_timeout_kills_long_command` | `BoxCommand::new("sleep").arg("60")` | **No** — no shell at all; the leader *is* `sleep` | passes; never exercises the orphan path |
+| `exec_options.rs::test_timeout_kills_sigalrm_ignoring_process` | `sh -c "trap '' ALRM; sleep 15"` | Yes | passes — it traps only ALRM, so SIGTERM reaps the shell promptly and both assertions (`exit_code != 0`, `elapsed < 8s`) hold. It never checks whether the *child* died. |
+| `timeout.rs::tests::timeout_target_signals_its_live_leader` | `/bin/sleep 30`, spawned directly | **No** | passes; asserts leader-only delivery, which is the very behaviour at fault |
+
+Every existing test observes the **leader's** fate. None observes the child's.
+That is the coverage gap, not an oversight in any single assertion.
+
+The sharper point: the primitive was already there and already tested.
+`process_instance.rs` ships
+`process_group_signal_reaches_a_background_descendant` — a unit test that
+covers exactly this orphan scenario at the `ProcessInstance` level — alongside
+`process_group_signal_refuses_a_non_leader`. Both predate this investigation
+and both pass. The group-signalling capability was built, guarded, and then
+simply never wired into the timeout watcher, which kept passing `false`. No
+test asserted *which* mode the watcher chose, so the gap sat between two
+well-tested layers.
+
+### Why the first reproducer attempt was a false negative
+
+An initial local reproducer using `sh -c "sleep 300"` on the alpine test image
+**passed**. Cause: busybox `ash` and `dash` both optimise a single trailing
+command by `exec`ing into it rather than forking, so the leader *becomes*
+`sleep` and SIGTERM lands on the right process. The debian-based
+`boxlite-agent-base` image used by the REST suite forks in the same expression.
+
+A reproducer must force the fork explicitly — `sh -c "sleep 300 & wait"` — and
+assert the precondition that a child actually exists, otherwise a pass is
+vacuous.
+
+| Workload | Forks? | Reproduces |
+|----------|--------|------------|
+| `exec("sleep", ["300"])` | No | ✘ |
+| `sh -c "sleep 300"` on alpine / busybox | No (exec-optimised) | ✘ |
+| `sh -c "sleep 300"` on agent-base / dash | Yes | ✔ |
+| `sh -c "sleep 300 & wait"` | Yes (forced by `&`) | ✔ any image |
+
+### Scope: guest-wide, not REST-specific
+
+The e2e symptom is a hang, which initially suggested a REST stream-pump problem
+— and `test_exec_timeout.py`'s own module docstring already blames the REST
+pump for a related `drain()` issue. That framing is wrong for this defect:
+
+- The **deadline bypass** reproduces on the local FFI path with no cloud stack
+  (`make test:integration:rust`), so it affects every caller.
+- The **`wait()` hang** is a REST-path amplification: the local path resolves
+  `wait()` from the reaper's leader-exit slot, while the runner gates its exit
+  frame on stream closure, which the orphan holds open.
+
+### Fix Options
+
+| Option | Approach | Pros | Cons |
+|--------|----------|------|------|
+| **A** | Signal the process group in the watcher | Bounds the whole job; one-line intent | Refuses when the leader leads no group — silently disables the timeout on the `spawn_with_pipes` path |
+| **B** | A + resolve the pgid once while the leader lives, reuse it for the escalation | Escalation survives the leader's death | Slightly more state in the watcher |
+| **C** | B + fall back to leader-only when no group is led | No regression on executors that leave the workload in an inherited group | Fallback keeps the old hole where it already existed |
+| **D** | `setpgid(0,0)` in `spawn_with_pipes` so every exec leads a group | Closes the hole on the default `GuestExecutor` path too | Changes signal-delivery semantics for the non-container executor |
+
+Applied: **C + D**.
+
+Option A alone is a *regression*: `ProcessInstance::signal(_, true)` requires
+`getpgid(pid) == pid` and returns `Ok(false)` otherwise. The container executor
+satisfies this (measured below), but `GuestExecutor::spawn_with_pipes` performed
+no `setpgid`, so its execs inherited the guest's group. Flipping the flag alone
+would have turned the timeout into a no-op there — worse than the bug being
+fixed.
+
+C alone is *incomplete*: the fallback keeps the old leader-only behaviour
+exactly where the hole already was. `GuestExecutor` is the **default** executor
+when `BOXLITE_EXECUTOR` is unset (`mod.rs:542`), so a forking workload on that
+path would still outlive its deadline. D closes it, which is why both ship
+together.
+
+**When the group is resolved matters as much as signalling it.** Any lookup
+that runs later than the spawn itself can be beaten by the reaper: a leader that
+exits *before* its own deadline — `sh -c "cmd &"` returns as soon as it has
+forked — leaves no `/proc` entry, so `getpgid` reports no group and the
+survivors quietly fall back to leader-only delivery. `TimeoutTarget::new` is
+already too late; it runs after `spawn_with_executor`, `reaper.register`, and
+`registry.publish`, each an await the exit can win.
+
+The pgid is therefore read inside `ProcessInstance::capture`, in the same breath
+as the start time and before any of those awaits, and carried as a field from
+there. Every later consumer reads that field instead of asking `/proc` again.
+
+The leader-only arm survives as a guard, not a supported mode: all three spawn
+paths now lead a group (container runtime, PTY via `setsid`, pipes via
+`setpgid`), so it is reached only when the process never led one at all.
+
+### The Fix
+
+`src/guest/src/service/exec/process_instance.rs`
+
+```rust
+// capture() reads start_time and pgid together, before any await the reaper
+// can win; own_process_group() then just returns the recorded field
+pub(super) fn own_process_group(&self) -> Option<Pid>
+
+// :92  signal a group by a pgid captured earlier — deliberately NO start-time
+//      guard, because the leader is allowed to be gone by now
+pub(super) fn signal_process_group(group: Pid, signal: Signal) -> Result<bool, Errno>
+```
+
+`src/guest/src/service/exec/timeout.rs`
+
+```rust
+// :40  TimeoutTarget::new()  — carries the pgid captured at spawn
+// :59  TimeoutTarget::signal_job(signal) — captured group, else leader
+// :85  signal_job(SIGTERM)
+// :104 signal_job(SIGKILL)   same captured group, never re-resolved
+```
+
+`src/guest/src/service/exec/executor.rs`
+
+```rust
+// spawn_with_pipes — pre_exec setpgid(0,0), so the default GuestExecutor path
+// leads a group like the PTY branch (setsid) and the container runtime already do
+```
+
+`src/guest/src/service/exec/state.rs`
+
+```rust
+// ExecutionState captures the pgid at spawn and uses it for process_group
+// kills, so the SSH bridge's SIGHUP/SIGTERM→SIGKILL escalation still reaches
+// survivors after the graceful stage has already reaped the leader
+```
+
+`src/guest/src/service/exec/mod.rs`
+
+```rust
+// spawn_execution warns when a captured execution turns out to lead no process
+// group: every spawn path is meant to provide one, so landing there means kills
+// reach the leader alone and a forking workload can outlive its deadline
+```
+
+`src/guest/src/service/exec/registry.rs`
+
+```rust
+// observe_terminal cancels at leader exit only when no live group remains.
+// It previously cancelled the moment the leader's exit slot resolved, which
+// for `sh -c "cmd &"` is immediately -- handing the survivor an unbounded
+// lifetime no matter how the signalling below is written.
+```
+
+That last one decides whether any of the rest is reachable. Capturing the group
+and addressing it correctly is inert if the watcher is aborted before it ever
+fires, and for every reserved (non-SSH) exec the terminal observer did exactly
+that.
+
+### The same-shape sibling, fixed in the same pass
+
+`ssh/bridge.rs::terminate_process_group` escalates SIGHUP/SIGTERM and then
+SIGKILL through `kill_execution(..., process_group = true)`. That routed into
+`ProcessInstance::signal(_, true)`, whose start-time guard returns `Ok(false)`
+once the leader is reaped — so the graceful stage could kill the leader and the
+forced stage would then silently refuse, leaving the same survivors behind.
+
+`ExecutionState` now captures the pgid at construction and addresses it directly
+for group kills, which fixes the SSH bridge and the explicit `KillRequest`
+group path together. `signal_owned_process_if_current` is untouched: it passes
+`process_group = false` deliberately, so registry shutdown keeps its existing
+leader-only semantics.
+
+### The captured pgid must not outlive its group
+
+Dropping the start-time guard on the group path buys reach past a dead leader,
+and costs the guard that made the identity unambiguous. The kernel keeps a PID
+reserved only while some process still references it as a process group ID —
+so a captured pgid names our group exactly as long as that group is non-empty.
+Once the last member exits, the number is free to be re-allocated, and a holder
+that still signals it can land SIGTERM/SIGKILL on an unrelated guest process
+group.
+
+A single liveness check immediately before signalling does not fix this: a
+re-allocated group is just as "alive" as ours was. What does fix it is never
+holding the pgid across an unobserved window — so the watcher polls
+(`GROUP_LIVENESS_POLL`, 100 ms) instead of sleeping straight through its
+deadline and its grace, and retires itself the moment the group is empty.
+Exposure drops from the whole deadline to one interval.
+
+Group emptiness is the right condition because it is the *only* one that
+answers both questions at once: nothing of the job is left to signal, and the
+captured pgid has stopped naming it. Two weaker signals were tried and are
+wrong:
+
+| Candidate | Why it fails |
+|---|---|
+| The leader's own exit | `sh -c "cmd &"` returns immediately; the children run on |
+| Output EOF | proves the exec's *pipes* were released, not that the group ended — `sh -c "cmd >/dev/null 2>&1 &"` reaches EOF at leader exit with the child still running |
+
+Every path that retires a deadline has to respect that condition, not just the
+terminal observer. `ExecutionState::release_resources` — reached by
+`prune_inner` after `RETAIN_GRACE` and by the SSH `release_ephemeral` once
+output reaches EOF — aborted the watcher unconditionally, which strands
+survivors of any exec whose deadline outlives those points. It now aborts only
+when the group is already empty. `observe_terminal` likewise cancels at leader
+exit only when no live group remains; otherwise the watcher keeps its own clock.
+
+Retirement is bounded; *use* of a captured pgid is not, and this fix does not
+pretend otherwise. `ExecutionState::signal_if_current` addresses the group with
+no identity guard, because no cheap one exists — an empty group already reports
+ESRCH without help, and a re-allocated pgid reads as alive, so a liveness probe
+there is inert. The entry's `released` flag does not supply the guarantee
+either: `release_resources` sets it whenever resources are reclaimed, not when
+the group drains.
+
+So the SSH termination ladder and the `process_group` kill RPC can, in
+principle, signal an unrelated group — if the job's group emptied and the
+kernel re-allocated that number before the call. Reaching orphans at all
+requires addressing a group without proof of identity, and the residual risk
+needs the guest to exhaust its PID space inside the call window. It is recorded
+here rather than papered over with a check that does not check anything.
+
+---
+
+## Debug Process
+
+### Step 1: Observe the e2e failures
+
+**Tool:** `pytest` against the local REST stack
+
+```bash
+cd apps/e2e && python3 -m pytest cases/test_exec_timeout.py -v
+```
+
+**Observation:** Both cases fail at `asyncio.wait_for(ex.wait(), timeout=45)`
+with `TimeoutError`, after ~45s, despite `timeout_secs=2.0`. Re-running
+produced the identical pair — stable, not flaky.
+
+**Conclusion:** Either the timeout never fires, or it fires and `wait()` fails
+to observe it. The failure signal alone cannot distinguish these.
+
+---
+
+### Step 2: Determine whether the process is killed at all
+
+**Tool:** direct SDK probe polling the box's own process table
+
+Started `sh -c "sleep 300"` with `timeout_secs=2.0`, then repeatedly exec'd
+`ps -eo pid,args | grep -c '[s]leep 300'` in the same box.
+
+```
++ 2.1s  'sleep 300' count='1'
++ 4.2s  'sleep 300' count='1'
+...
++16.1s  'sleep 300' count='1'
+wait() still pending at +26.1s
+```
+
+**Observation:** The workload is alive 16s after a 2s deadline.
+
+**Conclusion:** This is not a `wait()`/stream-pump bug. The deadline is not
+being enforced. Re-scoped the investigation to the kill path.
+
+---
+
+### Step 3: Prove the timeout parameter reaches the runner
+
+**Tool:** `tcpdump` on loopback, filtered to POST on the runner port
+
+```bash
+tcpdump -i lo -s 0 -A -l \
+  "tcp port 8080 and tcp[((tcp[12:1] & 0xf0) >> 2):4] = 0x504f5354"
+```
+
+**Observation:**
+
+```
+{"command":"sh","args":["-c","sleep 300"],"timeout_seconds":2,"tty":false}
+POST /v1/boxes/dLDhdvqwz4sU/exec   ×18
+```
+
+**Conclusion:** SDK → API → runner delivers `timeout_seconds` intact. The API
+is an `@All(':boxId/exec')` raw passthrough and the global `ValidationPipe` runs
+with `transform: true` only — no `whitelist`, so no field stripping. Every hop
+above the runner is exonerated.
+
+---
+
+### Step 4: Prove the watcher fires inside the guest
+
+**Tool:** per-box guest console log
+
+```bash
+RECENT=$(ls -t /var/lib/boxlite/boxes/*/logs/console.log | head -1)
+grep -aE "spawn completed|SIGTERM on timeout|SIGKILL after grace" "$RECENT" \
+  | sed 's/\x1b\[[0-9;]*m//g'
+```
+
+**Observation:**
+
+```
+10:27:53.299591  exec: spawn completed  program=sh
+10:27:55.303593  SIGTERM on timeout; grace before SIGKILL  grace_ms=2000
+```
+
+`SIGTERM on timeout` lands at +2.004s — exactly on the deadline. No
+`SIGKILL after grace expired` line ever appears, and no
+`failed to capture process identity` warning either.
+
+**Conclusion:** The watcher runs and stage 1 fires on time. Stage 2 does not
+report anything at all — the escalation is being skipped, not failing loudly.
+
+---
+
+### Step 5: Inspect the process tree in the surviving box
+
+**Tool:** SDK exec of `ps` against a box kept alive with `auto_remove=False`
+
+**Observation:**
+
+```
+ PID PPID STAT COMMAND
+   1    0 Ss   sleep infinity       ← container init
+   3    1 S    sleep 300            ← PPID=1: reparented
+   4    0 Ss   sh -c ps -eo pid,ppid,stat,args
+```
+
+The `sh` leader is gone; `sleep 300` has been adopted by init.
+
+**Conclusion:** SIGTERM killed the shell. Its forked child was orphaned rather
+than terminated — the leader-only signal is the defect.
+
+---
+
+### Step 6: Explain the `wait()` hang
+
+**Tool:** `/proc/<pid>/fd` inside the box
+
+**Observation:**
+
+```
+lr-x------ 0 -> pipe:[82]
+l-wx------ 1 -> pipe:[83]
+l-wx------ 2 -> pipe:[84]
+```
+
+**Conclusion:** The orphan still holds the exec's stdout/stderr write ends, so
+those pipes never reach EOF. The runner's stream pump waits on a closure that
+can never come, and the exit frame is never delivered. The hang is a downstream
+consequence of the orphan, not an independent bug.
+
+---
+
+### Step 7: Locate the defective argument
+
+**Tool:** source reading, `src/guest/src/service/exec/`
+
+```
+timeout.rs:35        process.signal(signal, false)      ← the only production call site
+process_instance.rs:20   fn signal(&self, signal, process_group: bool)
+process_instance.rs:21     if !self.is_current() { return Ok(false); }   ← blocks escalation
+process_instance.rs:33     else { self.pid }                             ← leader only
+```
+
+Cross-checked every other `.signal(` call site: `state.rs:876` and
+`process_instance.rs:149/201/207` pass `true`, but all of them are tests. The
+explicit kill API exposes `process_group` as a caller-supplied field
+(`mod.rs:272`, from `KillRequest`). `timeout.rs:35` was the sole production
+path hard-coding `false`.
+
+**Conclusion:** Single-site defect in the timeout path.
+
+---
+
+### Step 8: Check whether group signalling is even viable
+
+**Tool:** SDK probe printing `pid,ppid,pgid,sid`
+
+`ProcessInstance::signal(_, true)` refuses unless `getpgid(pid) == pid`, so this
+had to be measured before changing the flag.
+
+**Observation:**
+
+```
+ PID PPID PGID  SID COMMAND
+   2    0    2    2  sh -c sleep 300 & wait     ← PGID == PID, and a session leader
+   3    2    2    2  sleep 300                  ← same group
+```
+
+**Conclusion:** The container executor already places each exec in its own
+process group and session, so group signalling will be accepted. But
+`spawn_with_pipes` (the `GuestExecutor` path) had no `pre_exec` and performed
+no `setpgid` — only the PTY branch called `setsid` (`executor.rs:240`). A bare
+flag flip would have silently disabled the timeout there.
+
+That path is the **default** executor, not a corner case (`mod.rs:542` selects
+`GuestExecutor` when `BOXLITE_EXECUTOR` is unset), so a fallback alone would
+have left the original hole intact wherever it already was. The fix therefore
+does both: give `spawn_with_pipes` its own `setpgid`, and keep a leader-only
+fallback as a guard for the case where the leader exits before the first
+signal.
+
+---
+
+### Step 9: Two-sided verification
+
+**Tool:** `make test:integration:rust`, per the repository's reproducer rule
+
+The integration reproducers drive only the SDK, so they still compile against a
+fully reverted guest — no compatibility adapter is needed and the revert can be
+total rather than partial.
+
+Step 1 — **every** production file reverted to HEAD, only the tests kept:
+
+```
+$ git restore --source=HEAD --staged --worktree -- \
+    src/guest/src/service/exec/{timeout,process_instance,executor,state,registry,mod}.rs
+$ git status --short src/guest src/boxlite/tests
+MM src/boxlite/tests/exec_options.rs
+
+$ grep -n "process.signal(signal, false)" src/guest/src/service/exec/timeout.rs
+35:            Some(process) => process.signal(signal, false),
+$ sed -n '544p' src/guest/src/service/exec/registry.rs
+            state.cancel_timeout_task().await;
+$ grep -c own_process_group src/guest/src/service/exec/process_instance.rs
+0
+```
+
+Both reproducers fail, each for its own shape of the defect:
+
+```
+test_timeout_kills_forked_child_not_just_leader
+  FAILED — exec timeout left 1 orphaned `sleep 300` process(es) alive 6s
+           after a 2s deadline: the watcher signalled only the shell leader
+
+test_timeout_survives_a_leader_that_exits_before_its_deadline
+  FAILED — exec timeout left 1 orphaned `sleep 300` process(es) alive 6s
+           after a 2s deadline whose leader had already exited
+```
+
+Step 2 — fix restored in full:
+
+```
+make test:integration:rust FILTER=test_timeout
+  4 tests run: 4 passed, 277 skipped
+```
+
+**Conclusion:** Both reproducers fail for the original defect against a wholly
+unmodified guest, and pass only with the fix present. The second one also pins
+the `observe_terminal` change: without it the watcher is cancelled at leader
+exit and the captured group is never signalled.
+
+---
+
+## Environment Details
+
+| Component     | Detail                                                     |
+|---------------|------------------------------------------------------------|
+| Platform      | Ubuntu 24.04 on WSL2, x86_64, `/dev/kvm`                   |
+| Guest binary  | `boxlite-guest`, static-pie, musl                          |
+| Target triple | `x86_64-unknown-linux-musl`                                |
+| Local test image | alpine (`common::alpine_opts()`), busybox `ash`         |
+| REST test image  | `ghcr.io/boxlite-ai/boxlite-agent-base:v0.1.0`, dash    |
+| Cloud stack   | `apps/e2e` — API `:3000`, runner `:8080`, registry `:5000` |
+| Exec path     | `ContainerExecutor` (libcontainer), non-TTY, pipes          |
+| Deadline      | `timeout_secs = 2.0`, `TIMEOUT_GRACE = 2s`                  |
+
+## Timeout Signal Path
+
+```
+SDK BoxCommand::timeout(Duration)
+  ↓ rest/types.rs:621        timeout_seconds = cmd.timeout.map(as_secs_f64)
+API @All(':boxId/exec')      raw passthrough, body untouched
+  ↓
+runner boxlite_exec.go:73    startOpts.Timeout = TimeoutSeconds * time.Second
+  ↓ exec_manager.go:378      ExecutionOptions{ Timeout: opts.Timeout }
+Go SDK exec.go:241           BoxliteCommand{ timeout_secs: C.double(...) }
+  ↓
+C FFI command.rs:56          if timeout_secs != 0.0 → box_cmd.timeout_seconds()
+  ↓
+core portal exec.rs:282      timeout_ms = command.timeout.as_millis()
+  ↓
+guest exec/mod.rs:462        if req.timeout_ms > 0 → start_timeout_watcher(...)
+  ↓
+guest timeout.rs             ← DEFECT WAS HERE; every hop above is intact
+```
+
+## Test Results Summary
+
+| Suite | Before fix | After fix |
+|-------|-----------|-----------|
+| `exec_options::test_timeout_kills_forked_child_not_just_leader` (new) | 1 failed | 1 passed (32.71s) |
+| `make test:integration:rust FILTER=timeout` | — | 5 passed, 275 skipped |
+| `make test:unit:guest` | — | 336 passed, 4 skipped |
+| `apps/e2e cases/test_exec_timeout.py` | 2 failed (~45s each, `TimeoutError`) | 2 passed (9.18s total) |
+| Standalone REST reproducer | orphan alive at +6.1s, `wait()` hanging | `NOT reproduced`, `wait()` returned |
+
+Post-fix process tree in the reproducer, showing the mechanism inverted:
+
+```
+before:  3    1 S    sleep 300             ← alive, orphaned, holding the pipes
+after:   3    1 Z    [sleep] <defunct>     ← killed by the group signal, awaiting reap
+```
+
+## Tests Added
+
+| Test | Level | Guards |
+|------|-------|--------|
+| `exec_options.rs::test_timeout_kills_forked_child_not_just_leader` | integration (VM) | a forked child is dead 6s after a 2s deadline; asserts the fork precondition first so a pass cannot be vacuous |
+| `timeout.rs::tests::timeout_target_signals_the_whole_group_of_a_forking_leader` | guest unit | group SIGKILL reaches a background descendant; leader is a real `setpgid` group leader |
+| `timeout.rs::tests::timeout_target_signals_its_live_leader` | guest unit (updated) | now asserts `process_group().is_none()` first, pinning the leader-only fallback explicitly |
+| `executor.rs::tests::spawn_with_pipes_makes_the_child_a_process_group_leader` | guest unit | the default `GuestExecutor` path leaves each exec leading its own group, so a later `pre_exec` removal cannot silently reopen the hole |
+| `timeout.rs::tests::timeout_target_still_reaches_a_group_whose_leader_already_exited` | guest unit | a leader that exits before its deadline still loses its group; pins pgid capture to construction, not signal time |
+| `exec_options.rs::test_timeout_survives_a_leader_that_exits_before_its_deadline` | integration (VM) | the end-to-end leader-exits-early shape; the only test that fails if `observe_terminal` retires the deadline at leader exit |
+| `state.rs::tests::group_kill_reaches_members_that_outlived_the_leader` | guest unit | the externally reachable `KillRequest(process_group = true)` path delivers after the leader is reaped, pinning the dropped start-time guard |
+| `process_instance.rs::tests::captured_process_group_outlives_the_leaders_proc_entry` | guest unit | the recorded pgid survives the leader's `/proc` entry, so no later consumer can be beaten by the reaper |
+| `registry.rs::tests::terminal_observer_keeps_the_deadline_while_the_group_lives` | guest unit | neither the leader's exit nor output EOF retires a deadline whose group is still live |
+| `timeout.rs::tests::timeout_watcher_retires_itself_when_the_group_empties` | guest unit | the watcher stops on its own once the group is empty, so a captured pgid is never held across a window where it could be re-allocated |
+| `state.rs::tests::release_keeps_the_deadline_while_the_group_lives` | guest unit | prune and the SSH release path do not retire a deadline whose group still has members |
+| `process_instance.rs::tests::capture_of_a_dead_pid_reports_failure` | guest unit | a vanished process captures nothing, so a failed read is never reported as "leads no group" |
+
+## Diagnostic Techniques Reference
+
+| Technique | Source | What it reveals |
+|-----------|--------|-----------------|
+| `tcpdump -A` with a POST-matching `tcp[]` filter | libpcap | Whether a field survives every proxy hop, without instrumenting code |
+| `ps -eo pid,ppid,stat,args` inside the box | busybox/procps | Reparenting to init (`PPID=1`) — the orphan signature |
+| `ps -eo pid,ppid,pgid,sid` | procps | Whether a process leads its own group; decides if group signalling is viable |
+| `ls -l /proc/<pid>/fd` | procfs | Which pipes a survivor still holds open, explaining a stalled EOF |
+| `/var/lib/boxlite/boxes/*/logs/console.log` | BoxLite | Guest-side `tracing` output; shows which watcher stage ran |
+| `strings <wheel>.so \| grep <field>` | binutils | Whether an installed prebuilt SDK still speaks a given wire field |
+| `cargo nextest list -p <crate>` | nextest | Confirm a new test is actually collected, not silently filtered |
+
+## Files Read During Investigation
+
+```
+src/guest/src/service/exec/timeout.rs                (MODIFIED — fix + tests)
+src/guest/src/service/exec/process_instance.rs       (MODIFIED — group helpers)
+src/guest/src/service/exec/mod.rs                    (MODIFIED — no-group warning; watcher construction)
+src/guest/src/service/exec/state.rs                  (other signal call sites)
+src/guest/src/service/exec/executor.rs               (spawn_with_pipes / spawn_with_pty)
+src/boxlite/src/litebox/exec.rs                      (BoxCommand::timeout)
+src/boxlite/src/portal/interfaces/exec.rs            (timeout → timeout_ms)
+src/boxlite/src/rest/types.rs                        (timeout_seconds serialisation)
+src/boxlite/tests/exec_options.rs                    (MODIFIED — reproducer)
+sdks/c/src/exec/command.rs                           (C FFI timeout_secs)
+sdks/go/exec.go                                      (Go SDK → C command struct)
+apps/runner/pkg/api/controllers/boxlite_exec.go      (TimeoutSeconds DTO)
+apps/runner/pkg/boxlite/exec_manager.go              (StartOptions → ExecutionOptions)
+apps/api/src/boxlite-rest/boxlite-proxy.controller.ts (raw exec passthrough)
+apps/api/src/main.ts                                 (global ValidationPipe options)
+apps/e2e/cases/test_exec_timeout.py                  (failing e2e cases)
+```

--- a/src/boxlite/tests/exec_options.rs
+++ b/src/boxlite/tests/exec_options.rs
@@ -191,3 +191,119 @@ async fn test_working_dir_with_user() {
 
     tb.teardown().await;
 }
+
+/// The deadline must survive a leader that exits before it.
+///
+/// `sh -c "cmd &"` returns as soon as it has forked, so the leader is gone long
+/// before its own deadline while the workload it started keeps running and keeps
+/// the exec's pipes open. Both the group capture and the terminal observer have
+/// to account for that: a leader-anchored lookup would find nothing to signal,
+/// and retiring the timeout at leader exit would leave the survivor unbounded.
+#[tokio::test]
+async fn test_timeout_survives_a_leader_that_exits_before_its_deadline() {
+    let tb = TestBox::new().await;
+
+    let _execution = tb
+        .handle
+        .exec(
+            BoxCommand::new("sh")
+                .args(["-c", "sleep 300 &"])
+                .timeout(Duration::from_secs(2)),
+        )
+        .await
+        .expect("exec failed");
+
+    // Precondition: the workload outlived its leader, otherwise a pass below
+    // would prove nothing.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let before = run_stdout(
+        &tb.handle,
+        BoxCommand::new("sh").args(["-c", "ps | grep -c '[s]leep 300' || true"]),
+    )
+    .await;
+    assert_ne!(
+        before.trim(),
+        "0",
+        "precondition failed: no `sleep 300` running before the deadline"
+    );
+
+    // 2s deadline + 2s TIMEOUT_GRACE before SIGKILL, plus slack.
+    tokio::time::sleep(Duration::from_secs(6)).await;
+
+    let survivors = run_stdout(
+        &tb.handle,
+        BoxCommand::new("sh").args(["-c", "ps | grep -c '[s]leep 300' || true"]),
+    )
+    .await;
+
+    assert_eq!(
+        survivors.trim(),
+        "0",
+        "exec timeout left {} orphaned `sleep 300` process(es) alive 6s after a \
+         2s deadline whose leader had already exited",
+        survivors.trim()
+    );
+
+    tb.teardown().await;
+}
+
+/// An exec timeout must bound the whole process tree, not just the spawned
+/// leader.
+///
+/// A forking workload leaves the real work in a child of the captured leader.
+/// Signalling that leader alone reaps the shell and reparents the child to
+/// init, where it outlives a deadline the caller was told is hard; the SIGKILL
+/// escalation cannot recover either, being anchored to a leader that no longer
+/// exists. The guest bounds the leader's process group instead — see
+/// `src/guest/src/service/exec/timeout.rs`.
+#[tokio::test]
+async fn test_timeout_kills_forked_child_not_just_leader() {
+    let tb = TestBox::new().await;
+
+    // `sleep 300 & wait` forces a fork: a bare `sh -c "sleep 300"` lets ash/dash
+    // exec into the sleep, which makes the leader the sleep itself and never
+    // exercises the orphan path this test is about.
+    let _execution = tb
+        .handle
+        .exec(
+            BoxCommand::new("sh")
+                .args(["-c", "sleep 300 & wait"])
+                .timeout(Duration::from_secs(2)),
+        )
+        .await
+        .expect("exec failed");
+
+    // Precondition: the workload really did fork, otherwise a pass below would
+    // be vacuous.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let before = run_stdout(
+        &tb.handle,
+        BoxCommand::new("sh").args(["-c", "ps | grep -c '[s]leep 300' || true"]),
+    )
+    .await;
+    assert_ne!(
+        before.trim(),
+        "0",
+        "precondition failed: no `sleep 300` running before the deadline"
+    );
+
+    // 2s deadline + 2s TIMEOUT_GRACE before SIGKILL, plus slack.
+    tokio::time::sleep(Duration::from_secs(6)).await;
+
+    let survivors = run_stdout(
+        &tb.handle,
+        BoxCommand::new("sh").args(["-c", "ps | grep -c '[s]leep 300' || true"]),
+    )
+    .await;
+
+    assert_eq!(
+        survivors.trim(),
+        "0",
+        "exec timeout left {} orphaned `sleep 300` process(es) alive 6s after a \
+         2s deadline: the watcher signalled only the shell leader, so the forked \
+         child outlived its deadline",
+        survivors.trim()
+    );
+
+    tb.teardown().await;
+}

--- a/src/guest/src/service/exec/executor.rs
+++ b/src/guest/src/service/exec/executor.rs
@@ -132,6 +132,7 @@ impl Executor for GuestExecutor {
 fn spawn_with_pipes(req: &ExecRequest) -> BoxliteResult<ExecHandle> {
     use nix::unistd::Pid;
     use std::os::unix::io::{FromRawFd, IntoRawFd};
+    use std::os::unix::process::CommandExt;
     use std::process::Command;
 
     let mut cmd = Command::new(&req.program);
@@ -159,6 +160,22 @@ fn spawn_with_pipes(req: &ExecRequest) -> BoxliteResult<ExecHandle> {
         cmd.stdin(std::process::Stdio::from_raw_fd(stdin_read.into_raw_fd()));
         cmd.stdout(std::process::Stdio::from_raw_fd(stdout_write.into_raw_fd()));
         cmd.stderr(std::process::Stdio::from_raw_fd(stderr_write.into_raw_fd()));
+    }
+
+    // Lead a process group so a deadline can bound the whole job. Without this
+    // the child inherits the guest's group, `ProcessInstance::own_process_group`
+    // finds no group to address, and the exec timeout can only reach the leader
+    // -- letting a forking workload orphan its child past the deadline. The PTY
+    // branch gets the same property from its `setsid` below.
+    // SAFETY: `setpgid` is async-signal-safe and this closure allocates and
+    // locks nothing between fork and exec.
+    unsafe {
+        cmd.pre_exec(|| {
+            if nix::libc::setpgid(0, 0) == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
     }
 
     let mut child = cmd
@@ -313,6 +330,31 @@ fn terminate_child(child: &mut std::process::Child) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The pipe path must leave every exec leading its own process group.
+    /// Without it `own_process_group()` finds nothing to address and the exec
+    /// timeout degrades to leader-only delivery, which a forking workload
+    /// outlives (see `service::exec::timeout`).
+    #[tokio::test]
+    async fn spawn_with_pipes_makes_the_child_a_process_group_leader() {
+        let _fence = crate::reaper::reap_fence();
+        let req = ExecRequest {
+            program: "/bin/sh".to_string(),
+            args: vec!["-c".to_string(), "sleep 30".to_string()],
+            ..Default::default()
+        };
+
+        let handle = spawn_with_pipes(&req).expect("spawn via pipes");
+        let pid = handle.pid();
+
+        assert_eq!(
+            nix::unistd::getpgid(Some(pid)).expect("read child pgid"),
+            pid,
+            "exec leader must lead its own process group"
+        );
+
+        let _ = nix::sys::signal::kill(pid, nix::sys::signal::Signal::SIGKILL);
+    }
 
     #[test]
     fn terminate_child_kills_and_reaps_process() {

--- a/src/guest/src/service/exec/mod.rs
+++ b/src/guest/src/service/exec/mod.rs
@@ -417,6 +417,16 @@ async fn spawn_execution(
             pid = leader_pid.as_raw(),
             "failed to capture process identity; signals will be skipped"
         );
+    } else if process.is_some_and(|p| p.own_process_group().is_none()) {
+        // Every spawn path is meant to leave the leader heading its own group
+        // (container runtime, PTY setsid, pipes setpgid). Landing here means
+        // kills reach the leader only, so a forking workload can outlive its
+        // deadline -- say so rather than degrade quietly.
+        warn!(
+            execution_id = %execution_id,
+            pid = leader_pid.as_raw(),
+            "execution leads no process group; kills cannot reach forked children"
+        );
     }
 
     // Register this pid's exit slot at the spawn, not at the wait: a detached

--- a/src/guest/src/service/exec/process_instance.rs
+++ b/src/guest/src/service/exec/process_instance.rs
@@ -8,12 +8,36 @@ use nix::unistd::{getpgid, Pid};
 pub(crate) struct ProcessInstance {
     pid: Pid,
     start_time: u64,
+    /// The process group this PID led at capture, when it led one.
+    ///
+    /// Recorded here rather than re-read on demand: every later caller runs
+    /// after awaits that the reaper can win, and a `/proc` lookup then reports
+    /// "no group" for a process that did lead one -- silently degrading a group
+    /// kill to leader-only exactly when the survivors need it.
+    group: Option<Pid>,
 }
 
 impl ProcessInstance {
-    /// Capture the process start time immediately after its spawn returns.
+    /// Capture the process identity immediately after its spawn returns.
+    ///
+    /// Start time and process group are read together: both describe the
+    /// process as it exists at this instant, and they succeed or fail as one.
     pub(crate) fn capture(pid: Pid) -> Option<Self> {
-        Self::start_time_for(pid).map(|start_time| Self { pid, start_time })
+        let start_time = Self::start_time_for(pid)?;
+        // Distinguish "leads someone else's group" from a failed read. Only the
+        // former is a real answer; an error means the process is already gone,
+        // which is a failed capture, not a no-group execution. Collapsing them
+        // would make the caller's no-group diagnostic report the wrong cause.
+        let group = match getpgid(Some(pid)) {
+            Ok(group) if group == pid => Some(pid),
+            Ok(_) => None,
+            Err(_) => return None,
+        };
+        Some(Self {
+            pid,
+            start_time,
+            group,
+        })
     }
 
     /// Signal only when this PID still belongs to the process captured at spawn.
@@ -44,6 +68,15 @@ impl ProcessInstance {
         Self::start_time_for(self.pid) == Some(self.start_time)
     }
 
+    /// The process group this instance led at capture, or None when its
+    /// spawner left it in an inherited group.
+    ///
+    /// A group outlives its leader, so a caller that escalates after the leader
+    /// exits can still reach the children it left behind.
+    pub(super) fn own_process_group(&self) -> Option<Pid> {
+        self.group
+    }
+
     fn start_time_for(pid: Pid) -> Option<u64> {
         procfs::process::Process::new(pid.as_raw())
             .ok()?
@@ -60,6 +93,42 @@ impl ProcessInstance {
     #[cfg(test)]
     pub(super) fn with_start_time_for_test(self, start_time: u64) -> Self {
         Self { start_time, ..self }
+    }
+}
+
+/// Whether `group` still has any member.
+///
+/// The captured pgid names our job only while this holds: once the last member
+/// exits, the number is free to be re-allocated and a holder that keeps
+/// signalling it would reach an unrelated group.
+pub(super) fn process_group_alive(group: Pid) -> bool {
+    kill(Pid::from_raw(-group.as_raw()), None).is_ok()
+}
+
+/// Signal every member of `group`, addressed by a pgid captured while its
+/// leader was live.
+///
+/// Unlike [`ProcessInstance::signal`] this carries no start-time guard,
+/// because the leader is allowed to be gone by now — reaching the children it
+/// orphaned is the entire point.
+///
+/// The pgid is unambiguous only while the group is non-empty: the kernel keeps
+/// a PID reserved as long as some process still references it as a process
+/// group ID. Once the last member exits the number is free to be re-allocated,
+/// and a caller still holding it would signal an unrelated group.
+///
+/// There is no guard against that here, and none is cheap — an empty group
+/// already reports `ESRCH` without one, and a re-allocated pgid is
+/// indistinguishable from the original. Callers bound the exposure by how long
+/// they hold a captured pgid: `start_timeout_watcher` polls
+/// [`process_group_alive`] and retires as soon as the group empties, while
+/// `ExecutionState::signal_if_current` accepts the window because reaching
+/// orphans requires signalling without proof of identity.
+pub(super) fn signal_process_group(group: Pid, signal: Signal) -> Result<bool, Errno> {
+    match kill(Pid::from_raw(-group.as_raw()), signal) {
+        Ok(()) => Ok(true),
+        Err(Errno::ESRCH) => Ok(false),
+        Err(error) => Err(error),
     }
 }
 
@@ -98,6 +167,81 @@ mod tests {
         stat.rsplit_once(") ")
             .and_then(|(_, fields)| fields.chars().next())
             == Some('Z')
+    }
+
+    /// A pid with no process behind it captures nothing.
+    ///
+    /// Covers the reachable half of the failure handling: both reads fail, so
+    /// `capture` reports failure rather than inventing "leads no group". The
+    /// split-failure case — start time read, then the process vanishes before
+    /// the group read — needs the process to disappear between two adjacent
+    /// syscalls and cannot be staged deterministically; the `Err` arm exists so
+    /// that case is a failed capture too, not a false no-group answer.
+    #[tokio::test]
+    async fn capture_of_a_dead_pid_reports_failure() {
+        let _test_guard = crate::reaper::reap_test_guard().await;
+        let mut child = std::process::Command::new("/bin/sh")
+            .args(["-c", "exit 0"])
+            .spawn()
+            .expect("spawn short-lived child");
+        let pid = Pid::from_raw(child.id() as i32);
+        tokio::task::spawn_blocking(move || {
+            let _fence = crate::reaper::reap_fence();
+            child.wait().expect("wait for child")
+        })
+        .await
+        .expect("wait task must not panic");
+
+        assert!(
+            ProcessInstance::capture(pid).is_none(),
+            "a reaped pid must not capture as an identity"
+        );
+    }
+
+    /// The captured pgid must survive the leader's `/proc` entry.
+    ///
+    /// Every consumer runs after awaits the reaper can win; re-reading the
+    /// group then would report "no group" for a process that led one, and the
+    /// survivors would silently lose their deadline.
+    #[tokio::test]
+    async fn captured_process_group_outlives_the_leaders_proc_entry() {
+        use std::os::unix::process::CommandExt;
+
+        let _test_guard = crate::reaper::reap_test_guard().await;
+        let mut command = std::process::Command::new("/bin/sh");
+        command.args(["-c", "exit 0"]);
+        // SAFETY: `setpgid` is async-signal-safe and this closure allocates and
+        // locks nothing between fork and exec.
+        unsafe {
+            command.pre_exec(|| {
+                if nix::libc::setpgid(0, 0) == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        let mut child = command.spawn().expect("spawn group leader");
+        let leader = Pid::from_raw(child.id() as i32);
+        let identity = ProcessInstance::capture(leader).expect("capture while live");
+        assert_eq!(identity.own_process_group(), Some(leader));
+
+        // Reap the leader, removing its /proc entry.
+        tokio::task::spawn_blocking(move || {
+            let _fence = crate::reaper::reap_fence();
+            child.wait().expect("wait for leader")
+        })
+        .await
+        .expect("wait task must not panic");
+        assert!(
+            !identity.is_current(),
+            "leader must be gone for this to mean anything"
+        );
+
+        assert_eq!(
+            identity.own_process_group(),
+            Some(leader),
+            "the captured group must not depend on the leader still existing"
+        );
     }
 
     #[tokio::test]

--- a/src/guest/src/service/exec/registry.rs
+++ b/src/guest/src/service/exec/registry.rs
@@ -541,7 +541,17 @@ impl ExecutionRegistry {
         tokio::spawn(async move {
             registry.ensure_lifecycle_manager().await;
             let exit = state.wait_exit(&execution_id).await;
-            state.cancel_timeout_task().await;
+            // A leader that forks and returns -- `sh -c "cmd &"` -- exits long
+            // before its children, so its exit alone does not end the job and
+            // cancelling here would hand the survivors an unbounded lifetime.
+            // While the group lives the watcher keeps its own clock and retires
+            // itself once the group empties, which is the only condition that
+            // both ends the job and invalidates the captured pgid. Output EOF
+            // proves neither: a child that redirects its stdio releases these
+            // pipes at once and keeps running.
+            if !state.job_group_alive() {
+                state.cancel_timeout_task().await;
+            }
             let output = state.wait_terminal_output_summary().await;
             let snapshot = TerminalSnapshot { exit, output };
             let retained_bytes = state.retained_output_bytes().await;
@@ -678,6 +688,7 @@ mod release_tests {
     use crate::reaper::ExitSlot;
     use crate::service::exec::exec_handle::{ExecHandle, ExitStatus};
     use crate::service::exec::output::{OutputStreamSummary, OutputTerminalSummary};
+    use crate::service::exec::process_instance::ProcessInstance;
     use crate::service::exec::state::{ExecutionExit, TerminalSnapshot};
     use nix::unistd::{pipe, Pid};
     use std::os::unix::process::ExitStatusExt;
@@ -877,6 +888,89 @@ mod release_tests {
             Some(ExecutionLookup::Live(_))
         ));
         drop(stdout_peer);
+    }
+
+    /// A forking exec keeps its deadline while its group lives — through the
+    /// leader's exit and through output EOF alike.
+    ///
+    /// EOF is not the job's end: `sh -c "cmd >/dev/null 2>&1 &"` releases these
+    /// pipes the instant the leader returns while the child runs on. Retiring
+    /// the deadline on either signal would hand that child an unbounded life.
+    #[tokio::test]
+    async fn terminal_observer_keeps_the_deadline_while_the_group_lives() {
+        use std::os::unix::process::CommandExt;
+
+        let _test_guard = crate::reaper::reap_test_guard().await;
+        let mut command = std::process::Command::new("/bin/sh");
+        command.args(["-c", "sleep 30 & exit 0"]);
+        // SAFETY: `setpgid` is async-signal-safe and this closure allocates and
+        // locks nothing between fork and exec.
+        unsafe {
+            command.pre_exec(|| {
+                if nix::libc::setpgid(0, 0) == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        let mut child = command.spawn().expect("spawn group leader");
+        let leader = Pid::from_raw(child.id() as i32);
+        let process = ProcessInstance::capture(leader).expect("capture while live");
+
+        // Reap the leader: it forked and returned, the group lives on.
+        tokio::task::spawn_blocking(move || {
+            let _fence = crate::reaper::reap_fence();
+            child.wait().expect("wait for leader")
+        })
+        .await
+        .expect("wait task must not panic");
+
+        let registry = ExecutionRegistry::new();
+        let (_stdin_peer, stdin) = pipe().unwrap();
+        let (stdout, stdout_peer) = pipe().unwrap();
+        let (stderr, stderr_peer) = pipe().unwrap();
+        let state = ExecutionState::new(
+            ExecHandle::new(leader, stdin, stdout, Some(stderr))
+                .expect("test pipe must register with Tokio"),
+            ExitSlot::settled_for_test(ExitStatus::Code(0)),
+            Some(process),
+        );
+        assert!(
+            state.job_group_alive(),
+            "the forked child must outlive its leader for this test to mean anything"
+        );
+
+        let timeout_task = tokio::spawn(std::future::pending());
+        let timeout_abort = timeout_task.abort_handle();
+        state.set_timeout_task(timeout_task).await;
+
+        registry.register("forking-exec".into(), state).await;
+        registry.observe_terminal(
+            "forking-exec".into(),
+            registry.get("forking-exec").await.unwrap(),
+        );
+
+        // The leader is already gone; the deadline must survive it.
+        for _ in 0..20 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            !timeout_abort.is_finished(),
+            "deadline was retired at leader exit while the group was still live"
+        );
+
+        // Output EOF must not retire it either: the group is still live.
+        drop((stdout_peer, stderr_peer));
+        for _ in 0..20 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            !timeout_abort.is_finished(),
+            "deadline was retired at output EOF while the group was still live"
+        );
+
+        let _ = nix::sys::signal::kill(Pid::from_raw(-leader.as_raw()), Signal::SIGKILL);
+        timeout_abort.abort();
     }
 
     #[tokio::test]

--- a/src/guest/src/service/exec/state.rs
+++ b/src/guest/src/service/exec/state.rs
@@ -1,7 +1,9 @@
 use crate::service::exec::error::ExecutionError;
 use crate::service::exec::exec_handle::ExecHandle;
 use crate::service::exec::output::{OutputManager, OutputTerminalSummary};
-use crate::service::exec::process_instance::ProcessInstance;
+use crate::service::exec::process_instance::{
+    process_group_alive, signal_process_group, ProcessInstance,
+};
 use boxlite_shared::ExecOutput;
 use futures::{Stream, StreamExt as _};
 use std::os::unix::io::AsRawFd;
@@ -73,6 +75,10 @@ pub(crate) struct ExecutionState {
     /// status, and one that arrives before the process exits simply waits.
     exit: crate::reaper::ExitSlot,
     process: Option<ProcessInstance>,
+    /// Captured at spawn, while the leader is still live. A group outlives its
+    /// leader, so a forced kill that arrives after the leader was reaped can
+    /// still reach the children it left holding this execution's pipes.
+    group: Option<nix::unistd::Pid>,
     shutdown_managed: bool,
     consumer_lease: Arc<std::sync::atomic::AtomicBool>,
     /// Classified once: the container-death diagnosis drains init's pipes, so a
@@ -90,6 +96,7 @@ impl ExecutionState {
     ) -> Self {
         let output = OutputManager::new(handle.stdout(), handle.stderr());
         let consumer_lease = output.consumer_lease_flag();
+        let group = process.and_then(|process| process.own_process_group());
         Self {
             inner: Arc::new(Mutex::new(Inner {
                 output,
@@ -102,10 +109,20 @@ impl ExecutionState {
             })),
             exit,
             process,
+            group,
             shutdown_managed,
             consumer_lease,
             terminal_exit: Arc::new(OnceCell::new()),
         }
+    }
+
+    /// Whether anything this execution spawned is still running.
+    ///
+    /// The leader's own exit does not end the job when it forked children into
+    /// its process group: those survivors still hold the exec's pipes and are
+    /// still subject to its deadline.
+    pub(super) fn job_group_alive(&self) -> bool {
+        self.group.is_some_and(process_group_alive)
     }
 
     /// Whether a reader is currently streaming this execution's output.
@@ -503,9 +520,17 @@ impl ExecutionState {
             task.abort();
             let _ = task.await;
         }
+        // The deadline is not this entry's resource to reclaim while the job's
+        // process group still has members: aborting here -- from prune after
+        // RETAIN_GRACE, or from the SSH release once output reaches EOF --
+        // would strand those survivors past a deadline nothing else enforces.
+        // The watcher retires itself once the group empties, so leaving it
+        // running costs one polling task and no correctness.
         if let Some(task) = timeout_task {
-            task.abort();
-            let _ = task.await;
+            if !self.job_group_alive() {
+                task.abort();
+                let _ = task.await;
+            }
         }
         output.shutdown_drains().await;
         if self.shutdown_managed {
@@ -541,10 +566,26 @@ impl ExecutionState {
         if inner.released {
             return Ok(false);
         }
-        let Some(process) = self.process else {
-            return Ok(false);
+        // Address the group captured at spawn rather than re-deriving it from
+        // the leader: an escalation that follows a graceful signal runs after
+        // the leader is typically already reaped, and a leader-anchored lookup
+        // would refuse exactly when survivors still need the forced kill.
+        //
+        // The group arm therefore carries no identity guard, and no cheap one
+        // exists: an empty group already reports ESRCH without help, and a
+        // re-allocated pgid reads as alive, so a liveness probe here would be
+        // inert. Nothing else supplies the guarantee either -- `released` is set
+        // whenever resources are reclaimed, not when the group drains -- so a
+        // caller that reaches this after its group emptied and the number was
+        // re-allocated would signal an unrelated group. Reaching orphans
+        // requires addressing the group without proof of identity; the residual
+        // risk is that re-allocation, which needs the guest to exhaust its PID
+        // space inside the call window.
+        let result = match (process_group, self.group, self.process) {
+            (true, Some(group), _) => signal_process_group(group, signal),
+            (_, _, Some(process)) => process.signal(signal, process_group),
+            (_, _, None) => Ok(false),
         };
-        let result = process.signal(signal, process_group);
         drop(inner);
         result
     }
@@ -739,6 +780,166 @@ mod release_tests {
             status.signal(),
             Some(nix::sys::signal::Signal::SIGKILL as i32)
         );
+    }
+
+    /// An `ExecutionState` whose leader forked into its own group and exited,
+    /// leaving one live descendant. Returns the pipe peers so the caller keeps
+    /// the exec's output open for as long as it needs to.
+    async fn forking_state_with_live_group() -> (
+        ExecutionState,
+        Pid,
+        (
+            std::os::fd::OwnedFd,
+            std::os::fd::OwnedFd,
+            std::os::fd::OwnedFd,
+        ),
+    ) {
+        use std::os::unix::process::CommandExt;
+
+        let mut command = std::process::Command::new("/bin/sh");
+        command.args(["-c", "sleep 30 & exit 0"]);
+        // SAFETY: `setpgid` is async-signal-safe and this closure allocates and
+        // locks nothing between fork and exec.
+        unsafe {
+            command.pre_exec(|| {
+                if nix::libc::setpgid(0, 0) == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        let mut child = command.spawn().expect("spawn group leader");
+        let leader = Pid::from_raw(child.id() as i32);
+        let process = ProcessInstance::capture(leader).expect("capture while live");
+
+        tokio::task::spawn_blocking(move || {
+            let _fence = crate::reaper::reap_fence();
+            child.wait().expect("wait for leader")
+        })
+        .await
+        .expect("wait task must not panic");
+
+        let (stdin_peer, stdin) = pipe().unwrap();
+        let (stdout, stdout_peer) = pipe().unwrap();
+        let (stderr, stderr_peer) = pipe().unwrap();
+        let state = ExecutionState::new(
+            ExecHandle::new(leader, stdin, stdout, Some(stderr))
+                .expect("test pipes must register with Tokio"),
+            ExitSlot::settled_for_test(ExitStatus::Code(0)),
+            Some(process),
+        );
+        (state, leader, (stdin_peer, stdout_peer, stderr_peer))
+    }
+
+    /// Releasing an entry must not retire a deadline the job still needs.
+    ///
+    /// `prune_inner` reaches this after RETAIN_GRACE and the SSH path reaches
+    /// it at output EOF — neither proves the process group ended, so aborting
+    /// the watcher there would strand survivors past their deadline.
+    #[tokio::test]
+    async fn release_keeps_the_deadline_while_the_group_lives() {
+        let (state, leader, _peers) = forking_state_with_live_group().await;
+        assert!(state.job_group_alive());
+
+        let timeout_task = tokio::spawn(std::future::pending());
+        let timeout_abort = timeout_task.abort_handle();
+        state.set_timeout_task(timeout_task).await;
+
+        assert!(state.release_resources().await);
+        assert!(
+            !timeout_abort.is_finished(),
+            "release retired a deadline whose group was still live"
+        );
+
+        let _ = nix::sys::signal::kill(
+            Pid::from_raw(-leader.as_raw()),
+            nix::sys::signal::Signal::SIGKILL,
+        );
+        timeout_abort.abort();
+    }
+
+    /// A group kill must reach members that outlived the leader.
+    ///
+    /// `ProcessInstance::signal`'s start-time guard refuses once the leader is
+    /// reaped, which is exactly when the SSH bridge's forced stage runs. The
+    /// state captures the pgid at construction so that stage still lands.
+    #[tokio::test]
+    async fn group_kill_reaches_members_that_outlived_the_leader() {
+        use std::os::unix::process::CommandExt;
+
+        let _test_guard = crate::reaper::reap_test_guard().await;
+        let mut command = std::process::Command::new("/bin/sh");
+        command.args(["-c", "sleep 30 & echo $!"]);
+        command.stdout(std::process::Stdio::piped());
+        // SAFETY: `setpgid` is async-signal-safe and this closure allocates and
+        // locks nothing between fork and exec.
+        unsafe {
+            command.pre_exec(|| {
+                if nix::libc::setpgid(0, 0) == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        let mut child = command.spawn().expect("spawn group leader");
+        let leader = Pid::from_raw(child.id() as i32);
+        let process = ProcessInstance::capture(leader).expect("read child identity");
+
+        let (stdin_peer, stdin) = pipe().unwrap();
+        let (stdout, stdout_peer) = pipe().unwrap();
+        let (stderr, stderr_peer) = pipe().unwrap();
+        let (exit, _exit_tx) = ExitSlot::pending_for_test();
+        let state = ExecutionState::new(
+            ExecHandle::new(leader, stdin, stdout, Some(stderr))
+                .expect("test pipes must register with Tokio"),
+            exit,
+            Some(process),
+        );
+
+        // Read one line: the forked `sleep` inherits stdout, so waiting for EOF
+        // would wait out the whole workload.
+        let descendant = {
+            use std::io::Read;
+            let mut out = child.stdout.take().expect("piped stdout");
+            let mut buf = String::new();
+            let mut byte = [0u8; 1];
+            while out.read(&mut byte).expect("read descendant pid") == 1 {
+                if byte[0] == b'\n' {
+                    break;
+                }
+                buf.push(byte[0] as char);
+            }
+            Pid::from_raw(buf.trim().parse::<i32>().expect("descendant pid line"))
+        };
+
+        // Let the leader exit and be reaped, so the start-time guard would now
+        // refuse a leader-anchored signal.
+        tokio::task::spawn_blocking(move || {
+            let _fence = crate::reaper::reap_fence();
+            child.wait().expect("wait for leader")
+        })
+        .await
+        .expect("wait task must not panic");
+
+        assert!(
+            state.job_group_alive(),
+            "the descendant must outlive its leader for this test to mean anything"
+        );
+        assert!(
+            state.kill(nix::sys::signal::Signal::SIGKILL, true).await,
+            "group kill must be delivered after the leader was reaped"
+        );
+
+        let mut gone = false;
+        for _ in 0..50 {
+            if nix::sys::signal::kill(descendant, None).is_err() {
+                gone = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert!(gone, "descendant {descendant} survived the group kill");
+        drop((stdin_peer, stdout_peer, stderr_peer));
     }
 
     #[tokio::test]

--- a/src/guest/src/service/exec/timeout.rs
+++ b/src/guest/src/service/exec/timeout.rs
@@ -9,9 +9,12 @@ use std::time::Duration;
 
 use nix::errno::Errno;
 use nix::sys::signal::Signal;
+use nix::unistd::Pid;
 use tracing::{info, warn};
 
-use crate::service::exec::process_instance::ProcessInstance;
+use crate::service::exec::process_instance::{
+    process_group_alive, signal_process_group, ProcessInstance,
+};
 
 /// Grace period between SIGTERM and SIGKILL on exec timeout.
 ///
@@ -21,19 +24,77 @@ use crate::service::exec::process_instance::ProcessInstance;
 /// used by `ExecRegistry::shutdown_all` and `Container::shutdown`.
 const TIMEOUT_GRACE: Duration = Duration::from_secs(2);
 
+/// How often a waiting watcher re-checks that its captured group still exists.
+///
+/// A captured pgid is only unambiguous while its group is non-empty, so the
+/// watcher may not sleep straight through a window in which the group could
+/// empty and the number be re-allocated. This bounds that exposure to one
+/// interval instead of the whole deadline.
+const GROUP_LIVENESS_POLL: Duration = Duration::from_millis(100);
+
 pub(super) struct TimeoutTarget {
     process: Option<ProcessInstance>,
+    /// The process group to bound, or None when the workload leads no group.
+    group: Option<Pid>,
 }
 
 impl TimeoutTarget {
+    /// Resolve the process group here, not at signal time.
+    ///
+    /// The caller builds this immediately after spawn, the one moment the
+    /// leader is guaranteed live. A leader may exit long before its own
+    /// deadline while the children it forked keep running and keep the exec's
+    /// pipes open; resolving later would see that dead leader, find no group,
+    /// and leave the survivors unsignalled -- the very orphan this watcher
+    /// exists to prevent.
     pub(super) fn new(process: Option<ProcessInstance>) -> Self {
-        Self { process }
+        let group = process.and_then(|process| process.own_process_group());
+        Self { process, group }
     }
 
-    fn signal_if_live(&self, signal: Signal) -> Result<bool, Errno> {
-        match self.process {
-            Some(process) => process.signal(signal, false),
-            None => Ok(false),
+    #[cfg(test)]
+    fn process_group(&self) -> Option<Pid> {
+        self.group
+    }
+
+    /// Wait out `window`, reporting false if the job's group empties first.
+    ///
+    /// Returning false means there is nothing left to signal *and* the captured
+    /// pgid must not be used again — the two are the same condition.
+    async fn wait_while_job_lives(&self, window: Duration) -> bool {
+        let Some(group) = self.group else {
+            // Leader-only delivery re-checks identity at signal time, so there
+            // is no captured group to go stale.
+            tokio::time::sleep(window).await;
+            return true;
+        };
+        let started = tokio::time::Instant::now();
+        loop {
+            let remaining = window.saturating_sub(started.elapsed());
+            if remaining.is_zero() {
+                return true;
+            }
+            tokio::time::sleep(GROUP_LIVENESS_POLL.min(remaining)).await;
+            if !process_group_alive(group) {
+                return false;
+            }
+        }
+    }
+
+    /// Signal the whole job: its process group when it leads one, else the
+    /// captured leader alone.
+    ///
+    /// The group is what actually bounds the deadline. `sh -c "cmd"` may fork
+    /// rather than exec, and signalling only the leader then reaps the shell
+    /// while its child is reparented to init and runs on untouched. Falling
+    /// back to the leader keeps executors that leave their workload in an
+    /// inherited group -- with no group of its own to address -- working as
+    /// before.
+    fn signal_job(&self, signal: Signal) -> Result<bool, Errno> {
+        match (self.group, self.process) {
+            (Some(group), _) => signal_process_group(group, signal),
+            (None, Some(process)) => process.signal(signal, false),
+            (None, None) => Ok(false),
         }
     }
 }
@@ -53,9 +114,12 @@ pub(super) fn start_timeout_watcher(
     timeout: Duration,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
-        tokio::time::sleep(timeout).await;
+        if !target.wait_while_job_lives(timeout).await {
+            info!(execution_id = %exec_id, "job ended before its deadline");
+            return;
+        }
 
-        match target.signal_if_live(Signal::SIGTERM) {
+        match target.signal_job(Signal::SIGTERM) {
             Ok(true) => {}
             Ok(false) => return,
             Err(error) => {
@@ -69,9 +133,15 @@ pub(super) fn start_timeout_watcher(
             "SIGTERM on timeout; grace before SIGKILL"
         );
 
-        tokio::time::sleep(TIMEOUT_GRACE).await;
+        if !target.wait_while_job_lives(TIMEOUT_GRACE).await {
+            info!(execution_id = %exec_id, "exited within grace after SIGTERM");
+            return;
+        }
 
-        match target.signal_if_live(Signal::SIGKILL) {
+        // Escalate against the group captured at construction: by now SIGTERM
+        // may have reaped the leader while a child that ignores it lives on,
+        // and every leader-anchored check would refuse from here.
+        match target.signal_job(Signal::SIGKILL) {
             Ok(true) => {
                 warn!(
                     execution_id = %exec_id,
@@ -91,7 +161,9 @@ mod tests {
     use nix::sys::signal::Signal;
     use nix::unistd::Pid;
 
-    use super::TimeoutTarget;
+    use std::time::Duration;
+
+    use super::{start_timeout_watcher, TimeoutTarget};
     use crate::reaper::{reap_fence, reap_test_guard};
     use crate::service::exec::process_instance::ProcessInstance;
 
@@ -105,8 +177,11 @@ mod tests {
         let leader = Pid::from_raw(child.id() as i32);
         let target = TimeoutTarget::new(ProcessInstance::capture(leader));
 
+        // Spawned without setpgid, so it leads no group: this is the
+        // leader-only fallback path.
+        assert!(target.process_group().is_none());
         assert!(target
-            .signal_if_live(Signal::SIGTERM)
+            .signal_job(Signal::SIGTERM)
             .expect("signal the matching leader"));
         let status = tokio::task::spawn_blocking(move || {
             let _fence = reap_fence();
@@ -115,5 +190,180 @@ mod tests {
         .await
         .expect("wait task must not panic");
         assert_eq!(status.signal(), Some(Signal::SIGTERM as i32));
+    }
+
+    /// The watcher must let go of a captured pgid the moment its group empties.
+    ///
+    /// Holding it to the deadline would leave the number free to be
+    /// re-allocated, and the signals below would land on an unrelated group.
+    #[tokio::test]
+    async fn timeout_watcher_retires_itself_when_the_group_empties() {
+        use std::os::unix::process::CommandExt;
+
+        let _test_guard = reap_test_guard().await;
+        let mut command = std::process::Command::new("/bin/sh");
+        command.args(["-c", "sleep 0.2"]);
+        // SAFETY: `setpgid` is async-signal-safe and this closure allocates and
+        // locks nothing between fork and exec.
+        unsafe {
+            command.pre_exec(|| {
+                if nix::libc::setpgid(0, 0) == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        let mut child = command.spawn().expect("spawn group leader");
+        let leader = Pid::from_raw(child.id() as i32);
+        let target = TimeoutTarget::new(ProcessInstance::capture(leader));
+        assert_eq!(target.process_group(), Some(leader));
+
+        // A deadline far beyond the workload: the watcher must stop on its own.
+        let watcher =
+            start_timeout_watcher(target, "retire-me".to_string(), Duration::from_secs(30));
+
+        tokio::task::spawn_blocking(move || {
+            let _fence = reap_fence();
+            child.wait().expect("wait for leader")
+        })
+        .await
+        .expect("wait task must not panic");
+
+        tokio::time::timeout(Duration::from_secs(5), watcher)
+            .await
+            .expect("watcher must retire once its group is empty")
+            .expect("watcher task must not panic");
+    }
+
+    /// A leader that exits before its own deadline must not take the group's
+    /// escape hatch with it. The pgid is captured at construction precisely so
+    /// the survivors it forked are still reachable here.
+    #[tokio::test]
+    async fn timeout_target_still_reaches_a_group_whose_leader_already_exited() {
+        use std::os::unix::process::CommandExt;
+
+        let _test_guard = reap_test_guard().await;
+        let mut command = std::process::Command::new("/bin/sh");
+        // The shell forks, prints the child's PID, and exits immediately --
+        // leaving a live group behind a dead leader.
+        command.args(["-c", "sleep 30 & echo $!"]);
+        command.stdout(std::process::Stdio::piped());
+        // SAFETY: `setpgid` is async-signal-safe and this closure allocates
+        // and locks nothing between fork and exec.
+        unsafe {
+            command.pre_exec(|| {
+                if nix::libc::setpgid(0, 0) == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        let mut child = command.spawn().expect("spawn group leader");
+        let leader = Pid::from_raw(child.id() as i32);
+
+        // Construct while the leader is still live, as the spawn path does.
+        let target = TimeoutTarget::new(ProcessInstance::capture(leader));
+
+        let child_pid = {
+            use std::io::Read;
+            // Read exactly one line: the forked `sleep` inherits stdout, so
+            // waiting for EOF would wait out the whole workload.
+            let mut stdout = child.stdout.take().expect("piped stdout");
+            let mut buf = String::new();
+            let mut byte = [0u8; 1];
+            while stdout.read(&mut byte).expect("read child pid") == 1 {
+                if byte[0] == b'\n' {
+                    break;
+                }
+                buf.push(byte[0] as char);
+            }
+            Pid::from_raw(buf.trim().parse::<i32>().expect("child pid line"))
+        };
+
+        // Let the leader exit and be reaped before any signal is sent.
+        tokio::task::spawn_blocking(move || {
+            let _fence = reap_fence();
+            child.wait().expect("wait for leader")
+        })
+        .await
+        .expect("wait task must not panic");
+        assert!(!ProcessInstance::capture(leader).is_some_and(|p| p.is_current()));
+
+        assert!(target
+            .signal_job(Signal::SIGKILL)
+            .expect("signal the surviving group"));
+
+        for _ in 0..50 {
+            if nix::sys::signal::kill(child_pid, None).is_err() {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        panic!("group member {child_pid} survived after its leader exited");
+    }
+
+    /// A group leader that forks must not leave the child behind: signalling
+    /// the leader alone reaps the shell and reparents the workload to init,
+    /// which is exactly how a deadline gets bypassed.
+    #[tokio::test]
+    async fn timeout_target_signals_the_whole_group_of_a_forking_leader() {
+        use std::os::unix::process::CommandExt;
+
+        let _test_guard = reap_test_guard().await;
+        let mut command = std::process::Command::new("/bin/sh");
+        command.args(["-c", "sleep 30 & echo $! && wait"]);
+        command.stdout(std::process::Stdio::piped());
+        // SAFETY: `setpgid` is async-signal-safe and this closure allocates
+        // and locks nothing between fork and exec.
+        unsafe {
+            command.pre_exec(|| {
+                if nix::libc::setpgid(0, 0) == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        let mut child = command.spawn().expect("spawn group leader");
+
+        // The shell prints the forked child's PID before waiting on it.
+        let child_pid = {
+            use std::io::Read;
+            let mut stdout = child.stdout.take().expect("piped stdout");
+            let mut buf = String::new();
+            let mut byte = [0u8; 1];
+            while stdout.read(&mut byte).expect("read child pid") == 1 {
+                if byte[0] == b'\n' {
+                    break;
+                }
+                buf.push(byte[0] as char);
+            }
+            Pid::from_raw(buf.trim().parse::<i32>().expect("child pid line"))
+        };
+
+        let leader = Pid::from_raw(child.id() as i32);
+        let target = TimeoutTarget::new(ProcessInstance::capture(leader));
+        let group = target.process_group().expect("leader leads its own group");
+        assert_eq!(group, leader);
+
+        assert!(target
+            .signal_job(Signal::SIGKILL)
+            .expect("signal the whole group"));
+
+        let status = tokio::task::spawn_blocking(move || {
+            let _fence = reap_fence();
+            child.wait().expect("wait for terminated leader")
+        })
+        .await
+        .expect("wait task must not panic");
+        assert_eq!(status.signal(), Some(Signal::SIGKILL as i32));
+
+        // The forked child must be gone too, not orphaned onto init.
+        for _ in 0..50 {
+            if nix::sys::signal::kill(child_pid, None).is_err() {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        panic!("forked child {child_pid} survived a group SIGKILL");
     }
 }


### PR DESCRIPTION
## Call graph

```text
Before
  spawn_execution          (guest · src/guest/src/service/exec/mod.rs:396)                - captures pid + start_time only
  start_timeout_watcher    (guest · src/guest/src/service/exec/timeout.rs:111)            ← BUG: signals the captured leader alone, so a forked child is reparented to init and outlives the deadline; the SIGKILL stage then finds the leader gone and refuses silently
  observe_terminal         (guest · src/guest/src/service/exec/registry.rs:539)           ← BUG: retires the deadline at leader exit, which sh -c "cmd &" reaches immediately
  release_resources        (guest · src/guest/src/service/exec/state.rs:500)              ← BUG: aborts the watcher unconditionally, stranding survivors after prune or the SSH release
  signal_if_current        (guest · src/guest/src/service/exec/state.rs:560)              ← BUG: the leader start-time guard refuses once the leader is reaped, so the SSH forced stage cannot reach survivors

After
  spawn_execution          (guest · src/guest/src/service/exec/mod.rs:396)                - warns when an execution leads no group
  ProcessInstance::capture (guest · src/guest/src/service/exec/process_instance.rs:25)    - records pid + start_time + pgid together, before any await
  own_process_group        (guest · src/guest/src/service/exec/process_instance.rs:71)    - returns the recorded field, never re-reads /proc
  start_timeout_watcher    (guest · src/guest/src/service/exec/timeout.rs:111)            - polls group liveness, retires once the group empties
  wait_while_job_lives     (guest · src/guest/src/service/exec/timeout.rs:64)             - bounds both the deadline and the SIGTERM grace
  signal_job               (guest · src/guest/src/service/exec/timeout.rs:93)             - SIGTERM then SIGKILL against the captured group
  signal_process_group     (guest · src/guest/src/service/exec/process_instance.rs:117)   - kill(-pgid), reaching children the leader left behind
  spawn_with_pipes         (guest · src/guest/src/service/exec/executor.rs:132)           - setpgid(0,0), so the default GuestExecutor path leads a group too
  observe_terminal         (guest · src/guest/src/service/exec/registry.rs:539)           - cancels only when job_group_alive() is false
  release_resources        (guest · src/guest/src/service/exec/state.rs:500)              - aborts the watcher only when the group is already empty
  signal_if_current        (guest · src/guest/src/service/exec/state.rs:560)              - addresses the captured group directly
```

Fixes #1459

## Summary

An exec timeout signalled only the PID captured at spawn, so a workload whose leader forks kept running past its deadline as an orphan, and - still holding the exec pipes - hung Execution::wait() forever. Kills now address the leader process group, captured at spawn and held only while that group exists.

Tracked in Linear as POL-507. Full investigation: docs/investigations/exec-timeout-orphan.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Execution timeouts now terminate entire process trees, including child processes that continue after the main process exits.
  - Timeout enforcement now remains active while spawned child processes are still running.
  - Pipe-based command execution now correctly applies timeout handling to all related processes.
  - Improved warnings and diagnostics when process cleanup cannot reach child processes.

- **Documentation**
  - Added an investigation covering timeout behavior, affected scenarios, troubleshooting steps, and verification results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->