### PR TITLE
feat(scripts): provision Memorystore Redis for the API on GCP

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -8,6 +8,12 @@ DB_DATABASE=application_ctx
 
 REDIS_HOST=redis
 REDIS_PORT=6379
+# Set in cloud deployments (AWS ElastiCache, GCP Memorystore). Empty means no AUTH and no TLS.
+# REDIS_PASSWORD=
+# REDIS_TLS=true
+# Memorystore signs with a private CA: the PEM bundle from secret boxlite-dev-redis-ca.
+# Not read by the API yet; see scripts/deploy/gcp/README.md.
+# REDIS_TLS_CA=
 
 OIDC_CLIENT_ID=boxlite
 OIDC_ISSUER_BASE_URL=http://localhost:5556/dex

--- a/scripts/deploy/gcp/README.md
+++ b/scripts/deploy/gcp/README.md
@@ -1,0 +1,114 @@
+# GCP deployment scripts
+
+Imperative `gcloud` helpers for the pieces of BoxLite that run on Google Cloud.
+The control plane's IaC lives in [`apps/infra`](../../../apps/infra) and targets
+AWS; these scripts cover what that stack does not.
+
+| Script | Purpose |
+| --- | --- |
+| `create-instance.sh` | GCE VM with nested virtualization for running BoxLite itself |
+| `check-nested-virt.sh` | Verify nested KVM on such a VM |
+| `enable-nested-virt.sh` | Enable nested KVM on an existing VM |
+| `setup-kvm.sh` | KVM permissions on the VM |
+| `create-memorystore-redis.sh` | Memorystore for Redis for the BoxLite API, plus Secret Manager wiring |
+
+## Redis for the API
+
+`create-memorystore-redis.sh` provisions the Redis the API expects, matching the
+AWS ElastiCache settings in `apps/infra/stack/foundation.ts`: one node, cluster
+mode off, TLS required, AUTH required, private network only, no persistence.
+Memorystore for Redis (standalone) is the only GCP product that fits: the API
+uses logical DB 1, `EVAL`, `BRPOP`, multi-key pipelines and plain pub/sub (the
+Socket.IO Redis adapter adds pattern subscriptions on top), which do not all
+work on Memorystore for Valkey or Redis Cluster.
+
+Defaults match the `dev` stage in project `avid-vine-500315-u4`: instance
+`boxlite-dev-cache`, Basic tier, 1 GiB, Redis 7.2, region `asia-southeast1`,
+attached to VPC `boxlite-backoffice-dev` through its existing Private Service
+Access range. The project itself comes from the active gcloud configuration
+unless `--project` is given. Every value is a flag; `--help` lists them.
+
+### Run
+
+```bash
+gcloud auth login
+gcloud config set project avid-vine-500315-u4
+
+./scripts/deploy/gcp/create-memorystore-redis.sh --dry-run   # print the commands
+./scripts/deploy/gcp/create-memorystore-redis.sh             # create (5-10 min)
+```
+
+The operator needs `roles/editor` (or the equivalent Memorystore, Secret Manager
+and Service Usage permissions). The script is idempotent: an existing instance
+is left alone and only a settings drift warning is printed, and a secret version
+is added only when the stored value differs.
+
+What it creates:
+
+- Memorystore instance `boxlite-dev-cache`, reachable only from the VPC on a
+  `10.120.0.0/16` address. **With TLS the port is 6378, not 6379.**
+- Secret `boxlite-dev-redis-auth`: the AUTH string. The script never prints it.
+- Secret `boxlite-dev-redis-ca`: the instance's server CA bundle (PEM). Google
+  signs the TLS certificate with a private CA, so clients must trust this.
+
+### Wire the API
+
+The API reads `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD` and `REDIS_TLS`
+(`apps/api/src/config/configuration.ts`). On Cloud Run:
+
+```bash
+--set-env-vars=REDIS_HOST=<host>,REDIS_PORT=6378,REDIS_TLS=true \
+--set-secrets=REDIS_PASSWORD=boxlite-dev-redis-auth:latest,REDIS_TLS_CA=boxlite-dev-redis-ca:latest
+```
+
+Two follow-ups are outside this script:
+
+- `REDIS_TLS=true` currently gives ioredis an empty `tls: {}`, which rejects the
+  Google private CA. The API needs a `REDIS_TLS_CA` option before it can connect
+  to a TLS Memorystore instance. Only the CA is needed: the server certificate
+  carries the instance IP as a SAN, so Node's default hostname check passes.
+- Granting the API's service account `roles/secretmanager.secretAccessor` on the
+  two secrets requires `setIamPolicy`, which `roles/editor` lacks. A project
+  owner runs the `add-iam-policy-binding` commands the script prints.
+
+### Verify from inside the VPC
+
+Nothing outside the VPC can reach the instance. A throwaway Cloud Run job on the
+same subnet exercises the exact path the API will use:
+
+```bash
+REDIS_HOST=$(gcloud redis instances describe boxlite-dev-cache --region=asia-southeast1 --format='value(host)')
+gcloud run jobs create boxlite-dev-redis-smoke --region=asia-southeast1 \
+  --image=docker.io/library/redis:7.2-alpine \
+  --network=boxlite-backoffice-dev --subnet=boxlite-backoffice-dev --vpc-egress=private-ranges-only \
+  --service-account=<sa-with-secretAccessor> \
+  --set-env-vars=REDIS_HOST=$REDIS_HOST,REDIS_PORT=6378 \
+  --set-secrets=REDISCLI_AUTH=boxlite-dev-redis-auth:latest,/etc/redis-ca/ca.pem=boxlite-dev-redis-ca:latest \
+  --max-retries=0 --task-timeout=120s \
+  --command=sh --args=-c,'R="redis-cli --tls --cacert /etc/redis-ca/ca.pem -h $REDIS_HOST -p $REDIS_PORT"; $R PING && $R -n 1 SET smoke 1 EX 30 && $R EVAL "return 1" 0'
+gcloud run jobs execute boxlite-dev-redis-smoke --region=asia-southeast1 --wait
+gcloud run jobs delete boxlite-dev-redis-smoke --region=asia-southeast1 --quiet
+```
+
+`REDISCLI_AUTH` keeps the password out of argv and logs.
+
+### Rotate the AUTH string
+
+```bash
+./scripts/deploy/gcp/create-memorystore-redis.sh --rotate-auth
+```
+
+Memorystore has no regenerate verb, so rotation disables and re-enables AUTH.
+The instance accepts unauthenticated connections for a few seconds and drops
+every client. Fine for `dev`; do not run it against a stage that serves users.
+
+### Limits
+
+- Basic tier has no replica and no persistence. Maintenance and resizes clear
+  the data. The API treats Redis as a cache, lock store and wake-up hint with
+  Postgres as the source of truth, so this matches the AWS deployment.
+- Tier, network, connect mode, reserved range and transit encryption cannot be
+  changed after creation. The script warns on drift instead of recreating.
+- Google can add a second server CA before retiring the first. Rerunning the
+  script stores the new bundle as a secret version; the API must be redeployed
+  to pick it up.

--- a/scripts/deploy/gcp/README.md
+++ b/scripts/deploy/gcp/README.md
@@ -11,6 +11,102 @@ AWS; these scripts cover what that stack does not.
 | `enable-nested-virt.sh` | Enable nested KVM on an existing VM |
 | `setup-kvm.sh` | KVM permissions on the VM |
 | `create-memorystore-redis.sh` | Memorystore for Redis for the BoxLite API, plus Secret Manager wiring |
+| `create-network.sh` | A `boxlite-<stage>` VPC with subnet, Cloud NAT, ClickHouse firewall rules and Private Service Access |
+| `create-clickhouse-host.sh` | Self-hosted ClickHouse on a GCE VM with a persistent data disk, mirroring the AWS `self-hosted` mode |
+| `clickhouse-startup.sh` | The VM's startup script; not run by hand |
+
+The three database scripts (`create-network.sh`, `create-clickhouse-host.sh`,
+`create-memorystore-redis.sh`) take `--stage` and derive `boxlite-<stage>-*`
+names from it, are idempotent, support `--dry-run`, and never print a
+password. The operator needs `roles/editor`; `create-network.sh` additionally needs
+`roles/servicenetworking.networksAdmin` for the Private Service Access peering,
+and `create-clickhouse-host.sh` needs `roles/secretmanager.admin` on the
+`boxlite-<stage>-*` secrets to grant the VM's service account read access
+(both were granted to the operator as IAM-conditioned project bindings).
+
+## The dev-db stage
+
+`dev-db` is a dedicated VPC for validating these scripts. Bring it up in order:
+
+```bash
+./scripts/deploy/gcp/create-network.sh --stage dev-db
+./scripts/deploy/gcp/create-clickhouse-host.sh --stage dev-db --smoke
+./scripts/deploy/gcp/create-memorystore-redis.sh --stage dev-db \
+  --network boxlite-dev-db --reserved-ip-range boxlite-dev-db-private-services
+```
+
+`create-network.sh` creates VPC `boxlite-dev-db` (subnet 10.40.0.0/20 with
+Private Google Access, Cloud NAT for image pulls), two ingress rules (tcp:8123
+from the subnet and tcp:22 from the IAP range, both to tag `boxlite-clickhouse`),
+and the Private Service Access range `boxlite-dev-db-private-services`
+(10.90.0.0/16) that Memorystore attaches to. Without the peering permission it
+still creates everything else and prints the one `vpc-peerings connect` command
+for someone who has it.
+
+## ClickHouse
+
+`create-clickhouse-host.sh` is the GCE port of the AWS self-hosted mode in
+`apps/infra/stack/clickhouse.ts`, `apps/infra/scripts/clickhouse-host.ts` and
+`apps/infra/scripts/clickhouse-ops.mjs`: one `e2-standard-2` Ubuntu 24.04 VM, a
+50 GB `pd-balanced` data disk that is attached with `auto-delete=no` and never
+deleted by the script, the digest-pinned `clickhouse/clickhouse-server` image in
+Docker on host networking, plaintext HTTP on 8123 inside the VPC only, and the
+same three users: `boxlite_admin`, `otel_writer`, `otel_reader`. Their passwords
+live in Secret Manager as `boxlite-<stage>-clickhouse-{admin,writer,reader}`;
+the VM's own service account `boxlite-<stage>-clickhouse@` reads them at boot,
+and only their sha256 reaches ClickHouse.
+
+The schema is `apps/infra/clickhouse/otel-schema-v0.144.0.sql`, rendered with
+the 72-hour TTL and passed to the VM as the `clickhouse-schema` metadata
+attribute, so both clouds run one schema file.
+
+There is no SSH. `clickhouse-startup.sh` runs on every boot, formats and mounts
+the data disk once, installs Docker once, rewrites its files only when they
+change, starts the service, applies the schema, grants `otel_writer` and
+`otel_reader`, sets the TTL on all seven tables, asserts the result (table
+count, grants, one probe row per table as `otel_writer`, one read as
+`otel_reader`), and reports through the guest attribute `boxlite/clickhouse`:
+
+```text
+starting:<boot-id>          the script is running
+failed:<step>               e.g. failed:secret-access when the service account cannot read a secret
+ready:<digest>:7:<boot-id>  done; the operator script waits for this
+```
+
+Guest attributes survive a reset, so the boot id is what tells a fresh `ready`
+from the previous boot's; the operator script compares against the value it saw
+before rebooting.
+
+```bash
+gcloud compute instances get-guest-attributes boxlite-dev-db-clickhouse --zone asia-southeast1-b --query-path=boxlite/clickhouse
+gcloud compute instances get-serial-port-output boxlite-dev-db-clickhouse --zone asia-southeast1-b | tail -n 80
+```
+
+Routine operations:
+
+- `--reboot-vm` refreshes the startup script, schema, image reference and
+  retention on the instance metadata and resets the VM. Use it after editing
+  `clickhouse-startup.sh`, bumping the image digest, or rotating a password
+  (add a secret version first). This is the GCE equivalent of the AWS
+  `userDataReplaceOnChange`.
+- `--recreate-vm` deletes and recreates the VM for immutable changes (machine
+  type, service account, subnet). The data disk stays and is reattached.
+- `--smoke` runs a one-off Cloud Run job on the same subnet, as the VM's
+  service account, that inserts a marker row as `otel_writer`, reads it back as
+  `otel_reader`, and checks that `otel_reader` cannot insert and that a wrong
+  password is refused. Passwords reach the job through `--set-secrets`.
+
+Wiring, once a collector and API run in this VPC:
+
+```text
+otel-collector: CLICKHOUSE_ENDPOINT=http://<vm ip>:8123  CLICKHOUSE_USERNAME=otel_writer  CLICKHOUSE_PASSWORD=<boxlite-<stage>-clickhouse-writer>
+API:            CLICKHOUSE_URL=http://<vm ip>:8123       CLICKHOUSE_USERNAME=otel_reader  CLICKHOUSE_PASSWORD=<boxlite-<stage>-clickhouse-reader>
+```
+
+Limits: a single VM with no replica; a disk failure loses at most 72 hours of
+telemetry, which is what the AWS host accepts too. Port 9000 is bound on the
+host and only the firewall keeps it closed. The image is pinned by digest, so a
+security update is a deliberate digest bump plus `--reboot-vm`.
 
 ## Redis for the API
 
@@ -25,8 +121,11 @@ work on Memorystore for Valkey or Redis Cluster.
 Defaults match the `dev` stage in project `avid-vine-500315-u4`: instance
 `boxlite-dev-cache`, Basic tier, 1 GiB, Redis 7.2, region `asia-southeast1`,
 attached to VPC `boxlite-backoffice-dev` through its existing Private Service
-Access range. The project itself comes from the active gcloud configuration
-unless `--project` is given. Every value is a flag; `--help` lists them.
+Access range. `--stage` renames the instance, secrets, labels and display name
+to `boxlite-<stage>-*`; the network and reserved range stay explicit flags
+because the `dev` network does not follow that pattern. The project itself
+comes from the active gcloud configuration unless `--project` is given. Every
+value is a flag; `--help` lists them.
 
 ### Run
 

--- a/scripts/deploy/gcp/clickhouse-startup.sh
+++ b/scripts/deploy/gcp/clickhouse-startup.sh
@@ -1,0 +1,306 @@
+#!/bin/bash
+# GCE startup script for the BoxLite ClickHouse host. The GCP counterpart of
+# apps/infra/scripts/clickhouse-host.ts (EC2 user-data) plus the reconcile half
+# of apps/infra/scripts/clickhouse-ops.mjs, folded into one file because the
+# operator cannot SSH into the VM.
+#
+# GCE runs this on EVERY boot, so every step is idempotent: packages install
+# once, the data disk is formatted once, files are rewritten only when their
+# content changes, and the schema/grants/TTL statements are no-ops when the
+# database already matches.
+#
+# Parameters come from instance metadata attributes (set by
+# create-clickhouse-host.sh): clickhouse-image, clickhouse-retention-hours,
+# clickhouse-data-device, clickhouse-secret-admin, clickhouse-secret-writer,
+# clickhouse-secret-reader, clickhouse-schema (rendered SQL).
+#
+# Progress is reported to the guest attribute boxlite/clickhouse:
+#   starting:<boot-id>  failed:<step>  ready:<image digest>:<table count>:<boot-id>
+# Passwords are fetched from Secret Manager with the VM's service account and
+# never written to disk; only their sha256 reaches ClickHouse.
+
+set -Eeuo pipefail
+exec > >(tee -a /var/log/boxlite-clickhouse-setup.log) 2>&1
+
+MD="http://metadata.google.internal/computeMetadata/v1"
+md() { curl -sf -H 'Metadata-Flavor: Google' "$MD/$1"; }
+attr() { md "instance/attributes/$1"; }
+report() {
+    curl -sf -X PUT --data "$1" -H 'Metadata-Flavor: Google' \
+        "$MD/instance/guest-attributes/boxlite/clickhouse" >/dev/null 2>&1 || true
+}
+
+STEP=init
+on_error() {
+    report "failed:$STEP"
+    echo "FATAL: step $STEP failed" >&2
+}
+trap on_error ERR
+# The boot id makes every boot's `ready` value distinct, so an operator
+# waiting across a reset can tell a fresh report from the previous boot's.
+BOOT_ID="$(cut -c1-8 /proc/sys/kernel/random/boot_id)"
+report "starting:$BOOT_ID"
+
+TABLES=(otel_logs otel_traces otel_metrics_gauge otel_metrics_sum otel_metrics_summary otel_metrics_histogram otel_metrics_exponential_histogram)
+
+# ---------------------------------------------------------------------------
+STEP=metadata
+IMAGE="$(attr clickhouse-image)"
+RETENTION_HOURS="$(attr clickhouse-retention-hours)"
+DATA_DEVICE="$(attr clickhouse-data-device)"
+ADMIN_SECRET="$(attr clickhouse-secret-admin)"
+WRITER_SECRET="$(attr clickhouse-secret-writer)"
+READER_SECRET="$(attr clickhouse-secret-reader)"
+# One check per attribute: a failing test inside an && chain does not stop a
+# set -e script, so each one fails on its own.
+for name in IMAGE DATA_DEVICE ADMIN_SECRET WRITER_SECRET READER_SECRET; do
+    [ -n "${!name}" ] || { echo "FATAL: metadata attribute for $name is empty" >&2; false; }
+done
+[[ "$RETENTION_HOURS" =~ ^[0-9]+$ ]] || { echo "FATAL: clickhouse-retention-hours is not an integer: '$RETENTION_HOURS'" >&2; false; }
+install -d -m 0750 /opt/boxlite-clickhouse
+attr clickhouse-schema > /opt/boxlite-clickhouse/schema.sql.new
+grep -q 'CREATE TABLE' /opt/boxlite-clickhouse/schema.sql.new
+echo "image=$IMAGE retention=${RETENTION_HOURS}h device=$DATA_DEVICE"
+
+# ---------------------------------------------------------------------------
+STEP=packages
+if ! command -v docker >/dev/null 2>&1 || ! command -v python3 >/dev/null 2>&1; then
+    while fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do sleep 5; done
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io curl python3
+fi
+systemctl enable --now docker
+
+# ---------------------------------------------------------------------------
+STEP=disk
+DEVICE="/dev/disk/by-id/google-${DATA_DEVICE}"
+for _ in $(seq 1 120); do
+    [ -b "$DEVICE" ] && break
+    sleep 5
+done
+[ -b "$DEVICE" ] || { echo "FATAL: data disk $DEVICE is not attached" >&2; false; }
+if ! blkid "$DEVICE" >/dev/null 2>&1; then
+    mkfs.ext4 -F "$DEVICE"
+fi
+DATA_UUID="$(blkid -s UUID -o value "$DEVICE")"
+install -d -m 0750 /var/lib/boxlite-clickhouse
+if ! grep -q "UUID=${DATA_UUID}" /etc/fstab; then
+    printf 'UUID=%s /var/lib/boxlite-clickhouse ext4 defaults 0 2\n' "$DATA_UUID" >> /etc/fstab
+fi
+mountpoint -q /var/lib/boxlite-clickhouse || mount /var/lib/boxlite-clickhouse
+install -d -m 0750 /var/lib/boxlite-clickhouse/data
+
+# ---------------------------------------------------------------------------
+# Files are rewritten only when their content changes, so a warm boot does
+# not restart ClickHouse for nothing.
+CHANGED=0
+put_file() {
+    local path="$1" mode="$2" tmp
+    tmp="$(mktemp "${path}.XXXXXX")"
+    cat > "$tmp"
+    chmod "$mode" "$tmp"
+    if [ -f "$path" ] && cmp -s "$tmp" "$path"; then
+        rm -f "$tmp"
+    else
+        mv -f "$tmp" "$path"
+        CHANGED=1
+    fi
+}
+
+STEP=secret-access
+# Replaces the AWS `aws secretsmanager get-secret-value` helper. Exit codes
+# tell the boot log apart: 43 = no permission, 44 = no such secret/version.
+put_file /usr/local/bin/boxlite-clickhouse-secret 0700 <<'SCRIPT'
+#!/bin/bash
+# Print the latest version of Secret Manager secret $1 using the VM's service account.
+set -euo pipefail
+umask 077
+MD="http://metadata.google.internal/computeMetadata/v1"
+PROJECT="$(curl -sf -H 'Metadata-Flavor: Google' "$MD/project/project-id")"
+TOKEN="$(curl -sf -H 'Metadata-Flavor: Google' "$MD/instance/service-accounts/default/token" \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["access_token"])')"
+BODY="$(mktemp /run/boxlite-clickhouse-secret.XXXXXX)"
+trap 'rm -f "$BODY"' EXIT
+CODE="$(curl -s -o "$BODY" -w '%{http_code}' -H "Authorization: Bearer $TOKEN" \
+    "https://secretmanager.googleapis.com/v1/projects/$PROJECT/secrets/$1/versions/latest:access")"
+case "$CODE" in
+    200) ;;
+    403) echo "secret $1: HTTP 403, the VM service account lacks roles/secretmanager.secretAccessor" >&2; exit 43 ;;
+    404) echo "secret $1: HTTP 404, secret or enabled version missing" >&2; exit 44 ;;
+    *)   echo "secret $1: HTTP $CODE" >&2; exit 45 ;;
+esac
+python3 -c 'import sys,json,base64; sys.stdout.write(base64.b64decode(json.load(sys.stdin)["payload"]["data"]).decode())' < "$BODY"
+SCRIPT
+# Fail closed before writing any unit: probe the admin secret once so the
+# guest attribute names the exact problem.
+if /usr/local/bin/boxlite-clickhouse-secret "$ADMIN_SECRET" >/dev/null; then
+    probe_rc=0
+else
+    probe_rc=$?
+fi
+case "$probe_rc" in
+    0) ;;
+    44) STEP=secret-missing; false ;;
+    *) STEP=secret-access; false ;;
+esac
+
+# ---------------------------------------------------------------------------
+STEP=files
+put_file /etc/boxlite-clickhouse.conf 0600 <<ENV
+ADMIN_SECRET=${ADMIN_SECRET}
+WRITER_SECRET=${WRITER_SECRET}
+READER_SECRET=${READER_SECRET}
+CLICKHOUSE_IMAGE=${IMAGE}
+ENV
+
+# Runs as ExecStartPre on every service start, so a rotated admin secret only
+# needs a restart. The XML lives on tmpfs and holds hashes, not passwords.
+put_file /usr/local/bin/boxlite-clickhouse-credentials 0700 <<'SCRIPT'
+#!/bin/bash
+set -euo pipefail
+umask 077
+source /etc/boxlite-clickhouse.conf
+ADMIN_PASSWORD="$(/usr/local/bin/boxlite-clickhouse-secret "$ADMIN_SECRET")"
+ADMIN_HASH="$(printf %s "$ADMIN_PASSWORD" | sha256sum | awk '{print $1}')"
+unset ADMIN_PASSWORD
+cat > /run/boxlite-clickhouse-users.xml <<XML
+<clickhouse><users>
+  <default replace="replace"><password_sha256_hex>$ADMIN_HASH</password_sha256_hex><networks><ip>127.0.0.1</ip><ip>::1</ip></networks></default>
+  <boxlite_admin><password_sha256_hex>$ADMIN_HASH</password_sha256_hex><networks><ip>::/0</ip></networks><access_management>1</access_management></boxlite_admin>
+</users></clickhouse>
+XML
+chown 101:101 /run/boxlite-clickhouse-users.xml
+chmod 0400 /run/boxlite-clickhouse-users.xml
+SCRIPT
+
+put_file /usr/local/bin/boxlite-clickhouse-sql-users 0700 <<'SCRIPT'
+#!/bin/bash
+set -euo pipefail
+source /etc/boxlite-clickhouse.conf
+secret() { /usr/local/bin/boxlite-clickhouse-secret "$1"; }
+ADMIN_PASSWORD="$(secret "$ADMIN_SECRET")"
+WRITER_HASH="$(printf %s "$(secret "$WRITER_SECRET")" | sha256sum | awk '{print $1}')"
+READER_HASH="$(printf %s "$(secret "$READER_SECRET")" | sha256sum | awk '{print $1}')"
+for _ in $(seq 1 120); do
+    CLICKHOUSE_PASSWORD="$ADMIN_PASSWORD" docker exec -e CLICKHOUSE_PASSWORD boxlite-clickhouse \
+        clickhouse-client --user boxlite_admin --query 'SELECT 1' >/dev/null 2>&1 && break
+    sleep 5
+done
+CLICKHOUSE_PASSWORD="$ADMIN_PASSWORD" docker exec -e CLICKHOUSE_PASSWORD boxlite-clickhouse \
+    clickhouse-client --user boxlite_admin --query 'SELECT 1' >/dev/null
+CLICKHOUSE_PASSWORD="$ADMIN_PASSWORD" docker exec -i -e CLICKHOUSE_PASSWORD boxlite-clickhouse \
+    clickhouse-client --user boxlite_admin --multiquery <<SQL
+CREATE USER IF NOT EXISTS otel_writer IDENTIFIED WITH sha256_hash BY '$WRITER_HASH';
+ALTER USER otel_writer IDENTIFIED WITH sha256_hash BY '$WRITER_HASH';
+CREATE USER IF NOT EXISTS otel_reader IDENTIFIED WITH sha256_hash BY '$READER_HASH';
+ALTER USER otel_reader IDENTIFIED WITH sha256_hash BY '$READER_HASH';
+SQL
+unset ADMIN_PASSWORD WRITER_HASH READER_HASH
+SCRIPT
+
+put_file /etc/systemd/system/boxlite-clickhouse.service 0644 <<'UNIT'
+[Unit]
+Description=BoxLite ClickHouse
+After=docker.service network-online.target var-lib-boxlite\x2dclickhouse.mount
+Requires=docker.service
+RequiresMountsFor=/var/lib/boxlite-clickhouse
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/boxlite-clickhouse.conf
+ExecStartPre=/usr/local/bin/boxlite-clickhouse-credentials
+ExecStartPre=-/usr/bin/docker rm -f boxlite-clickhouse
+ExecStartPre=/usr/bin/docker pull $CLICKHOUSE_IMAGE
+ExecStart=/usr/bin/docker run --rm --name boxlite-clickhouse --network host --ulimit nofile=262144:262144 -v /var/lib/boxlite-clickhouse/data:/var/lib/clickhouse -v /run/boxlite-clickhouse-users.xml:/etc/clickhouse-server/users.d/boxlite-users.xml:ro $CLICKHOUSE_IMAGE
+ExecStop=/usr/bin/docker stop -t 60 boxlite-clickhouse
+Restart=always
+RestartSec=5
+TimeoutStartSec=0
+TimeoutStopSec=75
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+# ---------------------------------------------------------------------------
+STEP=service
+systemctl daemon-reload
+systemctl enable boxlite-clickhouse >/dev/null 2>&1 || true
+running_image="$(docker inspect --format '{{.Config.Image}}' boxlite-clickhouse 2>/dev/null || true)"
+if [ "$CHANGED" = 1 ] || [ "$running_image" != "$IMAGE" ]; then
+    systemctl restart boxlite-clickhouse
+else
+    systemctl start boxlite-clickhouse
+fi
+systemctl is-active --quiet boxlite-clickhouse
+
+# ---------------------------------------------------------------------------
+STEP=image
+# The pull happens inside ExecStartPre, so the container can take a while to
+# appear on a cold boot.
+for _ in $(seq 1 120); do
+    running_image="$(docker inspect --format '{{.Config.Image}}' boxlite-clickhouse 2>/dev/null || true)"
+    [ "$running_image" = "$IMAGE" ] && break
+    sleep 5
+done
+[ "$running_image" = "$IMAGE" ] || { echo "FATAL: running image '$running_image' is not '$IMAGE'" >&2; false; }
+
+# ---------------------------------------------------------------------------
+STEP=sql-users
+/usr/local/bin/boxlite-clickhouse-sql-users
+
+# ---------------------------------------------------------------------------
+# Everything below mirrors buildSelfHostedReadinessCommand in
+# apps/infra/scripts/clickhouse-ops.mjs.
+ch() {
+    # ch <user> <password> <clickhouse-client args...>; stdin passes through.
+    local user="$1" password="$2"
+    shift 2
+    CLICKHOUSE_PASSWORD="$password" docker exec -i -e CLICKHOUSE_PASSWORD boxlite-clickhouse \
+        clickhouse-client --user "$user" "$@"
+}
+ADMIN_PASSWORD="$(/usr/local/bin/boxlite-clickhouse-secret "$ADMIN_SECRET")"
+
+STEP=schema
+mv -f /opt/boxlite-clickhouse/schema.sql.new /opt/boxlite-clickhouse/schema.sql
+ch boxlite_admin "$ADMIN_PASSWORD" --multiquery < /opt/boxlite-clickhouse/schema.sql
+
+STEP=grants-ttl
+ttl_column() {
+    case "$1" in
+        otel_logs) echo TimestampTime ;;
+        otel_traces) echo Timestamp ;;
+        *) echo TimeUnix ;;
+    esac
+}
+{
+    echo "GRANT SELECT, INSERT, SHOW COLUMNS ON otel.* TO otel_writer;"
+    echo "GRANT SELECT, SHOW COLUMNS ON otel.* TO otel_reader;"
+    for table in "${TABLES[@]}"; do
+        echo "ALTER TABLE otel.${table} MODIFY TTL toDateTime($(ttl_column "$table")) + INTERVAL ${RETENTION_HOURS} HOUR;"
+    done
+} | ch boxlite_admin "$ADMIN_PASSWORD" --multiquery
+
+STEP=assert
+for table in "${TABLES[@]}"; do
+    ch boxlite_admin "$ADMIN_PASSWORD" --query "DESCRIBE TABLE otel.${table}" >/dev/null
+done
+table_count="$(ch boxlite_admin "$ADMIN_PASSWORD" --query \
+    "SELECT count() FROM system.tables WHERE database = 'otel' AND position(create_table_query, 'toIntervalHour(${RETENTION_HOURS})') > 0")"
+[ "$table_count" = "${#TABLES[@]}" ] || { echo "FATAL: $table_count of ${#TABLES[@]} tables carry the ${RETENTION_HOURS}h TTL" >&2; false; }
+ch boxlite_admin "$ADMIN_PASSWORD" --query "SHOW GRANTS FOR otel_writer" | grep -q 'SHOW COLUMNS'
+ch boxlite_admin "$ADMIN_PASSWORD" --query "SHOW GRANTS FOR otel_reader" | grep -q 'SELECT'
+WRITER_PASSWORD="$(/usr/local/bin/boxlite-clickhouse-secret "$WRITER_SECRET")"
+READER_PASSWORD="$(/usr/local/bin/boxlite-clickhouse-secret "$READER_SECRET")"
+for table in "${TABLES[@]}"; do
+    column=Timestamp
+    case "$table" in otel_logs|otel_traces) ;; *) column=TimeUnix ;; esac
+    ch otel_writer "$WRITER_PASSWORD" --query "INSERT INTO otel.${table} (${column}) VALUES (now64(9))"
+done
+ch otel_reader "$READER_PASSWORD" --query "SELECT count() FROM otel.otel_logs" >/dev/null
+unset ADMIN_PASSWORD WRITER_PASSWORD READER_PASSWORD
+
+# ---------------------------------------------------------------------------
+STEP=done
+report "ready:${IMAGE#*@}:${#TABLES[@]}:$BOOT_ID"
+echo "ClickHouse is ready: $IMAGE, ${#TABLES[@]} tables, ${RETENTION_HOURS}h TTL"

--- a/scripts/deploy/gcp/create-clickhouse-host.sh
+++ b/scripts/deploy/gcp/create-clickhouse-host.sh
@@ -1,0 +1,653 @@
+#!/bin/bash
+# Provision the self-hosted ClickHouse the BoxLite observability pipeline
+# writes to, on a GCE VM with a persistent data disk. The GCP counterpart of
+# the self-hosted mode in apps/infra/stack/clickhouse.ts: one VM, one 50 GB
+# data disk that outlives the VM, digest-pinned clickhouse-server in Docker,
+# plaintext HTTP on 8123 inside the VPC only, three passwords in Secret
+# Manager read by the VM's own service account.
+#
+# The VM configures itself from scripts/deploy/gcp/clickhouse-startup.sh on
+# every boot and reports through a guest attribute, so nothing here needs SSH.
+#
+# Usage:
+#   ./create-clickhouse-host.sh
+#   ./create-clickhouse-host.sh --stage dev-db --dry-run
+#   ./create-clickhouse-host.sh --reboot-vm      # push a new startup script / schema / image
+#   ./create-clickhouse-host.sh --smoke          # write/read through HTTP from a Cloud Run job
+
+set -euo pipefail
+
+GCP_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$GCP_SCRIPT_DIR/../../common.sh"
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+DEFAULT_STAGE="dev-db"
+DEFAULT_REGION="asia-southeast1"
+DEFAULT_ZONE="asia-southeast1-b"
+DEFAULT_MACHINE_TYPE="e2-standard-2"
+DEFAULT_IMAGE_FAMILY="ubuntu-2404-lts-amd64"
+DEFAULT_IMAGE_PROJECT="ubuntu-os-cloud"
+DEFAULT_BOOT_GB="20"
+DEFAULT_DATA_GB="50"
+DEFAULT_DATA_DISK_TYPE="pd-balanced"
+DEFAULT_RETENTION_HOURS="72"
+DEFAULT_WAIT_TIMEOUT="900"
+# Same digest as apps/infra/scripts/clickhouse-host.ts so both clouds run the
+# same server build.
+DEFAULT_CLICKHOUSE_IMAGE="clickhouse/clickhouse-server@sha256:c67cd26ea87301f3115e5fa7822905bcbb89cbd81e52bdd1ab7a938d1d5b77d8"
+SCHEMA_FILE="$GCP_SCRIPT_DIR/../../../apps/infra/clickhouse/otel-schema-v0.144.0.sql"
+STARTUP_FILE="$GCP_SCRIPT_DIR/clickhouse-startup.sh"
+DATA_DEVICE="clickhouse-data"
+CLICKHOUSE_TAG="boxlite-clickhouse"
+SMOKE_IMAGE="docker.io/curlimages/curl:8.22.0"
+
+PROJECT=""
+STAGE="$DEFAULT_STAGE"
+REGION="$DEFAULT_REGION"
+ZONE="$DEFAULT_ZONE"
+NETWORK=""
+SUBNET=""
+MACHINE_TYPE="$DEFAULT_MACHINE_TYPE"
+CLICKHOUSE_IMAGE="$DEFAULT_CLICKHOUSE_IMAGE"
+RETENTION_HOURS="$DEFAULT_RETENTION_HOURS"
+WAIT_TIMEOUT="$DEFAULT_WAIT_TIMEOUT"
+RECREATE_VM=false
+REBOOT_VM=false
+SMOKE=false
+SKIP_WAIT=false
+DRY_RUN=false
+
+# Derived in validate_args.
+NAME=""
+DISK=""
+SA_ID=""
+SA_EMAIL=""
+ADMIN_SECRET=""
+WRITER_SECRET=""
+READER_SECRET=""
+LABELS=""
+SCHEMA_TMP=""
+
+# Filled in by later steps.
+VM_IP=""
+BINDING_PENDING=false
+# Guest attribute value before a reboot/recreate. Guest attributes survive a
+# reset, so the wait must see the value change before trusting a `ready`.
+PREVIOUS_STATUS=""
+
+# ============================================================================
+# Functions
+# ============================================================================
+
+usage() {
+    cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Create the boxlite-<stage>-clickhouse VM, its persistent data disk, its
+service account, and the three ClickHouse passwords in Secret Manager. The VM
+builds the otel schema and users itself on boot and reports readiness through
+a guest attribute. Safe to re-run: existing resources are kept, passwords are
+never regenerated, and the data disk is never deleted.
+
+OPTIONS:
+    --project PROJECT        GCP project ID (default: gcloud config)
+    --region REGION          Region (default: $DEFAULT_REGION)
+    --zone ZONE              Zone (default: $DEFAULT_ZONE)
+    --stage STAGE            Stage; resources are boxlite-<stage>-* (default: $DEFAULT_STAGE)
+    --network NETWORK        VPC network (default: boxlite-<stage>)
+    --subnet SUBNET          Subnet (default: boxlite-<stage>)
+    --machine-type TYPE      Machine type (default: $DEFAULT_MACHINE_TYPE)
+    --image REF              clickhouse-server image reference (default: digest-pinned, see script)
+    --retention-hours HOURS  TTL applied to every otel table (default: $DEFAULT_RETENTION_HOURS)
+    --reboot-vm              Refresh metadata (startup script, schema, image) and reset the VM
+    --recreate-vm            Delete and recreate the VM, keeping the data disk
+    --smoke                  Run the HTTP write/read check from a Cloud Run job
+    --skip-wait              Do not wait for the ready guest attribute
+    --wait-timeout SECONDS   How long to wait for readiness (default: $DEFAULT_WAIT_TIMEOUT)
+    --dry-run                Print the mutating commands instead of running them
+    --help                   Show this help message
+
+EXAMPLES:
+    $(basename "$0")
+    $(basename "$0") --stage dev-db --dry-run
+    $(basename "$0") --reboot-vm --smoke
+
+EOF
+    exit 0
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --project)
+                PROJECT="$2"
+                shift 2
+                ;;
+            --region)
+                REGION="$2"
+                shift 2
+                ;;
+            --zone)
+                ZONE="$2"
+                shift 2
+                ;;
+            --stage)
+                STAGE="$2"
+                shift 2
+                ;;
+            --network)
+                NETWORK="$2"
+                shift 2
+                ;;
+            --subnet)
+                SUBNET="$2"
+                shift 2
+                ;;
+            --machine-type)
+                MACHINE_TYPE="$2"
+                shift 2
+                ;;
+            --image)
+                CLICKHOUSE_IMAGE="$2"
+                shift 2
+                ;;
+            --retention-hours)
+                RETENTION_HOURS="$2"
+                shift 2
+                ;;
+            --reboot-vm)
+                REBOOT_VM=true
+                shift
+                ;;
+            --recreate-vm)
+                RECREATE_VM=true
+                shift
+                ;;
+            --smoke)
+                SMOKE=true
+                shift
+                ;;
+            --skip-wait)
+                SKIP_WAIT=true
+                shift
+                ;;
+            --wait-timeout)
+                WAIT_TIMEOUT="$2"
+                shift 2
+                ;;
+            --dry-run)
+                DRY_RUN=true
+                shift
+                ;;
+            --help|-h)
+                usage
+                ;;
+            *)
+                print_error "Unknown option: $1"
+                usage
+                ;;
+        esac
+    done
+}
+
+validate_args() {
+    if [ -z "$PROJECT" ]; then
+        PROJECT="$(gcloud config get-value project 2>/dev/null || true)"
+    fi
+    if [ -z "$PROJECT" ]; then
+        print_error "No GCP project: pass --project or run 'gcloud config set project'"
+        exit 1
+    fi
+    if ! [[ "$STAGE" =~ ^[a-z][a-z0-9-]{0,20}$ ]]; then
+        print_error "--stage must be lowercase letters, digits and hyphens, got: $STAGE"
+        exit 1
+    fi
+    if ! [[ "$RETENTION_HOURS" =~ ^[0-9]+$ ]] || ! [[ "$WAIT_TIMEOUT" =~ ^[0-9]+$ ]]; then
+        print_error "--retention-hours and --wait-timeout must be integers"
+        exit 1
+    fi
+    if [ "$RECREATE_VM" = true ] && [ "$REBOOT_VM" = true ]; then
+        print_error "--recreate-vm and --reboot-vm are mutually exclusive"
+        exit 1
+    fi
+    if [ ! -f "$SCHEMA_FILE" ] || ! grep -q '__RETENTION_HOURS__' "$SCHEMA_FILE"; then
+        print_error "Schema template not found or missing __RETENTION_HOURS__: $SCHEMA_FILE"
+        exit 1
+    fi
+    if [ ! -f "$STARTUP_FILE" ] || ! bash -n "$STARTUP_FILE"; then
+        print_error "Startup script missing or not valid bash: $STARTUP_FILE"
+        exit 1
+    fi
+    NETWORK="${NETWORK:-boxlite-$STAGE}"
+    SUBNET="${SUBNET:-boxlite-$STAGE}"
+    NAME="boxlite-$STAGE-clickhouse"
+    DISK="$NAME-data"
+    SA_ID="boxlite-$STAGE-clickhouse"
+    SA_EMAIL="$SA_ID@$PROJECT.iam.gserviceaccount.com"
+    ADMIN_SECRET="boxlite-$STAGE-clickhouse-admin"
+    WRITER_SECRET="boxlite-$STAGE-clickhouse-writer"
+    READER_SECRET="boxlite-$STAGE-clickhouse-reader"
+    LABELS="app=boxlite,env=$STAGE,component=clickhouse,managed-by=create-clickhouse-host"
+}
+
+# Run a mutating gcloud command, or print it under --dry-run. Arguments are
+# passed through as an array so nothing is re-parsed by the shell.
+run() {
+    print_info "Running: $*"
+    if [ "$DRY_RUN" = true ]; then
+        return 0
+    fi
+    "$@"
+}
+
+warn_if_differs() {
+    local field="$1" expected="$2" actual="$3"
+    # A describe can transiently return nothing; that is not drift.
+    if [ -z "$actual" ]; then
+        print_warning "$field could not be read; rerun to check it against '$expected'"
+        return 0
+    fi
+    if [ "$actual" != "$expected" ]; then
+        print_warning "$field is '$actual' but this script expects '$expected'"
+    fi
+}
+
+vm_describe() {
+    gcloud compute instances describe "$NAME" --project="$PROJECT" --zone="$ZONE" --format="value($1)" 2>/dev/null
+}
+
+vm_exists() {
+    gcloud compute instances describe "$NAME" --project="$PROJECT" --zone="$ZONE" >/dev/null 2>&1
+}
+
+vm_status() {
+    gcloud compute instances get-guest-attributes "$NAME" --project="$PROJECT" --zone="$ZONE" \
+        --query-path=boxlite/clickhouse --format='value(value)' 2>/dev/null || true
+}
+
+secret_exists() {
+    gcloud secrets describe "$1" --project="$PROJECT" >/dev/null 2>&1
+}
+
+secret_latest_version() {
+    gcloud secrets versions list "$1" --project="$PROJECT" \
+        --filter="state=ENABLED" --sort-by="~createTime" --limit=1 \
+        --format="value(name)" 2>/dev/null || true
+}
+
+# Ensure a secret exists and holds $value as its latest version. The value
+# never touches argv or the log: it goes to gcloud on stdin, and the existing
+# version is compared in memory only. Prints nothing about the value itself.
+ensure_secret_value() {
+    local secret="$1" value="$2" current=""
+
+    if ! secret_exists "$secret"; then
+        run gcloud secrets create "$secret" --project="$PROJECT" \
+            --replication-policy=automatic --labels="$LABELS"
+    fi
+    if [ "$DRY_RUN" = true ]; then
+        print_info "Would add a version to $secret if the stored value differs"
+        return 0
+    fi
+
+    current="$(gcloud secrets versions access latest --secret="$secret" --project="$PROJECT" 2>/dev/null || true)"
+    if [ "$current" = "$value" ]; then
+        print_info "Secret $secret already holds the current value; no new version"
+        return 0
+    fi
+    # printf, not echo: echo would append a newline to the stored value.
+    printf '%s' "$value" | gcloud secrets versions add "$secret" --project="$PROJECT" --data-file=- >/dev/null
+    print_success "Added a new version to $secret"
+}
+
+# Grant the VM service account read access to one secret. Adding an existing
+# binding is a no-op. A permission error is reported, not fatal: the VM fails
+# closed until the binding exists, and the summary prints the command.
+bind_secret_accessor() {
+    local secret="$1" attempt stderr_file
+    if [ "$DRY_RUN" = true ]; then
+        print_info "Would bind roles/secretmanager.secretAccessor on $secret to $SA_EMAIL"
+        return 0
+    fi
+    stderr_file="$(mktemp)"
+    # A service account created seconds ago may not be visible to IAM yet.
+    for attempt in 1 2 3 4 5 6; do
+        if gcloud secrets add-iam-policy-binding "$secret" --project="$PROJECT" \
+            --member="serviceAccount:$SA_EMAIL" --role=roles/secretmanager.secretAccessor \
+            --condition=None >/dev/null 2>"$stderr_file"; then
+            rm -f "$stderr_file"
+            print_success "$SA_EMAIL can read $secret"
+            return 0
+        fi
+        if grep -qiE 'PERMISSION_DENIED|permission' "$stderr_file"; then
+            break
+        fi
+        sleep 5
+    done
+    if grep -qiE 'PERMISSION_DENIED|permission' "$stderr_file"; then
+        print_warning "Cannot bind secretAccessor on $secret (needs setIamPolicy on it); the VM will fail closed until someone does"
+    else
+        print_warning "Binding secretAccessor on $secret failed: $(head -c 300 "$stderr_file")"
+    fi
+    rm -f "$stderr_file"
+    BINDING_PENDING=true
+}
+
+step_enable_apis() {
+    print_header "Enabling APIs"
+    local apis=(compute.googleapis.com secretmanager.googleapis.com iam.googleapis.com)
+    if [ "$SMOKE" = true ]; then
+        apis+=(run.googleapis.com)
+    fi
+    run gcloud services enable "${apis[@]}" --project="$PROJECT"
+}
+
+step_preflight() {
+    print_header "Checking network $NETWORK / subnet $SUBNET"
+    if ! gcloud compute networks describe "$NETWORK" --project="$PROJECT" >/dev/null 2>&1; then
+        print_error "VPC network '$NETWORK' not found; run create-network.sh --stage $STAGE first"
+        exit 1
+    fi
+    if ! gcloud compute networks subnets describe "$SUBNET" --project="$PROJECT" --region="$REGION" >/dev/null 2>&1; then
+        print_error "Subnet '$SUBNET' not found in $REGION; run create-network.sh --stage $STAGE first"
+        exit 1
+    fi
+    print_success "Network and subnet exist"
+    # The server-side filter rejects direction combined with targetTags, so
+    # only the network is filtered remotely and the rest is matched here.
+    local rules
+    rules="$(gcloud compute firewall-rules list --project="$PROJECT" \
+        --filter="network:$NETWORK" \
+        --format='value(name,direction,targetTags.list(),allowed[].map().firewall_rule().list())' 2>/dev/null \
+        | awk -v tag="$CLICKHOUSE_TAG" '$2 == "INGRESS" && index($3, tag) && index($4, "tcp:8123") {print $1}' || true)"
+    if [ -z "$rules" ]; then
+        print_warning "No ingress rule on $NETWORK allows tcp:8123 to tag $CLICKHOUSE_TAG; clients will not reach the VM"
+    else
+        print_success "Firewall allows 8123 to tag $CLICKHOUSE_TAG: $rules"
+    fi
+}
+
+step_service_account() {
+    print_header "Creating service account $SA_ID"
+    if gcloud iam service-accounts describe "$SA_EMAIL" --project="$PROJECT" >/dev/null 2>&1; then
+        print_info "Service account $SA_EMAIL already exists"
+        return 0
+    fi
+    run gcloud iam service-accounts create "$SA_ID" --project="$PROJECT" \
+        --display-name="BoxLite $STAGE ClickHouse VM" \
+        --description="Reads the ClickHouse passwords from Secret Manager at boot"
+}
+
+step_secrets() {
+    print_header "Storing the ClickHouse passwords in Secret Manager"
+    local secret password
+    for secret in "$ADMIN_SECRET" "$WRITER_SECRET" "$READER_SECRET"; do
+        if secret_exists "$secret" && [ -n "$(secret_latest_version "$secret")" ]; then
+            print_info "Secret $secret already has a version; keeping it"
+        else
+            # 32 alphanumeric characters, like the AWS RandomPassword. The value
+            # exists only in this variable until ensure_secret_value ships it on
+            # stdin. `|| true` absorbs the SIGPIPE tr receives when head stops
+            # reading, which pipefail would otherwise turn into a silent exit.
+            password="$(LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 32 || true)"
+            if [ "${#password}" -ne 32 ]; then
+                print_error "Password generation produced ${#password} characters"
+                exit 1
+            fi
+            ensure_secret_value "$secret" "$password"
+            unset password
+        fi
+        bind_secret_accessor "$secret"
+    done
+}
+
+step_data_disk() {
+    print_header "Creating data disk $DISK"
+    local existing
+    existing="$(gcloud compute disks describe "$DISK" --project="$PROJECT" --zone="$ZONE" \
+        --format='value(sizeGb,type.basename())' 2>/dev/null || true)"
+    if [ -n "$existing" ]; then
+        local size type
+        read -r size type <<< "$existing"
+        print_info "Disk $DISK already exists; never recreated by this script"
+        warn_if_differs "sizeGb" "$DEFAULT_DATA_GB" "$size"
+        warn_if_differs "type" "$DEFAULT_DATA_DISK_TYPE" "$type"
+        return 0
+    fi
+    run gcloud compute disks create "$DISK" --project="$PROJECT" --zone="$ZONE" \
+        --size="${DEFAULT_DATA_GB}GB" --type="$DEFAULT_DATA_DISK_TYPE" --labels="$LABELS"
+}
+
+step_render_schema() {
+    SCHEMA_TMP="$(mktemp)"
+    trap 'rm -f "$SCHEMA_TMP"' EXIT
+    sed "s/__RETENTION_HOURS__/$RETENTION_HOURS/g" "$SCHEMA_FILE" > "$SCHEMA_TMP"
+    print_info "Rendered $(grep -c 'CREATE TABLE' "$SCHEMA_TMP") tables with a ${RETENTION_HOURS}h TTL"
+}
+
+metadata_args() {
+    printf '%s' "enable-guest-attributes=TRUE,enable-oslogin=TRUE,clickhouse-image=$CLICKHOUSE_IMAGE,clickhouse-retention-hours=$RETENTION_HOURS,clickhouse-data-device=$DATA_DEVICE,clickhouse-secret-admin=$ADMIN_SECRET,clickhouse-secret-writer=$WRITER_SECRET,clickhouse-secret-reader=$READER_SECRET"
+}
+
+metadata_file_args() {
+    printf '%s' "startup-script=$STARTUP_FILE,clickhouse-schema=$SCHEMA_TMP"
+}
+
+create_vm() {
+    run gcloud compute instances create "$NAME" --project="$PROJECT" --zone="$ZONE" \
+        --machine-type="$MACHINE_TYPE" \
+        --image-family="$DEFAULT_IMAGE_FAMILY" --image-project="$DEFAULT_IMAGE_PROJECT" \
+        --boot-disk-size="${DEFAULT_BOOT_GB}GB" --boot-disk-type=pd-balanced \
+        --disk="name=$DISK,device-name=$DATA_DEVICE,mode=rw,auto-delete=no" \
+        --network="$NETWORK" --subnet="$SUBNET" --no-address \
+        --service-account="$SA_EMAIL" --scopes=cloud-platform \
+        --tags="$CLICKHOUSE_TAG" --labels="$LABELS" \
+        --shielded-secure-boot --shielded-vtpm --shielded-integrity-monitoring \
+        --deletion-protection \
+        --metadata="$(metadata_args)" \
+        --metadata-from-file="$(metadata_file_args)"
+}
+
+step_vm() {
+    print_header "Creating VM $NAME"
+    if ! vm_exists; then
+        create_vm
+        return 0
+    fi
+
+    print_info "VM $NAME already exists"
+    warn_if_differs "machineType" "$MACHINE_TYPE" "$(vm_describe 'machineType.basename()')"
+    warn_if_differs "subnetwork" "$SUBNET" "$(vm_describe 'networkInterfaces[0].subnetwork.basename()')"
+    warn_if_differs "serviceAccount" "$SA_EMAIL" "$(vm_describe 'serviceAccounts[0].email')"
+    warn_if_differs "dataDisk.deviceName" "$DATA_DEVICE" "$(vm_describe 'disks[1].deviceName')"
+    warn_if_differs "dataDisk.autoDelete" "False" "$(vm_describe 'disks[1].autoDelete')"
+    local live_image live_script_sha local_script_sha
+    live_image="$(vm_describe 'metadata.items.filter(key:clickhouse-image).extract(value).flatten()')"
+    # Both sides go through $(...) so trailing newlines, which gcloud's value
+    # format adds and files end with, never count as drift.
+    live_script_sha="$(printf '%s' "$(vm_describe 'metadata.items.filter(key:startup-script).extract(value).flatten()')" | sha256sum | awk '{print $1}')"
+    local_script_sha="$(printf '%s' "$(cat "$STARTUP_FILE")" | sha256sum | awk '{print $1}')"
+    if [ "$live_image" != "$CLICKHOUSE_IMAGE" ] || [ "$live_script_sha" != "$local_script_sha" ]; then
+        if [ "$REBOOT_VM" = false ] && [ "$RECREATE_VM" = false ]; then
+            print_warning "Startup script or image on the VM differs from this checkout; pass --reboot-vm to push it"
+        fi
+    fi
+
+    if [ "$RECREATE_VM" = true ] || [ "$REBOOT_VM" = true ]; then
+        PREVIOUS_STATUS="$(vm_status)"
+    fi
+    if [ "$RECREATE_VM" = true ]; then
+        # The data disk is attached with auto-delete=no and --keep-disks=data
+        # says it again, so only the boot disk goes with the VM.
+        run gcloud compute instances update "$NAME" --project="$PROJECT" --zone="$ZONE" --no-deletion-protection
+        run gcloud compute instances delete "$NAME" --project="$PROJECT" --zone="$ZONE" --keep-disks=data --quiet
+        create_vm
+        return 0
+    fi
+    if [ "$REBOOT_VM" = true ]; then
+        # The GCE equivalent of userDataReplaceOnChange: refresh what the
+        # startup script reads, then reboot so it runs again.
+        run gcloud compute instances add-metadata "$NAME" --project="$PROJECT" --zone="$ZONE" \
+            --metadata="$(metadata_args)" --metadata-from-file="$(metadata_file_args)"
+        run gcloud compute instances reset "$NAME" --project="$PROJECT" --zone="$ZONE"
+    fi
+}
+
+step_wait_ready() {
+    print_header "Waiting for the VM to report ready"
+    if [ "$DRY_RUN" = true ] || [ "$SKIP_WAIT" = true ]; then
+        print_info "Not waiting (dry run or --skip-wait)"
+        return 0
+    fi
+    local deadline status expected_digest
+    deadline=$((SECONDS + WAIT_TIMEOUT))
+    expected_digest="${CLICKHOUSE_IMAGE#*@}"
+    while [ "$SECONDS" -lt "$deadline" ]; do
+        status="$(vm_status)"
+        # After a reboot the old value is still there until the startup script
+        # writes `starting:`; only a value that changed since then counts.
+        if [ -n "$PREVIOUS_STATUS" ] && [ "$status" = "$PREVIOUS_STATUS" ]; then
+            sleep 10
+            continue
+        fi
+        case "$status" in
+            ready:*)
+                local digest tables
+                digest="$(echo "$status" | cut -d: -f2,3)"
+                tables="$(echo "$status" | cut -d: -f4)"
+                warn_if_differs "running image digest" "$expected_digest" "$digest"
+                print_success "VM reports ready: $tables tables, image $digest (boot $(echo "$status" | cut -d: -f5))"
+                return 0
+                ;;
+            failed:*)
+                print_error "VM reports '$status'. Last serial console lines:"
+                gcloud compute instances get-serial-port-output "$NAME" --project="$PROJECT" --zone="$ZONE" 2>/dev/null | tail -n 80 >&2 || true
+                exit 1
+                ;;
+            *)
+                sleep 10
+                ;;
+        esac
+    done
+    print_error "VM did not report ready within ${WAIT_TIMEOUT}s (last status: '${status:-none}'). Last serial console lines:"
+    gcloud compute instances get-serial-port-output "$NAME" --project="$PROJECT" --zone="$ZONE" 2>/dev/null | tail -n 80 >&2 || true
+    exit 1
+}
+
+step_read_ip() {
+    if [ "$DRY_RUN" = true ]; then
+        VM_IP="<internal ip>"
+        return 0
+    fi
+    VM_IP="$(vm_describe 'networkInterfaces[0].networkIP')"
+}
+
+step_smoke() {
+    if [ "$SMOKE" != true ]; then
+        return 0
+    fi
+    print_header "Smoke test over HTTP from a Cloud Run job in $SUBNET"
+    local job="$NAME-smoke" marker body
+    marker="boxlite-smoke-$(date +%s)"
+    # POSIX sh for the curl image. Passwords arrive through --set-secrets, so
+    # the job spec never carries them.
+    body="$(cat <<'SMOKE'
+set -eu
+q() { curl -sS -o /tmp/out -w '%{http_code}' -H "X-ClickHouse-User: $1" -H "X-ClickHouse-Key: $2" --data-binary "$3" "$CH_URL"; }
+code=$(q otel_writer "$WRITER_PW" "INSERT INTO otel.otel_logs (Timestamp, ServiceName, Body) VALUES (now64(9), 'boxlite-smoke', '$MARKER')")
+[ "$code" = 200 ] || { echo "writer insert: HTTP $code $(cat /tmp/out)"; exit 1; }
+echo "writer insert: ok"
+code=$(q otel_reader "$READER_PW" "SELECT count() FROM otel.otel_logs WHERE Body = '$MARKER'")
+[ "$code" = 200 ] && [ "$(cat /tmp/out)" = 1 ] || { echo "reader count: HTTP $code $(cat /tmp/out)"; exit 1; }
+echo "reader count: ok"
+code=$(q otel_reader "$READER_PW" "INSERT INTO otel.otel_logs (Timestamp) VALUES (now64(9))")
+[ "$code" != 200 ] || { echo "reader INSERT was accepted"; exit 1; }
+echo "reader insert denied: HTTP $code"
+code=$(q otel_reader wrong-password "SELECT 1")
+[ "$code" != 200 ] || { echo "wrong password was accepted"; exit 1; }
+echo "wrong password denied: HTTP $code"
+echo SMOKE_OK
+SMOKE
+)"
+    if gcloud run jobs describe "$job" --project="$PROJECT" --region="$REGION" >/dev/null 2>&1; then
+        run gcloud run jobs delete "$job" --project="$PROJECT" --region="$REGION" --quiet
+    fi
+    # ^~^ makes ~ the list separator so the commas inside the SQL survive.
+    run gcloud run jobs create "$job" --project="$PROJECT" --region="$REGION" \
+        --image="$SMOKE_IMAGE" \
+        --network="$NETWORK" --subnet="$SUBNET" --vpc-egress=private-ranges-only \
+        --service-account="$SA_EMAIL" \
+        --set-env-vars="CH_URL=http://$VM_IP:8123/,MARKER=$marker" \
+        --set-secrets="WRITER_PW=$WRITER_SECRET:latest,READER_PW=$READER_SECRET:latest" \
+        --max-retries=0 --task-timeout=120s \
+        --command=sh --args="^~^-c~$body"
+    if [ "$DRY_RUN" = true ]; then
+        return 0
+    fi
+    local execution smoke_ok=true
+    if ! gcloud run jobs execute "$job" --project="$PROJECT" --region="$REGION" --wait >/dev/null 2>&1; then
+        smoke_ok=false
+    fi
+    execution="$(gcloud run jobs executions list --job="$job" --project="$PROJECT" --region="$REGION" --limit=1 --format='value(name)')"
+    sleep 5
+    gcloud logging read "resource.type=cloud_run_job AND resource.labels.job_name=$job AND labels.\"run.googleapis.com/execution_name\"=$execution" \
+        --project="$PROJECT" --format='value(textPayload)' --order=asc --limit=50 2>/dev/null | grep -v '^$' || true
+    run gcloud run jobs delete "$job" --project="$PROJECT" --region="$REGION" --quiet
+    if [ "$smoke_ok" != true ]; then
+        print_error "Smoke test failed; see the job output above"
+        exit 1
+    fi
+    print_success "Smoke test passed"
+}
+
+step_summary() {
+    print_header "ClickHouse host $NAME"
+    echo "URL:             http://$VM_IP:8123   (VPC $NETWORK only, plaintext like the AWS host)"
+    echo "Users:           boxlite_admin (management), otel_writer (collector), otel_reader (API)"
+    echo "Admin secret:    projects/$PROJECT/secrets/$ADMIN_SECRET"
+    echo "Writer secret:   projects/$PROJECT/secrets/$WRITER_SECRET"
+    echo "Reader secret:   projects/$PROJECT/secrets/$READER_SECRET"
+    echo "Data disk:       $DISK (never deleted by this script)"
+    echo "Boot log:        gcloud compute instances get-serial-port-output $NAME --zone $ZONE"
+    echo "Status:          gcloud compute instances get-guest-attributes $NAME --zone $ZONE --query-path=boxlite/clickhouse"
+    echo ""
+    echo "Collector env:   CLICKHOUSE_ENDPOINT=http://$VM_IP:8123  CLICKHOUSE_USERNAME=otel_writer  CLICKHOUSE_PASSWORD from $WRITER_SECRET"
+    echo "API env:         CLICKHOUSE_URL=http://$VM_IP:8123       CLICKHOUSE_USERNAME=otel_reader  CLICKHOUSE_PASSWORD from $READER_SECRET"
+    if [ "$BINDING_PENDING" = true ]; then
+        echo ""
+        echo "ACTION REQUIRED: the VM cannot read its secrets yet. Someone with setIamPolicy on them runs:"
+        local secret
+        for secret in "$ADMIN_SECRET" "$WRITER_SECRET" "$READER_SECRET"; do
+            echo "  gcloud secrets add-iam-policy-binding $secret --project=$PROJECT --member=serviceAccount:$SA_EMAIL --role=roles/secretmanager.secretAccessor"
+        done
+        echo "then: $(basename "$0") --stage $STAGE --reboot-vm"
+    fi
+}
+
+main() {
+    require_command gcloud "Install: https://cloud.google.com/sdk/docs/install"
+
+    parse_args "$@"
+    validate_args
+
+    step_enable_apis
+    step_preflight
+    step_service_account
+    step_secrets
+    step_data_disk
+    step_render_schema
+    step_vm
+    step_wait_ready
+    step_read_ip
+    step_smoke
+    step_summary
+}
+
+# ============================================================================
+# Entry point
+# ============================================================================
+
+main "$@"

--- a/scripts/deploy/gcp/create-memorystore-redis.sh
+++ b/scripts/deploy/gcp/create-memorystore-redis.sh
@@ -306,11 +306,17 @@ step_create_instance() {
         tls_mode="server-authentication"
     fi
 
+    # The API reports the standard tier as STANDARD_HA, not STANDARD.
+    local expected_tier="BASIC"
+    if [ "$TIER" = "standard" ]; then
+        expected_tier="STANDARD_HA"
+    fi
+
     local state
     state="$(redis_describe state || true)"
     if [ -n "$state" ]; then
         print_info "Instance $NAME already exists (state: $state); not recreating"
-        warn_if_differs "tier" "$(echo "$TIER" | tr '[:lower:]' '[:upper:]')" "$(redis_describe tier)"
+        warn_if_differs "tier" "$expected_tier" "$(redis_describe tier)"
         warn_if_differs "redisVersion" "$(echo "$REDIS_VERSION" | tr '[:lower:]' '[:upper:]')" "$(redis_describe redisVersion)"
         warn_if_differs "transitEncryptionMode" "$(echo "$tls_mode" | tr '[:lower:]-' '[:upper:]_')" "$(redis_describe transitEncryptionMode)"
         warn_if_differs "authEnabled" "True" "$(redis_describe authEnabled)"

--- a/scripts/deploy/gcp/create-memorystore-redis.sh
+++ b/scripts/deploy/gcp/create-memorystore-redis.sh
@@ -1,0 +1,477 @@
+#!/bin/bash
+# Provision the Memorystore for Redis instance the BoxLite API needs on GCP and
+# store its AUTH string and server CA in Secret Manager.
+#
+# Mirrors the AWS side (apps/infra/stack/foundation.ts: sst.aws.Redis with
+# cluster mode disabled): one node, TLS required, AUTH required, private
+# network only, no persistence. The API needs a non-clustered Redis because it
+# uses logical DB 1, EVAL, BRPOP, multi-key pipelines and pub/sub (the Socket.IO
+# Redis adapter adds pattern subscriptions), so this is Memorystore for Redis
+# (standalone), not Valkey or Redis Cluster.
+#
+# Usage:
+#   ./create-memorystore-redis.sh
+#   ./create-memorystore-redis.sh --project my-project --dry-run
+#   ./create-memorystore-redis.sh --rotate-auth
+
+set -euo pipefail
+
+GCP_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$GCP_SCRIPT_DIR/../../common.sh"
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+DEFAULT_NAME="boxlite-dev-cache"
+DEFAULT_REGION="asia-southeast1"
+DEFAULT_NETWORK="boxlite-backoffice-dev"
+DEFAULT_RESERVED_RANGE="boxlite-backoffice-dev-private-services"
+DEFAULT_TIER="basic"
+DEFAULT_SIZE="1"
+DEFAULT_REDIS_VERSION="redis_7_2"
+DEFAULT_AUTH_SECRET="boxlite-dev-redis-auth"
+DEFAULT_CA_SECRET="boxlite-dev-redis-ca"
+# UTC. 19:00 UTC is 03:00 in Singapore, where the stack runs.
+DEFAULT_MAINTENANCE_DAY="sunday"
+DEFAULT_MAINTENANCE_HOUR="19"
+LABELS="app=boxlite,env=dev,component=cache,managed-by=create-memorystore-redis"
+
+PROJECT=""
+NAME="$DEFAULT_NAME"
+REGION="$DEFAULT_REGION"
+NETWORK="$DEFAULT_NETWORK"
+RESERVED_RANGE="$DEFAULT_RESERVED_RANGE"
+TIER="$DEFAULT_TIER"
+SIZE="$DEFAULT_SIZE"
+REDIS_VERSION="$DEFAULT_REDIS_VERSION"
+AUTH_SECRET="$DEFAULT_AUTH_SECRET"
+CA_SECRET="$DEFAULT_CA_SECRET"
+ENABLE_TLS=true
+ROTATE_AUTH=false
+DRY_RUN=false
+
+# Filled in by step_read_endpoint.
+REDIS_HOST=""
+REDIS_PORT=""
+TLS_MODE=""
+AUTH_SECRET_VERSION=""
+CA_SECRET_VERSION=""
+
+# ============================================================================
+# Functions
+# ============================================================================
+
+usage() {
+    cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Create a Memorystore for Redis instance for the BoxLite API and store its
+AUTH string and server CA in Secret Manager. Safe to re-run: an existing
+instance is left alone and a secret version is added only when the value
+changed.
+
+OPTIONS:
+    --project PROJECT           GCP project ID (default: gcloud config)
+    --region REGION             Region (default: $DEFAULT_REGION)
+    --network NETWORK           VPC network name (default: $DEFAULT_NETWORK)
+    --reserved-ip-range NAME    Private Service Access range (default: $DEFAULT_RESERVED_RANGE)
+    --name NAME                 Instance name (default: $DEFAULT_NAME)
+    --tier basic|standard       Tier (default: $DEFAULT_TIER)
+    --size GIB                  Memory in GiB (default: $DEFAULT_SIZE)
+    --redis-version VERSION     e.g. redis_7_2 (default: $DEFAULT_REDIS_VERSION)
+    --auth-secret NAME          Secret Manager name for the AUTH string (default: $DEFAULT_AUTH_SECRET)
+    --ca-secret NAME            Secret Manager name for the server CA (default: $DEFAULT_CA_SECRET)
+    --no-tls                    Disable in-transit encryption (port 6379, no CA secret)
+    --rotate-auth               Regenerate the AUTH string of an existing instance
+    --dry-run                   Print the mutating commands instead of running them
+    --help                      Show this help message
+
+EXAMPLES:
+    $(basename "$0")
+    $(basename "$0") --project avid-vine-500315-u4 --dry-run
+    $(basename "$0") --rotate-auth
+
+EOF
+    exit 0
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --project)
+                PROJECT="$2"
+                shift 2
+                ;;
+            --region)
+                REGION="$2"
+                shift 2
+                ;;
+            --network)
+                NETWORK="$2"
+                shift 2
+                ;;
+            --reserved-ip-range)
+                RESERVED_RANGE="$2"
+                shift 2
+                ;;
+            --name)
+                NAME="$2"
+                shift 2
+                ;;
+            --tier)
+                TIER="$2"
+                shift 2
+                ;;
+            --size)
+                SIZE="$2"
+                shift 2
+                ;;
+            --redis-version)
+                REDIS_VERSION="$2"
+                shift 2
+                ;;
+            --auth-secret)
+                AUTH_SECRET="$2"
+                shift 2
+                ;;
+            --ca-secret)
+                CA_SECRET="$2"
+                shift 2
+                ;;
+            --no-tls)
+                ENABLE_TLS=false
+                shift
+                ;;
+            --rotate-auth)
+                ROTATE_AUTH=true
+                shift
+                ;;
+            --dry-run)
+                DRY_RUN=true
+                shift
+                ;;
+            --help|-h)
+                usage
+                ;;
+            *)
+                print_error "Unknown option: $1"
+                usage
+                ;;
+        esac
+    done
+}
+
+validate_args() {
+    if [ -z "$PROJECT" ]; then
+        PROJECT="$(gcloud config get-value project 2>/dev/null || true)"
+    fi
+    if [ -z "$PROJECT" ]; then
+        print_error "No GCP project: pass --project or run 'gcloud config set project'"
+        exit 1
+    fi
+    case "$TIER" in
+        basic|standard) ;;
+        *)
+            print_error "--tier must be basic or standard, got: $TIER"
+            exit 1
+            ;;
+    esac
+    if ! [[ "$SIZE" =~ ^[0-9]+$ ]]; then
+        print_error "--size must be an integer number of GiB, got: $SIZE"
+        exit 1
+    fi
+}
+
+# Run a mutating gcloud command, or print it under --dry-run. Arguments are
+# passed through as an array so nothing is re-parsed by the shell.
+run() {
+    print_info "Running: $*"
+    if [ "$DRY_RUN" = true ]; then
+        return 0
+    fi
+    "$@"
+}
+
+redis_describe() {
+    gcloud redis instances describe "$NAME" \
+        --project="$PROJECT" --region="$REGION" --format="value($1)" 2>/dev/null
+}
+
+secret_exists() {
+    gcloud secrets describe "$1" --project="$PROJECT" >/dev/null 2>&1
+}
+
+secret_latest_version() {
+    gcloud secrets versions list "$1" --project="$PROJECT" \
+        --filter="state=ENABLED" --sort-by="~createTime" --limit=1 \
+        --format="value(name)" 2>/dev/null || true
+}
+
+# Ensure a secret exists and holds $value as its latest version. The value
+# never touches argv or the log: it goes to gcloud on stdin, and the existing
+# version is compared in memory only. Prints nothing about the value itself.
+ensure_secret_value() {
+    local secret="$1" value="$2" current=""
+
+    if ! secret_exists "$secret"; then
+        run gcloud secrets create "$secret" --project="$PROJECT" \
+            --replication-policy=automatic --labels="$LABELS"
+    fi
+    if [ "$DRY_RUN" = true ]; then
+        print_info "Would add a version to $secret if the stored value differs"
+        return 0
+    fi
+
+    current="$(gcloud secrets versions access latest --secret="$secret" --project="$PROJECT" 2>/dev/null || true)"
+    if [ "$current" = "$value" ]; then
+        print_info "Secret $secret already holds the current value; no new version"
+        return 0
+    fi
+    # printf, not echo: echo would append a newline to the stored value.
+    printf '%s' "$value" | gcloud secrets versions add "$secret" --project="$PROJECT" --data-file=- >/dev/null
+    print_success "Added a new version to $secret"
+}
+
+step_enable_api() {
+    print_header "Enabling the Memorystore for Redis API"
+    # Must precede any `gcloud redis` call: with the API disabled those prompt
+    # interactively to enable it, which breaks non-interactive runs.
+    run gcloud services enable redis.googleapis.com --project="$PROJECT"
+}
+
+step_preflight() {
+    print_header "Checking the network the instance will attach to"
+
+    if ! gcloud compute networks describe "$NETWORK" --project="$PROJECT" >/dev/null 2>&1; then
+        print_error "VPC network '$NETWORK' not found in project $PROJECT"
+        exit 1
+    fi
+    print_success "Network $NETWORK exists"
+
+    local range_info
+    range_info="$(gcloud compute addresses describe "$RESERVED_RANGE" --global --project="$PROJECT" \
+        --format='value(purpose,network.basename(),address,prefixLength)' 2>/dev/null || true)"
+    if [ -z "$range_info" ]; then
+        print_error "Reserved range '$RESERVED_RANGE' not found. Private Service Access must be set up first."
+        exit 1
+    fi
+    local purpose range_network address prefix
+    read -r purpose range_network address prefix <<< "$range_info"
+    if [ "$purpose" != "VPC_PEERING" ] || [ "$range_network" != "$NETWORK" ]; then
+        print_error "Reserved range '$RESERVED_RANGE' is $purpose on network '$range_network', expected VPC_PEERING on '$NETWORK'"
+        exit 1
+    fi
+    print_success "Reserved range $RESERVED_RANGE = $address/$prefix on $NETWORK"
+
+    local peering_ranges
+    peering_ranges="$(gcloud services vpc-peerings list --network="$NETWORK" --project="$PROJECT" \
+        --format='value(reservedPeeringRanges)' 2>/dev/null || true)"
+    if [[ "$peering_ranges" != *"$RESERVED_RANGE"* ]]; then
+        print_warning "servicenetworking peering on $NETWORK does not list $RESERVED_RANGE; instance creation may fail"
+    else
+        print_success "servicenetworking peering includes $RESERVED_RANGE"
+    fi
+
+    # Memorystore needs no ingress rule on the consumer VPC. Only an explicit
+    # egress deny could block clients, so surface any that exist.
+    local egress_denies
+    egress_denies="$(gcloud compute firewall-rules list --project="$PROJECT" \
+        --filter="network:$NETWORK AND direction=EGRESS AND denied:*" \
+        --format='value(name)' 2>/dev/null || true)"
+    if [ -n "$egress_denies" ]; then
+        print_warning "Egress deny rules exist on $NETWORK; make sure they exempt the Redis port: $egress_denies"
+    else
+        print_success "No egress deny rules on $NETWORK"
+    fi
+}
+
+warn_if_differs() {
+    local field="$1" expected="$2" actual="$3"
+    # A describe can transiently return nothing; that is not drift.
+    if [ -z "$actual" ]; then
+        print_warning "$field could not be read; rerun to check it against '$expected'"
+        return 0
+    fi
+    if [ "$actual" != "$expected" ]; then
+        print_warning "$field is '$actual' but this script expects '$expected' (immutable; recreate the instance to change it)"
+    fi
+}
+
+step_create_instance() {
+    print_header "Creating Memorystore for Redis instance"
+
+    local tls_mode="disabled"
+    if [ "$ENABLE_TLS" = true ]; then
+        tls_mode="server-authentication"
+    fi
+
+    local state
+    state="$(redis_describe state || true)"
+    if [ -n "$state" ]; then
+        print_info "Instance $NAME already exists (state: $state); not recreating"
+        warn_if_differs "tier" "$(echo "$TIER" | tr '[:lower:]' '[:upper:]')" "$(redis_describe tier)"
+        warn_if_differs "redisVersion" "$(echo "$REDIS_VERSION" | tr '[:lower:]' '[:upper:]')" "$(redis_describe redisVersion)"
+        warn_if_differs "transitEncryptionMode" "$(echo "$tls_mode" | tr '[:lower:]-' '[:upper:]_')" "$(redis_describe transitEncryptionMode)"
+        warn_if_differs "authEnabled" "True" "$(redis_describe authEnabled)"
+        warn_if_differs "connectMode" "PRIVATE_SERVICE_ACCESS" "$(redis_describe connectMode)"
+        warn_if_differs "authorizedNetwork" "projects/$PROJECT/global/networks/$NETWORK" "$(redis_describe authorizedNetwork)"
+        return 0
+    fi
+
+    print_info "Instance: $NAME ($TIER, ${SIZE} GiB, $REDIS_VERSION, TLS $tls_mode)"
+    print_info "Network: $NETWORK via $RESERVED_RANGE in $REGION"
+
+    # Synchronous: creation takes several minutes and the later steps need the
+    # instance to be READY. --quiet answers the --enable-auth confirmation
+    # prompt so the script also works without a terminal.
+    run gcloud redis instances create "$NAME" \
+        --quiet \
+        --project="$PROJECT" \
+        --region="$REGION" \
+        --tier="$TIER" \
+        --size="$SIZE" \
+        --redis-version="$REDIS_VERSION" \
+        --network="projects/$PROJECT/global/networks/$NETWORK" \
+        --connect-mode=private-service-access \
+        --reserved-ip-range="$RESERVED_RANGE" \
+        --enable-auth \
+        --transit-encryption-mode="$tls_mode" \
+        --maintenance-window-day="$DEFAULT_MAINTENANCE_DAY" \
+        --maintenance-window-hour="$DEFAULT_MAINTENANCE_HOUR" \
+        --display-name="BoxLite dev cache" \
+        --labels="$LABELS"
+    if [ "$DRY_RUN" = true ]; then
+        print_info "Would create instance $NAME"
+    else
+        print_success "Instance $NAME created"
+    fi
+}
+
+step_rotate_auth() {
+    if [ "$ROTATE_AUTH" != true ]; then
+        return 0
+    fi
+    print_header "Rotating the AUTH string"
+    # Memorystore has no regenerate verb: disabling and re-enabling AUTH mints
+    # a new string. Between the two calls the instance accepts unauthenticated
+    # connections, and every client is disconnected.
+    print_warning "AUTH is briefly disabled during rotation and all clients are disconnected"
+    run gcloud redis instances update "$NAME" --project="$PROJECT" --region="$REGION" --no-enable-auth
+    run gcloud redis instances update "$NAME" --project="$PROJECT" --region="$REGION" --enable-auth
+    print_success "AUTH string rotated"
+}
+
+step_read_endpoint() {
+    if [ "$DRY_RUN" = true ]; then
+        REDIS_HOST="<host>"
+        REDIS_PORT="<port>"
+        TLS_MODE="<tls mode>"
+        return 0
+    fi
+    REDIS_HOST="$(redis_describe host)"
+    REDIS_PORT="$(redis_describe port)"
+    TLS_MODE="$(redis_describe transitEncryptionMode)"
+    if [ -z "$REDIS_HOST" ] || [ -z "$REDIS_PORT" ]; then
+        print_error "Could not read host/port of $NAME"
+        exit 1
+    fi
+}
+
+step_store_auth() {
+    print_header "Storing the AUTH string in Secret Manager"
+    local auth_string=""
+    if [ "$DRY_RUN" != true ]; then
+        auth_string="$(gcloud redis instances get-auth-string "$NAME" \
+            --project="$PROJECT" --region="$REGION" --format='value(authString)')"
+        if [ -z "$auth_string" ]; then
+            print_error "AUTH string is empty; AUTH is not enabled on $NAME"
+            exit 1
+        fi
+    fi
+    ensure_secret_value "$AUTH_SECRET" "$auth_string"
+    unset auth_string
+    if [ "$DRY_RUN" != true ]; then
+        AUTH_SECRET_VERSION="$(secret_latest_version "$AUTH_SECRET")"
+    fi
+}
+
+step_store_ca() {
+    if [ "$ENABLE_TLS" != true ]; then
+        print_info "TLS disabled; skipping the server CA secret"
+        return 0
+    fi
+    print_header "Storing the server CA in Secret Manager"
+    local ca_pem="" expected_count=0 actual_count=0
+    if [ "$DRY_RUN" != true ]; then
+        # Google can publish more than one CA during a rotation. Store all of
+        # them, and check the joined output really contains every certificate.
+        expected_count="$(redis_describe 'serverCaCerts.len()')"
+        # An empty read must fail the count check below, not the arithmetic.
+        expected_count="${expected_count:-0}"
+        ca_pem="$(gcloud redis instances describe "$NAME" --project="$PROJECT" --region="$REGION" \
+            --format='value[separator="\n"](serverCaCerts[].cert)')"
+        actual_count="$(printf '%s\n' "$ca_pem" | grep -c 'BEGIN CERTIFICATE' || true)"
+        if [ -z "$ca_pem" ] || [ "$actual_count" -ne "$expected_count" ]; then
+            print_error "Expected $expected_count server CA certificate(s), extracted $actual_count"
+            exit 1
+        fi
+        print_info "Server CA bundle has $actual_count certificate(s)"
+    fi
+    ensure_secret_value "$CA_SECRET" "$ca_pem"
+    if [ "$DRY_RUN" != true ]; then
+        CA_SECRET_VERSION="$(secret_latest_version "$CA_SECRET")"
+    fi
+}
+
+step_summary() {
+    print_header "Redis is ready"
+    echo "Instance:      projects/$PROJECT/locations/$REGION/instances/$NAME"
+    echo "Host:          $REDIS_HOST"
+    echo "Port:          $REDIS_PORT (transit encryption: $TLS_MODE)"
+    echo "AUTH secret:   projects/$PROJECT/secrets/$AUTH_SECRET${AUTH_SECRET_VERSION:+  (latest: $(basename "$AUTH_SECRET_VERSION"))}"
+    if [ "$ENABLE_TLS" = true ]; then
+        echo "CA secret:     projects/$PROJECT/secrets/$CA_SECRET${CA_SECRET_VERSION:+  (latest: $(basename "$CA_SECRET_VERSION"))}"
+    fi
+    echo ""
+    echo "API environment (apps/api reads these; see apps/api/.env.example):"
+    echo "  REDIS_HOST=$REDIS_HOST"
+    echo "  REDIS_PORT=$REDIS_PORT"
+    if [ "$ENABLE_TLS" = true ]; then
+        echo "  REDIS_TLS=true"
+        echo "  Cloud Run: --set-secrets=REDIS_PASSWORD=$AUTH_SECRET:latest,REDIS_TLS_CA=$CA_SECRET:latest"
+    else
+        echo "  REDIS_TLS=false"
+        echo "  Cloud Run: --set-secrets=REDIS_PASSWORD=$AUTH_SECRET:latest"
+    fi
+    echo ""
+    echo "Next, a project owner grants the API's service account read access:"
+    echo "  gcloud secrets add-iam-policy-binding $AUTH_SECRET --project=$PROJECT \\"
+    echo "    --member=serviceAccount:<api-sa> --role=roles/secretmanager.secretAccessor"
+    if [ "$ENABLE_TLS" = true ]; then
+        echo "  gcloud secrets add-iam-policy-binding $CA_SECRET --project=$PROJECT \\"
+        echo "    --member=serviceAccount:<api-sa> --role=roles/secretmanager.secretAccessor"
+    fi
+}
+
+main() {
+    require_command gcloud "Install: https://cloud.google.com/sdk/docs/install"
+
+    parse_args "$@"
+    validate_args
+
+    step_enable_api
+    step_preflight
+    step_create_instance
+    step_rotate_auth
+    step_read_endpoint
+    step_store_auth
+    step_store_ca
+    step_summary
+}
+
+# ============================================================================
+# Entry point
+# ============================================================================
+
+main "$@"

--- a/scripts/deploy/gcp/create-memorystore-redis.sh
+++ b/scripts/deploy/gcp/create-memorystore-redis.sh
@@ -23,30 +23,31 @@ source "$GCP_SCRIPT_DIR/../../common.sh"
 # Configuration
 # ============================================================================
 
-DEFAULT_NAME="boxlite-dev-cache"
+# Names, labels and the display name derive from the stage unless overridden:
+# boxlite-<stage>-cache, boxlite-<stage>-redis-auth, boxlite-<stage>-redis-ca.
+DEFAULT_STAGE="dev"
 DEFAULT_REGION="asia-southeast1"
 DEFAULT_NETWORK="boxlite-backoffice-dev"
 DEFAULT_RESERVED_RANGE="boxlite-backoffice-dev-private-services"
 DEFAULT_TIER="basic"
 DEFAULT_SIZE="1"
 DEFAULT_REDIS_VERSION="redis_7_2"
-DEFAULT_AUTH_SECRET="boxlite-dev-redis-auth"
-DEFAULT_CA_SECRET="boxlite-dev-redis-ca"
 # UTC. 19:00 UTC is 03:00 in Singapore, where the stack runs.
 DEFAULT_MAINTENANCE_DAY="sunday"
 DEFAULT_MAINTENANCE_HOUR="19"
-LABELS="app=boxlite,env=dev,component=cache,managed-by=create-memorystore-redis"
 
 PROJECT=""
-NAME="$DEFAULT_NAME"
+STAGE="$DEFAULT_STAGE"
+NAME=""
 REGION="$DEFAULT_REGION"
 NETWORK="$DEFAULT_NETWORK"
 RESERVED_RANGE="$DEFAULT_RESERVED_RANGE"
 TIER="$DEFAULT_TIER"
 SIZE="$DEFAULT_SIZE"
 REDIS_VERSION="$DEFAULT_REDIS_VERSION"
-AUTH_SECRET="$DEFAULT_AUTH_SECRET"
-CA_SECRET="$DEFAULT_CA_SECRET"
+AUTH_SECRET=""
+CA_SECRET=""
+LABELS=""
 ENABLE_TLS=true
 ROTATE_AUTH=false
 DRY_RUN=false
@@ -74,14 +75,15 @@ changed.
 OPTIONS:
     --project PROJECT           GCP project ID (default: gcloud config)
     --region REGION             Region (default: $DEFAULT_REGION)
+    --stage STAGE               Stage; derives names and labels (default: $DEFAULT_STAGE)
     --network NETWORK           VPC network name (default: $DEFAULT_NETWORK)
     --reserved-ip-range NAME    Private Service Access range (default: $DEFAULT_RESERVED_RANGE)
-    --name NAME                 Instance name (default: $DEFAULT_NAME)
+    --name NAME                 Instance name (default: boxlite-<stage>-cache)
     --tier basic|standard       Tier (default: $DEFAULT_TIER)
     --size GIB                  Memory in GiB (default: $DEFAULT_SIZE)
     --redis-version VERSION     e.g. redis_7_2 (default: $DEFAULT_REDIS_VERSION)
-    --auth-secret NAME          Secret Manager name for the AUTH string (default: $DEFAULT_AUTH_SECRET)
-    --ca-secret NAME            Secret Manager name for the server CA (default: $DEFAULT_CA_SECRET)
+    --auth-secret NAME          Secret Manager name for the AUTH string (default: boxlite-<stage>-redis-auth)
+    --ca-secret NAME            Secret Manager name for the server CA (default: boxlite-<stage>-redis-ca)
     --no-tls                    Disable in-transit encryption (port 6379, no CA secret)
     --rotate-auth               Regenerate the AUTH string of an existing instance
     --dry-run                   Print the mutating commands instead of running them
@@ -90,6 +92,7 @@ OPTIONS:
 EXAMPLES:
     $(basename "$0")
     $(basename "$0") --project avid-vine-500315-u4 --dry-run
+    $(basename "$0") --stage dev-db --network boxlite-dev-db --reserved-ip-range boxlite-dev-db-private-services
     $(basename "$0") --rotate-auth
 
 EOF
@@ -105,6 +108,10 @@ parse_args() {
                 ;;
             --region)
                 REGION="$2"
+                shift 2
+                ;;
+            --stage)
+                STAGE="$2"
                 shift 2
                 ;;
             --network)
@@ -181,6 +188,14 @@ validate_args() {
         print_error "--size must be an integer number of GiB, got: $SIZE"
         exit 1
     fi
+    if ! [[ "$STAGE" =~ ^[a-z][a-z0-9-]{0,20}$ ]]; then
+        print_error "--stage must be lowercase letters, digits and hyphens, got: $STAGE"
+        exit 1
+    fi
+    NAME="${NAME:-boxlite-$STAGE-cache}"
+    AUTH_SECRET="${AUTH_SECRET:-boxlite-$STAGE-redis-auth}"
+    CA_SECRET="${CA_SECRET:-boxlite-$STAGE-redis-ca}"
+    LABELS="app=boxlite,env=$STAGE,component=cache,managed-by=create-memorystore-redis"
 }
 
 # Run a mutating gcloud command, or print it under --dry-run. Arguments are
@@ -345,7 +360,7 @@ step_create_instance() {
         --transit-encryption-mode="$tls_mode" \
         --maintenance-window-day="$DEFAULT_MAINTENANCE_DAY" \
         --maintenance-window-hour="$DEFAULT_MAINTENANCE_HOUR" \
-        --display-name="BoxLite dev cache" \
+        --display-name="BoxLite $STAGE cache" \
         --labels="$LABELS"
     if [ "$DRY_RUN" = true ]; then
         print_info "Would create instance $NAME"

--- a/scripts/deploy/gcp/create-network.sh
+++ b/scripts/deploy/gcp/create-network.sh
@@ -1,0 +1,377 @@
+#!/bin/bash
+# Create the VPC a BoxLite stage's databases live in on GCP: a custom-mode
+# network, one regional subnet with Private Google Access, Cloud NAT for
+# outbound traffic (image pulls), the firewall rules the ClickHouse host needs,
+# and the Private Service Access range plus peering that Memorystore requires.
+#
+# Safe to re-run: every resource is created only when missing, and immutable
+# settings that differ from the flags produce a warning.
+#
+# Usage:
+#   ./create-network.sh
+#   ./create-network.sh --stage dev-db --dry-run
+
+set -euo pipefail
+
+GCP_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$GCP_SCRIPT_DIR/../../common.sh"
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+DEFAULT_STAGE="dev-db"
+DEFAULT_REGION="asia-southeast1"
+DEFAULT_SUBNET_RANGE="10.40.0.0/20"
+DEFAULT_PSA_ADDRESS="10.90.0.0"
+DEFAULT_PSA_PREFIX="16"
+# Google's IAP TCP-forwarding source range; the rule stays dormant until the
+# operator holds iap.tunnelInstances.accessViaIAP.
+IAP_RANGE="35.235.240.0/20"
+CLICKHOUSE_TAG="boxlite-clickhouse"
+CLICKHOUSE_PORT="8123"
+
+PROJECT=""
+STAGE="$DEFAULT_STAGE"
+REGION="$DEFAULT_REGION"
+SUBNET_RANGE="$DEFAULT_SUBNET_RANGE"
+PSA_ADDRESS="$DEFAULT_PSA_ADDRESS"
+PSA_PREFIX="$DEFAULT_PSA_PREFIX"
+SKIP_PEERING=false
+DRY_RUN=false
+
+# Derived in validate_args from the stage name.
+NETWORK=""
+SUBNET=""
+ROUTER=""
+NAT=""
+PSA_RANGE=""
+FW_CLICKHOUSE=""
+FW_IAP=""
+
+# Filled in by step_psa_peering: connected | pending | skipped.
+PSA_STATUS=""
+
+# ============================================================================
+# Functions
+# ============================================================================
+
+usage() {
+    cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Create the boxlite-<stage> VPC with a subnet, Cloud NAT, the ClickHouse
+firewall rules, and the Private Service Access range and peering that
+Memorystore needs. Safe to re-run.
+
+OPTIONS:
+    --project PROJECT       GCP project ID (default: gcloud config)
+    --region REGION         Region (default: $DEFAULT_REGION)
+    --stage STAGE           Stage name; resources are boxlite-<stage>-* (default: $DEFAULT_STAGE)
+    --subnet-range CIDR     Subnet range (default: $DEFAULT_SUBNET_RANGE)
+    --psa-address ADDRESS   First address of the Private Service Access range (default: $DEFAULT_PSA_ADDRESS)
+    --psa-prefix LENGTH     Prefix length of that range (default: $DEFAULT_PSA_PREFIX)
+    --skip-peering          Reserve the range but do not connect the servicenetworking peering
+    --dry-run               Print the mutating commands instead of running them
+    --help                  Show this help message
+
+EXAMPLES:
+    $(basename "$0")
+    $(basename "$0") --stage dev-db --dry-run
+
+EOF
+    exit 0
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --project)
+                PROJECT="$2"
+                shift 2
+                ;;
+            --region)
+                REGION="$2"
+                shift 2
+                ;;
+            --stage)
+                STAGE="$2"
+                shift 2
+                ;;
+            --subnet-range)
+                SUBNET_RANGE="$2"
+                shift 2
+                ;;
+            --psa-address)
+                PSA_ADDRESS="$2"
+                shift 2
+                ;;
+            --psa-prefix)
+                PSA_PREFIX="$2"
+                shift 2
+                ;;
+            --skip-peering)
+                SKIP_PEERING=true
+                shift
+                ;;
+            --dry-run)
+                DRY_RUN=true
+                shift
+                ;;
+            --help|-h)
+                usage
+                ;;
+            *)
+                print_error "Unknown option: $1"
+                usage
+                ;;
+        esac
+    done
+}
+
+validate_args() {
+    if [ -z "$PROJECT" ]; then
+        PROJECT="$(gcloud config get-value project 2>/dev/null || true)"
+    fi
+    if [ -z "$PROJECT" ]; then
+        print_error "No GCP project: pass --project or run 'gcloud config set project'"
+        exit 1
+    fi
+    if ! [[ "$STAGE" =~ ^[a-z][a-z0-9-]{0,20}$ ]]; then
+        print_error "--stage must be lowercase letters, digits and hyphens, got: $STAGE"
+        exit 1
+    fi
+    if ! [[ "$SUBNET_RANGE" =~ ^[0-9.]+/[0-9]+$ ]]; then
+        print_error "--subnet-range must be a CIDR, got: $SUBNET_RANGE"
+        exit 1
+    fi
+    if ! [[ "$PSA_PREFIX" =~ ^[0-9]+$ ]]; then
+        print_error "--psa-prefix must be an integer, got: $PSA_PREFIX"
+        exit 1
+    fi
+    NETWORK="boxlite-$STAGE"
+    SUBNET="boxlite-$STAGE"
+    ROUTER="boxlite-$STAGE"
+    NAT="boxlite-$STAGE"
+    PSA_RANGE="boxlite-$STAGE-private-services"
+    FW_CLICKHOUSE="boxlite-$STAGE-allow-clickhouse-http"
+    FW_IAP="boxlite-$STAGE-allow-iap-ssh"
+}
+
+# Run a mutating gcloud command, or print it under --dry-run. Arguments are
+# passed through as an array so nothing is re-parsed by the shell.
+run() {
+    print_info "Running: $*"
+    if [ "$DRY_RUN" = true ]; then
+        return 0
+    fi
+    "$@"
+}
+
+warn_if_differs() {
+    local field="$1" expected="$2" actual="$3"
+    # A describe can transiently return nothing; that is not drift.
+    if [ -z "$actual" ]; then
+        print_warning "$field could not be read; rerun to check it against '$expected'"
+        return 0
+    fi
+    if [ "$actual" != "$expected" ]; then
+        print_warning "$field is '$actual' but this script expects '$expected' (immutable; recreate the resource to change it)"
+    fi
+}
+
+step_enable_apis() {
+    print_header "Enabling the Compute and Service Networking APIs"
+    run gcloud services enable compute.googleapis.com servicenetworking.googleapis.com --project="$PROJECT"
+}
+
+step_network() {
+    print_header "Creating VPC network $NETWORK"
+    if gcloud compute networks describe "$NETWORK" --project="$PROJECT" >/dev/null 2>&1; then
+        print_info "Network $NETWORK already exists"
+        return 0
+    fi
+    run gcloud compute networks create "$NETWORK" --project="$PROJECT" \
+        --subnet-mode=custom --bgp-routing-mode=regional
+}
+
+step_subnet() {
+    print_header "Creating subnet $SUBNET ($SUBNET_RANGE)"
+    local existing
+    existing="$(gcloud compute networks subnets describe "$SUBNET" --project="$PROJECT" --region="$REGION" \
+        --format='value(ipCidrRange,privateIpGoogleAccess,network.basename())' 2>/dev/null || true)"
+    if [ -n "$existing" ]; then
+        local range pga network
+        read -r range pga network <<< "$existing"
+        print_info "Subnet $SUBNET already exists"
+        warn_if_differs "ipCidrRange" "$SUBNET_RANGE" "$range"
+        warn_if_differs "privateIpGoogleAccess" "True" "$pga"
+        warn_if_differs "network" "$NETWORK" "$network"
+        return 0
+    fi
+    # Private Google Access lets the ClickHouse VM (no external IP) reach
+    # Secret Manager and other Google APIs without going through the NAT.
+    run gcloud compute networks subnets create "$SUBNET" --project="$PROJECT" \
+        --network="$NETWORK" --region="$REGION" --range="$SUBNET_RANGE" \
+        --enable-private-ip-google-access
+}
+
+step_nat() {
+    print_header "Creating Cloud NAT $NAT"
+    if ! gcloud compute routers describe "$ROUTER" --project="$PROJECT" --region="$REGION" >/dev/null 2>&1; then
+        run gcloud compute routers create "$ROUTER" --project="$PROJECT" \
+            --network="$NETWORK" --region="$REGION"
+    else
+        print_info "Router $ROUTER already exists"
+    fi
+    if gcloud compute routers nats describe "$NAT" --router="$ROUTER" --project="$PROJECT" --region="$REGION" >/dev/null 2>&1; then
+        print_info "NAT $NAT already exists"
+        return 0
+    fi
+    # VMs without external IPs pull the ClickHouse image from Docker Hub
+    # through this NAT. Error-only logging keeps the log volume small.
+    run gcloud compute routers nats create "$NAT" --project="$PROJECT" \
+        --router="$ROUTER" --region="$REGION" \
+        --auto-allocate-nat-external-ips --nat-all-subnet-ip-ranges \
+        --enable-logging --log-filter=ERRORS_ONLY
+}
+
+step_firewall() {
+    print_header "Creating firewall rules"
+    if gcloud compute firewall-rules describe "$FW_CLICKHOUSE" --project="$PROJECT" >/dev/null 2>&1; then
+        print_info "Firewall rule $FW_CLICKHOUSE already exists"
+    else
+        # Mirrors the AWS security group: only the HTTP port, only from the VPC.
+        run gcloud compute firewall-rules create "$FW_CLICKHOUSE" --project="$PROJECT" \
+            --network="$NETWORK" --direction=INGRESS \
+            --allow="tcp:$CLICKHOUSE_PORT" --source-ranges="$SUBNET_RANGE" \
+            --target-tags="$CLICKHOUSE_TAG" \
+            --description="ClickHouse HTTP from the $SUBNET subnet"
+    fi
+    if gcloud compute firewall-rules describe "$FW_IAP" --project="$PROJECT" >/dev/null 2>&1; then
+        print_info "Firewall rule $FW_IAP already exists"
+    else
+        run gcloud compute firewall-rules create "$FW_IAP" --project="$PROJECT" \
+            --network="$NETWORK" --direction=INGRESS \
+            --allow=tcp:22 --source-ranges="$IAP_RANGE" \
+            --target-tags="$CLICKHOUSE_TAG" \
+            --description="SSH through IAP for debugging the ClickHouse host"
+    fi
+}
+
+step_psa_address() {
+    print_header "Reserving the Private Service Access range $PSA_RANGE"
+    local existing
+    existing="$(gcloud compute addresses describe "$PSA_RANGE" --global --project="$PROJECT" \
+        --format='value(purpose,address,prefixLength,network.basename())' 2>/dev/null || true)"
+    if [ -n "$existing" ]; then
+        local purpose address prefix network
+        read -r purpose address prefix network <<< "$existing"
+        print_info "Range $PSA_RANGE already exists"
+        warn_if_differs "purpose" "VPC_PEERING" "$purpose"
+        warn_if_differs "address" "$PSA_ADDRESS" "$address"
+        warn_if_differs "prefixLength" "$PSA_PREFIX" "$prefix"
+        warn_if_differs "network" "$NETWORK" "$network"
+        return 0
+    fi
+    run gcloud compute addresses create "$PSA_RANGE" --project="$PROJECT" \
+        --global --purpose=VPC_PEERING \
+        --addresses="$PSA_ADDRESS" --prefix-length="$PSA_PREFIX" \
+        --network="$NETWORK"
+}
+
+step_psa_peering() {
+    print_header "Connecting the servicenetworking peering"
+    if [ "$SKIP_PEERING" = true ]; then
+        print_info "Skipping the peering (--skip-peering)"
+        PSA_STATUS="skipped"
+        return 0
+    fi
+
+    local peering_ranges
+    peering_ranges="$(gcloud services vpc-peerings list --network="$NETWORK" --project="$PROJECT" \
+        --format='value(reservedPeeringRanges)' 2>/dev/null || true)"
+    if [[ "$peering_ranges" == *"$PSA_RANGE"* ]]; then
+        print_success "Peering already includes $PSA_RANGE"
+        PSA_STATUS="connected"
+        return 0
+    fi
+
+    # `connect` creates the peering; a second range on an existing peering
+    # needs `update`. Both need servicenetworking.services.addPeering, which
+    # roles/editor does not include, so a permission error is reported with
+    # the exact command for someone who holds it rather than failing the run:
+    # nothing else in this script depends on the peering.
+    local verb="connect"
+    if [ -n "$peering_ranges" ]; then
+        verb="update"
+    fi
+    local cmd=(gcloud services vpc-peerings "$verb" --project="$PROJECT" --network="$NETWORK"
+        --service=servicenetworking.googleapis.com --ranges="$PSA_RANGE")
+    if [ "$verb" = "update" ]; then
+        cmd+=(--force)
+    fi
+    print_info "Running: ${cmd[*]}"
+    if [ "$DRY_RUN" = true ]; then
+        PSA_STATUS="pending"
+        return 0
+    fi
+    local stderr_file
+    stderr_file="$(mktemp)"
+    if "${cmd[@]}" 2>"$stderr_file"; then
+        rm -f "$stderr_file"
+        print_success "Peering connected for $PSA_RANGE"
+        PSA_STATUS="connected"
+        return 0
+    fi
+    if grep -qiE 'PERMISSION_DENIED|permission' "$stderr_file"; then
+        rm -f "$stderr_file"
+        PSA_STATUS="pending"
+        print_warning "ACTION REQUIRED: this account cannot create the peering (needs roles/servicenetworking.networksAdmin)."
+        print_warning "Someone with that role runs: ${cmd[*]}"
+        return 0
+    fi
+    cat "$stderr_file" >&2
+    rm -f "$stderr_file"
+    print_error "Peering $verb failed"
+    exit 1
+}
+
+step_summary() {
+    print_header "Network $NETWORK"
+    echo "Network:       $NETWORK"
+    echo "Subnet:        $SUBNET  $SUBNET_RANGE  ($REGION, Private Google Access on)"
+    echo "Cloud NAT:     $NAT on router $ROUTER"
+    echo "Firewall:      $FW_CLICKHOUSE (tcp:$CLICKHOUSE_PORT from subnet), $FW_IAP (tcp:22 from IAP)"
+    echo "PSA range:     $PSA_RANGE = $PSA_ADDRESS/$PSA_PREFIX  (peering: $PSA_STATUS)"
+    echo ""
+    echo "Next:"
+    echo "  $GCP_SCRIPT_DIR/create-clickhouse-host.sh --stage $STAGE"
+    if [ "$PSA_STATUS" = "connected" ]; then
+        echo "  $GCP_SCRIPT_DIR/create-memorystore-redis.sh --stage $STAGE --network $NETWORK --reserved-ip-range $PSA_RANGE"
+    else
+        echo "  (after the peering is connected) $GCP_SCRIPT_DIR/create-memorystore-redis.sh --stage $STAGE --network $NETWORK --reserved-ip-range $PSA_RANGE"
+    fi
+}
+
+main() {
+    require_command gcloud "Install: https://cloud.google.com/sdk/docs/install"
+
+    parse_args "$@"
+    validate_args
+
+    step_enable_apis
+    step_network
+    step_subnet
+    step_nat
+    step_firewall
+    step_psa_address
+    step_psa_peering
+    step_summary
+}
+
+# ============================================================================
+# Entry point
+# ============================================================================
+
+main "$@"


### PR DESCRIPTION
## Call graph
```text
Before
  deployStack           (Stack · apps/infra/stack/deploy.ts:17)          - AWS only
    └─ createFoundation (Foundation · apps/infra/stack/foundation.ts:14)
         └─ sst.aws.Redis (ElastiCache · apps/infra/stack/foundation.ts:51) - 1 node, TLS, AUTH, private subnets
              └─ buildApi (Api · apps/infra/stack/api.ts:199)             - REDIS_HOST/PORT/PASSWORD, REDIS_TLS=true
  …                                                                        - no GCP counterpart
After
  main                     (Script · scripts/deploy/gcp/create-memorystore-redis.sh:463)
    ├─ step_enable_api     (Script · scripts/deploy/gcp/create-memorystore-redis.sh:236) - redis.googleapis.com before any gcloud redis call
    ├─ step_preflight      (Script · scripts/deploy/gcp/create-memorystore-redis.sh:243) - VPC, PSA range, peering, egress-deny rules, read-only
    ├─ step_create_instance (Script · scripts/deploy/gcp/create-memorystore-redis.sh:301) - Memorystore for Redis: basic, 1 GiB, redis_7_2, PSA, AUTH, TLS
    ├─ step_store_auth     (Script · scripts/deploy/gcp/create-memorystore-redis.sh:387) - get-auth-string to Secret Manager via stdin, new version only on change
    ├─ step_store_ca       (Script · scripts/deploy/gcp/create-memorystore-redis.sh:405) - serverCaCerts[] to Secret Manager, count-checked
    └─ step_summary        (Script · scripts/deploy/gcp/create-memorystore-redis.sh:433) - host, port, secret names; never the password
  …
  getRedisConfig           (TypedConfigService · apps/api/src/config/typed-config.service.ts:170) - unchanged; REDIS_TLS_CA is a follow-up
```

## Summary
Add a checked-in `gcloud` script that provisions the Redis the BoxLite API needs on GCP, matching the AWS ElastiCache settings in `apps/infra`, and stores the AUTH string and server CA in Secret Manager. First step of running the control plane on GCP; the API itself is not deployed there yet.

## Changes
- `scripts/deploy/gcp/create-memorystore-redis.sh`: idempotent provisioning script following the conventions of `create-instance.sh`. Immutable instance settings only produce a drift warning; `--dry-run`, `--no-tls`, `--rotate-auth` flags.
- `scripts/deploy/gcp/README.md`: index of the GCP scripts, Redis runbook, Cloud Run wiring, in-VPC verification, rotation, limits.
- `apps/api/.env.example`: document `REDIS_PASSWORD`, `REDIS_TLS`, `REDIS_TLS_CA`.

Memorystore for Redis standalone is the only GCP product that fits: the API relies on logical DB 1 (`app.module.ts:141`), `EVAL` (`redis-lock.provider.ts`), pub/sub with pattern subscriptions from `@socket.io/redis-adapter`, `BRPOP` (`job.service.ts`) and multi-key pipelines, which do not all work on Valkey or Redis Cluster.

## How to verify
- `bash -n scripts/deploy/gcp/create-memorystore-redis.sh`
- `./scripts/deploy/gcp/create-memorystore-redis.sh --dry-run` prints the exact `gcloud` commands without mutating anything.
- Against project `avid-vine-500315-u4` the script has been run for real: instance `boxlite-dev-cache` is READY at `10.120.118.67:6378` with TLS + AUTH, secrets `boxlite-dev-redis-auth` and `boxlite-dev-redis-ca` hold one version each, and a re-run creates nothing. A Cloud Run job on the same subnet verified PING, DB 1 SET/GET, EVAL, BRPOP, PSUBSCRIBE, plus rejection of plaintext and of a wrong password.

## Risks / rollout
- With TLS the port is 6378. `REDIS_TLS=true` currently gives ioredis `tls: {}`, which rejects the Google private CA, so the API needs a `REDIS_TLS_CA` option before it can connect (separate PR). The server certificate observed in the smoke test carries an IP SAN, so only the CA is needed.
- Basic tier has no persistence; maintenance clears the data. Same posture as the AWS deployment, where Redis is a cache and lock store with Postgres as the source of truth.
- Granting the API service account access to the two secrets needs setIamPolicy, which the deploying editor lacks; the script prints the commands for a project owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a GCP deployment script for provisioning a private Memorystore for Redis instance with TLS, authentication, validation, dry-run support, and secret storage.
  - Added support for rotating Redis authentication credentials and safely reusing existing infrastructure.

- **Documentation**
  - Added deployment guidance for GCP helper scripts, Redis setup, Cloud Run configuration, connectivity testing, credential rotation, and known configuration limitations.
  - Documented optional Redis security environment variables for cloud deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->