### PR TITLE
fix(exec): surface missing-binary spawn as ExecutionError (422)

### DIFF
--- a/apps/runner/pkg/api/controllers/boxlite_exec.go
+++ b/apps/runner/pkg/api/controllers/boxlite_exec.go
@@ -75,24 +75,37 @@ func BoxliteExec(ctx *gin.Context) {
 
 	execId, err := execManager.Start(ctx.Request.Context(), bx, boxId, startOpts)
 	if err != nil {
-		// Classify so a stopped / wrong-state box surfaces as 4xx, not
-		// 500. Without this the box-stopped case leaks
-		//   internal error: HTTP 500 Internal Server Error:
-		//   {"error":"exec failed: failed to start execution: boxlite: stopped:
-		//    Handle invalidated after stop(). ... (code=11)"}
-		// and the SDK's 'all 5xx is bug' guard fires. The Go SDK already
-		// gives us a typed bool for the two states that aren't 500 from
-		// the runner's perspective (the box exists but isn't accepting
-		// execs right now).
-		if sdkboxlite.IsStopped(err) || sdkboxlite.IsInvalidState(err) {
-			ctx.JSON(http.StatusConflict, gin.H{"error": fmt.Sprintf("exec failed: %s", err)})
-			return
-		}
-		ctx.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("exec failed: %s", err)})
+		writeExecStartError(ctx, err)
 		return
 	}
 
 	ctx.JSON(http.StatusCreated, ExecResponse{ExecutionID: execId})
+}
+
+// writeExecStartError answers a failed exec start: box-state conflicts and
+// known runtime classes keep their 4xx envelope, everything else stays a 500.
+func writeExecStartError(ctx *gin.Context, err error) {
+	if sdkboxlite.IsStopped(err) || sdkboxlite.IsInvalidState(err) {
+		ctx.JSON(http.StatusConflict, gin.H{"error": fmt.Sprintf("exec failed: %s", err)})
+		return
+	}
+	if class, message, ok := execStartErrorClass(err); ok {
+		respondError(ctx, class.status, message, class.errorType, class.code)
+		return
+	}
+	ctx.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("exec failed: %s", err)})
+}
+
+// execStartErrorClass maps a runtime error to its typed envelope when the
+// exec-start branch may answer it; server faults fall through to a plain 500.
+func execStartErrorClass(err error) (copyErrorClass, string, bool) {
+	var runtimeErr *sdkboxlite.Error
+	if errors.As(err, &runtimeErr) {
+		if class, ok := copyErrorClasses[runtimeErr.Code]; ok && class.status < http.StatusInternalServerError {
+			return class, runtimeErr.Message, true
+		}
+	}
+	return copyErrorClass{}, "", false
 }
 
 // allowedExecSignals is the whitelist of POSIX signal numbers callers may

--- a/apps/runner/pkg/api/controllers/boxlite_exec_test.go
+++ b/apps/runner/pkg/api/controllers/boxlite_exec_test.go
@@ -11,9 +11,148 @@ import (
 	"sync/atomic"
 	"testing"
 
+	sdkboxlite "github.com/boxlite-ai/boxlite/sdks/go"
 	"github.com/boxlite-ai/runner/pkg/boxlite"
 	"github.com/gin-gonic/gin"
 )
+
+func TestExecStartErrorClass(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantOK     bool
+		wantStatus int
+		wantType   string
+		wantCode   string
+	}{
+		{
+			name:       "missing binary classifies as ExecutionError 422",
+			err:        &sdkboxlite.Error{Code: sdkboxlite.ErrExecution, Message: "exec process failed with error executable '/nonexistent/binary' not found in $PATH"},
+			wantOK:     true,
+			wantStatus: http.StatusUnprocessableEntity,
+			wantType:   "ExecutionError",
+			wantCode:   "execution_failed",
+		},
+		{
+			name:   "internal stays a server fault",
+			err:    &sdkboxlite.Error{Code: sdkboxlite.ErrInternal, Message: "boom"},
+			wantOK: false,
+		},
+		{
+			name:   "engine-unavailable (503 class) stays a server fault",
+			err:    &sdkboxlite.Error{Code: sdkboxlite.ErrEngine, Message: "engine down"},
+			wantOK: false,
+		},
+		{
+			name:   "non-boxlite error falls through",
+			err:    context.Canceled,
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			class, message, ok := execStartErrorClass(tt.err)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if class.status != tt.wantStatus || class.errorType != tt.wantType || class.code != tt.wantCode {
+				t.Fatalf("class = %+v, want status=%d type=%s code=%s", class, tt.wantStatus, tt.wantType, tt.wantCode)
+			}
+			if !strings.Contains(message, "nonexistent") {
+				t.Fatalf("message = %q, want runtime detail preserved", message)
+			}
+		})
+	}
+}
+
+func TestWriteExecStartError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const detail = "exec process failed with error executable '/nonexistent/binary' not found in $PATH"
+
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantType   string
+		wantCode   string
+	}{
+		{
+			name:       "execution error keeps the typed envelope",
+			err:        &sdkboxlite.Error{Code: sdkboxlite.ErrExecution, Message: detail},
+			wantStatus: http.StatusUnprocessableEntity,
+			wantType:   "ExecutionError",
+			wantCode:   "execution_failed",
+		},
+		{
+			name:       "invalid argument is a 400 envelope",
+			err:        &sdkboxlite.Error{Code: sdkboxlite.ErrInvalidArgument, Message: detail},
+			wantStatus: http.StatusBadRequest,
+			wantType:   "InvalidArgumentError",
+			wantCode:   "invalid_argument",
+		},
+		{
+			name:       "stopped box is a 409",
+			err:        &sdkboxlite.Error{Code: sdkboxlite.ErrStopped, Message: detail},
+			wantStatus: http.StatusConflict,
+		},
+		{
+			name:       "engine fault stays a 500",
+			err:        &sdkboxlite.Error{Code: sdkboxlite.ErrEngine, Message: detail},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:       "non-boxlite error stays a 500",
+			err:        context.Canceled,
+			wantStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			ctx, _ := gin.CreateTestContext(w)
+
+			writeExecStartError(ctx, tt.err)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d body=%s", w.Code, tt.wantStatus, w.Body.String())
+			}
+			if tt.wantType == "" {
+				var body struct {
+					Error string `json:"error"`
+				}
+				if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+					t.Fatalf("unmarshal failed: %v body=%s", err, w.Body.String())
+				}
+				if !strings.Contains(body.Error, tt.err.Error()) {
+					t.Fatalf("body = %s, want the original error preserved", w.Body.String())
+				}
+				return
+			}
+			var body struct {
+				Error struct {
+					Message string `json:"message"`
+					Type    string `json:"type"`
+					Code    string `json:"code"`
+				} `json:"error"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+				t.Fatalf("unmarshal failed: %v body=%s", err, w.Body.String())
+			}
+			if body.Error.Type != tt.wantType || body.Error.Code != tt.wantCode {
+				t.Fatalf("envelope = %+v, want type=%s code=%s", body.Error, tt.wantType, tt.wantCode)
+			}
+			if want := tt.err.(*sdkboxlite.Error).Message; body.Error.Message != want {
+				t.Fatalf("message = %q, want %q", body.Error.Message, want)
+			}
+		})
+	}
+}
 
 // signalCapturingExec is a minimal boxlite.ExecHandle stub that records
 // every Signal call so tests can assert the controller plumbed the

--- a/apps/runner/pkg/api/controllers/boxlite_exec_wiring_test.go
+++ b/apps/runner/pkg/api/controllers/boxlite_exec_wiring_test.go
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 BoxLite AI
+
+package controllers
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// TestBoxliteExecAnswersStartFailureThroughWriteExecStartError guards the call
+// site that routes a failed exec start into writeExecStartError. The class and
+// envelope tests cannot see that wiring — drop the call and both stay green
+// while a missing binary goes back to a bare 500 — so this asserts the shape of
+// the source, like TestCreateHasNoFallibleStepAfterStart in pkg/boxlite.
+func TestBoxliteExecAnswersStartFailureThroughWriteExecStartError(t *testing.T) {
+	fileSet := token.NewFileSet()
+	parsed, err := parser.ParseFile(fileSet, "boxlite_exec.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse boxlite_exec.go: %v", err)
+	}
+
+	handler := findFuncDecl(parsed, "BoxliteExec")
+	if handler == nil {
+		t.Fatal("BoxliteExec not found in boxlite_exec.go; update this guard if it was renamed")
+	}
+
+	if err := assertExecStartErrorAnswered(fileSet, handler, "execManager", "Start", "writeExecStartError"); err != nil {
+		t.Errorf("%v", err)
+	}
+}
+
+// TestExecStartErrorAnsweredGuard exercises the guard itself against the shape
+// production uses and the wiring regressions it exists to catch; a guard that
+// silently stops covering the invariant is worse than no guard.
+func TestExecStartErrorAnsweredGuard(t *testing.T) {
+	const shapeBoxliteExecUses = `package controllers
+
+func BoxliteExec(ctx *gin.Context) {
+	execId, err := execManager.Start(ctx.Request.Context(), bx, boxId, startOpts)
+	if err != nil {
+		START_ERROR_HANDLER
+	}
+
+	ctx.JSON(http.StatusCreated, ExecResponse{ExecutionID: execId})
+}
+`
+
+	tests := []struct {
+		name            string
+		startErrorBody  string
+		wantErrContains string
+	}{
+		{
+			name:           "failure is answered through writeExecStartError",
+			startErrorBody: "		writeExecStartError(ctx, err)\n		return",
+		},
+		{
+			name:            "failure is answered with a hard-coded 500",
+			startErrorBody:  `		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err})`,
+			wantErrContains: "writeExecStartError",
+		},
+		{
+			name:            "failure is not answered at all",
+			startErrorBody:  "",
+			wantErrContains: "writeExecStartError",
+		},
+		{
+			name:            "failure is forwarded as nil",
+			startErrorBody:  "		writeExecStartError(ctx, nil)\n		return",
+			wantErrContains: "writeExecStartError(ctx, err)",
+		},
+		{
+			name:            "failure is forwarded as another error",
+			startErrorBody:  "		writeExecStartError(ctx, startErr)\n		return",
+			wantErrContains: "writeExecStartError(ctx, err)",
+		},
+		{
+			name:            "handler keeps going after answering",
+			startErrorBody:  "		writeExecStartError(ctx, err)\n		ctx.Next()",
+			wantErrContains: "return",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := strings.Replace(shapeBoxliteExecUses, "START_ERROR_HANDLER", tt.startErrorBody, 1)
+			fileSet := token.NewFileSet()
+			parsed, err := parser.ParseFile(fileSet, "synthetic.go", source, 0)
+			if err != nil {
+				t.Fatalf("parse synthetic source: %v", err)
+			}
+
+			handler := findFuncDecl(parsed, "BoxliteExec")
+			if handler == nil {
+				t.Fatal("synthetic source lost BoxliteExec")
+			}
+
+			err = assertExecStartErrorAnswered(fileSet, handler, "execManager", "Start", "writeExecStartError")
+			if tt.wantErrContains == "" {
+				if err != nil {
+					t.Fatalf("got %v, want the wiring accepted", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected the guard to report the dropped wiring, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErrContains) {
+				t.Fatalf("got error %q, want it to mention %s", err, tt.wantErrContains)
+			}
+		})
+	}
+}
+
+// assertExecStartErrorAnswered reports whether fn hands the failure of a
+// receiver.method call to answerFunc. The call must sit in an if-init that
+// already guards on `err != nil`, or be followed immediately by that guard;
+// any other shape is reported as an error rather than guessed at.
+func assertExecStartErrorAnswered(fileSet *token.FileSet, fn *ast.FuncDecl, receiver, method, answerFunc string) error {
+	for index, statement := range fn.Body.List {
+		if findCall(statement, receiver, method) == nil {
+			continue
+		}
+
+		guard, err := execStartErrorGuard(fn.Body.List, index, receiver, method)
+		if err != nil {
+			return fmt.Errorf("%s: %w", fileSet.Position(statement.Pos()), err)
+		}
+		if err := assertAnsweredWith(guard.Body, answerFunc, "ctx", "err"); err != nil {
+			return fmt.Errorf(
+				"%s: the guard on %s.%s at %s no longer answers through %s; a caller "+
+					"mistake like a missing binary would surface as a bare 500 again: %w",
+				fileSet.Position(guard.Pos()), receiver, method,
+				fileSet.Position(statement.Pos()), answerFunc, err,
+			)
+		}
+		return nil
+	}
+
+	return fmt.Errorf(
+		"%s no longer calls %s.%s; update this guard if the exec start moved",
+		fn.Name.Name, receiver, method,
+	)
+}
+
+// execStartErrorGuard returns the `if err != nil` statement that owns the
+// failure of statements[index]: the statement itself when the call sits in an
+// if-init, otherwise the statement right after it.
+func execStartErrorGuard(statements []ast.Stmt, index int, receiver, method string) (*ast.IfStmt, error) {
+	if guard, ok := statements[index].(*ast.IfStmt); ok && guard.Init != nil {
+		if !isErrNotNil(guard.Cond) {
+			return nil, fmt.Errorf("the guard on %s.%s is no longer of the form `if err != nil`", receiver, method)
+		}
+		return guard, nil
+	}
+
+	if index+1 >= len(statements) {
+		return nil, fmt.Errorf("%s.%s is the last statement the handler runs, so its failure has nowhere to go", receiver, method)
+	}
+	guard, ok := statements[index+1].(*ast.IfStmt)
+	if !ok || guard.Init != nil || !isErrNotNil(guard.Cond) {
+		return nil, fmt.Errorf("the statement after %s.%s is no longer of the form `if err != nil`", receiver, method)
+	}
+	return guard, nil
+}
+
+// assertAnsweredWith requires the guard body to answer with
+// answerFunc(ctxArg, errArg) and to stop there. Anything else — nil, another
+// error, or running on into the success path — leaves the typed response
+// unprotected, which is the regression this guard exists to catch.
+func assertAnsweredWith(body *ast.BlockStmt, answerFunc, ctxArg, errArg string) error {
+	call := fmt.Sprintf("%s(%s, %s)", answerFunc, ctxArg, errArg)
+
+	for index, statement := range body.List {
+		expression, ok := statement.(*ast.ExprStmt)
+		if !ok {
+			continue
+		}
+		invocation, ok := expression.X.(*ast.CallExpr)
+		if !ok {
+			continue
+		}
+		identifier, ok := invocation.Fun.(*ast.Ident)
+		if !ok || identifier.Name != answerFunc {
+			continue
+		}
+		if len(invocation.Args) != 2 ||
+			!isIdent(invocation.Args[0], ctxArg) ||
+			!isIdent(invocation.Args[1], errArg) {
+			return fmt.Errorf("the guard no longer answers with %s", call)
+		}
+		if index+1 >= len(body.List) {
+			return fmt.Errorf("%s is the last statement, so the handler runs on into the success path", call)
+		}
+		if _, ok := body.List[index+1].(*ast.ReturnStmt); !ok {
+			return fmt.Errorf("the statement after %s is no longer a return, so the handler runs on into the success path", call)
+		}
+		return nil
+	}
+
+	return fmt.Errorf("the guard no longer answers through %s", call)
+}
+
+func isErrNotNil(condition ast.Expr) bool {
+	binary, ok := condition.(*ast.BinaryExpr)
+	if !ok || binary.Op != token.NEQ {
+		return false
+	}
+	errIdent, ok := binary.X.(*ast.Ident)
+	if !ok || errIdent.Name != "err" {
+		return false
+	}
+	remaining, ok := binary.Y.(*ast.Ident)
+	return ok && remaining.Name == "nil"
+}
+
+func isIdent(expression ast.Expr, name string) bool {
+	identifier, ok := expression.(*ast.Ident)
+	return ok && identifier.Name == name
+}
+
+func findFuncDecl(file *ast.File, name string) *ast.FuncDecl {
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if ok && function.Recv == nil && function.Body != nil && function.Name.Name == name {
+			return function
+		}
+	}
+	return nil
+}
+
+// findCall returns the first receiver.method call in node, as in
+// execManager.Start.
+func findCall(node ast.Node, receiver, method string) *ast.CallExpr {
+	var found *ast.CallExpr
+	ast.Inspect(node, func(candidate ast.Node) bool {
+		if found != nil {
+			return false
+		}
+		call, ok := candidate.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || selector.Sel.Name != method {
+			return true
+		}
+		if identifier, ok := selector.X.(*ast.Ident); ok && identifier.Name == receiver {
+			found = call
+			return false
+		}
+		return true
+	})
+	return found
+}

--- a/src/boxlite/src/portal/interfaces/exec.rs
+++ b/src/boxlite/src/portal/interfaces/exec.rs
@@ -62,10 +62,7 @@ impl ExecutionInterface {
         // Start execution
         let exec_response = self.client.exec(request).await?.into_inner();
         if let Some(err) = exec_response.error {
-            return Err(BoxliteError::Internal(format!(
-                "{}: {}",
-                err.reason, err.detail
-            )));
+            return Err(classify_exec_error(&err.reason, &err.detail));
         }
 
         let execution_id = exec_response.execution_id.clone();
@@ -867,6 +864,17 @@ impl OutputTracker {
     }
 }
 
+/// Map the guest's wire reason onto the typed error the caller sees; unknown
+/// reasons stay `Internal` so a server fault never becomes a 4xx.
+fn classify_exec_error(reason: &str, detail: &str) -> BoxliteError {
+    match reason {
+        "invalid_argument" => BoxliteError::InvalidArgument(detail.to_string()),
+        "execution_failed" => BoxliteError::Execution(detail.to_string()),
+        "execution_exists" => BoxliteError::AlreadyExists(detail.to_string()),
+        _ => BoxliteError::Internal(format!("{reason}: {detail}")),
+    }
+}
+
 // ============================================================================
 // UNIT TESTS
 // ============================================================================
@@ -875,6 +883,28 @@ impl OutputTracker {
 mod tests {
     use super::*;
     use std::time::Duration;
+
+    #[test]
+    fn classify_exec_error_maps_guest_reasons_to_typed_errors() {
+        assert!(matches!(
+            classify_exec_error("execution_failed", "cannot spawn /nope: no such file"),
+            BoxliteError::Execution(_)
+        ));
+        assert!(matches!(
+            classify_exec_error("invalid_argument", "execution_id is required"),
+            BoxliteError::InvalidArgument(_)
+        ));
+        assert!(matches!(
+            classify_exec_error("execution_exists", "already reserved"),
+            BoxliteError::AlreadyExists(_)
+        ));
+        // Unknown reasons stay server faults: the guest may have learned a
+        // new reason this host does not understand yet.
+        assert!(matches!(
+            classify_exec_error("mystery_reason", "detail"),
+            BoxliteError::Internal(_)
+        ));
+    }
 
     /// Test that CancellationToken correctly signals cancelled state.
     #[tokio::test]

--- a/src/cli/tests/exec.rs
+++ b/src/cli/tests/exec.rs
@@ -395,3 +395,22 @@ fn test_exec_self_terminate_maps_to_143() {
 
     cleanup(&ctx, &box_id);
 }
+
+/// A missing binary must surface as ExecutionError, not an internal error
+/// (the SDK treats 5xx as a bug).
+#[test]
+fn test_exec_missing_binary_reports_execution_error() {
+    let mut ctx = common::boxlite();
+
+    ctx.cmd.args(["run", "-d", "alpine:latest", "sleep", "300"]);
+    let output = ctx.cmd.assert().success().get_output().clone();
+    let box_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+    ctx.new_cmd()
+        .args(["exec", &box_id, "--", "/nonexistent/binary"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Execution error"));
+
+    cleanup(&ctx, &box_id);
+}

--- a/src/guest/src/container/zygote.rs
+++ b/src/guest/src/container/zygote.rs
@@ -158,9 +158,7 @@ impl Zygote {
         send_request(fd, &ZygoteRequest::Build(spec), fds)?;
         match recv_response(fd)? {
             ZygoteResponse::Build(BuildResult::Spawned { pid }) => Ok(Pid::from_raw(pid)),
-            ZygoteResponse::Build(BuildResult::Failed { error }) => {
-                Err(BoxliteError::Internal(error))
-            }
+            ZygoteResponse::Build(BuildResult::Failed { error }) => Err(build_failure(error)),
             other => Err(BoxliteError::Internal(format!(
                 "zygote protocol violation: Build answered with {other:?}"
             ))),
@@ -199,6 +197,16 @@ impl Zygote {
                 "zygote protocol violation: environment probe answered with {other:?}"
             ))),
         }
+    }
+}
+
+/// Youki stringifies payload-exec failures before they reach us; the pinned
+/// rev's marker keeps caller-caused exec failures out of `Internal`.
+fn build_failure(error: String) -> BoxliteError {
+    if error.contains("exec process failed with error") {
+        BoxliteError::Execution(error)
+    } else {
+        BoxliteError::Internal(error)
     }
 }
 
@@ -682,6 +690,28 @@ mod tests {
         let json = serde_json::to_vec(&result).unwrap();
         let decoded: BuildResult = serde_json::from_slice(&json).unwrap();
         assert_eq!(result, decoded);
+    }
+
+    /// Pins both sides of the marker `build_failure` matches on. The guest
+    /// answers `Internal` — and so a bare 500 — whenever youki's wording
+    /// changes, so the strings below are taken from the pinned rev's own
+    /// sources rather than from a guess about what a failure looks like.
+    #[test]
+    fn build_failure_classifies_the_youki_exec_marker() {
+        // channel.rs wraps ExecError as "exec process failed with error {0}"
+        // around the missing-path text workload/default.rs builds.
+        let missing_binary = "build failed: exec process failed with error executable \
+                              '/nonexistent/binary' not found in $PATH";
+        match build_failure(missing_binary.to_string()) {
+            BoxliteError::Execution(message) => assert_eq!(message, missing_binary),
+            other => panic!("a youki payload failure must be Execution, got {other:?}"),
+        }
+
+        let runtime_fault = "build failed: failed to set container root path: Permission denied";
+        match build_failure(runtime_fault.to_string()) {
+            BoxliteError::Internal(message) => assert_eq!(message, runtime_fault),
+            other => panic!("a build fault must stay Internal, got {other:?}"),
+        }
     }
 
     // --- ZygoteRequest/ZygoteResponse tagged enum serde tests ---

--- a/src/guest/src/service/exec/executor.rs
+++ b/src/guest/src/service/exec/executor.rs
@@ -128,6 +128,18 @@ impl Executor for GuestExecutor {
     }
 }
 
+/// A missing or non-executable program is the caller's mistake: surface it
+/// as ExecutionError (422), not Internal.
+fn classify_spawn_error(program: &str, e: std::io::Error) -> BoxliteError {
+    let message = format!("Failed to spawn '{}': {}", program, e);
+    match e.kind() {
+        std::io::ErrorKind::NotFound | std::io::ErrorKind::PermissionDenied => {
+            BoxliteError::Execution(message)
+        }
+        _ => BoxliteError::Internal(message),
+    }
+}
+
 /// Spawn process with pipes (standard mode).
 fn spawn_with_pipes(req: &ExecRequest) -> BoxliteResult<ExecHandle> {
     use nix::unistd::Pid;
@@ -163,7 +175,7 @@ fn spawn_with_pipes(req: &ExecRequest) -> BoxliteResult<ExecHandle> {
 
     let mut child = cmd
         .spawn()
-        .map_err(|e| BoxliteError::Internal(format!("Failed to spawn '{}': {}", req.program, e)))?;
+        .map_err(|e| classify_spawn_error(&req.program, e))?;
 
     let pid = child.id();
 
@@ -250,7 +262,7 @@ fn spawn_with_pty(req: &ExecRequest, config: PtyConfig) -> BoxliteResult<ExecHan
 
     let mut child = cmd
         .spawn()
-        .map_err(|e| BoxliteError::Internal(format!("Failed to spawn '{}': {}", req.program, e)))?;
+        .map_err(|e| classify_spawn_error(&req.program, e))?;
 
     let pid = child.id();
 
@@ -313,6 +325,30 @@ fn terminate_child(child: &mut std::process::Child) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The two io errors a caller causes by naming a program that is not
+    /// there, or that it may not run, must stay `Execution` and keep the
+    /// program in the message; every other io error is a runtime fault.
+    #[test]
+    fn spawn_error_classifies_caller_mistakes_as_execution() {
+        use std::io::{Error, ErrorKind};
+
+        for kind in [ErrorKind::NotFound, ErrorKind::PermissionDenied] {
+            match classify_spawn_error("/nonexistent/binary", Error::from(kind)) {
+                BoxliteError::Execution(message) => {
+                    assert!(message.contains("nonexistent"), "message = {message}");
+                }
+                other => panic!("{kind:?} must be Execution, got {other:?}"),
+            }
+        }
+
+        match classify_spawn_error("/bin/true", Error::from(ErrorKind::InvalidInput)) {
+            BoxliteError::Internal(message) => {
+                assert!(message.contains("/bin/true"), "message = {message}");
+            }
+            other => panic!("a runtime fault must stay Internal, got {other:?}"),
+        }
+    }
 
     #[test]
     fn terminate_child_kills_and_reaps_process() {

--- a/src/guest/src/service/exec/mod.rs
+++ b/src/guest/src/service/exec/mod.rs
@@ -506,6 +506,27 @@ fn spawn_error(exec_id: &str, err: String) -> ExecResponse {
     }
 }
 
+/// Map a typed spawn failure onto the wire reason the host portal trusts:
+/// caller-caused failures keep their class, anything else stays `spawn_failed`.
+fn exec_error(exec_id: &str, err: boxlite_shared::errors::BoxliteError) -> ExecResponse {
+    let (reason, detail) = match err {
+        boxlite_shared::errors::BoxliteError::Execution(message) => ("execution_failed", message),
+        boxlite_shared::errors::BoxliteError::InvalidArgument(message) => {
+            ("invalid_argument", message)
+        }
+        other => ("spawn_failed", other.to_string()),
+    };
+    ExecResponse {
+        execution_id: exec_id.to_string(),
+        pid: 0,
+        started_at_ms: 0,
+        error: Some(ExecError {
+            reason: reason.to_string(),
+            detail,
+        }),
+    }
+}
+
 fn now_ms() -> u64 {
     use std::time::{SystemTime, UNIX_EPOCH};
     SystemTime::now()
@@ -552,7 +573,7 @@ async fn spawn_with_executor(
             let handle = GuestExecutor
                 .spawn(req)
                 .await
-                .map_err(|e| spawn_error(execution_id, e.to_string()))?;
+                .map_err(|e| exec_error(execution_id, e))?;
             Ok((handle, None))
         }
         Some(s) if s.starts_with(executor_const::CONTAINER_KEY) => {
@@ -661,7 +682,7 @@ async fn spawn_with_executor(
                                 }
                                 return Err(spawn_error(execution_id, msg));
                             }
-                            return Err(spawn_error(execution_id, e.to_string()));
+                            return Err(exec_error(execution_id, e));
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

A missing binary inside a running box surfaced as `Internal` (HTTP 500) instead
of the canonical `ExecutionError` (HTTP 422 `execution_failed`): every guest
spawn failure carried the same `spawn_failed` reason and the portal folded every
reason into `Internal`. The guest now derives the reason from the typed error
and the portal maps known reasons onto their canonical variants, so caller
mistakes and server faults are distinguishable on the wire.

## Call graph

Before

```
box.exec                  (BoxHandle · src/boxlite/src/litebox/box_impl.rs)
  └─ ExecutionInterface::exec  (portal · src/boxlite/src/portal/interfaces/exec.rs:64)
       └─ any ExecResponse.error → BoxliteError::Internal  ← BUG: reason ignored
            └─ guest ExecResponse.reason="spawn_failed" (src/guest/src/service/exec/mod.rs)
                 └─ ContainerExecutor spawn error → Internal (src/guest/src/container/zygote.rs)
                      └─ runner exec start → HTTP 500 (apps/runner/pkg/api/controllers/boxlite_exec.go)
```

After

```
box.exec                  (BoxHandle · src/boxlite/src/litebox/box_impl.rs)
  └─ ExecutionInterface::exec  (portal · src/boxlite/src/portal/interfaces/exec.rs)
       └─ classify_exec_error(reason) → Execution/InvalidArgument/AlreadyExists/Internal
            └─ guest exec_error() derives reason from BoxliteError variant
                 ├─ GuestExecutor spawn io NotFound/PermissionDenied → Execution
                 └─ zygote build_failure(): youki payload-exec marker → Execution
                      └─ runner exec start → 422 ExecutionError / execution_failed
```

Fixes #1472

## Changes

- src/guest/src/service/exec/executor.rs — map not-found / permission-denied
  spawn failures to `Execution` instead of `Internal`.
- src/guest/src/container/zygote.rs — classify tenant build failures carrying
  the youki payload-exec marker as `Execution`; infra failures stay `Internal`.
- src/guest/src/service/exec/mod.rs — derive `ExecResponse.error.reason` from
  the typed error (`execution_failed` / `invalid_argument` / `spawn_failed`).
- src/boxlite/src/portal/interfaces/exec.rs — map reasons onto canonical
  variants instead of folding every reason into `Internal`, with unit coverage.
- apps/runner/pkg/api/controllers/boxlite_exec.go — answer exec-start with the
  typed envelope the file routes already emit; the branch lives in
  `writeExecStartError`.
- apps/runner/pkg/api/controllers/boxlite_exec_test.go — replace the envelope
  test that asserted its own hard-coded values with a table-driven test that
  feeds `writeExecStartError` real SDK errors, covering the 422 envelope, the
  stopped 409 and both 500 fallbacks.

## How to verify

- Unit: `cargo test -p boxlite classify_exec_error` and
  `GOFLAGS=-tags=boxlite_dev go test ./pkg/api/controllers/ -run 'TestExecStartErrorClass|TestWriteExecStartError' -count=1`.
- CLI integration on a real VM (also part of `make test:integration:cli`):
  `cargo test -p boxlite-cli --test exec test_exec_missing_binary_reports_execution_error`.
- REST contract on a real VM: run `target/debug/boxlite serve --port 8100`,
  create a box, then exec a missing binary:

  ```bash
  curl -w '%{http_code}' -X POST localhost:8100/v1/boxes/<id>/exec \
    -H 'Content-Type: application/json' \
    -d '{"command":"/nonexistent/binary","args":[],"timeout_seconds":30}'
  # expected → 422 ExecutionError / execution_failed
  ```

- If the container registry is unreachable, create the box from a local bundle
  instead: `docker save <image> -o img.tar` produces an OCI layout, which can be
  passed as `{"rootfs_path": "<dir>"}` on `POST /v1/boxes`.

## Risks / rollout

- Guest reason strings are an internal guest↔host contract; the only consumer is
  the portal seam this PR updates. No client-facing API shape changes.
- Full SDK→API→runner e2e is still blocked by the in-progress image rewrite on
  main, so end-to-end verification is through `boxlite serve` + a real VM.
- Before merging, check
  `apps/e2e/cases/test_error_code_mapping.py::test_execution_invalid_command_returns_422`:
  it is `xfail(strict=True)` and its reason points at the boxlite-shim → exec
  process build seam, which this PR does not touch. If it starts passing on a
  real VM, strict mode fails CI and the marker has to be removed here; if it
  still fails, say so rather than leaving the reader to infer it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved execution error handling across the CLI and API.
  - Missing or non-executable programs now return clear execution errors instead of generic internal errors.
  - Preserved runtime error details in API responses.
  - Classified known execution failures with appropriate HTTP error responses.
  - Improved consistency for execution failures across pipe-based and PTY-based processes.

- **Tests**
  - Added coverage for execution error classification, response formatting, process spawning, API routing, and CLI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->