### PR TITLE
fix(exec): close the residual PID-reuse TOCTOU via pidfd

### DIFF
--- a/src/guest/src/service/exec/mod.rs
+++ b/src/guest/src/service/exec/mod.rs
@@ -418,6 +418,11 @@ async fn spawn_execution(
             "failed to capture process identity; signals will be skipped"
         );
     }
+    // Share the process identity with the timeout watcher before the state
+    // takes it by value. `ProcessInstance` is `Clone` (not `Copy`) because it
+    // owns an `Arc<OwnedFd>` pidfd; the clone bumps the `Arc` refcount so
+    // both holders share one fd.
+    let process_for_timeout = process.clone();
 
     // Register this pid's exit slot at the spawn, not at the wait: a detached
     // exec sends no Wait until its caller chooses to, and in between the exit
@@ -461,7 +466,7 @@ async fn spawn_execution(
     // Step 3: Start timeout watcher (if requested)
     if req.timeout_ms > 0 {
         let timeout_task = timeout::start_timeout_watcher(
-            timeout::TimeoutTarget::new(process),
+            timeout::TimeoutTarget::new(process_for_timeout),
             execution_id.clone(),
             std::time::Duration::from_millis(req.timeout_ms),
         );

--- a/src/guest/src/service/exec/process_instance.rs
+++ b/src/guest/src/service/exec/process_instance.rs
@@ -1,42 +1,190 @@
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::sync::Arc;
+
 use nix::errno::Errno;
 use nix::sys::signal::{kill, Signal};
 use nix::unistd::{getpgid, Pid};
 
 /// A process instance distinguished from a prior process that used the same
 /// PID.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+///
+/// Carries a kernel-atomic incarnation pin (`pidfd`) when the kernel supports
+/// `pidfd_open` (Linux 5.3+). Signals are delivered via `pidfd_send_signal`,
+/// which returns `ESRCH` once the incarnation is gone and never reaches a
+/// later owner of a recycled PID — closing the TOCTOU window that a
+/// `/proc/<pid>/stat` start-time comparison followed by `kill(pid)` leaves
+/// open. On kernels without `pidfd_open`, falls back to the start-time
+/// fingerprint (`is_current`).
+#[derive(Clone, Debug)]
 pub(crate) struct ProcessInstance {
     pid: Pid,
+    /// Used only by the `/proc` fallback path when `pidfd` is `None` (old
+    /// kernel — `pidfd_open` returned `ENOSYS` — or the process was already
+    /// reaped at capture time). On the pidfd path the start-time fingerprint
+    /// is never read; it is kept because the fallback is the sole identity
+    /// check when no pidfd is held.
     start_time: u64,
+    /// Kernel-atomic incarnation pin. `None` when `pidfd_open` failed; the
+    /// `/proc` start-time path remains the fallback in that case. Shared via
+    /// `Arc` so every clone of one `ProcessInstance` owns one fd, closed when
+    /// the last clone is dropped.
+    pidfd: Option<Arc<OwnedFd>>,
 }
 
 impl ProcessInstance {
-    /// Capture the process start time immediately after its spawn returns.
+    /// Capture the process identity immediately after its spawn returns.
+    ///
+    /// Reads `/proc/<pid>/stat.starttime` (always — the fallback needs it)
+    /// and opens a pidfd when the kernel supports it. Returns `None` if the
+    /// `/proc` read fails; the caller logs "failed to capture process
+    /// identity; signals will be skipped" and no signals are sent.
     pub(crate) fn capture(pid: Pid) -> Option<Self> {
-        Self::start_time_for(pid).map(|start_time| Self { pid, start_time })
+        let start_time = Self::start_time_for(pid)?;
+        let pidfd = Self::open_pidfd(pid);
+        Some(Self {
+            pid,
+            start_time,
+            pidfd,
+        })
     }
 
-    /// Signal only when this PID still belongs to the process captured at spawn.
+    /// Signal this process only while it still belongs to the incarnation
+    /// captured at spawn.
+    ///
+    /// `process_group=false` (single-pid): uses `pidfd_send_signal` when a
+    /// pidfd is held (atomic — `ESRCH` once the incarnation is gone) and
+    /// falls back to `is_current()` + `kill(pid)` on old kernels.
+    ///
+    /// `process_group=true`: verifies the leader is still our incarnation
+    /// (`pidfd_send_signal(fd, 0)` probe when a pidfd is held, `is_current()`
+    /// fallback), then signals the process group by pgid number via
+    /// `kill(-pgid)`. Signalling by pgid number is not a PID-recycling hazard.
     pub(super) fn signal(&self, signal: Signal, process_group: bool) -> Result<bool, Errno> {
+        if process_group {
+            return self.signal_group(signal);
+        }
+        if let Some(pidfd) = &self.pidfd {
+            return self.send_signal_via_pidfd(pidfd, signal);
+        }
         if !self.is_current() {
             return Ok(false);
         }
-
-        let target = if process_group {
-            match getpgid(Some(self.pid)) {
-                Ok(group) if group == self.pid => {}
-                Ok(_) | Err(Errno::ESRCH) => return Ok(false),
-                Err(error) => return Err(error),
-            }
-            Pid::from_raw(-self.pid.as_raw())
-        } else {
-            self.pid
-        };
-
-        match kill(target, signal) {
+        match kill(self.pid, signal) {
             Ok(()) => Ok(true),
             Err(Errno::ESRCH) => Ok(false),
             Err(error) => Err(error),
+        }
+    }
+
+    /// Group-signal path: leader-identity check, then `kill(-pgid)`.
+    ///
+    /// The leader check is `pidfd_send_signal(fd, 0)` (atomic) when a pidfd
+    /// is held and `is_current()` on the `/proc` fallback. The subsequent
+    /// `getpgid` + `kill(-pgid)` signals by pgid number — a captured value,
+    /// so a recycled PID in a different process group is not reached.
+    fn signal_group(&self, signal: Signal) -> Result<bool, Errno> {
+        let alive = match &self.pidfd {
+            Some(pidfd) => self.probe_via_pidfd(pidfd),
+            None => self.is_current(),
+        };
+        if !alive {
+            return Ok(false);
+        }
+        match getpgid(Some(self.pid)) {
+            Ok(group) if group == self.pid => {}
+            Ok(_) | Err(Errno::ESRCH) => return Ok(false),
+            Err(error) => return Err(error),
+        }
+        match kill(Pid::from_raw(-self.pid.as_raw()), signal) {
+            Ok(()) => Ok(true),
+            Err(Errno::ESRCH) => Ok(false),
+            Err(error) => Err(error),
+        }
+    }
+
+    /// Open a pidfd for the process. `None` when the kernel lacks
+    /// `pidfd_open` (`ENOSYS`), the process is already gone (`ESRCH`), or
+    /// permission is denied (`EPERM` — should not happen for our own child).
+    /// In every failure case the `/proc` start-time fallback applies.
+    fn open_pidfd(pid: Pid) -> Option<Arc<OwnedFd>> {
+        // SAFETY: `pidfd_open` takes (pid_t pid, u32 flags) and returns a
+        // non-negative fd with CLOEXEC set on success, or -1 + errno on
+        // failure. We treat every failure as "no pidfd, use /proc fallback".
+        let ret = unsafe { nix::libc::syscall(nix::libc::SYS_pidfd_open, pid.as_raw(), 0u32) };
+        if ret < 0 {
+            return None;
+        }
+        // SAFETY: `ret` is a freshly allocated fd we own; `OwnedFd` closes
+        // it on drop. `Arc` lets every clone of `ProcessInstance` share one
+        // fd rather than duplicate it.
+        Some(Arc::new(unsafe { OwnedFd::from_raw_fd(ret as i32) }))
+    }
+
+    /// `pidfd_send_signal(fd, sig)` — atomic signal to the incarnation.
+    ///
+    /// On `EPERM`, distinguish a reaped incarnation from a real permission
+    /// denial by re-checking the `/proc` start-time. `pidfd_send_signal`
+    /// performs its own permission check at call time (independent of the
+    /// `pidfd_open` capture-time check), so a real `EPERM` is possible if the
+    /// child changed credentials after capture (e.g. `setuid` to a different
+    /// user). The kernel also returns `EPERM`, rather than the documented
+    /// `ESRCH`, for a reaped pidfd on some configurations (observed: kernel
+    /// 5.4 under the Rust runtime). If `is_current` is false the process is
+    /// gone, so the `EPERM` is the reaped quirk (`Ok(false)`); if it is still
+    /// live, the `EPERM` is a real denial to propagate.
+    fn send_signal_via_pidfd(&self, pidfd: &OwnedFd, signal: Signal) -> Result<bool, Errno> {
+        // SAFETY: `pidfd_send_signal` takes (int pidfd, int sig, siginfo_t*,
+        // u32 flags). Returns 0 on success, -1 + errno on failure.
+        let ret = unsafe {
+            nix::libc::syscall(
+                nix::libc::SYS_pidfd_send_signal,
+                pidfd.as_raw_fd(),
+                signal as i32,
+                std::ptr::null::<std::ffi::c_void>(),
+                0u32,
+            )
+        };
+        // `libc::syscall` returns `-errno` (negative `c_long`) on failure;
+        // `Errno::from_raw` is `pub const fn` in nix 0.29, so there is no
+        // `Errno::last()` read that could race with another thread's syscall.
+        if ret == 0 {
+            Ok(true)
+        } else {
+            match Errno::from_raw((-ret) as i32) {
+                Errno::ESRCH => Ok(false),
+                Errno::EPERM if !self.is_current() => Ok(false),
+                other => Err(other),
+            }
+        }
+    }
+
+    /// `pidfd_send_signal(fd, 0)` — atomic no-op probe used by the group
+    /// path's leader check. `sig=0` performs the existence/permission check
+    /// without delivering a signal. Returns `true` only when the incarnation
+    /// is alive and still signalable by us.
+    fn probe_via_pidfd(&self, pidfd: &OwnedFd) -> bool {
+        // SAFETY: as above, sig=0 is the no-op probe form.
+        let ret = unsafe {
+            nix::libc::syscall(
+                nix::libc::SYS_pidfd_send_signal,
+                pidfd.as_raw_fd(),
+                0i32,
+                std::ptr::null::<std::ffi::c_void>(),
+                0u32,
+            )
+        };
+        if ret == 0 {
+            return true;
+        }
+        match Errno::from_raw((-ret) as i32) {
+            Errno::ESRCH => false,
+            // Same reaped-vs-real distinction as `send_signal_via_pidfd`: a
+            // reaped pidfd returns EPERM on some kernels (→ not alive); a
+            // live-setuid leader is still our incarnation (→ alive, let
+            // `signal_group` proceed to `getpgid` + `kill(-pgid)`, which
+            // signals the group by pgid number).
+            Errno::EPERM => self.is_current(),
+            _ => false,
         }
     }
 
@@ -58,8 +206,27 @@ impl ProcessInstance {
     }
 
     #[cfg(test)]
+    pub(super) fn has_pidfd(&self) -> bool {
+        self.pidfd.is_some()
+    }
+
+    /// Test-only: set a stale `start_time` to prove the `/proc` fallback
+    /// rejects a recycled PID's start time. Keeps the pidfd; chain with
+    /// `with_no_pidfd_for_test` to exercise the fallback path.
+    #[cfg(test)]
     pub(super) fn with_start_time_for_test(self, start_time: u64) -> Self {
         Self { start_time, ..self }
+    }
+
+    /// Test-only: drop the pidfd so the `/proc` start-time fallback is
+    /// exercised (the shape `capture` produces on a kernel without
+    /// `pidfd_open`).
+    #[cfg(test)]
+    pub(super) fn with_no_pidfd_for_test(self) -> Self {
+        Self {
+            pidfd: None,
+            ..self
+        }
     }
 }
 
@@ -163,6 +330,15 @@ mod tests {
         assert_eq!(nix::unistd::getpgid(Some(descendant)).unwrap(), leader);
 
         let identity = ProcessInstance::capture(leader).expect("read leader identity");
+        // Two-side guard for the group probe: if `probe_via_pidfd` is
+        // reverted to return `false`, `signal_group` returns `Ok(false)`,
+        // failing the `assert!(identity.signal(SIGTERM, true)...)` below
+        // (Ok(false) → assert!(false) → panic) before `try_wait` is reached.
+        // The `has_pidfd` assertion pins that the pidfd branch was taken.
+        assert!(
+            identity.has_pidfd(),
+            "pidfd must be captured so the group probe is atomic"
+        );
         assert!(identity
             .signal(Signal::SIGTERM, true)
             .expect("signal matching process group"));
@@ -182,6 +358,93 @@ mod tests {
         assert!(
             is_gone_or_zombie(descendant),
             "background descendant survived process-group SIGKILL"
+        );
+    }
+
+    /// A live process gets a pidfd at capture. Two-side: revert `open_pidfd`
+    /// to return `None` and this fails (the field is `None`).
+    #[tokio::test]
+    async fn pidfd_is_captured_for_a_live_process() {
+        let _test_guard = crate::reaper::reap_test_guard().await;
+        let mut child = Command::new("/bin/sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn sleep");
+        let pid = Pid::from_raw(child.id() as i32);
+        let identity = ProcessInstance::capture(pid).expect("read child identity");
+        assert!(
+            identity.has_pidfd(),
+            "pidfd must be captured on a kernel with pidfd_open (>= 5.3)"
+        );
+
+        child.kill().expect("kill test child");
+        let status = tokio::task::spawn_blocking(move || {
+            let _fence = crate::reaper::reap_fence();
+            child.wait().expect("wait for test child")
+        })
+        .await
+        .expect("wait task must not panic");
+        assert_eq!(status.signal(), Some(Signal::SIGKILL as i32));
+    }
+
+    /// `pidfd_send_signal` delivers the signal to our incarnation. Two-side:
+    /// revert `send_signal_via_pidfd` to return `Ok(false)` and the child
+    /// survives the SIGTERM.
+    #[tokio::test]
+    async fn pidfd_signal_reaches_a_live_process() {
+        let _test_guard = crate::reaper::reap_test_guard().await;
+        let mut child = Command::new("/bin/sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn sleep");
+        let pid = Pid::from_raw(child.id() as i32);
+        let identity = ProcessInstance::capture(pid).expect("read child identity");
+        assert!(identity.has_pidfd(), "pidfd must be captured");
+
+        assert!(identity
+            .signal(Signal::SIGTERM, false)
+            .expect("signal the matching incarnation"));
+        let status = tokio::task::spawn_blocking(move || {
+            let _fence = crate::reaper::reap_fence();
+            child.wait().expect("terminated child must exit")
+        })
+        .await
+        .expect("wait task must not panic");
+        assert_eq!(status.signal(), Some(Signal::SIGTERM as i32));
+    }
+
+    /// After the process exits and is reaped, `pidfd_send_signal` returns
+    /// `ESRCH` (or `EPERM`, on some configurations — see
+    /// `send_signal_via_pidfd`) and no signal is sent. This is a
+    /// behavior-preservation smoke test, NOT a defect guard — the `/proc`
+    /// fallback also returns `Ok(false)` after exit (the PID is unallocated).
+    /// The defect guard for the TOCTOU is `pidfd_send_signal`'s kernel
+    /// contract, documented in the code.
+    #[tokio::test]
+    async fn pidfd_signal_returns_false_after_exit() {
+        let _test_guard = crate::reaper::reap_test_guard().await;
+        let mut child = Command::new("/bin/sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn sleep");
+        let pid = Pid::from_raw(child.id() as i32);
+        let identity = ProcessInstance::capture(pid).expect("read child identity");
+        assert!(identity.has_pidfd(), "pidfd must be captured");
+
+        child.kill().expect("kill test child");
+        let _ = tokio::task::spawn_blocking(move || {
+            let _fence = crate::reaper::reap_fence();
+            child.wait().expect("wait for test child")
+        })
+        .await
+        .expect("wait task must not panic");
+
+        assert!(
+            !identity
+                .signal(Signal::SIGTERM, false)
+                .expect("ESRCH/EPERM is a safe non-signal outcome"),
+            "pidfd_send_signal must return false for a reaped incarnation, \
+             not claim to have signalled"
         );
     }
 }

--- a/src/guest/src/service/exec/state.rs
+++ b/src/guest/src/service/exec/state.rs
@@ -541,7 +541,7 @@ impl ExecutionState {
         if inner.released {
             return Ok(false);
         }
-        let Some(process) = self.process else {
+        let Some(process) = self.process.as_ref() else {
             return Ok(false);
         };
         let result = process.signal(signal, process_group);
@@ -552,7 +552,10 @@ impl ExecutionState {
     pub(crate) async fn owned_process_is_current(&self) -> bool {
         self.shutdown_managed
             && !self.inner.lock().await.released
-            && self.process.is_some_and(|process| process.is_current())
+            && self
+                .process
+                .as_ref()
+                .is_some_and(|process| process.is_current())
     }
 
     /// Kill process with signal.
@@ -651,6 +654,12 @@ mod release_tests {
 
     #[tokio::test]
     async fn release_closes_handle_fds_and_aborts_forwarders_idempotently() {
+        // Serializes against child-spawning tests: this test asserts that raw
+        // fd numbers are closed (`fd_is_open(raw_fd)` checks the *number*,
+        // which a parallel test can recycle into a fresh descriptor between
+        // `release_resources` and the assertion). Without the guard the
+        // assertion is flaky under parallel fd churn.
+        let _test_guard = crate::reaper::reap_test_guard().await;
         let (state, tracked_fds, _peers) = state_with_tracked_handle();
         let retained_clone = state.clone();
         let (task_fd, task_peer) = pipe().unwrap();
@@ -716,12 +725,16 @@ mod release_tests {
             .expect("spawn sleep");
         let pid = Pid::from_raw(child.id() as i32);
         let identity = ProcessInstance::capture(pid).expect("read child identity");
-        let stale = identity.with_start_time_for_test(
-            identity
-                .start_time()
-                .checked_sub(1)
-                .expect("process start time must be nonzero"),
-        );
+        // Read the start time before moving `identity` into the test helper
+        // (`with_start_time_for_test` takes `self` by value now that
+        // `ProcessInstance` is `Clone`, not `Copy`).
+        let stale_start = identity
+            .start_time()
+            .checked_sub(1)
+            .expect("process start time must be nonzero");
+        let stale = identity
+            .with_start_time_for_test(stale_start)
+            .with_no_pidfd_for_test();
 
         assert!(!stale
             .signal(nix::sys::signal::Signal::SIGTERM, false)
@@ -865,12 +878,16 @@ mod release_tests {
         let mut child = command.spawn().expect("spawn process-group leader");
         let pid = Pid::from_raw(child.id() as i32);
         let identity = ProcessInstance::capture(pid).expect("read child identity");
-        let stale = identity.with_start_time_for_test(
-            identity
-                .start_time()
-                .checked_sub(1)
-                .expect("process start time must be nonzero"),
-        );
+        // Read the start time before moving `identity` into the test helper
+        // (`with_start_time_for_test` takes `self` by value now that
+        // `ProcessInstance` is `Clone`, not `Copy`).
+        let stale_start = identity
+            .start_time()
+            .checked_sub(1)
+            .expect("process start time must be nonzero");
+        let stale = identity
+            .with_start_time_for_test(stale_start)
+            .with_no_pidfd_for_test();
 
         assert!(!stale
             .signal(nix::sys::signal::Signal::SIGTERM, true)

--- a/src/guest/src/service/exec/timeout.rs
+++ b/src/guest/src/service/exec/timeout.rs
@@ -31,7 +31,7 @@ impl TimeoutTarget {
     }
 
     fn signal_if_live(&self, signal: Signal) -> Result<bool, Errno> {
-        match self.process {
+        match &self.process {
             Some(process) => process.signal(signal, false),
             None => Ok(false),
         }


### PR DESCRIPTION
## Summary

Closes the residual TOCTOU between PR #1185's `/proc/<pid>/stat` start-time check and the `kill(pid)` syscall — a PID can recycle between the two non-atomic syscalls — by capturing a `pidfd` at spawn and signalling via the kernel-atomic `pidfd_send_signal`.

## Call graph

Before
  spawn_execution  (GuestServer · src/guest/src/service/exec/mod.rs:413)  — captures pid + /proc start_time
    └─ ExecutionState::signal_if_current  (ExecutionState · src/guest/src/service/exec/state.rs:535)
         └─ ProcessInstance::signal  (ProcessInstance · src/guest/src/service/exec/process_instance.rs:20)  ← BUG: is_current() reads /proc, then kill(pid) — two non-atomic syscalls; PID can recycle between them
              └─ kill(pid, signal)  (nix · process_instance.rs:36)  — can land on a recycled owner

After
  spawn_execution  (GuestServer · src/guest/src/service/exec/mod.rs:413)  — captures pid + /proc start_time + pidfd
    └─ ExecutionState::signal_if_current  (ExecutionState · src/guest/src/service/exec/state.rs:535)
         └─ ProcessInstance::signal  (ProcessInstance · src/guest/src/service/exec/process_instance.rs:62)  — routes by process_group
              └─ send_signal_via_pidfd  (ProcessInstance · src/guest/src/service/exec/process_instance.rs:135)
                   └─ pidfd_send_signal(fd, signal)  (kernel)  — atomic; ESRCH/EPERM once the incarnation is gone, never reaches a recycled owner

Fixes #1184

## Changes

- `ProcessInstance` gains `Option<Arc<OwnedFd>>` pidfd; `capture` opens it at spawn via `pidfd_open` (Linux 5.3+); `Copy` → `Clone` (shared via `Arc`, one fd per incarnation).
- Single-pid signal path (`Kill` RPC, `shutdown_all`, timeout watcher, `abort_unpublished`) uses `pidfd_send_signal` (atomic); the group path uses `pidfd_send_signal(fd, 0)` as the leader probe before `getpgid` + `kill(-pgid)`.
- On `EPERM`, re-check the `/proc` start-time (`is_current()`) to distinguish a reaped incarnation (the kernel returns EPERM, not the documented ESRCH, for a reaped pidfd under the Rust runtime on 5.4) from a real permission denial (child `setuid`'d); reaped → `Ok(false)`, live → `Err(EPERM)` propagated.
- `/proc` start-time path remains the `ENOSYS` fallback on kernels without `pidfd_open` — no behavior change on old kernels.
- `Copy→Clone` ripple: `state.rs` (two `as_ref()`), `timeout.rs` (one `&self.process`), `mod.rs` (`process_for_timeout = process.clone()` before the state takes `process` by value).
- Added `reap_test_guard` to `release_closes_handle_fds_and_aborts_forwarders_idempotently` — its raw-fd-number check is racy under parallel fd churn; the new pidfd tests increased the churn and made a pre-existing flakiness deterministic.

## How to verify

- `make fmt:check:rust`
- `make clippy` (covers the `x86_64-unknown-linux-musl` cross-target)
- `make test:unit:rust`, or scoped: `cargo test -p boxlite-guest --bin boxlite-guest 'service::exec::'` (69 pass) and `'reaper::'` (19 pass)
- Manual two-side: revert `open_pidfd` → `pidfd_is_captured_for_a_live_process` fails; revert `send_signal_via_pidfd` → `Ok(false)` → `pidfd_signal_reaches_a_live_process` fails; revert `probe_via_pidfd` → `false` → `process_group_signal_reaches_a_background_descendant` fails.

## Risks / rollout

- Kernel ≥ 5.3 required for `pidfd_open`; older kernels get `ENOSYS` and fall back to PR #1185's `/proc` start-time path (no behavior change).
- The EPERM-on-reaped-pidfd quirk (observed: kernel 5.4 + Rust runtime) is handled by the `is_current()` re-check.
- Out of scope: the group path's post-`getpgid` window — `kill(-pgid)` is pgid-number-safe; the narrower "recycled PID re-setsids to the same pgid" residual is issue #1184's named "follow-up group primitive".
