### PR TITLE
feat(volumes): add a GCS/gcsfuse backend alongside S3/mount-s3

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -54,6 +54,14 @@ S3_DEFAULT_BUCKET=boxlite
 S3_ACCOUNT_ID=/
 S3_ROLE_NAME=/
 
+# Which object store backs volume buckets: s3 (default) or gcs. Must match the
+# runner's VOLUME_STORAGE_BACKEND — the API creates the buckets it mounts.
+# GCS credentials come from Application Default Credentials, never a key file,
+# so only placement is configured here.
+VOLUME_STORAGE_BACKEND=s3
+GCS_LOCATION=
+GCS_PROJECT_ID=
+
 ENVIRONMENT=dev
 
 MAX_AUTO_ARCHIVE_INTERVAL=43200

--- a/apps/api/src/box/managers/volume.manager.ts
+++ b/apps/api/src/box/managers/volume.manager.ts
@@ -10,12 +10,11 @@ import { Repository, In } from 'typeorm'
 import { Volume } from '../entities/volume.entity'
 import { VolumeState } from '../enums/volume-state.enum'
 import { Cron, CronExpression, SchedulerRegistry } from '@nestjs/schedule'
-import { S3Client, CreateBucketCommand, ListObjectsV2Command, PutBucketTaggingCommand } from '@aws-sdk/client-s3'
 import { InjectRedis } from '@nestjs-modules/ioredis'
 import { Redis } from 'ioredis'
 import { RedisLockProvider } from '../common/redis-lock.provider'
 import { TypedConfigService } from '../../config/typed-config.service'
-import { deleteS3Bucket } from '../../common/utils/delete-s3-bucket'
+import { createVolumeBucketStore, VolumeBucketNotEmptyError, VolumeBucketStore } from '../stores/volume-bucket.store'
 
 import { TrackableJobExecutions } from '../../common/interfaces/trackable-job-executions'
 import { TrackJobExecution } from '../../common/decorators/track-job-execution.decorator'
@@ -34,7 +33,7 @@ export class VolumeManager
   private readonly logger = new Logger(VolumeManager.name)
   private processingVolumes: Set<string> = new Set()
   private skipTestConnection = false
-  private s3Client: S3Client | null = null
+  private bucketStore: VolumeBucketStore | null = null
 
   constructor(
     @InjectRepository(Volume)
@@ -44,44 +43,17 @@ export class VolumeManager
     private readonly redisLockProvider: RedisLockProvider,
     private readonly schedulerRegistry: SchedulerRegistry,
   ) {
-    if (!this.configService.get('s3.endpoint')) {
-      return
-    }
-
-    const endpoint = this.configService.getOrThrow('s3.endpoint')
-    const region = this.configService.getOrThrow('s3.region')
-    const accessKeyId = this.configService.get('s3.accessKey')
-    const secretAccessKey = this.configService.get('s3.secretKey')
     this.skipTestConnection = this.configService.get('skipConnections')
-
-    // Both-or-neither: a lone key is a typo'd pair, and silently falling back
-    // to the SDK default chain would mask the misconfig.
-    if ((accessKeyId && !secretAccessKey) || (!accessKeyId && secretAccessKey)) {
-      throw new Error('S3_ACCESS_KEY and S3_SECRET_KEY must be set together')
-    }
-    // MinIO cannot use the SDK default chain — fail fast at boot with a clear
-    // message instead of a generic auth error from the connection probe.
-    if (endpoint.includes('minio') && !accessKeyId) {
-      throw new Error('MinIO requires S3_ACCESS_KEY and S3_SECRET_KEY to be configured')
-    }
-
-    this.s3Client = new S3Client({
-      endpoint: endpoint.startsWith('http') ? endpoint : `http://${endpoint}`,
-      region,
-      // Static keys for S3-compatible deployments (MinIO); unset on AWS,
-      // where the SDK default chain supplies the ECS task-role credentials.
-      ...(accessKeyId && secretAccessKey ? { credentials: { accessKeyId, secretAccessKey } } : {}),
-      forcePathStyle: true,
-    })
+    this.bucketStore = createVolumeBucketStore(this.configService)
   }
 
   async onModuleInit() {
-    if (!this.s3Client) {
+    if (!this.bucketStore) {
       return
     }
 
     if (this.skipTestConnection) {
-      this.logger.debug('Skipping S3 connection test')
+      this.logger.debug('Skipping volume bucket store connection test')
       return
     }
 
@@ -89,7 +61,7 @@ export class VolumeManager
   }
 
   onApplicationBootstrap() {
-    if (!this.s3Client) {
+    if (!this.bucketStore) {
       return
     }
 
@@ -105,21 +77,11 @@ export class VolumeManager
   }
 
   private async testConnection() {
-    // Probe a bucket we already know instead of ListBuckets: same
-    // connectivity+auth signal, but needs no account-wide
-    // s3:ListAllMyBuckets grant on the task role.
-    const bucket = this.configService.get('s3.defaultBucket')
-    if (!bucket) {
-      this.logger.debug('No default bucket configured; skipping S3 connection test')
-      return
-    }
-
     try {
-      const command = new ListObjectsV2Command({ Bucket: bucket, MaxKeys: 1 })
-      await this.s3Client.send(command)
-      this.logger.debug('Successfully connected to S3')
+      await this.bucketStore.probe()
+      this.logger.debug('Successfully connected to the volume bucket store')
     } catch (error) {
-      this.logger.error('Failed to connect to S3:', error)
+      this.logger.error('Failed to connect to the volume bucket store:', error)
       throw error
     }
   }
@@ -129,7 +91,7 @@ export class VolumeManager
   @LogExecution('process-pending-volumes')
   @WithInstrumentation()
   async processPendingVolumes() {
-    if (!this.s3Client) {
+    if (!this.bucketStore) {
       return
     }
 
@@ -207,37 +169,14 @@ export class VolumeManager
         state: VolumeState.CREATING,
       })
 
-      // Refresh lock before S3 operation
+      // Refresh lock before the object-store operation
       await this.redis.setex(lockKey, 30, '1')
 
-      // Create bucket in Minio/S3
-      const createBucketCommand = new CreateBucketCommand({
-        Bucket: volume.getBucketName(),
+      await this.bucketStore.create(volume.getBucketName(), {
+        VolumeId: volume.id,
+        OrganizationId: volume.organizationId,
+        Environment: this.configService.get('environment'),
       })
-
-      await this.s3Client.send(createBucketCommand)
-
-      await this.s3Client.send(
-        new PutBucketTaggingCommand({
-          Bucket: volume.getBucketName(),
-          Tagging: {
-            TagSet: [
-              {
-                Key: 'VolumeId',
-                Value: volume.id,
-              },
-              {
-                Key: 'OrganizationId',
-                Value: volume.organizationId,
-              },
-              {
-                Key: 'Environment',
-                Value: this.configService.get('environment'),
-              },
-            ],
-          },
-        }),
-      )
 
       // Refresh lock before final state update
       await this.redis.setex(lockKey, 30, '1')
@@ -269,20 +208,17 @@ export class VolumeManager
         state: VolumeState.DELETING,
       })
 
-      // Refresh lock before S3 operation
+      // Refresh lock before the object-store operation
       await this.redis.setex(lockKey, 30, '1')
 
-      // Delete bucket from Minio/S3
+      // A bucket that is already gone is absorbed by the store as success.
       try {
-        await deleteS3Bucket(this.s3Client, volume.getBucketName())
+        await this.bucketStore.destroy(volume.getBucketName())
       } catch (error) {
-        if (error.name === 'NoSuchBucket') {
-          this.logger.warn(`Bucket for volume ${volume.id} does not exist, treating as already deleted`)
-        } else if (error.name === 'BucketNotEmpty') {
+        if (error instanceof VolumeBucketNotEmptyError) {
           throw new Error('Volume deletion failed because the bucket is not empty. You may retry deletion.')
-        } else {
-          throw error
         }
+        throw error
       }
 
       // Refresh lock before final state update

--- a/apps/api/src/box/services/volume.service.ts
+++ b/apps/api/src/box/services/volume.service.ts
@@ -29,6 +29,7 @@ import { RedisLockProvider } from '../common/redis-lock.provider'
 import { BoxRepository } from '../repositories/box.repository'
 import { BoxDesiredState } from '../enums/box-desired-state.enum'
 import { setTimeout as sleep } from 'timers/promises'
+import { isVolumeStorageConfigured } from '../stores/volume-bucket.store'
 
 // Shape Postgres accepts for a `uuid` column. Used to keep plain names out of
 // an id predicate, not to validate ids - the database is the authority.
@@ -48,7 +49,7 @@ export class VolumeService {
   ) {}
 
   async create(organization: Organization, createVolumeDto: CreateVolumeDto): Promise<Volume> {
-    if (!this.configService.get('s3.endpoint')) {
+    if (!isVolumeStorageConfigured(this.configService)) {
       throw new ServiceUnavailableException('Object storage is not configured')
     }
 

--- a/apps/api/src/box/stores/volume-bucket.store.spec.ts
+++ b/apps/api/src/box/stores/volume-bucket.store.spec.ts
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Storage } from '@google-cloud/storage'
+import { createVolumeBucketStore, VolumeBucketNotEmptyError } from './volume-bucket.store'
+
+const mockCreateBucket = jest.fn()
+const mockGetAccessToken = jest.fn()
+const mockSetLabels = jest.fn()
+const mockDeleteFiles = jest.fn()
+const mockDeleteBucket = jest.fn()
+
+const mockDeleteS3Bucket = jest.fn()
+
+jest.mock('../../common/utils/delete-s3-bucket', () => ({
+  deleteS3Bucket: (...args: unknown[]) => mockDeleteS3Bucket(...args),
+}))
+
+jest.mock('@google-cloud/storage', () => ({
+  Storage: jest.fn().mockImplementation(() => ({
+    createBucket: mockCreateBucket,
+    authClient: { getAccessToken: mockGetAccessToken },
+    bucket: jest.fn(() => ({
+      setLabels: mockSetLabels,
+      deleteFiles: mockDeleteFiles,
+      delete: mockDeleteBucket,
+    })),
+  })),
+}))
+
+function buildStore(values: Record<string, unknown>) {
+  const configService = {
+    get: jest.fn((key: string) => values[key]),
+    getOrThrow: jest.fn((key: string) => {
+      const value = values[key]
+      if (value === undefined) {
+        throw new Error(`Missing config: ${key}`)
+      }
+      return value
+    }),
+  }
+  return createVolumeBucketStore(configService as any)
+}
+
+const gcsConfig = {
+  'volume.storageBackend': 'gcs',
+  'gcs.location': 'us-central1',
+}
+
+describe('createVolumeBucketStore', () => {
+  afterEach(() => jest.clearAllMocks())
+
+  // Compatibility: no VOLUME_STORAGE_BACKEND means the S3 path, which is also
+  // the path that stays dormant when object storage is not configured at all.
+  it('defaults to S3 and stays dormant when no endpoint is configured', () => {
+    expect(buildStore({})).toBeNull()
+    expect(buildStore({ 'volume.storageBackend': 's3' })).toBeNull()
+    expect(Storage).not.toHaveBeenCalled()
+  })
+
+  it('builds an S3 store once an endpoint is configured', () => {
+    const store = buildStore({
+      's3.endpoint': 'https://s3.ap-southeast-1.amazonaws.com',
+      's3.region': 'ap-southeast-1',
+    })
+
+    expect(store).not.toBeNull()
+    expect(Storage).not.toHaveBeenCalled()
+  })
+
+  // A GCS deployment that forgets the location would otherwise silently land
+  // every volume bucket in the client's default region, away from the runners.
+  // A .env file spells an unset key as the empty string, not undefined, and
+  // getOrThrow would wave that through into createBucket as location:''.
+  it.each([undefined, '', '   '])('refuses a GCS backend whose location is %p', (location) => {
+    const values: Record<string, unknown> = { 'volume.storageBackend': 'gcs' }
+    if (location !== undefined) {
+      values['gcs.location'] = location
+    }
+    expect(() => buildStore(values)).toThrow('GCS_LOCATION')
+  })
+
+  // The runner refuses an unknown backend at startup via validate:"oneof=s3 gcs".
+  // Without the same refusal here a typo keeps the API quietly on S3 while the
+  // runner will not boot, and the two disagree about where a volume lives.
+  it.each(['gsc', 'GCS', 's3 ', 'filestore'])('refuses the unrecognised backend %p', (backend) => {
+    expect(() => buildStore({ 'volume.storageBackend': backend, 's3.endpoint': 'http://minio:9000' })).toThrow(
+      'VOLUME_STORAGE_BACKEND',
+    )
+  })
+
+  // No credentials are passed anywhere: the client must resolve ADC.
+  it('constructs the GCS client without credentials', () => {
+    buildStore(gcsConfig)
+    expect(Storage).toHaveBeenCalledWith({})
+
+    jest.clearAllMocks()
+    buildStore({ ...gcsConfig, 'gcs.projectId': 'boxlite-prod' })
+    expect(Storage).toHaveBeenCalledWith({ projectId: 'boxlite-prod' })
+  })
+})
+
+describe('GCS volume bucket store', () => {
+  // clearAllMocks resets call records but not implementations, so each case
+  // re-establishes the happy path; otherwise a rejection set by one case leaks
+  // into the next and silently short-circuits the code under test.
+  beforeEach(() => {
+    mockGetAccessToken.mockResolvedValue('ya29.token')
+    mockCreateBucket.mockResolvedValue(undefined)
+    mockSetLabels.mockResolvedValue(undefined)
+    mockDeleteFiles.mockResolvedValue(undefined)
+    mockDeleteBucket.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => jest.clearAllMocks())
+
+  // The point of the probe is to fail at boot when the credential chain is
+  // broken. getProjectId() would have returned the cached option here and let
+  // a misconfigured deployment start, so the assertion is the rejection, not
+  // that some method was called.
+  it('fails when the credential chain cannot mint a token', async () => {
+    mockGetAccessToken.mockRejectedValue(new Error('Could not load the default credentials'))
+
+    await expect(buildStore(gcsConfig).probe()).rejects.toThrow('default credentials')
+  })
+
+  it('passes once a token can be minted, without needing a storage grant', async () => {
+    await expect(buildStore(gcsConfig).probe()).resolves.toBeUndefined()
+    expect(mockGetAccessToken).toHaveBeenCalled()
+  })
+
+  it('creates the bucket in the configured location with uniform access', async () => {
+    await buildStore(gcsConfig).create('boxlite-volume-abc', {})
+
+    expect(mockCreateBucket).toHaveBeenCalledWith('boxlite-volume-abc', {
+      location: 'us-central1',
+      iamConfiguration: { uniformBucketLevelAccess: { enabled: true } },
+    })
+  })
+
+  // GCS labels reject the S3 tag keys verbatim: uppercase is not allowed. A
+  // pass-through would fail the create, not merely lose the labels.
+  it('normalises S3 tag keys into GCS label syntax', async () => {
+    await buildStore(gcsConfig).create('boxlite-volume-abc', {
+      VolumeId: 'abc-123',
+      OrganizationId: 'org-1',
+      Environment: 'Dev',
+    })
+
+    expect(mockSetLabels).toHaveBeenCalledWith({ volumeid: 'abc-123', organizationid: 'org-1', environment: 'dev' }, {})
+  })
+
+  // Order is the assertion: GCS refuses to delete a non-empty bucket with a
+  // 409, so a reordering would surface as a failed volume deletion in
+  // production while both calls still "happened".
+  it('deletes objects before the bucket', async () => {
+    const order: string[] = []
+    mockDeleteFiles.mockImplementation(async () => void order.push('files'))
+    mockDeleteBucket.mockImplementation(async () => void order.push('bucket'))
+
+    await buildStore(gcsConfig).destroy('boxlite-volume-abc')
+
+    expect(mockDeleteFiles).toHaveBeenCalledWith({ force: true })
+    expect(order).toEqual(['files', 'bucket'])
+  })
+
+  // Deletion is retried by the volume state machine, so a bucket that a prior
+  // attempt already removed must not wedge the volume in DELETING forever.
+  it('treats an already-deleted bucket as success', async () => {
+    mockDeleteBucket.mockRejectedValue(Object.assign(new Error('Not Found'), { code: 404 }))
+
+    await expect(buildStore(gcsConfig).destroy('boxlite-volume-abc')).resolves.toBeUndefined()
+  })
+
+  // Under `force` deleteFiles rejects with an ARRAY of per-object errors, so a
+  // handler that reads error.code off the rejection sees undefined, skips
+  // every branch, and reports the failure as `undefined` to the caller.
+  it('reports per-object delete failures instead of an empty error', async () => {
+    mockDeleteFiles.mockRejectedValue([
+      Object.assign(new Error('retention policy'), { code: 403 }),
+      Object.assign(new Error('still uploading'), { code: 412 }),
+    ])
+
+    const destroy = buildStore(gcsConfig).destroy('boxlite-volume-abc')
+
+    await expect(destroy).rejects.toThrow(/retention policy; still uploading/)
+    expect(mockDeleteBucket).not.toHaveBeenCalled()
+  })
+
+  // An object deleted concurrently leaves nothing to clean up, so the bucket
+  // delete must still run rather than the volume failing on a benign race.
+  it('ignores objects that vanished mid-delete', async () => {
+    mockDeleteFiles.mockRejectedValue([Object.assign(new Error('Not Found'), { code: 404 })])
+
+    await expect(buildStore(gcsConfig).destroy('boxlite-volume-abc')).resolves.toBeUndefined()
+    expect(mockDeleteBucket).toHaveBeenCalled()
+  })
+
+  // The manager branches on this type to produce a retryable user-facing
+  // message; a raw 409 would fall through to the generic error path.
+  it('maps a non-empty bucket onto the shared error type', async () => {
+    mockDeleteBucket.mockRejectedValue(Object.assign(new Error('conflict'), { code: 409 }))
+
+    await expect(buildStore(gcsConfig).destroy('boxlite-volume-abc')).rejects.toBeInstanceOf(VolumeBucketNotEmptyError)
+  })
+
+  it('rethrows anything else', async () => {
+    mockDeleteBucket.mockRejectedValue(Object.assign(new Error('permission denied'), { code: 403 }))
+
+    await expect(buildStore(gcsConfig).destroy('boxlite-volume-abc')).rejects.toThrow('permission denied')
+  })
+})
+
+describe('S3 volume bucket store', () => {
+  const s3Config = {
+    's3.endpoint': 'https://s3.ap-southeast-1.amazonaws.com',
+    's3.region': 'ap-southeast-1',
+  }
+
+  afterEach(() => jest.clearAllMocks())
+
+  // Deletion is retried by the volume state machine; a bucket a prior attempt
+  // already removed must not wedge the volume in DELETING.
+  it('treats an already-deleted bucket as success', async () => {
+    mockDeleteS3Bucket.mockRejectedValue(Object.assign(new Error('gone'), { name: 'NoSuchBucket' }))
+
+    await expect(buildStore(s3Config).destroy('boxlite-volume-abc')).resolves.toBeUndefined()
+  })
+
+  // Both backends must raise the same type: the manager turns it into the
+  // retryable user-facing message and would otherwise fall through to the
+  // generic error path on one backend only.
+  it('maps a non-empty bucket onto the shared error type', async () => {
+    mockDeleteS3Bucket.mockRejectedValue(Object.assign(new Error('not empty'), { name: 'BucketNotEmpty' }))
+
+    await expect(buildStore(s3Config).destroy('boxlite-volume-abc')).rejects.toBeInstanceOf(VolumeBucketNotEmptyError)
+  })
+
+  it('rethrows anything else', async () => {
+    mockDeleteS3Bucket.mockRejectedValue(Object.assign(new Error('access denied'), { name: 'AccessDenied' }))
+
+    await expect(buildStore(s3Config).destroy('boxlite-volume-abc')).rejects.toThrow('access denied')
+  })
+})

--- a/apps/api/src/box/stores/volume-bucket.store.ts
+++ b/apps/api/src/box/stores/volume-bucket.store.ts
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2026 BoxLite AI
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Logger } from '@nestjs/common'
+import { S3Client, CreateBucketCommand, PutBucketTaggingCommand, ListObjectsV2Command } from '@aws-sdk/client-s3'
+import { Storage } from '@google-cloud/storage'
+import { TypedConfigService } from '../../config/typed-config.service'
+import { deleteS3Bucket } from '../../common/utils/delete-s3-bucket'
+
+/**
+ * Raised by `destroy` when the bucket still holds objects. The two backends
+ * signal this differently — S3 with a `BucketNotEmpty` error name, GCS with a
+ * 409 — so it is normalised here; a caller that branched on either backend's
+ * native shape would silently stop handling the case on the other.
+ */
+export class VolumeBucketNotEmptyError extends Error {
+  constructor(bucket: string) {
+    super(`Volume bucket ${bucket} is not empty`)
+    this.name = 'VolumeBucketNotEmptyError'
+  }
+}
+
+/**
+ * The object-store operations a volume's lifecycle needs. One volume is one
+ * bucket, so the whole surface is create/destroy plus a boot-time reachability
+ * probe.
+ */
+export interface VolumeBucketStore {
+  /** Fail fast at boot rather than on the first volume a user creates. */
+  probe(): Promise<void>
+  create(bucket: string, labels: Record<string, string>): Promise<void>
+  /** Idempotent: a bucket that is already gone resolves rather than throwing. */
+  destroy(bucket: string): Promise<void>
+}
+
+/**
+ * Whether volumes can be served at all. Both the request path and the
+ * reconciler need this answer and they must not drift: a request accepted by
+ * one and refused by the other leaves a volume stuck in PENDING_CREATE.
+ */
+export function isVolumeStorageConfigured(configService: TypedConfigService): boolean {
+  if (configService.get('volume.storageBackend') === 'gcs') {
+    return true
+  }
+  return Boolean(configService.get('s3.endpoint'))
+}
+
+/**
+ * Builds the store for the configured backend, or null when object storage is
+ * not configured at all — the caller uses that to keep the whole volume
+ * subsystem dormant, which is how an API without S3_ENDPOINT behaves today.
+ */
+export function createVolumeBucketStore(configService: TypedConfigService): VolumeBucketStore | null {
+  const backend = configService.get('volume.storageBackend')
+
+  // The runner applies default:"s3" before validate:"oneof=s3 gcs", so an unset
+  // value is the S3 backend on both sides. A value that is set but unrecognised
+  // is a typo, and staying silent would keep the API on S3 while the runner
+  // refuses to boot — the two would then disagree about where a volume lives.
+  if (backend && backend !== 's3' && backend !== 'gcs') {
+    throw new Error(`VOLUME_STORAGE_BACKEND must be "s3" or "gcs", got "${backend}"`)
+  }
+
+  if (backend === 'gcs') {
+    // getOrThrow only rejects undefined, but an unset key in a .env file is the
+    // empty string and a fat-fingered one is whitespace. Either would reach
+    // createBucket as a blank location and place every volume bucket in the
+    // client's default region, failing at the first user volume instead of at
+    // boot. Trimmed here as well as in configuration.ts: the guard that throws
+    // should not depend on its caller having normalised the value.
+    const location = configService.get('gcs.location')?.trim()
+    if (!location) {
+      throw new Error('GCS_LOCATION must be set when VOLUME_STORAGE_BACKEND is "gcs"')
+    }
+    return new GcsVolumeBucketStore(location, configService.get('gcs.projectId')?.trim() || undefined)
+  }
+
+  if (!isVolumeStorageConfigured(configService)) {
+    return null
+  }
+  return new S3VolumeBucketStore(configService)
+}
+
+class S3VolumeBucketStore implements VolumeBucketStore {
+  private readonly logger = new Logger(S3VolumeBucketStore.name)
+  private readonly client: S3Client
+  private readonly probeBucket?: string
+
+  constructor(configService: TypedConfigService) {
+    const endpoint = configService.getOrThrow('s3.endpoint')
+    const region = configService.getOrThrow('s3.region')
+    const accessKeyId = configService.get('s3.accessKey')
+    const secretAccessKey = configService.get('s3.secretKey')
+
+    // Both-or-neither: a lone key is a typo'd pair, and silently falling back
+    // to the SDK default chain would mask the misconfig.
+    if ((accessKeyId && !secretAccessKey) || (!accessKeyId && secretAccessKey)) {
+      throw new Error('S3_ACCESS_KEY and S3_SECRET_KEY must be set together')
+    }
+    // MinIO cannot use the SDK default chain — fail fast at boot with a clear
+    // message instead of a generic auth error from the connection probe.
+    if (endpoint.includes('minio') && !accessKeyId) {
+      throw new Error('MinIO requires S3_ACCESS_KEY and S3_SECRET_KEY to be configured')
+    }
+
+    this.probeBucket = configService.get('s3.defaultBucket')
+    this.client = new S3Client({
+      endpoint: endpoint.startsWith('http') ? endpoint : `http://${endpoint}`,
+      region,
+      // Static keys for S3-compatible deployments (MinIO); unset on AWS,
+      // where the SDK default chain supplies the ECS task-role credentials.
+      ...(accessKeyId && secretAccessKey ? { credentials: { accessKeyId, secretAccessKey } } : {}),
+      forcePathStyle: true,
+    })
+  }
+
+  async probe(): Promise<void> {
+    // Probe a bucket we already know instead of ListBuckets: same
+    // connectivity+auth signal, but needs no account-wide
+    // s3:ListAllMyBuckets grant on the task role.
+    if (!this.probeBucket) {
+      return
+    }
+    await this.client.send(new ListObjectsV2Command({ Bucket: this.probeBucket, MaxKeys: 1 }))
+  }
+
+  async create(bucket: string, labels: Record<string, string>): Promise<void> {
+    await this.client.send(new CreateBucketCommand({ Bucket: bucket }))
+    await this.client.send(
+      new PutBucketTaggingCommand({
+        Bucket: bucket,
+        Tagging: { TagSet: Object.entries(labels).map(([Key, Value]) => ({ Key, Value })) },
+      }),
+    )
+  }
+
+  async destroy(bucket: string): Promise<void> {
+    try {
+      await deleteS3Bucket(this.client, bucket)
+    } catch (error) {
+      if (error.name === 'NoSuchBucket') {
+        this.logger.warn(`Bucket ${bucket} does not exist, treating as already deleted`)
+        return
+      }
+      if (error.name === 'BucketNotEmpty') {
+        throw new VolumeBucketNotEmptyError(bucket)
+      }
+      throw error
+    }
+  }
+}
+
+class GcsVolumeBucketStore implements VolumeBucketStore {
+  private readonly logger = new Logger(GcsVolumeBucketStore.name)
+  private readonly storage: Storage
+
+  constructor(
+    private readonly location: string,
+    projectId?: string,
+  ) {
+    // No credentials are passed: the client resolves Application Default
+    // Credentials — the attached service account on GCE/GKE/Cloud Run, or
+    // `gcloud auth application-default login` locally. Service-account key
+    // files are deliberately not supported.
+    this.storage = new Storage(projectId ? { projectId } : {})
+  }
+
+  async probe(): Promise<void> {
+    // Minting a token is what actually exercises the credential chain — the
+    // metadata server on GCE, or the ADC file locally. getProjectId() cannot
+    // serve here: with projectId configured it returns the cached option
+    // without touching credentials at all, so a broken chain would still boot.
+    //
+    // This proves credentials resolve, not that the bucket-admin role is
+    // present; the first createBucket remains the check for that.
+    await this.storage.authClient.getAccessToken()
+  }
+
+  async create(bucket: string, labels: Record<string, string>): Promise<void> {
+    await this.storage.createBucket(bucket, {
+      location: this.location,
+      // Volume buckets are private platform storage; uniform access removes
+      // per-object ACLs as a way to widen that by accident.
+      iamConfiguration: { uniformBucketLevelAccess: { enabled: true } },
+    })
+    await this.storage.bucket(bucket).setLabels(toGcsLabels(labels), {})
+  }
+
+  async destroy(bucket: string): Promise<void> {
+    const handle = this.storage.bucket(bucket)
+
+    try {
+      // GCS has no bulk delete; deleteFiles pages and deletes. `force` keeps it
+      // going past individual failures so one stuck object cannot strand the
+      // whole volume — but it also changes the rejection shape to an array of
+      // per-object errors, which is why this cannot share the catch below.
+      // No `versions`: volume buckets are created without object versioning.
+      await handle.deleteFiles({ force: true })
+    } catch (error) {
+      // An object deleted concurrently reports 404 and leaves nothing to clean
+      // up, so only the other failures are real.
+      const failures = asErrorArray(error).filter((each) => statusOf(each) !== 404)
+      if (failures.length > 0) {
+        throw new Error(`Failed to empty volume bucket ${bucket}: ${failures.map((each) => each.message).join('; ')}`)
+      }
+    }
+
+    try {
+      await handle.delete()
+    } catch (error) {
+      if (statusOf(error) === 404) {
+        this.logger.warn(`Bucket ${bucket} does not exist, treating as already deleted`)
+        return
+      }
+      if (statusOf(error) === 409) {
+        throw new VolumeBucketNotEmptyError(bucket)
+      }
+      throw error
+    }
+  }
+}
+
+/**
+ * deleteFiles rejects with an array of per-object errors under `force`, and
+ * with a single error everywhere else; both shapes reach the same handler.
+ */
+function asErrorArray(error: unknown): Error[] {
+  return Array.isArray(error) ? error : [error as Error]
+}
+
+function statusOf(error: unknown): number | undefined {
+  return (error as { code?: number } | undefined)?.code
+}
+
+/**
+ * GCS labels accept only lowercase letters, digits, dashes and underscores, so
+ * the S3 tag keys (`VolumeId`, `OrganizationId`, …) would be rejected verbatim.
+ */
+function toGcsLabels(labels: Record<string, string>): Record<string, string> {
+  const normalise = (s: string) => s.toLowerCase().replace(/[^a-z0-9_-]/g, '-')
+  return Object.fromEntries(Object.entries(labels).map(([key, value]) => [normalise(key), normalise(value)]))
+}

--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -437,6 +437,18 @@ const configuration = {
     accountId: process.env.S3_ACCOUNT_ID,
     roleName: process.env.S3_ROLE_NAME,
   },
+  volume: {
+    // Which object store backs volume buckets. Must match the runner's
+    // VOLUME_STORAGE_BACKEND: the API creates the bucket the runner mounts.
+    storageBackend: process.env.VOLUME_STORAGE_BACKEND || 's3',
+  },
+  gcs: {
+    // Credentials come from Application Default Credentials, never a key file,
+    // so only placement is configured here. Keep the location co-located with
+    // the runner fleet: cross-region reads are billed and slower.
+    location: process.env.GCS_LOCATION?.trim(),
+    projectId: process.env.GCS_PROJECT_ID?.trim(),
+  },
   notificationGatewayDisabled: process.env.NOTIFICATION_GATEWAY_DISABLED === 'true',
   skipConnections: process.env.SKIP_CONNECTIONS === 'true',
   maintananceMode: process.env.MAINTENANCE_MODE === 'true',

--- a/apps/package.json
+++ b/apps/package.json
@@ -56,6 +56,7 @@
     "@clickhouse/client": "^1.16.0",
     "@dotenvx/dotenvx": "^1.25.1",
     "@esm2cjs/cacheable-lookup": "^7.0.0",
+    "@google-cloud/storage": "^8.0.1",
     "@iarna/toml": "^2.2.5",
     "@iconify-json/pixelarticons": "^1.2.6",
     "@iconify/react": "^6.0.2",

--- a/apps/runner/cmd/runner/config/config.go
+++ b/apps/runner/cmd/runner/config/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	AWSAccessKeyId                     string        `envconfig:"AWS_ACCESS_KEY_ID"`
 	AWSSecretAccessKey                 string        `envconfig:"AWS_SECRET_ACCESS_KEY"`
 	AWSDefaultBucket                   string        `envconfig:"AWS_DEFAULT_BUCKET"`
+	VolumeStorageBackend               string        `envconfig:"VOLUME_STORAGE_BACKEND" default:"s3" validate:"oneof=s3 gcs"`
 	ResourceLimitsDisabled             bool          `envconfig:"RESOURCE_LIMITS_DISABLED"`
 	BoxStartTimeoutSec                 int           `envconfig:"BOX_START_TIMEOUT_SEC"`
 	UseSnapshotEntrypoint              bool          `envconfig:"USE_SNAPSHOT_ENTRYPOINT"`

--- a/apps/runner/cmd/runner/main.go
+++ b/apps/runner/cmd/runner/main.go
@@ -118,6 +118,7 @@ func run() int {
 		AWSEndpointUrl:               cfg.AWSEndpointUrl,
 		AWSAccessKeyId:               cfg.AWSAccessKeyId,
 		AWSSecretAccessKey:           cfg.AWSSecretAccessKey,
+		VolumeStorageBackend:         cfg.VolumeStorageBackend,
 		VolumeCleanupInterval:        cfg.VolumeCleanupInterval,
 		VolumeCleanupDryRun:          cfg.VolumeCleanupDryRun,
 		VolumeCleanupExclusionPeriod: cfg.VolumeCleanupExclusionPeriod,

--- a/apps/runner/pkg/boxlite/client.go
+++ b/apps/runner/pkg/boxlite/client.go
@@ -33,6 +33,7 @@ type Client struct {
 	awsEndpointUrl     string
 	awsAccessKeyId     string
 	awsSecretAccessKey string
+	volumeBackend      string
 	volumeMutexes      map[string]*sync.Mutex
 	volumeMutexesMutex sync.Mutex
 	volumeCleanupMutex sync.Mutex
@@ -53,6 +54,7 @@ type ClientConfig struct {
 	AWSEndpointUrl               string
 	AWSAccessKeyId               string
 	AWSSecretAccessKey           string
+	VolumeStorageBackend         string
 	VolumeCleanupInterval        time.Duration
 	VolumeCleanupDryRun          bool
 	VolumeCleanupExclusionPeriod time.Duration
@@ -195,6 +197,7 @@ func NewClient(ctx context.Context, config ClientConfig) (*Client, error) {
 		awsEndpointUrl:     config.AWSEndpointUrl,
 		awsAccessKeyId:     config.AWSAccessKeyId,
 		awsSecretAccessKey: config.AWSSecretAccessKey,
+		volumeBackend:      config.VolumeStorageBackend,
 		volumeMutexes:      make(map[string]*sync.Mutex),
 		volumeCleanup: volumeCleanupConfig{
 			interval:        config.VolumeCleanupInterval,

--- a/apps/runner/pkg/boxlite/volumes.go
+++ b/apps/runner/pkg/boxlite/volumes.go
@@ -7,6 +7,7 @@ package boxlite
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -23,6 +24,22 @@ import (
 
 const volumeMountPrefix = "boxlite-volume-"
 const volumeMountRecordDir = ".boxlite-volume-mounts"
+
+// How long a mount command may run before it is killed. The request context
+// cannot serve as this bound: Create is handed an undeadlined gin request
+// context, and gcsfuse retries an unreachable bucket forever, so without an
+// explicit deadline a misconfigured backend wedges box creation indefinitely.
+const volumeMountTimeout = 90 * time.Second
+
+// Bound for the local mount probes and teardown. A wedged FUSE mount blocks
+// stat and umount indefinitely, which is exactly the state these run in.
+const volumeProbeTimeout = 10 * time.Second
+
+// Bound for the readiness loop as a whole. It has to be a deadline rather than
+// a retry count: each probe can now burn volumeProbeTimeout against a wedged
+// mount, so counting attempts would multiply into minutes of holding the
+// per-volume mutex.
+const volumeReadyTimeout = 30 * time.Second
 
 type volumeCleanupConfig struct {
 	interval        time.Duration
@@ -131,7 +148,13 @@ func (c *Client) ensureVolumeFuseMounted(ctx context.Context, volumeId string, m
 	volumeMutex.Lock()
 	defer volumeMutex.Unlock()
 
-	if c.isDirectoryMounted(mountPath) {
+	mounted, err := c.isDirectoryMounted(ctx, mountPath)
+	if err != nil {
+		// Guessing here is what makes a stale mount look absent: we would mount
+		// over it, then treat the directory as pre-existing and tear it down.
+		return fmt.Errorf("cannot determine whether volume %s is already mounted: %w", volumeId, err)
+	}
+	if mounted {
 		c.logger.DebugContext(ctx, "volume already mounted", "volumeId", volumeId, "mountPath", mountPath)
 		return nil
 	}
@@ -139,82 +162,236 @@ func (c *Client) ensureVolumeFuseMounted(ctx context.Context, volumeId string, m
 	_, statErr := os.Stat(mountPath)
 	dirExisted := statErr == nil
 
-	err := os.MkdirAll(mountPath, 0755)
-	if err != nil {
+	if err = os.MkdirAll(mountPath, 0755); err != nil {
 		return fmt.Errorf("failed to create mount directory %s: %s", mountPath, err)
 	}
 
-	c.logger.InfoContext(ctx, "mounting S3 volume", "volumeId", volumeId, "mountPath", mountPath)
+	c.logger.InfoContext(ctx, "mounting volume", "volumeId", volumeId, "mountPath", mountPath, "backend", c.volumeBackend)
 
-	cmd := c.getMountCmd(ctx, volumeId, mountPath)
-	err = cmd.Run()
-	if err != nil {
-		if !dirExisted {
-			removeErr := os.Remove(mountPath)
-			if removeErr != nil {
-				c.logger.WarnContext(ctx, "failed to remove mount directory", "path", mountPath, "error", removeErr)
-			}
-		}
-		return fmt.Errorf("failed to mount S3 volume %s to %s: %s", volumeId, mountPath, err)
+	mountCtx, cancelMount := context.WithTimeout(ctx, volumeMountTimeout)
+	defer cancelMount()
+
+	cmd := c.getMountCmd(mountCtx, volumeId, mountPath)
+	if err = cmd.Run(); err != nil {
+		c.cleanUpFailedMount(ctx, mountPath, dirExisted)
+		return fmt.Errorf("failed to mount volume %s to %s via %s backend: %s", volumeId, mountPath, c.volumeBackend, err)
 	}
 
-	err = c.waitForMountReady(ctx, mountPath)
-	if err != nil {
-		if !dirExisted {
-			umountErr := exec.Command("umount", mountPath).Run()
-			if umountErr != nil {
-				c.logger.WarnContext(ctx, "failed to unmount during cleanup", "path", mountPath, "error", umountErr)
-			}
-			removeErr := os.Remove(mountPath)
-			if removeErr != nil {
-				c.logger.WarnContext(ctx, "failed to remove mount directory during cleanup", "path", mountPath, "error", removeErr)
-			}
-		}
+	if err = c.waitForMountReady(ctx, mountPath); err != nil {
+		c.cleanUpFailedMount(ctx, mountPath, dirExisted)
 		return fmt.Errorf("mount %s not ready after mounting: %s", mountPath, err)
 	}
 
-	c.logger.InfoContext(ctx, "mounted S3 volume", "volumeId", volumeId, "mountPath", mountPath)
+	c.logger.InfoContext(ctx, "mounted volume", "volumeId", volumeId, "mountPath", mountPath, "backend", c.volumeBackend)
 	return nil
 }
 
-func (c *Client) isDirectoryMounted(path string) bool {
-	cmd := exec.Command("mountpoint", path)
-	_, err := cmd.Output()
-
-	return err == nil
+// mountProbeCmd and umountCmd exist as separate builders so a test can assert
+// the commands are context-bound. Running them cannot show that: mountpoint
+// and umount fail on an ordinary directory whatever the context says.
+func mountProbeCmd(ctx context.Context, path string) *exec.Cmd {
+	return exec.CommandContext(ctx, "mountpoint", path)
 }
 
-func (c *Client) waitForMountReady(ctx context.Context, path string) error {
-	maxAttempts := 50
-	sleepDuration := 100 * time.Millisecond
+func umountCmd(ctx context.Context, path string) *exec.Cmd {
+	return exec.CommandContext(ctx, "umount", path)
+}
 
-	for i := 0; i < maxAttempts; i++ {
-		if !c.isDirectoryMounted(path) {
-			return fmt.Errorf("mount disappeared during readiness check")
-		}
+// cleanupContext detaches from the caller's cancellation while keeping its
+// values, and gives the teardown a bound of its own. Extracted so a test can
+// hold it to that: derived straight from ctx, the whole cleanup becomes a
+// no-op in the cases that call it.
+func cleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), volumeProbeTimeout*2)
+}
 
-		_, err := os.Stat(path)
-		if err == nil {
-			_, err = os.ReadDir(path)
-			if err == nil {
-				c.logger.InfoContext(ctx, "mount is ready", "path", path, "attempts", i+1)
-				return nil
-			}
-		}
+// cleanUpFailedMount undoes a mount attempt that did not reach a usable state.
+//
+// It deliberately does not use the caller's context. The two things that bring
+// us here — volumeMountTimeout firing, and the client disconnecting — both
+// leave that context cancelled, and every exec under a cancelled context
+// returns without running. Inheriting it would mean the cleanup silently does
+// nothing in exactly the cases it exists for.
+//
+// The unmount is not gated on dirExisted: a mount tool can attach to a
+// directory that was already there, and leaving that behind is the worse
+// failure. A later ensureVolumeFuseMounted would see isDirectoryMounted report
+// true and hand a box a wedged mount. Only removing the directory is gated,
+// because only then did we create it.
+func (c *Client) cleanUpFailedMount(ctx context.Context, mountPath string, dirExisted bool) {
+	cleanupCtx, cancel := cleanupContext(ctx)
+	defer cancel()
 
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("context cancelled while waiting for mount ready: %w", ctx.Err())
-		case <-time.After(sleepDuration):
+	var unmountErr error
+	mounted, probeErr := c.isDirectoryMounted(cleanupCtx, mountPath)
+	if probeErr != nil {
+		// Unknown state: leave both the mount and the directory alone rather
+		// than remove a path that may still be a live mountpoint.
+		c.logger.WarnContext(ctx, "skipping mount cleanup, probe inconclusive", "path", mountPath, "error", probeErr)
+		return
+	}
+	if mounted {
+		if unmountErr = c.umountPath(cleanupCtx, mountPath); unmountErr != nil {
+			c.logger.WarnContext(ctx, "failed to unmount after failed mount", "path", mountPath, "error", unmountErr)
 		}
 	}
 
-	return fmt.Errorf("mount did not become ready within timeout")
+	if shouldRemoveMountDir(dirExisted, unmountErr) {
+		if err := os.Remove(mountPath); err != nil {
+			c.logger.WarnContext(ctx, "failed to remove mount directory", "path", mountPath, "error", err)
+		}
+	}
+}
+
+// shouldRemoveMountDir keeps the teardown ordering honest. The directory goes
+// only when we created it AND nothing is still mounted on it: removing a live
+// mountpoint stranded the mount under an empty path, and removing a directory
+// we did not create destroys someone else's.
+func shouldRemoveMountDir(dirExisted bool, unmountErr error) bool {
+	return !dirExisted && unmountErr == nil
+}
+
+// isDirectoryMounted answers whether path is a mountpoint. The error is
+// non-nil only when the probe could not run to an answer — a finished context,
+// or a deadline hit mid-probe.
+//
+// The two must stay distinguishable. A probe that cannot run and reports
+// "false" is not a harmless default: callers use it to decide whether a mount
+// is already in place and whether one is theirs to tear down, so the false
+// negative makes them remount over a live mount, or unmount someone else's.
+func (c *Client) isDirectoryMounted(ctx context.Context, path string) (bool, error) {
+	probeCtx, cancel := context.WithTimeout(ctx, volumeProbeTimeout)
+	defer cancel()
+
+	_, err := mountProbeCmd(probeCtx, path).Output()
+	if probeCtx.Err() != nil {
+		return false, fmt.Errorf("mount probe on %s did not complete: %w", path, probeCtx.Err())
+	}
+	if err == nil {
+		return true, nil
+	}
+
+	// A non-zero exit is mountpoint's way of saying "not a mountpoint"; any
+	// other failure means we never got an answer.
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return false, nil
+	}
+	return false, fmt.Errorf("mount probe on %s failed: %w", path, err)
+}
+
+// umountPath tears a mount down under the same bound as the probe: a mount
+// whose backend is gone will not answer, and an unbounded umount here would
+// simply move the hang from the mount to its cleanup.
+func (c *Client) umountPath(ctx context.Context, path string) error {
+	umountCtx, cancel := context.WithTimeout(ctx, volumeProbeTimeout)
+	defer cancel()
+
+	return umountCmd(umountCtx, path).Run()
+}
+
+// readable answers whether the mountpoint can be listed, without inheriting a
+// hang if it cannot. os.Stat and os.ReadDir are uninterruptible on a FUSE mount
+// whose daemon has attached and then wedged — exactly the state this readiness
+// loop exists to detect — so the syscalls run on their own goroutine and the
+// caller stops waiting on the bound. That goroutine stays parked until the
+// kernel releases it; the alternative is parking the whole box creation.
+func readable(ctx context.Context, path string) bool {
+	probeCtx, cancel := context.WithTimeout(ctx, volumeProbeTimeout)
+	defer cancel()
+
+	done := make(chan bool, 1)
+	go func() {
+		if _, err := os.Stat(path); err != nil {
+			done <- false
+			return
+		}
+		_, err := os.ReadDir(path)
+		done <- err == nil
+	}()
+
+	select {
+	case ok := <-done:
+		return ok
+	case <-probeCtx.Done():
+		return false
+	}
+}
+
+// notReadyError names why the readiness wait ended: the caller gave up, or the
+// mount simply never came up within our own bound. Both reach here through the
+// same finished readyCtx, so the caller's context is what tells them apart.
+func notReadyError(ctx context.Context, readyCtx context.Context) error {
+	if ctx.Err() != nil {
+		return fmt.Errorf("context cancelled while waiting for mount ready: %w", ctx.Err())
+	}
+	return fmt.Errorf("mount did not become ready within %s: %w", volumeReadyTimeout, readyCtx.Err())
+}
+
+func (c *Client) waitForMountReady(ctx context.Context, path string) error {
+	sleepDuration := 100 * time.Millisecond
+
+	readyCtx, cancel := context.WithTimeout(ctx, volumeReadyTimeout)
+	defer cancel()
+
+	for attempt := 1; ; attempt++ {
+		mounted, err := c.isDirectoryMounted(readyCtx, path)
+		if err != nil {
+			return notReadyError(ctx, readyCtx)
+		}
+		if !mounted {
+			return fmt.Errorf("mount disappeared during readiness check")
+		}
+
+		if readable(readyCtx, path) {
+			c.logger.InfoContext(ctx, "mount is ready", "path", path, "attempts", attempt)
+			return nil
+		}
+
+		select {
+		case <-readyCtx.Done():
+			return notReadyError(ctx, readyCtx)
+		case <-time.After(sleepDuration):
+		}
+	}
+}
+
+// Volume storage backends the runner can mount with, selected by
+// VOLUME_STORAGE_BACKEND. The default is s3, so a deployment that does not set
+// it keeps mount-s3 and its exact argv.
+//
+// Each value names a binary the host must already provide — s3 needs mount-s3,
+// gcs needs gcsfuse 2.0 or later, which is where --metadata-cache-ttl-secs
+// replaced --stat-cache-ttl — and neither is installed by the runner. Verified
+// against mount-s3 1.20.0 and gcsfuse 3.8.4. The API must be set to the same
+// backend: it creates the buckets mounted here.
+const (
+	volumeBackendS3  = "s3"
+	volumeBackendGCS = "gcs"
+)
+
+// mountSpec is one backend's mount invocation. Keeping the binary, its argv
+// and its credential environment together is what lets wrapMountCmd stay
+// backend-agnostic.
+type mountSpec struct {
+	bin  string
+	args []string
+	env  []string
 }
 
 func (c *Client) getMountCmd(ctx context.Context, volume string, path string) *exec.Cmd {
+	if c.volumeBackend == volumeBackendGCS {
+		return c.wrapMountCmd(ctx, gcsfuseMountSpec(volume, path))
+	}
+	return c.wrapMountCmd(ctx, c.mountS3Spec(volume, path))
+}
+
+// mountS3Spec builds the Mountpoint for Amazon S3 invocation. Credentials are
+// injected only when configured: a runner host sets none of them, so mount-s3
+// falls through to the EC2 instance role.
+func (c *Client) mountS3Spec(bucket string, path string) mountSpec {
 	args := []string{"--allow-other", "--allow-delete", "--allow-overwrite", "--file-mode", "0666", "--dir-mode", "0777"}
-	args = append(args, volume, path)
+	args = append(args, bucket, path)
 
 	var envVars []string
 	if c.awsEndpointUrl != "" {
@@ -230,17 +407,65 @@ func (c *Client) getMountCmd(ctx context.Context, volume string, path string) *e
 		envVars = append(envVars, "AWS_REGION="+c.awsRegion)
 	}
 
-	cmd := exec.Command("mount-s3", args...)
-	cmd.Env = envVars
+	return mountSpec{bin: "mount-s3", args: args, env: envVars}
+}
 
-	_, err := os.Stat("/run/systemd/system")
-	if err == nil {
+// gcsfuseMountSpec builds the Cloud Storage FUSE invocation. It is not a
+// one-to-one translation of mountS3Spec's argv:
+//
+//   - --allow-delete and --allow-overwrite have no counterpart because gcsfuse
+//     permits both by default; passing them is a hard "unknown flag" error.
+//   - --implicit-dirs is required for parity. Without it a directory that
+//     exists only as an object-name prefix is invisible, while mount-s3 shows it.
+//   - --metadata-cache-ttl-secs is pinned to 0 because gcsfuse otherwise caches
+//     metadata for 60s, while mount-s3 defaults to strong read-after-write
+//     consistency. Inheriting the gcsfuse default would silently hand a box a
+//     staleness window it does not have today. Raising this is the first knob to
+//     reach for once GCS request volume is measured.
+//
+// The spec contributes no credential environment of its own; gcsfuse resolves
+// Application Default Credentials, which on GCE is the attached instance
+// service account. The runner's own environment is still inherited (cmd.Env is
+// nil), which is what lets a GOOGLE_APPLICATION_CREDENTIALS path work off-GCE.
+// What this does buy is that no secret is placed on the systemd-run argv, where
+// /proc/<pid>/cmdline exposes it to every local user.
+func gcsfuseMountSpec(bucket string, path string) mountSpec {
+	return mountSpec{
+		bin: "gcsfuse",
+		args: []string{
+			"-o", "allow_other",
+			"--file-mode", "0666",
+			"--dir-mode", "0777",
+			"--implicit-dirs",
+			"--metadata-cache-ttl-secs", "0",
+			bucket, path,
+		},
+	}
+}
+
+// wrapMountCmd turns a spec into the command to run.
+//
+// On a systemd host the mount is launched in its own transient scope. A FUSE
+// daemon started as a plain child of the runner service lands in that service's
+// cgroup, so the next `systemctl restart boxlite-runner` kills every mount and
+// leaves the boxes bound to them reading a dead mountpoint.
+//
+// Both branches bind the context so volumeMountTimeout can kill a mount command
+// that never returns; the request context alone carries no deadline. The kill
+// reaches the foreground process only — a mount tool that has already forked its
+// FUSE daemon leaves that daemon behind, which is what the unmount in the
+// caller's failure path is for.
+func (c *Client) wrapMountCmd(ctx context.Context, spec mountSpec) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, spec.bin, spec.args...)
+	cmd.Env = spec.env
+
+	if _, err := os.Stat("/run/systemd/system"); err == nil {
 		sdArgs := []string{"--scope"}
-		for _, env := range envVars {
+		for _, env := range spec.env {
 			sdArgs = append(sdArgs, "--setenv="+env)
 		}
-		sdArgs = append(sdArgs, "--", "mount-s3")
-		sdArgs = append(sdArgs, args...)
+		sdArgs = append(sdArgs, "--", spec.bin)
+		sdArgs = append(sdArgs, spec.args...)
 		cmd = exec.CommandContext(ctx, "systemd-run", sdArgs...)
 	}
 
@@ -397,8 +622,15 @@ func (c *Client) unmountAndRemoveDir(ctx context.Context, path string) {
 		return
 	}
 
-	if c.isDirectoryMounted(cleanPath) {
-		if err := exec.Command("umount", cleanPath).Run(); err != nil {
+	mounted, probeErr := c.isDirectoryMounted(ctx, cleanPath)
+	if probeErr != nil {
+		// The reclaimer runs again; deleting a path we cannot prove is unmounted
+		// would strand the mount under it.
+		c.logger.WarnContext(ctx, "skipping volume reclaim, probe inconclusive", "path", cleanPath, "error", probeErr)
+		return
+	}
+	if mounted {
+		if err := c.umountPath(ctx, cleanPath); err != nil {
 			c.logger.ErrorContext(ctx, "failed to unmount directory", "path", cleanPath, "error", err)
 			return
 		}

--- a/apps/runner/pkg/boxlite/volumes_test.go
+++ b/apps/runner/pkg/boxlite/volumes_test.go
@@ -1,0 +1,357 @@
+// Copyright 2026 BoxLite AI
+// SPDX-License-Identifier: AGPL-3.0
+
+package boxlite
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"os/exec"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// mountArgv returns the mount binary and its arguments, unwrapping the
+// transient-scope wrapper when getMountCmd took the systemd branch. Tests
+// assert on the mount command itself; whether systemd wraps it is a property
+// of the host, not of the argv under test.
+func mountArgv(t *testing.T, cmd *exec.Cmd) (string, []string) {
+	t.Helper()
+
+	args := cmd.Args
+	if len(args) == 0 {
+		t.Fatal("mount command has no argv")
+	}
+	if filepathBase(args[0]) != "systemd-run" {
+		return filepathBase(args[0]), args[1:]
+	}
+	for i, a := range args {
+		if a == "--" {
+			if i+1 >= len(args) {
+				t.Fatal("systemd-run argv ends at the -- separator")
+			}
+			return args[i+1], args[i+2:]
+		}
+	}
+	t.Fatalf("systemd-run argv has no -- separator: %v", args)
+	return "", nil
+}
+
+func filepathBase(p string) string {
+	for i := len(p) - 1; i >= 0; i-- {
+		if p[i] == '/' {
+			return p[i+1:]
+		}
+	}
+	return p
+}
+
+// scopeEnvSetenv returns the --setenv= values systemd-run was asked to pass
+// through, or nil when getMountCmd took the plain exec branch.
+func scopeEnvSetenv(cmd *exec.Cmd) []string {
+	var out []string
+	for _, a := range cmd.Args {
+		if a == "--" {
+			break
+		}
+		if len(a) > len("--setenv=") && a[:len("--setenv=")] == "--setenv=" {
+			out = append(out, a[len("--setenv="):])
+		}
+	}
+	return out
+}
+
+// mountEnv returns the credential environment the mount process will see,
+// from whichever branch getMountCmd took.
+func mountEnv(cmd *exec.Cmd) []string {
+	if e := scopeEnvSetenv(cmd); e != nil {
+		return e
+	}
+	return cmd.Env
+}
+
+func testClient(t *testing.T) *Client {
+	t.Helper()
+	return &Client{logger: slog.New(slog.NewTextHandler(os.Stderr, nil))}
+}
+
+// The production shape: no AWS_* is injected on a runner host, so mount-s3
+// falls through to the instance role. Pinned byte-for-byte because the GCS
+// backend must not perturb it.
+func TestMountS3ArgvWithoutCredentials(t *testing.T) {
+	c := testClient(t)
+
+	bin, args := mountArgv(t, c.getMountCmd(context.Background(), "boxlite-volume-abc", "/mnt/boxlite-volume-abc"))
+
+	if bin != "mount-s3" {
+		t.Errorf("mount binary = %q, want mount-s3", bin)
+	}
+	want := []string{
+		"--allow-other", "--allow-delete", "--allow-overwrite",
+		"--file-mode", "0666", "--dir-mode", "0777",
+		"boxlite-volume-abc", "/mnt/boxlite-volume-abc",
+	}
+	if !reflect.DeepEqual(args, want) {
+		t.Errorf("argv mismatch\n got: %v\nwant: %v", args, want)
+	}
+}
+
+// The MinIO / development shape: all four AWS_* are injected, in this order.
+func TestMountS3ArgvWithCredentials(t *testing.T) {
+	c := testClient(t)
+	c.awsEndpointUrl = "http://minio:9000"
+	c.awsAccessKeyId = "minioadmin"
+	c.awsSecretAccessKey = "minioadmin"
+	c.awsRegion = "us-east-1"
+
+	cmd := c.getMountCmd(context.Background(), "boxlite-volume-abc", "/mnt/boxlite-volume-abc")
+
+	bin, args := mountArgv(t, cmd)
+	if bin != "mount-s3" {
+		t.Errorf("mount binary = %q, want mount-s3", bin)
+	}
+	want := []string{
+		"--allow-other", "--allow-delete", "--allow-overwrite",
+		"--file-mode", "0666", "--dir-mode", "0777",
+		"boxlite-volume-abc", "/mnt/boxlite-volume-abc",
+	}
+	if !reflect.DeepEqual(args, want) {
+		t.Errorf("argv mismatch\n got: %v\nwant: %v", args, want)
+	}
+
+	wantEnv := []string{
+		"AWS_ENDPOINT_URL=http://minio:9000",
+		"AWS_ACCESS_KEY_ID=minioadmin",
+		"AWS_SECRET_ACCESS_KEY=minioadmin",
+		"AWS_REGION=us-east-1",
+	}
+	if got := mountEnv(cmd); !reflect.DeepEqual(got, wantEnv) {
+		t.Errorf("credential env mismatch\n got: %v\nwant: %v", got, wantEnv)
+	}
+}
+
+// A partially configured backend injects only what is set: a lone region must
+// not synthesise empty key variables, which mount-s3 would read as a broken
+// static credential pair instead of falling back to the instance role.
+func TestMountS3ArgvInjectsOnlyConfiguredCredentials(t *testing.T) {
+	c := testClient(t)
+	c.awsRegion = "eu-west-1"
+
+	cmd := c.getMountCmd(context.Background(), "boxlite-volume-abc", "/mnt/boxlite-volume-abc")
+
+	wantEnv := []string{"AWS_REGION=eu-west-1"}
+	if got := mountEnv(cmd); !reflect.DeepEqual(got, wantEnv) {
+		t.Errorf("credential env mismatch\n got: %v\nwant: %v", got, wantEnv)
+	}
+}
+
+// The GCS argv is deliberately not a translation of the mount-s3 one; the
+// differences that matter are pinned here so a later edit cannot drop them.
+func TestGcsfuseArgv(t *testing.T) {
+	c := testClient(t)
+	c.volumeBackend = volumeBackendGCS
+
+	bin, args := mountArgv(t, c.getMountCmd(context.Background(), "boxlite-volume-abc", "/mnt/boxlite-volume-abc"))
+
+	if bin != "gcsfuse" {
+		t.Errorf("mount binary = %q, want gcsfuse", bin)
+	}
+	want := []string{
+		"-o", "allow_other",
+		"--file-mode", "0666",
+		"--dir-mode", "0777",
+		"--implicit-dirs",
+		"--metadata-cache-ttl-secs", "0",
+		"boxlite-volume-abc", "/mnt/boxlite-volume-abc",
+	}
+	if !reflect.DeepEqual(args, want) {
+		t.Errorf("argv mismatch\n got: %v\nwant: %v", args, want)
+	}
+}
+
+// mount-s3's flags are hard errors on gcsfuse, so a translation that leaked
+// them through would fail at mount time rather than at review time.
+func TestGcsfuseArgvOmitsMountS3OnlyFlags(t *testing.T) {
+	c := testClient(t)
+	c.volumeBackend = volumeBackendGCS
+
+	_, args := mountArgv(t, c.getMountCmd(context.Background(), "boxlite-volume-abc", "/mnt/boxlite-volume-abc"))
+
+	for _, rejected := range []string{"--allow-other", "--allow-delete", "--allow-overwrite"} {
+		for _, got := range args {
+			if got == rejected {
+				t.Errorf("gcsfuse argv carries mount-s3 flag %q, which gcsfuse rejects as an unknown flag", rejected)
+			}
+		}
+	}
+}
+
+// The GCS spec adds no credential environment of its own, so a configured
+// AWS_* pair cannot be turned into a systemd-run --setenv= argument, where
+// /proc/<pid>/cmdline would expose it to every local user. This says nothing
+// about the runner's own environment: cmd.Env is nil, so the child still
+// inherits os.Environ() — that is how an off-GCE
+// GOOGLE_APPLICATION_CREDENTIALS reaches gcsfuse.
+func TestGcsfuseCarriesNoCredentialEnv(t *testing.T) {
+	c := testClient(t)
+	c.volumeBackend = volumeBackendGCS
+	c.awsEndpointUrl = "http://minio:9000"
+	c.awsAccessKeyId = "minioadmin"
+	c.awsSecretAccessKey = "minioadmin"
+	c.awsRegion = "us-east-1"
+
+	cmd := c.getMountCmd(context.Background(), "boxlite-volume-abc", "/mnt/boxlite-volume-abc")
+
+	if got := mountEnv(cmd); len(got) != 0 {
+		t.Errorf("gcsfuse must carry no credential env, got %v", got)
+	}
+	for _, a := range cmd.Args {
+		if a == "--setenv=AWS_SECRET_ACCESS_KEY=minioadmin" {
+			t.Error("secret leaked into systemd-run argv")
+		}
+	}
+}
+
+// Compatibility: an existing deployment sets no VOLUME_STORAGE_BACKEND, so the
+// zero value must select mount-s3 rather than an unconfigured backend.
+func TestUnsetBackendSelectsMountS3(t *testing.T) {
+	c := testClient(t)
+	c.volumeBackend = ""
+
+	bin, _ := mountArgv(t, c.getMountCmd(context.Background(), "boxlite-volume-abc", "/mnt/boxlite-volume-abc"))
+	if bin != "mount-s3" {
+		t.Errorf("unset backend selected %q, want mount-s3", bin)
+	}
+
+	c.volumeBackend = volumeBackendS3
+	bin, _ = mountArgv(t, c.getMountCmd(context.Background(), "boxlite-volume-abc", "/mnt/boxlite-volume-abc"))
+	if bin != "mount-s3" {
+		t.Errorf("explicit s3 backend selected %q, want mount-s3", bin)
+	}
+}
+
+// Pins the exec to the context. gcsfuse retries an unreachable bucket forever
+// and the request context carries no deadline, so ensureVolumeFuseMounted's
+// volumeMountTimeout is the only thing that can end such a mount — and it can
+// only do so if the command is built with CommandContext. Asserted through
+// Cmd.Cancel, which exec.CommandContext sets and exec.Command leaves nil:
+// running the command instead would only report whichever mount binary this
+// host happens to be missing.
+func TestMountCmdIsBoundToTheContext(t *testing.T) {
+	for _, backend := range []string{volumeBackendS3, volumeBackendGCS} {
+		t.Run(backend, func(t *testing.T) {
+			c := testClient(t)
+			c.volumeBackend = backend
+
+			cmd := c.getMountCmd(context.Background(), "boxlite-volume-abc", "/mnt/boxlite-volume-abc")
+			if cmd.Cancel == nil {
+				t.Error("mount command is not context-bound; a hung mount could not be killed")
+			}
+		})
+	}
+}
+
+// The probe and teardown run against a mount whose backend may be gone, where
+// stat and umount block on the kernel. Asserted through Cmd.Cancel, which
+// exec.CommandContext sets and exec.Command leaves nil: running them proves
+// nothing, since both fail on an ordinary directory whatever the context says.
+func TestMountProbeAndTeardownAreContextBound(t *testing.T) {
+	ctx := context.Background()
+
+	if mountProbeCmd(ctx, "/mnt/x").Cancel == nil {
+		t.Error("mountpoint probe is not context-bound; a dead mount would block it forever")
+	}
+	if umountCmd(ctx, "/mnt/x").Cancel == nil {
+		t.Error("umount is not context-bound; cleanup would inherit the hang it exists to clear")
+	}
+}
+
+// The two things that trigger the post-failure teardown — volumeMountTimeout
+// firing and the client disconnecting — both leave the caller's context
+// cancelled, and every exec under a cancelled context returns without running.
+// A cleanup context derived from it would therefore do nothing in exactly the
+// cases it exists for, leaving a stale FUSE mount behind.
+func TestCleanupContextSurvivesCallerCancellation(t *testing.T) {
+	parent, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cleanupCtx, done := cleanupContext(parent)
+	defer done()
+
+	if err := cleanupCtx.Err(); err != nil {
+		t.Fatalf("cleanup context inherited the caller's cancellation: %v", err)
+	}
+	if _, ok := cleanupCtx.Deadline(); !ok {
+		t.Error("cleanup context has no deadline; a wedged unmount would hang it forever")
+	}
+}
+
+// A readiness wait that ends must say which of the two things happened. The
+// probe cannot tell them apart on its own: under a finished context it returns
+// before it runs, which reads exactly like an unmounted path.
+func TestNotReadyErrorDistinguishesTimeoutFromCancellation(t *testing.T) {
+	expired, cancelExpired := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancelExpired()
+
+	if err := notReadyError(context.Background(), expired); err == nil ||
+		!strings.Contains(err.Error(), "did not become ready") {
+		t.Errorf("our own bound expiring must report a timeout, got %v", err)
+	}
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := notReadyError(cancelled, cancelled); err == nil ||
+		!strings.Contains(err.Error(), "context cancelled") {
+		t.Errorf("a cancelled caller must be reported as cancellation, got %v", err)
+	}
+}
+
+// Teardown ordering: the directory may only go once nothing is mounted on it.
+func TestShouldRemoveMountDir(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		dirExisted bool
+		unmountErr error
+		want       bool
+	}{
+		{"created by us and unmounted cleanly", false, nil, true},
+		{"created by us but still mounted", false, errors.New("device busy"), false},
+		{"pre-existing directory is never ours to delete", true, nil, false},
+		{"pre-existing and still mounted", true, errors.New("device busy"), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldRemoveMountDir(tc.dirExisted, tc.unmountErr); got != tc.want {
+				t.Errorf("shouldRemoveMountDir(%v, %v) = %v, want %v", tc.dirExisted, tc.unmountErr, got, tc.want)
+			}
+		})
+	}
+}
+
+// The probe must never answer "not mounted" when it could not run. Callers use
+// that answer to decide whether a mount already exists and whether one is
+// theirs to tear down, so a false negative makes them mount over a live mount
+// or unmount a directory they never created.
+func TestMountProbeSeparatesCannotRunFromNotMounted(t *testing.T) {
+	c := testClient(t)
+	dir := t.TempDir()
+
+	mounted, err := c.isDirectoryMounted(context.Background(), dir)
+	if err != nil || mounted {
+		t.Fatalf("an ordinary directory is simply not a mountpoint, got mounted=%v err=%v", mounted, err)
+	}
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	mounted, err = c.isDirectoryMounted(cancelled, dir)
+	if err == nil {
+		t.Error("a probe that could not run reported an answer instead of an error")
+	}
+	if mounted {
+		t.Error("a probe that could not run must not claim the path is mounted")
+	}
+}

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -4640,6 +4640,51 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@google-cloud/paginator@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "@google-cloud/paginator@npm:7.0.1"
+  dependencies:
+    extend: "npm:^3.0.2"
+  checksum: 10c0/1d6826c68e6a10585e96ab9249c23b798732c63247ae29f1c228ba5a8aa84b32a89ba16bc30bd0c58283de9c90b62da4e43c1dc7c39d5025617c154635f49f67
+  languageName: node
+  linkType: hard
+
+"@google-cloud/projectify@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "@google-cloud/projectify@npm:6.0.1"
+  checksum: 10c0/d4550e26632c76fa0ce40405cb7e24b4325c639797af84a45ce0df6d2a2d3433876a48b8dd35b783c9f2d50c37815c02691e536550be329328965aa7d40d9860
+  languageName: node
+  linkType: hard
+
+"@google-cloud/promisify@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "@google-cloud/promisify@npm:6.0.1"
+  checksum: 10c0/0cf58db036b7a30bcb80a06ed4c94cf0a49d368a50cbe26762363fa4584d64d80d1d8fa2faacf6a7840eefc748f5d075f1f85d2a936f34c4fdd974f41c9ceb59
+  languageName: node
+  linkType: hard
+
+"@google-cloud/storage@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "@google-cloud/storage@npm:8.0.1"
+  dependencies:
+    "@google-cloud/paginator": "npm:^7.0.1"
+    "@google-cloud/projectify": "npm:^6.0.1"
+    "@google-cloud/promisify": "npm:^6.0.1"
+    abort-controller: "npm:^3.0.0"
+    async-retry: "npm:^1.3.3"
+    duplexify: "npm:^4.1.3"
+    fast-xml-parser: "npm:^5.3.4"
+    gaxios: "npm:^6.0.2"
+    google-auth-library: "npm:^9.6.3"
+    html-entities: "npm:^2.5.2"
+    mime: "npm:^3.0.0"
+    p-limit: "npm:^3.0.1"
+    retry-request: "npm:^9.0.1"
+    teeny-request: "npm:^11.0.1"
+  checksum: 10c0/60ac015a4ae3dfacca3a21c6c0751bb8cd7ddb2b8e58bc776e571a023f565f7c9770b8094103a381041375f74888c10a6d1eb5a8daed5319a012874ac2920563
+  languageName: node
+  linkType: hard
+
 "@grpc/grpc-js@npm:^1.11.1, @grpc/grpc-js@npm:^1.14.3":
   version: 1.14.4
   resolution: "@grpc/grpc-js@npm:1.14.4"
@@ -7745,6 +7790,13 @@ __metadata:
   version: 2.1.0
   resolution: "@nodable/entities@npm:2.1.0"
   checksum: 10c0/5a4cba2b61a5b6c726328b18b1de6d033cae4a658a118644bf31e0bcbda126ea7b69385043dc556cf1ed859b9ca220e82b81b5e5c48ef1b519fb8ec104575dee
+  languageName: node
+  linkType: hard
+
+"@nodable/entities@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@nodable/entities@npm:3.0.0"
+  checksum: 10c0/5e57422ce08d9f83a7ad09d8f90953e2e63b3274c3f941bf7ddf64f290473e70d47acbd6c8b9e60169c2a8c5c2424c4131bdd99b937792413f55a4a146f76658
   languageName: node
   linkType: hard
 
@@ -15811,6 +15863,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"anynum@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "anynum@npm:1.0.1"
+  checksum: 10c0/cfda92c9215722fc4b15faa33d0eb3d5dfd28fba6cb67c1f50d214feaa7ba6497814a3e110777853585de6d91c8c962a1ae425b637d3598d9f9d8f6f6802e5bb
+  languageName: node
+  linkType: hard
+
 "apache-md5@npm:1.1.8":
   version: 1.1.8
   resolution: "apache-md5@npm:1.1.8"
@@ -16266,6 +16325,15 @@ __metadata:
   version: 1.0.0
   resolution: "async-generator-function@npm:1.0.0"
   checksum: 10c0/2c50ef856c543ad500d8d8777d347e3c1ba623b93e99c9263ecc5f965c1b12d2a140e2ab6e43c3d0b85366110696f28114649411cbcd10b452a92a2318394186
+  languageName: node
+  linkType: hard
+
+"async-retry@npm:^1.3.3":
+  version: 1.3.3
+  resolution: "async-retry@npm:1.3.3"
+  dependencies:
+    retry: "npm:0.13.1"
+  checksum: 10c0/cabced4fb46f8737b95cc88dc9c0ff42656c62dc83ce0650864e891b6c155a063af08d62c446269b51256f6fbcb69a6563b80e76d0ea4a5117b0c0377b6b19d8
   languageName: node
   linkType: hard
 
@@ -16749,7 +16817,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base64-js@npm:^1.0.2, base64-js@npm:^1.3.1":
+"base64-js@npm:^1.0.2, base64-js@npm:^1.3.0, base64-js@npm:^1.3.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
   checksum: 10c0/f23823513b63173a001030fae4f2dabe283b99a9d324ade3ad3d148e218134676f1ee8568c877cd79ec1c53158dcf2d2ba527a97c606618928ba99dd930102bf
@@ -16856,6 +16924,13 @@ __metadata:
   version: 5.2.2
   resolution: "big.js@npm:5.2.2"
   checksum: 10c0/230520f1ff920b2d2ce3e372d77a33faa4fa60d802fe01ca4ffbc321ee06023fe9a741ac02793ee778040a16b7e497f7d60c504d1c402b8fdab6f03bb785a25f
+  languageName: node
+  linkType: hard
+
+"bignumber.js@npm:^9.0.0":
+  version: 9.3.1
+  resolution: "bignumber.js@npm:9.3.1"
+  checksum: 10c0/61342ba5fe1c10887f0ecf5be02ff6709271481aff48631f86b4d37d55a99b87ce441cfd54df3d16d10ee07ceab7e272fc0be430c657ffafbbbf7b7d631efb75
   languageName: node
   linkType: hard
 
@@ -17041,6 +17116,7 @@ __metadata:
     "@esbuild-plugins/node-modules-polyfill": "npm:^0.2.2"
     "@eslint/js": "npm:^9.8.0"
     "@esm2cjs/cacheable-lookup": "npm:^7.0.0"
+    "@google-cloud/storage": "npm:^8.0.1"
     "@iarna/toml": "npm:^2.2.5"
     "@iconify-json/pixelarticons": "npm:^1.2.6"
     "@iconify/react": "npm:^6.0.2"
@@ -19325,6 +19401,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"data-uri-to-buffer@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "data-uri-to-buffer@npm:4.0.1"
+  checksum: 10c0/20a6b93107597530d71d4cb285acee17f66bcdfc03fd81040921a81252f19db27588d87fc8fc69e1950c55cfb0bf8ae40d0e5e21d907230813eb5d5a7f9eb45b
+  languageName: node
+  linkType: hard
+
 "data-uri-to-buffer@npm:^6.0.2":
   version: 6.0.2
   resolution: "data-uri-to-buffer@npm:6.0.2"
@@ -20124,6 +20207,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"duplexify@npm:^4.1.3":
+  version: 4.1.3
+  resolution: "duplexify@npm:4.1.3"
+  dependencies:
+    end-of-stream: "npm:^1.4.1"
+    inherits: "npm:^2.0.3"
+    readable-stream: "npm:^3.1.1"
+    stream-shift: "npm:^1.0.2"
+  checksum: 10c0/8a7621ae95c89f3937f982fe36d72ea997836a708471a75bb2a0eecde3330311b1e128a6dad510e0fd64ace0c56bff3484ed2e82af0e465600c82117eadfbda5
+  languageName: node
+  linkType: hard
+
 "eastasianwidth@npm:^0.2.0":
   version: 0.2.0
   resolution: "eastasianwidth@npm:0.2.0"
@@ -20153,7 +20248,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ecdsa-sig-formatter@npm:1.0.11":
+"ecdsa-sig-formatter@npm:1.0.11, ecdsa-sig-formatter@npm:^1.0.11":
   version: 1.0.11
   resolution: "ecdsa-sig-formatter@npm:1.0.11"
   dependencies:
@@ -21991,7 +22086,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"extend@npm:^3.0.0, extend@npm:~3.0.2":
+"extend@npm:^3.0.0, extend@npm:^3.0.2, extend@npm:~3.0.2":
   version: 3.0.2
   resolution: "extend@npm:3.0.2"
   checksum: 10c0/73bf6e27406e80aa3e85b0d1c4fd987261e628064e170ca781125c0b635a3dabad5e05adbf07595ea0cf1e6c5396cacb214af933da7cbaf24fe75ff14818e8f9
@@ -22139,6 +22234,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-xml-builder@npm:^1.2.0":
+  version: 1.3.1
+  resolution: "fast-xml-builder@npm:1.3.1"
+  dependencies:
+    path-expression-matcher: "npm:^1.6.2"
+    xml-naming: "npm:^0.3.0"
+  checksum: 10c0/5aaf30465e6ba4ae9780eb3916878d5bd40763a3fd6b8b079a76aabe8f3e9e852327280e7c1be2b63ec141424b6ec61b7ab8acca8b3948779b164b004a294b4c
+  languageName: node
+  linkType: hard
+
 "fast-xml-parser@npm:5.7.3":
   version: 5.7.3
   resolution: "fast-xml-parser@npm:5.7.3"
@@ -22150,6 +22255,22 @@ __metadata:
   bin:
     fxparser: src/cli/cli.js
   checksum: 10c0/eeb802855e852ce16121396297f04131c6dbc74f863be94f19e26e386656bdb31677af469ddc6627983a48b99d8842888460ac5413063cb648fde547bb579978
+  languageName: node
+  linkType: hard
+
+"fast-xml-parser@npm:^5.3.4":
+  version: 5.11.1
+  resolution: "fast-xml-parser@npm:5.11.1"
+  dependencies:
+    "@nodable/entities": "npm:^3.0.0"
+    fast-xml-builder: "npm:^1.2.0"
+    is-unsafe: "npm:^2.0.0"
+    path-expression-matcher: "npm:^1.6.2"
+    strnum: "npm:^2.4.2"
+    xml-naming: "npm:^0.3.0"
+  bin:
+    fxparser: src/cli/cli.js
+  checksum: 10c0/04a1cf600130c4fc146e9f5bcb0a0e88354c5b9725debfa849f9028afd90b77a3e4c9339a3a7f5d22d749b74ac78567428eb1385679319fabf4d6f03065248d6
   languageName: node
   linkType: hard
 
@@ -22205,6 +22326,16 @@ __metadata:
     picomatch:
       optional: true
   checksum: 10c0/e345083c4306b3aed6cb8ec551e26c36bab5c511e99ea4576a16750ddc8d3240e63826cc624f5ae17ad4dc82e68a253213b60d556c11bfad064b7607847ed07f
+  languageName: node
+  linkType: hard
+
+"fetch-blob@npm:^3.1.2, fetch-blob@npm:^3.1.4":
+  version: 3.2.0
+  resolution: "fetch-blob@npm:3.2.0"
+  dependencies:
+    node-domexception: "npm:^1.0.0"
+    web-streams-polyfill: "npm:^3.0.3"
+  checksum: 10c0/60054bf47bfa10fb0ba6cb7742acec2f37c1f56344f79a70bb8b1c48d77675927c720ff3191fa546410a0442c998d27ab05e9144c32d530d8a52fbe68f843b69
   languageName: node
   linkType: hard
 
@@ -22619,6 +22750,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"formdata-polyfill@npm:^4.0.10":
+  version: 4.0.10
+  resolution: "formdata-polyfill@npm:4.0.10"
+  dependencies:
+    fetch-blob: "npm:^3.1.2"
+  checksum: 10c0/5392ec484f9ce0d5e0d52fb5a78e7486637d516179b0eb84d81389d7eccf9ca2f663079da56f761355c0a65792810e3b345dc24db9a8bbbcf24ef3c8c88570c6
+  languageName: node
+  linkType: hard
+
 "forwarded-parse@npm:2.1.2":
   version: 2.1.2
   resolution: "forwarded-parse@npm:2.1.2"
@@ -22845,6 +22985,30 @@ __metadata:
     strip-ansi: "npm:^6.0.1"
     wide-align: "npm:^1.1.5"
   checksum: 10c0/ef10d7981113d69225135f994c9f8c4369d945e64a8fc721d655a3a38421b738c9fe899951721d1b47b73c41fdb5404ac87cc8903b2ecbed95d2800363e7e58c
+  languageName: node
+  linkType: hard
+
+"gaxios@npm:^6.0.0, gaxios@npm:^6.0.2, gaxios@npm:^6.1.1":
+  version: 6.7.1
+  resolution: "gaxios@npm:6.7.1"
+  dependencies:
+    extend: "npm:^3.0.2"
+    https-proxy-agent: "npm:^7.0.1"
+    is-stream: "npm:^2.0.0"
+    node-fetch: "npm:^2.6.9"
+    uuid: "npm:^9.0.1"
+  checksum: 10c0/53e92088470661c5bc493a1de29d05aff58b1f0009ec5e7903f730f892c3642a93e264e61904383741ccbab1ce6e519f12a985bba91e13527678b32ee6d7d3fd
+  languageName: node
+  linkType: hard
+
+"gcp-metadata@npm:^6.1.0":
+  version: 6.1.1
+  resolution: "gcp-metadata@npm:6.1.1"
+  dependencies:
+    gaxios: "npm:^6.1.1"
+    google-logging-utils: "npm:^0.0.2"
+    json-bigint: "npm:^1.0.0"
+  checksum: 10c0/71f6ad4800aa622c246ceec3955014c0c78cdcfe025971f9558b9379f4019f5e65772763428ee8c3244fa81b8631977316eaa71a823493f82e5c44d7259ffac8
   languageName: node
   linkType: hard
 
@@ -23212,6 +23376,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"google-auth-library@npm:^9.6.3":
+  version: 9.15.1
+  resolution: "google-auth-library@npm:9.15.1"
+  dependencies:
+    base64-js: "npm:^1.3.0"
+    ecdsa-sig-formatter: "npm:^1.0.11"
+    gaxios: "npm:^6.1.1"
+    gcp-metadata: "npm:^6.1.0"
+    gtoken: "npm:^7.0.0"
+    jws: "npm:^4.0.0"
+  checksum: 10c0/6eef36d9a9cb7decd11e920ee892579261c6390104b3b24d3e0f3889096673189fe2ed0ee43fd563710e2560de98e63ad5aa4967b91e7f4e69074a422d5f7b65
+  languageName: node
+  linkType: hard
+
+"google-logging-utils@npm:^0.0.2":
+  version: 0.0.2
+  resolution: "google-logging-utils@npm:0.0.2"
+  checksum: 10c0/9a4bbd470dd101c77405e450fffca8592d1d7114f245a121288d04a957aca08c9dea2dd1a871effe71e41540d1bb0494731a0b0f6fea4358e77f06645e4268c1
+  languageName: node
+  linkType: hard
+
 "gopd@npm:^1.0.1, gopd@npm:^1.2.0":
   version: 1.2.0
   resolution: "gopd@npm:1.2.0"
@@ -23372,6 +23557,16 @@ __metadata:
   bin:
     gt: bin/main.js
   checksum: 10c0/e67f5d8384cc6ec057df422a2bffca95048f5b06b25be4ff0b0560b09c3eb5a252fafb991ae0201abe235667f254adc2284ab0a08de16bc902613060ce5792d7
+  languageName: node
+  linkType: hard
+
+"gtoken@npm:^7.0.0":
+  version: 7.1.0
+  resolution: "gtoken@npm:7.1.0"
+  dependencies:
+    gaxios: "npm:^6.0.0"
+    jws: "npm:^4.0.0"
+  checksum: 10c0/0a3dcacb1a3c4578abe1ee01c7d0bf20bffe8ded3ee73fc58885d53c00f6eb43b4e1372ff179f0da3ed5cfebd5b7c6ab8ae2776f1787e90d943691b4fe57c716
   languageName: node
   linkType: hard
 
@@ -23970,7 +24165,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"html-entities@npm:^2.6.0":
+"html-entities@npm:^2.5.2, html-entities@npm:^2.6.0":
   version: 2.6.0
   resolution: "html-entities@npm:2.6.0"
   checksum: 10c0/7c8b15d9ea0cd00dc9279f61bab002ba6ca8a7a0f3c36ed2db3530a67a9621c017830d1d2c1c65beb9b8e3436ea663e9cf8b230472e0e413359399413b27c8b7
@@ -24248,7 +24443,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:^7.0.6":
+"https-proxy-agent@npm:^7.0.1, https-proxy-agent@npm:^7.0.6":
   version: 7.0.6
   resolution: "https-proxy-agent@npm:7.0.6"
   dependencies:
@@ -25236,6 +25431,13 @@ __metadata:
   version: 0.1.0
   resolution: "is-unicode-supported@npm:0.1.0"
   checksum: 10c0/00cbe3455c3756be68d2542c416cab888aebd5012781d6819749fefb15162ff23e38501fe681b3d751c73e8ff561ac09a5293eba6f58fdf0178462ce6dcb3453
+  languageName: node
+  linkType: hard
+
+"is-unsafe@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "is-unsafe@npm:2.0.2"
+  checksum: 10c0/3f92f6534e326ae13f4a4733d0d6b9f06f2b7ab80d99c1973eb32b33b00cf9bc7a8505e3260f36209c9109f56a46bb64cc6bd0a27e37fee08cd35892a2b6ae44
   languageName: node
   linkType: hard
 
@@ -26541,6 +26743,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-bigint@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "json-bigint@npm:1.0.0"
+  dependencies:
+    bignumber.js: "npm:^9.0.0"
+  checksum: 10c0/e3f34e43be3284b573ea150a3890c92f06d54d8ded72894556357946aeed9877fd795f62f37fe16509af189fd314ab1104d0fd0f163746ad231b9f378f5b33f4
+  languageName: node
+  linkType: hard
+
 "json-buffer@npm:3.0.1":
   version: 3.0.1
   resolution: "json-buffer@npm:3.0.1"
@@ -26812,7 +27023,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jws@npm:^4.0.1":
+"jws@npm:^4.0.0, jws@npm:^4.0.1":
   version: 4.0.1
   resolution: "jws@npm:4.0.1"
   dependencies:
@@ -28899,7 +29110,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime@npm:3.0.0":
+"mime@npm:3.0.0, mime@npm:^3.0.0":
   version: 3.0.0
   resolution: "mime@npm:3.0.0"
   bin:
@@ -29601,6 +29812,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-domexception@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "node-domexception@npm:1.0.0"
+  checksum: 10c0/5e5d63cda29856402df9472335af4bb13875e1927ad3be861dc5ebde38917aecbf9ae337923777af52a48c426b70148815e890a5d72760f1b4d758cc671b1a2b
+  languageName: node
+  linkType: hard
+
 "node-exports-info@npm:^1.6.0":
   version: 1.6.0
   resolution: "node-exports-info@npm:1.6.0"
@@ -29620,7 +29838,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:2.7.0, node-fetch@npm:^2.6.1":
+"node-fetch@npm:2.7.0, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.9":
   version: 2.7.0
   resolution: "node-fetch@npm:2.7.0"
   dependencies:
@@ -29631,6 +29849,17 @@ __metadata:
     encoding:
       optional: true
   checksum: 10c0/b55786b6028208e6fbe594ccccc213cab67a72899c9234eb59dba51062a299ea853210fcf526998eaa2867b0963ad72338824450905679ff0fa304b8c5093ae8
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^3.3.2":
+  version: 3.3.2
+  resolution: "node-fetch@npm:3.3.2"
+  dependencies:
+    data-uri-to-buffer: "npm:^4.0.0"
+    fetch-blob: "npm:^3.1.4"
+    formdata-polyfill: "npm:^4.0.10"
+  checksum: 10c0/f3d5e56190562221398c9f5750198b34cf6113aa304e34ee97c94fd300ec578b25b2c2906edba922050fce983338fde0d5d34fcb0fc3336ade5bd0e429ad7538
   languageName: node
   linkType: hard
 
@@ -30467,7 +30696,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-limit@npm:^3.0.2, p-limit@npm:^3.1.0":
+"p-limit@npm:^3.0.1, p-limit@npm:^3.0.2, p-limit@npm:^3.1.0":
   version: 3.1.0
   resolution: "p-limit@npm:3.1.0"
   dependencies:
@@ -30857,6 +31086,13 @@ __metadata:
   version: 1.5.0
   resolution: "path-expression-matcher@npm:1.5.0"
   checksum: 10c0/646cb5bc66cd7d809a52288336f3ac1e6223f156fd8e912936e490e590f7f93e8056d4fd25fcbcc7da61bb698fa520112cb050372a3f65e7b79bd4afa0f77610
+  languageName: node
+  linkType: hard
+
+"path-expression-matcher@npm:^1.6.2":
+  version: 1.6.2
+  resolution: "path-expression-matcher@npm:1.6.2"
+  checksum: 10c0/8241302f563de367a81acacd417055a22dd3792a84700569dc2a7888da31aa18eb01131c55f05200c92790b6c45b01fee1984b02540cc5f15726ba1b73a8a075
   languageName: node
   linkType: hard
 
@@ -34079,17 +34315,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"retry-request@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "retry-request@npm:9.0.1"
+  dependencies:
+    extend: "npm:^3.0.2"
+    teeny-request: "npm:^11.0.0"
+  checksum: 10c0/aa18fe6c7785036ab1a9049ebe6b848f90c6b97b2f45ceacd28115ee6d1b252c5961a1864d429f7e0d9a455a66f0aa00d4e1ad3d7356a057b68bd83292ff58ee
+  languageName: node
+  linkType: hard
+
+"retry@npm:0.13.1, retry@npm:^0.13.1":
+  version: 0.13.1
+  resolution: "retry@npm:0.13.1"
+  checksum: 10c0/9ae822ee19db2163497e074ea919780b1efa00431d197c7afdb950e42bf109196774b92a49fc9821f0b8b328a98eea6017410bfc5e8a0fc19c85c6d11adb3772
+  languageName: node
+  linkType: hard
+
 "retry@npm:^0.12.0":
   version: 0.12.0
   resolution: "retry@npm:0.12.0"
   checksum: 10c0/59933e8501727ba13ad73ef4a04d5280b3717fd650408460c987392efe9d7be2040778ed8ebe933c5cbd63da3dcc37919c141ef8af0a54a6e4fca5a2af177bfe
-  languageName: node
-  linkType: hard
-
-"retry@npm:^0.13.1":
-  version: 0.13.1
-  resolution: "retry@npm:0.13.1"
-  checksum: 10c0/9ae822ee19db2163497e074ea919780b1efa00431d197c7afdb950e42bf109196774b92a49fc9821f0b8b328a98eea6017410bfc5e8a0fc19c85c6d11adb3772
   languageName: node
   linkType: hard
 
@@ -36203,6 +36449,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stream-events@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "stream-events@npm:1.0.5"
+  dependencies:
+    stubs: "npm:^3.0.0"
+  checksum: 10c0/5d235a5799a483e94ea8829526fe9d95d76460032d5e78555fe4f801949ac6a27ea2212e4e0827c55f78726b3242701768adf2d33789465f51b31ed8ebd6b086
+  languageName: node
+  linkType: hard
+
 "stream-http@npm:^3.2.0":
   version: 3.2.0
   resolution: "stream-http@npm:3.2.0"
@@ -36222,7 +36477,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stream-shift@npm:^1.0.0":
+"stream-shift@npm:^1.0.0, stream-shift@npm:^1.0.2":
   version: 1.0.3
   resolution: "stream-shift@npm:1.0.3"
   checksum: 10c0/939cd1051ca750d240a0625b106a2b988c45fb5a3be0cebe9a9858cb01bc1955e8c7b9fac17a9462976bea4a7b704e317c5c2200c70f0ca715a3363b9aa4fd3b
@@ -36537,12 +36792,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strnum@npm:^2.4.2":
+  version: 2.4.2
+  resolution: "strnum@npm:2.4.2"
+  dependencies:
+    anynum: "npm:^1.0.1"
+  checksum: 10c0/71a94dcc12cf3187e10089ed2ddcf7c289fed168ce4a33ee393bbd009a9199c237e3ef71597f3c91fac4203dd1e675c090eb4131226fd70af6fa2a31b0175de2
+  languageName: node
+  linkType: hard
+
 "strtok3@npm:^10.2.0, strtok3@npm:^10.3.4":
   version: 10.3.5
   resolution: "strtok3@npm:10.3.5"
   dependencies:
     "@tokenizer/token": "npm:^0.3.0"
   checksum: 10c0/8d2477b239054c9f1f5b14a65d531147ca158ab9887fdc2d0938e77b7ec8891fb683b58254c7643afd5d98a421a59207534d491762b111f58c795071ecbe9fd1
+  languageName: node
+  linkType: hard
+
+"stubs@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "stubs@npm:3.0.0"
+  checksum: 10c0/841a4ab8c76795d34aefe129185763b55fbf2e4693208215627caea4dd62e1299423dcd96f708d3128e3dfa0e669bae2cb912e6e906d7d81eaf6493196570923
   languageName: node
   linkType: hard
 
@@ -36956,6 +37227,18 @@ __metadata:
     debug: "npm:4.3.1"
     is2: "npm:^2.0.6"
   checksum: 10c0/a5fb29e35f1e452f1064e3671d02b6d65e7d9bffad98d8da688270b6ffdaa9a8351fe8321aedf131f3904af70b569d9c5f6d9fe75d57dda19c466abac2bc025a
+  languageName: node
+  linkType: hard
+
+"teeny-request@npm:^11.0.0, teeny-request@npm:^11.0.1":
+  version: 11.0.1
+  resolution: "teeny-request@npm:11.0.1"
+  dependencies:
+    http-proxy-agent: "npm:^7.0.0"
+    https-proxy-agent: "npm:^7.0.1"
+    node-fetch: "npm:^3.3.2"
+    stream-events: "npm:^1.0.5"
+  checksum: 10c0/a8458265dc773ec2aaa704056ecaddef04c45f0f74914f4cab017e51a02fea7274144a2f089432874d203ff8b94808f91036f3668ad94094271138b49e9c2dee
   languageName: node
   linkType: hard
 
@@ -38728,7 +39011,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^9.0.0":
+"uuid@npm:^9.0.0, uuid@npm:^9.0.1":
   version: 9.0.1
   resolution: "uuid@npm:9.0.1"
   bin:
@@ -39406,6 +39689,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"web-streams-polyfill@npm:^3.0.3":
+  version: 3.3.3
+  resolution: "web-streams-polyfill@npm:3.3.3"
+  checksum: 10c0/64e855c47f6c8330b5436147db1c75cb7e7474d924166800e8e2aab5eb6c76aac4981a84261dd2982b3e754490900b99791c80ae1407a9fa0dcff74f82ea3a7f
+  languageName: node
+  linkType: hard
+
 "web-tree-sitter@npm:^0.26.6":
   version: 0.26.8
   resolution: "web-tree-sitter@npm:0.26.8"
@@ -39966,6 +40256,13 @@ __metadata:
   version: 0.1.0
   resolution: "xml-naming@npm:0.1.0"
   checksum: 10c0/8c7614865361bcb7e53e3e091dac21c567e2b92d447919b2f072775aa9dcfc94a5255bd52fbaa0fd53c93513e53a23a6a835218ad2af512451dbc678392f85fe
+  languageName: node
+  linkType: hard
+
+"xml-naming@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "xml-naming@npm:0.3.0"
+  checksum: 10c0/48bfc4fe888cdf1c3eceb7853632ebce59e4aa71f0ae33c3f9ce1fbd3213caad293457de0a311114491f0d4efcfba70977dcba3a4f66dfed8c92edbb938056bf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds a GCS/gcsfuse backend for managed volumes alongside the existing S3/mount-s3
one. `VOLUME_STORAGE_BACKEND` selects it and defaults to `s3`, so a deployment
that does not set it keeps today's behaviour byte for byte.

## Call graph

```text
Before
  create                   (VolumeService · apps/api/src/box/services/volume.service.ts:51)  — gates on s3.endpoint
  handlePendingCreate      (VolumeManager · apps/api/src/box/managers/volume.manager.ts:199)
    ├─ s3Client.send(CreateBucketCommand)                                     — client assembled inline in the constructor
    └─ s3Client.send(PutBucketTaggingCommand)
  handlePendingDelete      (VolumeManager · apps/api/src/box/managers/volume.manager.ts:261)
    └─ deleteS3Bucket      (util · apps/api/src/common/utils/delete-s3-bucket.ts:15)

  ensureVolumeFuseMounted  (Client · apps/runner/pkg/boxlite/volumes.go:122)   — unbounded exec
    └─ getMountCmd         (Client · apps/runner/pkg/boxlite/volumes.go:215)   — argv, credential env and the systemd wrapper in one function
         └─ exec.Command("mount-s3", …)                                       — the only backend

After
  create                   (VolumeService · apps/api/src/box/services/volume.service.ts:52)
    └─ isVolumeStorageConfigured  (fn · apps/api/src/box/stores/volume-bucket.store.ts:43)  — one predicate, shared with the reconciler
  handlePendingCreate      (VolumeManager · apps/api/src/box/managers/volume.manager.ts:161)
    └─ VolumeBucketStore.create   (iface · apps/api/src/box/stores/volume-bucket.store.ts:33)
         ├─ S3VolumeBucketStore   — CreateBucket + PutBucketTagging, unchanged
         └─ GcsVolumeBucketStore  — createBucket + setLabels
  handlePendingDelete      (VolumeManager · apps/api/src/box/managers/volume.manager.ts:200)
    └─ VolumeBucketStore.destroy  (iface · apps/api/src/box/stores/volume-bucket.store.ts:35)
         ├─ S3VolumeBucketStore   — deleteS3Bucket, unchanged
         └─ GcsVolumeBucketStore  — deleteFiles (array rejection) then delete

  ensureVolumeFuseMounted  (Client · apps/runner/pkg/boxlite/volumes.go:132)   — volumeMountTimeout; unmounts before rmdir on failure
    ├─ getMountCmd         (Client · apps/runner/pkg/boxlite/volumes.go:273)   — selects the backend, nothing else
    │    ├─ mountS3Spec      (Client · apps/runner/pkg/boxlite/volumes.go:283) — existing argv and AWS_* env, verbatim
    │    ├─ gcsfuseMountSpec (func   · apps/runner/pkg/boxlite/volumes.go:323) — gcsfuse argv; no credential env, resolves ADC
    │    └─ wrapMountCmd     (Client · apps/runner/pkg/boxlite/volumes.go:346) — shared systemd --scope wrapper, context-bound
    ├─ isDirectoryMounted  (Client · apps/runner/pkg/boxlite/volumes.go:230)   — now bounded; stat on a dead mount blocks
    └─ umountPath          (Client · apps/runner/pkg/boxlite/volumes.go:242)   — new, same bound
```

## Changes

- **Runner** — `getMountCmd` split into backend selection, two argv builders and a
  shared wrapper. The gcsfuse argv is not a one-to-one translation:
  `--allow-delete` / `--allow-overwrite` have no counterpart (gcsfuse permits both
  by default and rejects the flags), `--implicit-dirs` is required for parity, and
  `--metadata-cache-ttl-secs` is pinned to `0` because gcsfuse otherwise caches
  metadata for 60s where mount-s3 defaults to strong read-after-write consistency.
- **Runner** — the mount runs under `exec.CommandContext` in both branches. gcsfuse
  retries an unreachable endpoint indefinitely, so the previously unbounded exec
  would wedge box creation.
- **Runner** — `systemd-run --scope` is kept for both backends. A FUSE daemon started
  as a plain child of the runner service lands in that service's cgroup and dies with
  the next `systemctl restart`, leaving mounted boxes on a dead mountpoint.
- **API** — `VolumeManager` no longer builds an S3 client; it depends on a
  `VolumeBucketStore` with `probe` / `create` / `destroy`. The S3 implementation is
  the existing code moved verbatim, including the both-or-neither key validation and
  the scoped `ListObjectsV2` probe.
- **API** — the GCS implementation normalises two backend differences that would
  otherwise break silently: `BucketNotEmpty` vs HTTP 409 (callers branch on the
  shared `VolumeBucketNotEmptyError`), and GCS labels rejecting the uppercase S3 tag
  keys.
- **Credentials** — the GCS paths pass none. gcsfuse and `@google-cloud/storage` both
  resolve Application Default Credentials, mirroring how the S3 paths fall through to
  the instance and task roles. That also keeps secrets out of the `systemd-run` argv.
- Adds `@google-cloud/storage` to the apps workspace.

## How to verify

```bash
# Runner: the three mount-s3 cases pin today's argv and env; they pass unchanged
# against the pre-refactor code as well.
cd apps/runner && go test ./pkg/boxlite/ -run 'TestMountS3|TestGcsfuse|TestUnsetBackend' -v

# API
cd apps && npx jest --config api/jest.config.ts \
  --testPathPatterns 'volume-bucket.store.spec|volume.manager.spec'
```

## Risks / rollout

- Default is `s3`; an unset `VOLUME_STORAGE_BACKEND` selects mount-s3, covered by a test.
- `exec.Command` → `exec.CommandContext` also affects the S3 path, but only on hosts
  without systemd; the systemd branch was already context-bound.
- Selecting `gcs` requires the API and the runner to agree, and the runner host to have
  `gcsfuse` installed. Mixing backends across the two would create buckets one side
  cannot mount.
- **`apps/infra` is deliberately untouched, so no deployment this repository builds can
  select the new backend.** That stack provisions AWS EC2 runners, which run the s3
  backend; installing gcsfuse into its AMI or wiring a GCS-only variable into its systemd
  unit would ship configuration those hosts can never use. A gcs-capable host is
  provisioned outside this repository. Flagging it explicitly because it is a scope
  boundary, not an omission — say the word and the plumbing goes in.
- Selecting a backend does not install its mount binary: the host must already provide
  mount-s3, or gcsfuse 2.0+ (where `--metadata-cache-ttl-secs` replaced `--stat-cache-ttl`).
- **Readiness timing changes for both backends.** `waitForMountReady` moves from 50 fixed
  attempts (~5s) to a 30s deadline, because each probe can now spend up to
  `volumeProbeTimeout` against a wedged mount and counting attempts would multiply into
  minutes of holding the per-volume mutex. A slow mount that used to fail at ~5s now
  succeeds — user-visible, and the reason the bound is a deadline rather than a count.
- `TestMountProbeSeparatesCannotRunFromNotMounted` needs the `mountpoint` binary
  (util-linux) on the test host. Present on ubuntu-latest; on a host without it the case
  fails rather than skips.

## Verified by hand

- **gcsfuse** against a real GCS bucket with this exact argv: mount, daemonisation,
  `--implicit-dirs`, `--only-dir` tenant isolation, read/write, file rename. Directory
  rename fails on a flat bucket (`--rename-dir-limit` defaults to 0) exactly as it does
  on mount-s3, and reports `EMFILE`, which is worth knowing when triaging.
- **mount-s3 1.20.0** against MinIO with the argv this PR must not change: mount, read,
  write, delete, unmount — and the same two cases through `ensureVolumeFuseMounted`
  itself, covering the new timeout, the context-bound probes and the failure cleanup.
- Not exercised: the virtiofs hop into a box, and the 90s timeout firing (mount-s3 does
  not hang the way gcsfuse does, so it was not reproducible here).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Google Cloud Storage support for volume buckets and mounting.
  - Added configurable volume storage backend selection, with S3 remaining the default.
  - Added GCS location and project configuration options.

- **Bug Fixes**
  - Improved volume mount readiness checks, timeouts, cleanup, and unmount handling.
  - Improved handling of missing, incomplete, or non-empty storage buckets.
  - Prevented storage credentials from appearing in mount command arguments.

- **Documentation**
  - Added architecture documentation for the GCS volume storage backend.

- **Tests**
  - Added coverage for S3 and GCS bucket operations and volume mounting scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->