### PR TITLE
fix(net): make allow_net wildcard rules actually resolve

### DIFF
--- a/src/deps/libgvproxy-sys/gvproxy-bridge/dns_filter.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/dns_filter.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"net"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/containers/gvisor-tap-vsock/pkg/types"
@@ -48,6 +49,12 @@ func buildAllowNetWithResolver(allowNet []string, lookup func(context.Context, s
 	zoneRecords := make(map[string][]types.Record)
 	exactIPs := make(map[string][]net.IP)
 	suffixIPs := make(map[string][]net.IP)
+	// One resolution per canonical hostname. Two rules naming the same host
+	// ("x.com:443" beside "x.com", say) would otherwise be looked up twice: both answers become zone records,
+	// the resolver serves the first, and the pin map keeps only the last — so a
+	// round-robin host resolves to an address AllowHostToIP rejects. That is
+	// the coupling contract this type documents.
+	resolved := make(map[string]bool)
 
 	for _, rule := range allowNet {
 		rule = strings.TrimSpace(rule)
@@ -72,22 +79,103 @@ func buildAllowNetWithResolver(allowNet []string, lookup func(context.Context, s
 		// Wildcard: *.example.com — pinned to the base domain's resolution.
 		if strings.HasPrefix(host, "*.") {
 			domain := host[2:]
+			if resolved["*."+domain] {
+				continue
+			}
+			resolved["*."+domain] = true
 			zoneName := domain + "."
-			zoneRecords[zoneName] = append(zoneRecords[zoneName], types.Record{
-				Regexp: regexp.MustCompile(".*"),
-			})
-			suffixIPs["."+strings.ToLower(domain)] = resolveAndAddRecords(domain, zoneName, zoneRecords, lookup)
+			ips := resolveAndAddRecords(domain, zoneName, zoneRecords, lookup)
+			suffix := "." + strings.ToLower(domain)
+			// Union, not overwrite: a second spelling of this domain resolves
+			// separately, and DNS may serve either answer, so the pin has to
+			// permit both or AllowHostToIP blocks the address it served.
+			suffixIPs[suffix] = append(suffixIPs[suffix], ips...)
+			// The catch-all answers with the base domain's own addresses, the
+			// same set AllowHostToIP pins this wildcard to. Adding it without an
+			// IP (as this did) matched every subdomain and answered with none,
+			// so a wildcard rule resolved to nothing at all.
+			for _, ip := range ips {
+				zoneRecords[zoneName] = append(zoneRecords[zoneName], types.Record{
+					Regexp: regexp.MustCompile(".*"),
+					IP:     ip,
+				})
+			}
 			continue
 		}
 
 		// Exact hostname: api.openai.com
+		if resolved[host] {
+			continue
+		}
+		resolved[host] = true
 		parts := strings.SplitN(host, ".", 2)
 		if len(parts) == 2 {
 			zoneName := parts[1] + "."
-			exactIPs[strings.ToLower(host)] = resolveAndAddRecords(host, zoneName, zoneRecords, lookup)
+			key := strings.ToLower(host)
+			exactIPs[key] = append(exactIPs[key], resolveAndAddRecords(host, zoneName, zoneRecords, lookup)...)
 		} else {
-			exactIPs[strings.ToLower(host)] = resolveAndAddRecords(host, host+".", zoneRecords, lookup)
+			key := strings.ToLower(host)
+			exactIPs[key] = append(exactIPs[key], resolveAndAddRecords(host, host+".", zoneRecords, lookup)...)
 		}
+	}
+
+	// Coverage a zone inherits from a wider wildcard. An exact rule creates a
+	// zone at its parent's depth ("api.team.x.test" -> zone "team.x.test."),
+	// and the resolver answers from the first matching zone alone — so that new
+	// zone would sinkhole "other.team.x.test" even while "*.x.test" allows it.
+	// The egress filter already treats those siblings as allowed
+	// (MatchesHostname suffix-matches at any depth); this keeps DNS from
+	// disagreeing with it.
+	wildcardSuffixes := make([]string, 0, len(suffixIPs))
+	for suffix := range suffixIPs {
+		wildcardSuffixes = append(wildcardSuffixes, suffix)
+	}
+	sort.Slice(wildcardSuffixes, func(i, j int) bool {
+		if len(wildcardSuffixes[i]) != len(wildcardSuffixes[j]) {
+			return len(wildcardSuffixes[i]) > len(wildcardSuffixes[j])
+		}
+		return wildcardSuffixes[i] < wildcardSuffixes[j]
+	})
+	for zoneName, records := range zoneRecords {
+		if hasCatchAll(records) {
+			continue
+		}
+		name := strings.ToLower(strings.TrimSuffix(zoneName, "."))
+		// Most specific covering wildcard wins, and only it contributes:
+		// suffixIPs is a map, so taking every match in range order would let
+		// the answer for an existing host change from one run to the next.
+		for _, suffix := range wildcardSuffixes {
+			if !strings.HasSuffix(name, suffix) {
+				continue
+			}
+			// A wildcard whose own lookup failed has no address to inherit;
+			// fall through to a broader one that resolved rather than leaving
+			// the zone with a bare sinkhole.
+			ips := suffixIPs[suffix]
+			if len(ips) == 0 {
+				continue
+			}
+			for _, ip := range ips {
+				records = append(records, types.Record{
+					Regexp: regexp.MustCompile(".*"),
+					IP:     ip,
+				})
+			}
+			break
+		}
+		zoneRecords[zoneName] = records
+	}
+
+	// Exact records before the catch-all, within every zone. The resolver
+	// returns the first matching record, and a wildcard's `.*` matches any
+	// subdomain — including one an exact rule also names, whose own resolution
+	// is what the egress pin holds. Rule order in allow_net must not decide
+	// which of the two answers.
+	for zoneName, records := range zoneRecords {
+		sort.SliceStable(records, func(i, j int) bool {
+			return records[i].Regexp == nil && records[j].Regexp != nil
+		})
+		zoneRecords[zoneName] = records
 	}
 
 	var zones []types.Zone
@@ -103,6 +191,22 @@ func buildAllowNetWithResolver(allowNet []string, lookup func(context.Context, s
 		}).Debug("allowNet: added DNS zone")
 	}
 
+	// Most specific zone first. The resolver takes the FIRST zone whose suffix
+	// matches and answers from that zone alone — with its sinkhole DefaultIP
+	// when no record inside it matches (gvisor-tap-vsock dns.go). So when one
+	// zone name is a suffix of another ("com." and "example.com.", which the
+	// rules "example.com" and "api.example.com" produce), visiting the shorter
+	// one first sinkholes a host the longer one explicitly allows. zoneRecords
+	// is a map, so without this the order — and the outcome — is random.
+	// A longer name is never less specific, so descending length is enough;
+	// the name tiebreak only keeps the result stable.
+	sort.Slice(zones, func(i, j int) bool {
+		if len(zones[i].Name) != len(zones[j].Name) {
+			return len(zones[i].Name) > len(zones[j].Name)
+		}
+		return zones[i].Name < zones[j].Name
+	})
+
 	// Catch-all root zone: sinkhole everything not explicitly allowed
 	zones = append(zones, types.Zone{
 		Name:      "",
@@ -115,6 +219,17 @@ func buildAllowNetWithResolver(allowNet []string, lookup func(context.Context, s
 	}).Info("allowNet: DNS sinkhole configured")
 
 	return allowNetResolution{zones: zones, exactIPs: exactIPs, suffixIPs: suffixIPs}
+}
+
+// hasCatchAll reports whether a zone already answers for names no exact record
+// in it names.
+func hasCatchAll(records []types.Record) bool {
+	for _, record := range records {
+		if record.Regexp != nil {
+			return true
+		}
+	}
+	return false
 }
 
 // buildAllowNetDNSZones creates DNS zones that implement allowlist filtering.

--- a/src/deps/libgvproxy-sys/gvproxy-bridge/dns_filter_test.go
+++ b/src/deps/libgvproxy-sys/gvproxy-bridge/dns_filter_test.go
@@ -2,8 +2,14 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"testing"
+	"time"
+
+	"github.com/containers/gvisor-tap-vsock/pkg/services/dns"
+	"github.com/containers/gvisor-tap-vsock/pkg/types"
+	mdns "github.com/miekg/dns"
 )
 
 func TestBuildAllowNetDNSZones(t *testing.T) {
@@ -116,5 +122,349 @@ func TestBuildAllowNet_PinCoversSameHostsAsDNS(t *testing.T) {
 	}
 	if len(res.exactIPs) != 1 || len(res.suffixIPs) != 1 {
 		t.Errorf("IP/CIDR rules must not produce hostname pin keys, got exact=%v suffix=%v", res.exactIPs, res.suffixIPs)
+	}
+}
+
+// TestBuildAllowNet_OverlappingZonesResolveTheMoreSpecificRule pins the zone
+// ordering contract through the real resolver.
+//
+// "example.com" builds zone "com." and "api.example.com" builds zone
+// "example.com.", so both zones suffix-match a query for api.example.com. The
+// resolver answers from the first match alone, falling back to that zone's
+// sinkhole when no record inside it matches — so if "com." is consulted first,
+// an explicitly allowed host resolves to 0.0.0.0.
+//
+// Asserting ordering directly would only restate the sort; this serves the
+// zones and queries them, so the answer comes from production code.
+func TestBuildAllowNet_OverlappingZonesResolveTheMoreSpecificRule(t *testing.T) {
+	lookup := func(_ context.Context, host string) ([]net.IP, error) {
+		switch host {
+		case "example.com":
+			return []net.IP{net.IPv4(203, 0, 113, 10)}, nil
+		case "api.example.com":
+			return []net.IP{net.IPv4(203, 0, 113, 11)}, nil
+		}
+		return nil, fmt.Errorf("unexpected lookup for %q", host)
+	}
+
+	// Rebuild repeatedly: zoneRecords is a map, so a single pass could pass by
+	// luck on the pre-sort code.
+	for i := 0; i < 20; i++ {
+		res := buildAllowNetWithResolver([]string{"example.com", "api.example.com"}, lookup)
+		addr := serveZones(t, res.zones)
+
+		if got := queryA(t, addr, "api.example.com"); got != "203.0.113.11" {
+			t.Fatalf("iteration %d: api.example.com resolved to %q, want 203.0.113.11 "+
+				"(a less specific zone swallowed the query)", i, got)
+		}
+		if got := queryA(t, addr, "example.com"); got != "203.0.113.10" {
+			t.Fatalf("iteration %d: example.com resolved to %q, want 203.0.113.10", i, got)
+		}
+		// Nothing else under the allowed zones leaks through.
+		if got := queryA(t, addr, "other.example.com"); got != "0.0.0.0" {
+			t.Fatalf("iteration %d: other.example.com resolved to %q, want the sinkhole", i, got)
+		}
+	}
+}
+
+// serveZones runs the production DNS service over the given zones on a local
+// UDP socket and returns its address.
+func serveZones(t *testing.T, zones []types.Zone) string {
+	t.Helper()
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+	srv, err := dns.New(pc, nil, zones)
+	if err != nil {
+		t.Fatalf("dns.New: %v", err)
+	}
+	go func() { _ = srv.Serve() }()
+	return pc.LocalAddr().String()
+}
+
+// queryA asks for one A record and returns it, or "" when there is no answer.
+func queryA(t *testing.T, addr, name string) string {
+	t.Helper()
+	c := &mdns.Client{Timeout: 3 * time.Second}
+	m := new(mdns.Msg)
+	m.SetQuestion(mdns.Fqdn(name), mdns.TypeA)
+	resp, _, err := c.Exchange(m, addr)
+	if err != nil {
+		t.Fatalf("dns exchange %s: %v", name, err)
+	}
+	for _, rr := range resp.Answer {
+		if a, ok := rr.(*mdns.A); ok {
+			return a.A.To4().String()
+		}
+	}
+	return ""
+}
+
+// TestBuildAllowNet_WildcardAndExactRulesShareAZone pins record precedence
+// inside one zone.
+//
+// "*.example.com" installs a catch-all for the zone and "api.example.com"
+// installs an exact record in the same zone. The resolver returns the first
+// matching record, so the catch-all must come last: the exact rule's own
+// resolution is what the egress pin holds for that host, and rule order in
+// allow_net must not decide the answer. The catch-all itself has to carry the
+// base domain's addresses — the set AllowHostToIP pins the wildcard to —
+// otherwise a wildcard rule answers with no address at all.
+func TestBuildAllowNet_WildcardAndExactRulesShareAZone(t *testing.T) {
+	const (
+		baseIP  = "203.0.113.30"
+		exactIP = "203.0.113.31"
+	)
+	lookup := func(_ context.Context, host string) ([]net.IP, error) {
+		switch host {
+		case "example.com":
+			return []net.IP{net.ParseIP(baseIP)}, nil
+		case "api.example.com":
+			return []net.IP{net.ParseIP(exactIP)}, nil
+		}
+		return nil, fmt.Errorf("unexpected lookup for %q", host)
+	}
+
+	// Both rule orders: the outcome must not depend on which came first.
+	for _, rules := range [][]string{
+		{"*.example.com", "api.example.com"},
+		{"api.example.com", "*.example.com"},
+	} {
+		res := buildAllowNetWithResolver(rules, lookup)
+		addr := serveZones(t, res.zones)
+
+		if got := queryA(t, addr, "api.example.com"); got != exactIP {
+			t.Errorf("rules=%v: api.example.com resolved to %q, want its own %s", rules, got, exactIP)
+		}
+		// Any other subdomain falls to the wildcard, answered with the base
+		// domain's address rather than an empty record.
+		if got := queryA(t, addr, "other.example.com"); got != baseIP {
+			t.Errorf("rules=%v: other.example.com resolved to %q, want the base %s", rules, got, baseIP)
+		}
+	}
+}
+
+// A wildcard rule on its own must still answer with an address.
+func TestBuildAllowNet_WildcardAloneResolvesSubdomains(t *testing.T) {
+	const baseIP = "203.0.113.40"
+	lookup := func(_ context.Context, host string) ([]net.IP, error) {
+		if host != "example.com" {
+			return nil, fmt.Errorf("unexpected lookup for %q", host)
+		}
+		return []net.IP{net.ParseIP(baseIP)}, nil
+	}
+
+	res := buildAllowNetWithResolver([]string{"*.example.com"}, lookup)
+	addr := serveZones(t, res.zones)
+
+	if got := queryA(t, addr, "foo.example.com"); got != baseIP {
+		t.Fatalf("foo.example.com resolved to %q, want %s", got, baseIP)
+	}
+}
+
+// TestBuildAllowNet_DeeperZoneInheritsParentWildcard covers the zone an exact
+// rule introduces underneath a wildcard.
+//
+// "api.team.example.test" creates zone "team.example.test.", which suffix-
+// matches every sibling under it. Since the resolver answers from the first
+// matching zone alone, that zone must carry the coverage "*.example.test"
+// already grants — otherwise adding one exact rule silently sinkholes the
+// siblings, and DNS disagrees with the egress filter, whose MatchesHostname
+// suffix-matches at any depth.
+func TestBuildAllowNet_DeeperZoneInheritsParentWildcard(t *testing.T) {
+	const (
+		baseIP  = "203.0.113.50"
+		exactIP = "203.0.113.51"
+	)
+	lookup := func(_ context.Context, host string) ([]net.IP, error) {
+		switch host {
+		case "example.test":
+			return []net.IP{net.ParseIP(baseIP)}, nil
+		case "api.team.example.test":
+			return []net.IP{net.ParseIP(exactIP)}, nil
+		}
+		return nil, fmt.Errorf("unexpected lookup for %q", host)
+	}
+
+	res := buildAllowNetWithResolver(
+		[]string{"*.example.test", "api.team.example.test"},
+		lookup,
+	)
+	addr := serveZones(t, res.zones)
+
+	if got := queryA(t, addr, "api.team.example.test"); got != exactIP {
+		t.Errorf("the exact rule's own resolution must win, got %q want %s", got, exactIP)
+	}
+	if got := queryA(t, addr, "other.team.example.test"); got != baseIP {
+		t.Errorf("a sibling still covered by *.example.test was sinkholed: got %q want %s", got, baseIP)
+	}
+	if got := queryA(t, addr, "elsewhere.example.test"); got != baseIP {
+		t.Errorf("the wildcard's own zone must keep working, got %q want %s", got, baseIP)
+	}
+	// Outside the wildcard entirely.
+	if got := queryA(t, addr, "example.org"); got != "0.0.0.0" {
+		t.Errorf("an unrelated host must still be sinkholed, got %q", got)
+	}
+}
+
+// TestBuildAllowNet_DuplicateHostResolvesOnce pins the coupling contract for
+// two rules naming one host.
+//
+// "github.test:443" and "github.test" are the same canonical name. Resolving
+// twice would
+// put both answers in the zone and leave the pin holding only the last, so a
+// round-robin host would resolve to an address AllowHostToIP rejects — the
+// allowed host blocked, intermittently. The resolver here returns a fresh
+// address per call, so a second lookup cannot go unnoticed.
+func TestBuildAllowNet_DuplicateHostResolvesOnce(t *testing.T) {
+	calls := 0
+	lookup := func(_ context.Context, host string) ([]net.IP, error) {
+		if host != "github.test" {
+			return nil, fmt.Errorf("unexpected lookup for %q", host)
+		}
+		calls++
+		return []net.IP{net.IPv4(203, 0, 113, byte(100+calls))}, nil
+	}
+
+	res := buildAllowNetWithResolver([]string{"github.test:443", "github.test"}, lookup)
+	if calls != 1 {
+		t.Fatalf("resolved github.test %d times, want 1", calls)
+	}
+
+	pinned := res.exactIPs["github.test"]
+	if len(pinned) != 1 {
+		t.Fatalf("pin holds %v, want exactly one address", pinned)
+	}
+
+	addr := serveZones(t, res.zones)
+	served := queryA(t, addr, "github.test")
+	if served != pinned[0].String() {
+		t.Fatalf("DNS serves %q but the egress pin permits %q; the guest would be blocked",
+			served, pinned[0])
+	}
+}
+
+// TestBuildAllowNet_BothSpellingsOfAHostStayReachable covers one host written
+// two ways.
+//
+// The resolver compares zone suffixes and record names case-sensitively, so
+// the two spellings are two distinct rules and each answers only its own
+// query. The pin maps are keyed on the folded name, so they must hold the
+// union of both resolutions: keeping only the last would make DNS serve an
+// address AllowHostToIP then rejects. Each spelling is queried — checking one
+// only would pass whichever resolution happened to land last.
+func TestBuildAllowNet_BothSpellingsOfAHostStayReachable(t *testing.T) {
+	newCountingResolver := func() func(context.Context, string) ([]net.IP, error) {
+		calls := 0
+		return func(_ context.Context, _ string) ([]net.IP, error) {
+			calls++
+			return []net.IP{net.IPv4(203, 0, 113, byte(60+calls))}, nil
+		}
+	}
+
+	assertServedIsPinned := func(t *testing.T, addr, query string, pinned []net.IP) {
+		t.Helper()
+		served := queryA(t, addr, query)
+		if served == "0.0.0.0" || served == "" || served == "<nil>" {
+			t.Fatalf("%s got no usable answer (%q)", query, served)
+		}
+		for _, ip := range pinned {
+			if ip.String() == served {
+				return
+			}
+		}
+		t.Fatalf("DNS served %q for %s but the pin permits %v; the guest would be blocked",
+			served, query, pinned)
+	}
+
+	t.Run("exact rules", func(t *testing.T) {
+		res := buildAllowNetWithResolver([]string{"GitHub.test", "github.test"}, newCountingResolver())
+		addr := serveZones(t, res.zones)
+		for _, query := range []string{"github.test", "GitHub.test"} {
+			assertServedIsPinned(t, addr, query, res.exactIPs["github.test"])
+		}
+	})
+
+	t.Run("wildcard rules", func(t *testing.T) {
+		res := buildAllowNetWithResolver([]string{"*.Example.test", "*.example.test"}, newCountingResolver())
+		addr := serveZones(t, res.zones)
+		for _, query := range []string{"sub.example.test", "sub.Example.test"} {
+			assertServedIsPinned(t, addr, query, res.suffixIPs[".example.test"])
+		}
+	})
+}
+
+// TestBuildAllowNet_NestedWildcardInheritanceIsDeterministic pins which
+// wildcard a deeper zone inherits from.
+//
+// Zone "deep.sub.example.test." is created by an exact rule and covered by two
+// wildcards. suffixIPs is a map, so taking every match in range order would let
+// a sibling's answer flip between the two wildcards' addresses from one build
+// to the next. The most specific wildcard wins, as it does for zone selection.
+func TestBuildAllowNet_NestedWildcardInheritanceIsDeterministic(t *testing.T) {
+	const (
+		wideIP   = "203.0.113.70"
+		narrowIP = "203.0.113.71"
+		exactIP  = "203.0.113.72"
+	)
+	lookup := func(_ context.Context, host string) ([]net.IP, error) {
+		switch host {
+		case "example.test":
+			return []net.IP{net.ParseIP(wideIP)}, nil
+		case "sub.example.test":
+			return []net.IP{net.ParseIP(narrowIP)}, nil
+		case "api.deep.sub.example.test":
+			return []net.IP{net.ParseIP(exactIP)}, nil
+		}
+		return nil, fmt.Errorf("unexpected lookup for %q", host)
+	}
+
+	for i := 0; i < 20; i++ {
+		res := buildAllowNetWithResolver([]string{
+			"*.example.test",
+			"*.sub.example.test",
+			"api.deep.sub.example.test",
+		}, lookup)
+		addr := serveZones(t, res.zones)
+
+		if got := queryA(t, addr, "other.deep.sub.example.test"); got != narrowIP {
+			t.Fatalf("iteration %d: sibling inherited %q, want the most specific wildcard %s",
+				i, got, narrowIP)
+		}
+		if got := queryA(t, addr, "api.deep.sub.example.test"); got != exactIP {
+			t.Fatalf("iteration %d: the exact rule resolved to %q, want %s", i, got, exactIP)
+		}
+	}
+}
+
+// TestBuildAllowNet_InheritanceSkipsAnUnresolvedWildcard covers a narrower
+// wildcard whose own lookup failed. It has no address to hand down, so the
+// zone must inherit from the broader wildcard that did resolve instead of
+// being left with a bare sinkhole.
+func TestBuildAllowNet_InheritanceSkipsAnUnresolvedWildcard(t *testing.T) {
+	const wideIP = "203.0.113.80"
+	lookup := func(_ context.Context, host string) ([]net.IP, error) {
+		switch host {
+		case "example.test":
+			return []net.IP{net.ParseIP(wideIP)}, nil
+		case "sub.example.test":
+			return nil, fmt.Errorf("simulated resolution failure")
+		case "api.deep.sub.example.test":
+			return []net.IP{net.ParseIP("203.0.113.81")}, nil
+		}
+		return nil, fmt.Errorf("unexpected lookup for %q", host)
+	}
+
+	res := buildAllowNetWithResolver([]string{
+		"*.example.test",
+		"*.sub.example.test",
+		"api.deep.sub.example.test",
+	}, lookup)
+	addr := serveZones(t, res.zones)
+
+	if got := queryA(t, addr, "other.deep.sub.example.test"); got != wideIP {
+		t.Fatalf("sibling resolved to %q, want the broader wildcard's %s", got, wideIP)
 	}
 }


### PR DESCRIPTION
## Summary

A wildcard rule in `allow_net` has never worked. Its catch-all DNS record was installed with no address, so every subdomain under the wildcard resolved to nothing and the guest could not reach any of them — while the egress filter went on reporting them as allowed. This has been true since `allow_net` was introduced.

## Call graph

```text
Before
  buildAllowNetWithResolver      (· src/deps/libgvproxy-sys/gvproxy-bridge/dns_filter.go:48)
    ├─ {Regexp: ".*"}            (· dns_filter.go:76)   ← BUG (POL-563): no IP, and first in the
    │                                                      zone's record list
    │    └─ addLocalAnswers      (dnsHandler · gvisor-tap-vsock dns.go:57)
    │         └─ A: record.IP    — nil; matched everything, answered with nothing, returned
    │                              before the real record and before the zone sinkhole
    ├─ zones from a Go map       (· dns_filter.go:102)  ← BUG: emitted in map order, so a less
    │                                                      specific zone could swallow a query
    └─ exactIPs[key] = …         (· dns_filter.go:89)   ← BUG: overwritten, so two spellings of
                                                           one host left the pin behind DNS

After
  buildAllowNetWithResolver      (· dns_filter.go:48)
    ├─ resolved[…]               (· dns_filter.go:56)   — one resolution per canonical name
    ├─ {Regexp: ".*", IP: ip}    (· dns_filter.go:94)   — the base domain's own addresses, the
    │                                                      set AllowHostToIP pins the wildcard to
    ├─ inherited coverage        (· dns_filter.go:120)  — a zone under a wildcard keeps it
    ├─ records: exact first      (· dns_filter.go:158)  — a catch-all cannot mask an exact rule
    ├─ zones: most specific first(· dns_filter.go:190)  — deterministic zone selection
    └─ exactIPs/suffixIPs union  (· dns_filter.go:89)   — the pin permits whatever DNS serves
```

Refs POL-563

## Changes

- **The catch-all carries the base domain's addresses.** That is the same set `AllowHostToIP` already pins the wildcard to, so DNS and the egress pin agree instead of contradicting each other.
- **Zone selection is deterministic and most-specific-first.** The resolver answers from the first zone whose suffix matches, sinkhole included; with `com.` and `example.com.` both present, map order decided whether an allowed host resolved or was sinkholed.
- **Within a zone, exact records precede the catch-all**, so `*.x.com` cannot mask the resolution `api.x.com` pinned for itself.
- **A zone created beneath a wildcard inherits its coverage**, skipping a covering wildcard whose own lookup failed. Without this, adding one exact rule silently sinkholed every sibling the wildcard still allows.
- **Each canonical hostname resolves once, and the pins union.** `"x.com:443"` beside `"x.com"` resolved twice: both answers became zone records, the resolver serves the first, and the pin kept only the last — so a round-robin host resolved to an address `AllowHostToIP` then rejected.

## How to verify

```bash
make test:unit:gvproxy GOTEST_FILTER='-run TestBuildAllowNet'
```

Two-side verification — revert `dns_filter.go` alone, keep the tests:

| Reproducer | Pre-fix signal |
|---|---|
| `…_WildcardAloneResolvesSubdomains` | `foo.example.com resolved to "<nil>"` |
| `…_WildcardAndExactRulesShareAZone` | `api.example.com resolved to "<nil>"` |
| `…_DeeperZoneInheritsParentWildcard` | `a sibling still covered by *.example.test was sinkholed: got "<nil>"` |
| `…_NestedWildcardInheritanceIsDeterministic` | sibling inherits the wrong wildcard |
| `…_InheritanceSkipsAnUnresolvedWildcard` | sibling left on a bare sinkhole |
| `…_OverlappingZonesResolveTheMoreSpecificRule` | `api.example.com resolved to "0.0.0.0"` |
| `…_DuplicateHostResolvesOnce` | `resolved github.test 2 times, want 1` |

`…_BothSpellingsOfAHostStayReachable` covers the pin union specifically; reverting just the two `append`s back to assignment fails it with `DNS served "203.0.113.61" for GitHub.test but the pin permits [203.0.113.62]`.

The pre-existing `TestBuildAllowNetDNSZones_PerTLDZonesHaveSinkholeDefaultIP` fails on this machine on baseline too — it resolves `example.com` over real DNS, which this sandbox cannot reach.

## Risks / rollout

- **Behavior widens for wildcard users**, from "no subdomain resolves" to "subdomains resolve to the base domain's address". The egress filter already permitted these hosts, so this makes DNS agree with the policy rather than granting anything new.
- A wildcard whose base domain fails to resolve still yields no address — unchanged, and now diagnosable from the zone it leaves behind.
- Why the existing tests missed it: they asserted zone counts and sinkhole defaults but never resolved a name. The new tests serve the built zones and query them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
