### PR TITLE
fix(api): reject fractional box resources at create

### DIFF
--- a/apps/api/src/boxlite-rest/dto/create-box.dto.spec.ts
+++ b/apps/api/src/boxlite-rest/dto/create-box.dto.spec.ts
@@ -41,6 +41,21 @@ describe('CreateBoxDto resource minimums', () => {
   })
 })
 
+// Resource sizes are integers end to end (integer DB columns); pin the
+// boundary so fractions never reach the warm-pool integer query.
+describe('CreateBoxDto resource integrality', () => {
+  it.each([
+    ['cpus', { cpus: 1.5 }],
+    ['memory_mib', { memory_mib: 256.5 }],
+    ['disk_size_gb', { disk_size_gb: 1.5 }],
+  ])('rejects fractional %s with an isInt constraint', async (field, body) => {
+    const errors = await validate(plainToInstance(CreateBoxDto, body))
+
+    const fieldError = errors.find((error) => error.property === field)
+    expect(fieldError?.constraints).toHaveProperty('isInt')
+  })
+})
+
 describe('CreateBoxDto lifecycle policy', () => {
   it('accepts second-based lifecycle fields', async () => {
     const errors = await validate(plainToInstance(CreateBoxDto, { auto_stop: 900, auto_delete: 604800 }))

--- a/apps/api/src/boxlite-rest/dto/create-box.dto.ts
+++ b/apps/api/src/boxlite-rest/dto/create-box.dto.ts
@@ -12,6 +12,7 @@ import {
   IsOptional,
   IsString,
   IsNumber,
+  IsInt,
   IsBoolean,
   IsObject,
   IsArray,
@@ -211,16 +212,19 @@ export class CreateBoxDto {
   // a box that fails to start.
   @IsOptional()
   @IsNumber()
+  @IsInt()
   @Min(1)
   cpus?: number
 
   @IsOptional()
   @IsNumber()
+  @IsInt()
   @Min(256)
   memory_mib?: number
 
   @IsOptional()
   @IsNumber()
+  @IsInt()
   @Min(1)
   disk_size_gb?: number
 


### PR DESCRIPTION
CreateBoxDto validated resources with @Min only, so cpus=1.5 passed the boundary and failed later in the warm-pool query (Postgres 22P02) as a
500. @IsInt on cpus, memory_mib and disk_size_gb rejects fractions with 400, matching the published integer contract.

Fixes #1470

## Summary

`CreateBoxDto` validated resource sizes with `@Min` only, so a fractional value
like `cpus: 1.5` passed the boundary and failed later in the warm-pool query as
an HTTP 500 (`invalid input syntax for type integer`, 22P02). Adding `@IsInt`
to `cpus`, `memory_mib` and `disk_size_gb` rejects fractions with 400 at the
boundary, which is what the endpoint's published contract already requires.

## Call graph

Before

```
POST /v1/boxes           (BoxliteBoxController.createBox · boxlite-box.controller.ts)
  └─ CreateBoxDto cpus=1.5   (dto/create-box.dto.ts — @Min only)
       └─ BoxService.create
            └─ BoxWarmPoolService.fetchWarmPoolBox  ← BUG: int column = 1.5 → 22P02 → 500
```

After

```
POST /v1/boxes           (BoxliteBoxController.createBox · boxlite-box.controller.ts)
  └─ CreateBoxDto cpus=1.5   (dto/create-box.dto.ts — @IsInt + @Min) → 400
       └─ BoxService.create (valid integers only)
```

## Changes

- apps/api/src/boxlite-rest/dto/create-box.dto.ts — add `@IsInt()` to `cpus`,
  `memory_mib` and `disk_size_gb`.
- apps/api/src/boxlite-rest/dto/create-box.dto.spec.ts — pin the fractional
  cases next to the existing minimum assertions.
- This enforces a contract rather than adding a restriction:
  `openapi/box.openapi.yaml` declares all three fields `type: integer`, and the
  boxlite-rest controllers are `@ApiExcludeController()`
  (boxlite-box.controller.ts:44), so that file is the only published schema for
  the endpoint. Integer sizes are also what the engine (`u8`/`u32`/`u64`), the
  CLI and the integer DB columns can represent.

## How to verify

- Call create box with a fractional size; expect 400 with the per-field message
  instead of a 500:

  ```bash
  curl -X POST <api>/api/v1/boxes -H 'Authorization: Bearer <key>' \
    -H 'Content-Type: application/json' \
    -d '{"image":"python","cpus":1.5,"memory_mib":512,"disk_size_gb":4}'
  # expected → 400 "cpus must be an integer number"
  ```

- Same for `memory_mib=256.5` and `disk_size_gb=1.5`.
- Control: `cpus=1` must still pass validation (on a deployment without a
  runner it returns 400 "No available runners"), and `cpus=0` must still be
  rejected by the existing `@Min`.
- Unit: `cd apps/api && ../node_modules/.bin/jest --config ./jest.config.ts src/boxlite-rest/dto/create-box.dto.spec.ts`.

## Risks / rollout

- Behaviour change is limited to inputs that previously failed deeper with a
  500 or were silently truncated by integer casts; there is no schema or
  wire-shape change.
- Two neighbouring limits are intentionally left as they are, and reviewers
  should not read them as gaps: `cpus` has no upper bound in the DTO because
  the cloud ceiling is per-organization policy
  (`organization.maxCpuPerBox` via `assertWithinPerBoxLimits`,
  box.service.ts:206), not the dialect's `max_cpus` capability value; and
  `memory_mib` requires ≥256 while the portable contract says ≥128, because
  resource floors are service policy rather than a runtime invariant (#662,
  d46ae987).
- The raw before/after requests, responses and API log lines are recorded in
  the linked issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resource configuration fields now reject fractional values, ensuring CPU, memory, and disk size settings use whole numbers only.
  * Existing minimum-value validation remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->