### PR TITLE
fix(vmm): move box teardown off Tokio worker threads

### DIFF
--- a/src/boxlite/src/litebox/box_impl.rs
+++ b/src/boxlite/src/litebox/box_impl.rs
@@ -53,7 +53,7 @@ pub type SharedBoxImpl = Arc<BoxImpl>;
 /// Separated from BoxImpl to allow operations like `info()` without initializing LiveState.
 pub(crate) struct LiveState {
     // VM process control
-    handler: std::sync::Mutex<Box<dyn VmmHandler>>,
+    handler: Arc<std::sync::Mutex<Box<dyn VmmHandler>>>,
     guest_session: GuestSession,
 
     /// Host-side network control backend (gvproxy ServicesMux client), owned
@@ -94,7 +94,7 @@ impl LiveState {
         #[cfg(target_os = "linux")] bind_mount: Option<BindMountHandle>,
     ) -> Self {
         Self {
-            handler: std::sync::Mutex::new(handler),
+            handler: Arc::new(std::sync::Mutex::new(handler)),
             guest_session,
             network: network.map(Arc::from),
             published_ports,
@@ -725,10 +725,25 @@ impl BoxImpl {
                 tracing::warn!(box_id = %self.config.id, "Guest shutdown timed out after 10s");
             }
 
-            // Stop handler
-            if let Ok(mut handler) = live.handler.lock() {
-                handler.stop()?;
-            }
+            // Stop handler. `ShimHandler::stop` polls graceful shutdown
+            // with `std::thread::sleep` for up to `GRACEFUL_SHUTDOWN_TIMEOUT_MS`,
+            // so it must NOT run on this Tokio worker — it would park the
+            // worker and the `tokio::time::timeout` guarding `stop()`
+            // (runtime shutdown / AutoStop sweeper) cannot preempt a
+            // synchronous sleep. Run it on a blocking thread; the await
+            // here is the cancellation point the outer timeout can actually
+            // fire on, and dropping the JoinHandle on cancel detaches —
+            // the task still runs to completion, killing the VM in the
+            // background. See docs/investigations/issue-1242-teardown-blocks-worker.md.
+            let handler = Arc::clone(&live.handler);
+            tokio::task::spawn_blocking(move || {
+                let mut handler = handler
+                    .lock()
+                    .map_err(|e| BoxliteError::Internal(format!("handler lock poisoned: {}", e)))?;
+                handler.stop()
+            })
+            .await
+            .map_err(|e| BoxliteError::Internal(format!("spawn_blocking failed: {}", e)))??;
         }
         // If live_state() failed (vmm_attach said Absent — shim is gone),
         // or status wasn't Running, fall through to cleanup.
@@ -2125,6 +2140,128 @@ mod tests {
         assert!(
             !is_process_alive(pid),
             "stop() must kill the recovered shim process when self.live is None"
+        );
+
+        // ChildGuard's Drop reaps the (now-dead) child.
+        drop(child);
+    }
+
+    // Reproducer for issue #1242: `ShimHandler::stop` polls graceful
+    // shutdown with `std::thread::sleep` for up to
+    // `GRACEFUL_SHUTDOWN_TIMEOUT_MS` (2 s). Before the fix this sleep ran
+    // on the calling Tokio worker, parking it for the whole window — the
+    // `tokio::time::timeout` guarding `stop()` (runtime shutdown / REST
+    // AutoStop) could not preempt it. This test proves the graceful
+    // teardown now runs on a blocking thread: a concurrent async task on
+    // the *same* (current-thread, single-worker) runtime makes progress
+    // while `stop()` is inside the graceful window.
+    //
+    // The stand-in must ignore SIGTERM — otherwise `graceful_stop`'s
+    // `waitpid(WNOHANG)` reaps the process on the first poll and the 2 s
+    // `thread::sleep` loop is never entered, so the bug would not
+    // manifest and the test would pass both with and without the fix
+    // (`sleep 300` dies on SIGTERM, so it cannot be the stand-in). `sh -c
+    // "trap '' TERM; while true; do sleep 1; done"` ignores SIGTERM and
+    // loops forever (the `while` prevents an `exec` optimization that
+    // would replace the shell and drop the trap), forcing `graceful_stop`
+    // into the full 2 s poll loop until SIGKILL lands.
+    #[tokio::test]
+    async fn stop_does_not_park_tokio_worker_during_graceful_shutdown() {
+        let temp_dir = TempDir::new_in("/tmp").expect("create temp dir");
+        // `new_for_test` skips the host KVM preflight — this test uses a
+        // stand-in process (not a real VM), so no hypervisor is needed.
+        let runtime = RuntimeImpl::new_for_test(BoxliteOptions {
+            home_dir: temp_dir.path().to_path_buf(),
+            image_registries: vec![],
+        })
+        .expect("create runtime");
+
+        let child = ChildGuard(
+            std::process::Command::new("sh")
+                .arg("-c")
+                .arg("trap '' TERM; while true; do sleep 1; done")
+                .spawn()
+                .expect("spawn SIGTERM-ignoring stand-in"),
+        );
+        let pid = child.0.id();
+
+        let id = BoxIDMint::mint();
+        let box_home = runtime.layout.boxes_dir().join(id.as_str());
+        let config = BoxConfig {
+            id: id.clone(),
+            name: None,
+            created_at: Utc::now(),
+            container: ContainerRuntimeConfig {
+                id: ContainerID::new(),
+            },
+            options: BoxOptions {
+                rootfs: RootfsSpec::Image("alpine:latest".into()),
+                detach: false,
+                auto_delete: Some(0),
+                ..Default::default()
+            },
+            engine_kind: VmmKind::Libkrun,
+            box_home: box_home.clone(),
+        };
+
+        let mut state = BoxState::new();
+        state.status = BoxStatus::Running;
+        state.pid = Some(pid);
+        let lock_id = runtime.lock_manager.allocate().expect("allocate lock");
+        state.set_lock_id(lock_id);
+
+        std::fs::create_dir_all(&box_home).expect("create box dir");
+        let st = crate::util::process_start_time(pid).expect("OS reports start_time");
+        let layout = runtime
+            .layout
+            .box_layout(config.id.as_str(), false)
+            .expect("box_layout is infallible");
+        let pid_file = layout.pid_file_path();
+        std::fs::write(&pid_file, format!("{pid}\n{st}\n")).expect("write pid file");
+
+        runtime
+            .box_manager
+            .add_box(&config, &state)
+            .expect("add box to manager");
+
+        let litebox = runtime
+            .get(config.id.as_str())
+            .await
+            .expect("get box")
+            .expect("box exists");
+
+        // A 50 ms beacon on the *same* current-thread runtime. With the
+        // bug, `stop()`'s sync `thread::sleep` parks the worker for ~2 s,
+        // the beacon is never polled, and `stop()` wins the select at
+        // ~2 s. With the fix, `stop()` yields at the `spawn_blocking`
+        // join, the worker polls the beacon, and the beacon wins at
+        // ~50 ms.
+        let beacon = tokio::time::sleep(Duration::from_millis(50));
+        tokio::pin!(beacon);
+        let stop_fut = litebox.stop();
+        tokio::pin!(stop_fut);
+
+        let beacon_won = tokio::select! {
+            _ = &mut beacon => true,
+            _ = &mut stop_fut => false,
+        };
+
+        assert!(
+            beacon_won,
+            "stop() parked the Tokio worker during graceful shutdown; the graceful \
+             teardown must run on a blocking thread, not the worker"
+        );
+
+        // Let the (still running) graceful teardown complete for cleanup —
+        // the SIGKILL lands at the 2 s graceful timeout.
+        stop_fut.await.expect("stop should complete after beacon");
+
+        // Give SIGKILL a moment to land and be reaped.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert!(
+            !is_process_alive(pid),
+            "stop() must still kill the stand-in (via SIGKILL at the graceful timeout) \
+             even though it ran on a blocking thread"
         );
 
         // ChildGuard's Drop reaps the (now-dead) child.

--- a/src/boxlite/src/litebox/init/types.rs
+++ b/src/boxlite/src/litebox/init/types.rs
@@ -250,11 +250,38 @@ impl Drop for CleanupGuard {
 
         tracing::warn!(box_id = %self.box_id, reason = %reason, "Box initialization failed, cleaning up");
 
-        // Stop handler if started
-        if let Some(ref mut handler) = self.handler
-            && let Err(e) = handler.stop()
-        {
-            tracing::warn!("Failed to stop handler during cleanup: {}", e);
+        // Stop handler if started. `ShimHandler::stop` polls graceful
+        // shutdown with `std::thread::sleep` (≤ `GRACEFUL_SHUTDOWN_TIMEOUT_MS`),
+        // so it must NOT run on the Tokio worker this `Drop` runs on. A
+        // `Drop` cannot `.await`, so fire-and-forget on a blocking thread.
+        // This is safe here specifically: init-failure cleanup is
+        // best-effort, and the `ShimHandler`'s `keepalive` (dropped with
+        // the handler when the task is dropped, whether it ran or was
+        // abandoned) closes the watchdog pipe, delivering POLLHUP to the
+        // shim and triggering its self-shutdown — the kernel-level safety
+        // net that covers the case where the task never starts.
+        // See docs/investigations/issue-1242-teardown-blocks-worker.md.
+        if let Some(mut handler) = self.handler.take() {
+            let box_id = self.box_id.clone();
+            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                handle.spawn_blocking(move || {
+                    if let Err(e) = handler.stop() {
+                        tracing::warn!(
+                            box_id = %box_id,
+                            "Failed to stop handler during cleanup: {}", e
+                        );
+                    }
+                });
+            } else {
+                // No Tokio runtime context (e.g. a `Drop` outside any
+                // runtime) — block in place; there is no worker to park.
+                if let Err(e) = handler.stop() {
+                    tracing::warn!(
+                        box_id = %box_id,
+                        "Failed to stop handler during cleanup: {}", e
+                    );
+                }
+            }
         }
 
         // DON'T cleanup filesystem - preserve diagnostic files for debugging

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -1822,7 +1822,19 @@ impl super::backend::RuntimeBackend for LocalRuntime {
     }
 
     async fn remove(&self, id_or_name: &str, force: bool) -> BoxliteResult<()> {
-        self.0.remove(id_or_name, force)
+        // `RuntimeImpl::remove` is entirely synchronous (DB lookups,
+        // dependency checks, `ShimHandler::from_pid(pid).stop()` on the
+        // force path with its ≤2 s graceful-shutdown poll, DB removal).
+        // Running it on a Tokio worker parks the worker for that whole
+        // window — see issue #1242. Move the entire sync call onto a
+        // blocking thread; the `.await` here yields, the runtime stays
+        // responsive, and the inner `GRACEFUL_SHUTDOWN_TIMEOUT_MS` still
+        // bounds the kill.
+        let this = Arc::clone(&self.0);
+        let id_or_name = id_or_name.to_string();
+        tokio::task::spawn_blocking(move || this.remove(&id_or_name, force))
+            .await
+            .map_err(|e| BoxliteError::Internal(format!("spawn_blocking failed: {}", e)))?
     }
 
     async fn shutdown(&self, timeout: Option<i32>) -> BoxliteResult<()> {


### PR DESCRIPTION
## Summary
Move the ~2 s synchronous graceful-shutdown poll (`ShimHandler::stop` / `graceful_stop`, `thread::sleep(50ms) × ≤40`) off Tokio worker threads at every async-reachable call site, so the worker is no longer parked and the `tokio::time::timeout` guarding `stop()` can actually fire.

## Call graph

Before
```
BoxImpl::stop                       (async fn · src/boxlite/src/litebox/box_impl.rs:729)
  └─ live.handler.lock()           (std::Mutex · box_impl.rs:56)
     └─ ShimHandler::stop          (VmmHandler · src/boxlite/src/vmm/controller/shim.rs:175)
        └─ graceful_stop           (fn · shim.rs:86)  thread::sleep(50ms) × ≤40  ← BUG: parks the Tokio worker ~2s; tokio::time::timeout at rt_impl.rs:822 / serve/mod.rs:917 cannot preempt a sync sleep
LocalRuntime::remove                (async · src/boxlite/src/runtime/rt_impl.rs:1824)
  └─ RuntimeImpl::remove            (sync fn · rt_impl.rs:638)
     └─ remove_box(force=true)     (sync fn · rt_impl.rs:1011)
        └─ ShimHandler::stop        (VmmHandler · shim.rs:175)  ← BUG: same ~2s sync block, no timeout at all
CleanupGuard::drop                  (Drop · src/boxlite/src/litebox/init/types.rs:255)
  └─ handler.stop()                 (VmmHandler · shim.rs:175)  ← BUG: same ~2s sync block on the init-failure path
```

After
```
BoxImpl::stop                       (async fn · src/boxlite/src/litebox/box_impl.rs:729)
  └─ spawn_blocking(|| { live.handler.lock(); handler.stop() }).await  (tokio task · box_impl.rs:738)
     └─ ShimHandler::stop          (VmmHandler · shim.rs:175)
        └─ graceful_stop           (fn · shim.rs:86)  — thread::sleep on the blocking pool; outer timeout now fires at the await (detached task still completes SIGTERM→SIGKILL→reap)
LocalRuntime::remove                (async · src/boxlite/src/runtime/rt_impl.rs:1824)
  └─ spawn_blocking(|| this.remove(...)).await  (tokio task · rt_impl.rs:1830)
     └─ RuntimeImpl::remove → remove_box(force=true) → ShimHandler::stop
CleanupGuard::drop                  (Drop · src/boxlite/src/litebox/init/types.rs:255)
  └─ Handle::try_current().spawn_blocking(|| handler.stop())  (fire-and-forget; keepalive Drop is the abandonment safety net)
     └─ ShimHandler::stop
```

Fixes #1242

## Changes
- `LiveState::handler` (`box_impl.rs:56`) wrapped in `Arc` so the `spawn_blocking` closure holds a `Send + 'static` ref to lock, without borrowing across the await. `metrics()`/`pid()` lockers unchanged — `Arc` derefs to `Mutex`.
- `BoxImpl::stop` runs `handler.stop()` inside `spawn_blocking`; the await is the cancellation point the outer `tokio::time::timeout` (shutdown / AutoStop) can actually fire on. Dropping the `JoinHandle` on cancel detaches — the kill still runs to completion in the background.
- `LocalRuntime::remove` wraps the entire sync `RuntimeImpl::remove` in `spawn_blocking` at the async boundary. Sync callers (`BoxImpl::stop`'s `remove_box(force=false)` at `box_impl.rs:818`, sync unit tests) are untouched — they don't go through this wrapper.
- `CleanupGuard::drop` fire-and-forgets `handler.stop()` via `Handle::try_current()`; falls back to blocking in place when no runtime context. The `ShimHandler` keepalive (dropped with the handler) is the kernel-level safety net for the case where the task never starts.

## How to verify
- `BOXLITE_DEPS_STUB=1 cargo clippy -p boxlite --lib --tests --all-features -- -D warnings`
- `BOXLITE_DEPS_STUB=1 cargo test -p boxlite --lib box_impl::tests::stop_does_not_park` — new reproducer; passes with the fix, fails ("stop() parked the Tokio worker...") with Change A reverted (two-sided verified).
- KVM-equipped CI: the existing `test_stop_recovered_box_kills_orphan_process`, `remove_box` / `shutdown_sync` suites, and `cleanup_guard_drop_persists_failed_state_and_keeps_record`.

## Risks / rollout
- On `tokio::time::timeout` cancel of `box_impl.stop()`, the box's post-kill state transition (mark `Stopped`, remove PID file, DB save) is skipped for that call; the detached `spawn_blocking` still completes the kill. The box self-heals on the next `stop()` (idempotent: `graceful_stop` takes `process` → `None` the second time → attached-mode `waitpid`/`kill` on the dead pid) and via `recover_boxes` at next runtime start.
- `metrics()` vs `stop()` on multi-threaded runtimes has a residual microsecond TOCTOU race (token check vs lock acquire) that can block a worker for ~2 s. Issue option 1 does not cover this; the token check (`box_impl.rs:651`, cancelled before `stop()` locks at `705`) handles the realistic case. Leaving it avoids an untested `try_lock` branch or a trait-wide `tokio::sync::Mutex` change with larger blast radius.
- Grace periods and the `std::sync::Mutex` are unchanged; the qcow2 flush guarantee is preserved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented box shutdown and removal operations from blocking asynchronous workers during graceful cleanup.
  - Timeouts and other concurrent asynchronous tasks now remain responsive while shutdown work is in progress.
  - Improved automatic cleanup behavior to avoid duplicate shutdown attempts and safely handle cleanup with or without an active runtime.

- **Documentation**
  - Added investigation and implementation guidance for shutdown-related worker blocking and timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->