### PR TITLE
fix(cli): query committed metadata when runtime home is in use

### DIFF
--- a/sdks/c/src/error.rs
+++ b/sdks/c/src/error.rs
@@ -90,7 +90,7 @@ impl Default for FFIError {
 /// Map BoxliteError to BoxliteErrorCode
 pub fn error_to_code(err: &BoxliteError) -> BoxliteErrorCode {
     match err {
-        BoxliteError::Internal(_) => BoxliteErrorCode::Internal,
+        BoxliteError::Internal(_) | BoxliteError::RuntimeInUse { .. } => BoxliteErrorCode::Internal,
         BoxliteError::NotFound(_) => BoxliteErrorCode::NotFound,
         BoxliteError::AlreadyExists(_) => BoxliteErrorCode::AlreadyExists,
         BoxliteError::InvalidState(_) => BoxliteErrorCode::InvalidState,

--- a/sdks/c/src/tests.rs
+++ b/sdks/c/src/tests.rs
@@ -68,6 +68,12 @@ fn test_version_string() {
 #[test]
 fn test_error_code_mapping() {
     assert_eq!(
+        error_to_code(&BoxliteError::RuntimeInUse {
+            home_dir: "/tmp/boxlite".into()
+        }),
+        BoxliteErrorCode::Internal
+    );
+    assert_eq!(
         error_to_code(&BoxliteError::NotFound("test".into())),
         BoxliteErrorCode::NotFound
     );

--- a/src/boxlite/src/db/mod.rs
+++ b/src/boxlite/src/db/mod.rs
@@ -78,6 +78,41 @@ impl Database {
         })
     }
 
+    /// Open an existing database and pin a committed snapshot, including its
+    /// schema version. Drop all handles promptly to release the read transaction.
+    /// This path never initializes schema or changes the journal mode.
+    pub(crate) fn open_read_only_snapshot(db_path: &Path) -> BoxliteResult<Self> {
+        let conn = Connection::open_with_flags(db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .map_err(|e| {
+                BoxliteError::Database(format!(
+                    "Failed to open read-only database {}: {e}",
+                    db_path.display()
+                ))
+            })?;
+        // Queries must not inherit the owner's 100-second mutation timeout.
+        db_err!(conn.busy_timeout(std::time::Duration::from_secs(1)))?;
+        db_err!(conn.execute_batch("BEGIN DEFERRED"))?;
+        let version: Option<i32> = db_err!(
+            conn.query_row(
+                "SELECT version FROM schema_version WHERE id = 1",
+                [],
+                |row| row.get(0)
+            )
+            .optional()
+        )?;
+        if version != Some(schema::SCHEMA_VERSION) {
+            return Err(BoxliteError::Database(format!(
+                "Read-only schema version mismatch at {}: database has {:?}, process expects v{}. No migration was attempted; use a matching BoxLite version or stop the owner before upgrading.",
+                db_path.display(),
+                version,
+                schema::SCHEMA_VERSION
+            )));
+        }
+        Ok(Self {
+            conn: Arc::new(Mutex::new(conn)),
+        })
+    }
+
     /// Acquire the database connection.
     pub(crate) fn conn(&self) -> MutexGuard<'_, Connection> {
         self.conn.lock()

--- a/src/boxlite/src/images/manager.rs
+++ b/src/boxlite/src/images/manager.rs
@@ -12,8 +12,6 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use chrono::{DateTime, Utc};
-
 use super::blob_source::{BlobSource, LocalBundleBlobSource, StoreBlobSource};
 use super::object::ImageObject;
 use crate::db::Database;
@@ -21,8 +19,6 @@ use crate::images::store::{ImageStore, SharedImageStore};
 use crate::runtime::options::ImageRegistry;
 use crate::runtime::types::ImageInfo;
 use boxlite_shared::errors::BoxliteResult;
-use oci_client::Reference;
-use std::str::FromStr;
 
 // ============================================================================
 // INTERNAL TYPES
@@ -130,38 +126,10 @@ impl ImageManager {
     pub async fn list(&self) -> BoxliteResult<Vec<ImageInfo>> {
         let raw_images = self.store.list().await?;
 
-        let mut images = Vec::with_capacity(raw_images.len());
-        for (reference, cached) in raw_images {
-            // If parsing fails, default to UNIX_EPOCH to signal error
-            let cached_at = DateTime::parse_from_rfc3339(&cached.cached_at)
-                .map(|dt| dt.with_timezone(&Utc))
-                .unwrap_or_else(|e| {
-                    tracing::warn!("Invalid cached_at timestamp: {}, using epoch", e);
-                    DateTime::<Utc>::from(std::time::SystemTime::UNIX_EPOCH)
-                });
-
-            let (repository, tag) = match Reference::from_str(&reference) {
-                Ok(r) => (
-                    r.repository().to_string(),
-                    r.tag().unwrap_or("latest").to_string(),
-                ),
-                Err(_) => {
-                    // Fallback if reference stored in DB is invalid
-                    (reference.clone(), "<none>".to_string())
-                }
-            };
-
-            images.push(ImageInfo {
-                reference,
-                repository,
-                tag,
-                id: cached.manifest_digest,
-                cached_at,
-                size: None, // Size calculation is expensive now? omitted for list temporarily
-            });
-        }
-
-        Ok(images)
+        Ok(raw_images
+            .into_iter()
+            .map(|(reference, cached)| ImageInfo::from_cached(reference, cached))
+            .collect())
     }
 
     /// Load an OCI/Docker image from a local directory.

--- a/src/boxlite/src/runtime/lock.rs
+++ b/src/boxlite/src/runtime/lock.rs
@@ -64,11 +64,9 @@ impl RuntimeLock {
             if result != 0 {
                 let err = std::io::Error::last_os_error();
                 if err.kind() == std::io::ErrorKind::WouldBlock {
-                    return Err(BoxliteError::Internal(format!(
-                        "Another BoxliteRuntime is already using directory: {}\n\
-                         Only one runtime instance can use a BOXLITE_HOME directory at a time.",
-                        home_dir.display()
-                    )));
+                    return Err(BoxliteError::RuntimeInUse {
+                        home_dir: home_dir.to_path_buf(),
+                    });
                 } else {
                     return Err(BoxliteError::Storage(format!(
                         "failed to acquire lock: {}",
@@ -144,7 +142,9 @@ mod tests {
         let result = RuntimeLock::acquire(&dir_path);
         assert!(result.is_err());
 
-        let err_msg = result.unwrap_err().to_string();
+        let error = result.unwrap_err();
+        assert!(matches!(&error, BoxliteError::RuntimeInUse { home_dir } if home_dir == &dir_path));
+        let err_msg = error.to_string();
         assert!(err_msg.contains("Another BoxliteRuntime"));
     }
 

--- a/src/boxlite/src/runtime/mod.rs
+++ b/src/boxlite/src/runtime/mod.rs
@@ -7,6 +7,7 @@ pub mod images;
 pub mod layout;
 pub(crate) mod lock;
 pub mod options;
+pub mod query;
 pub(crate) mod signal_handler;
 pub mod types;
 pub mod volumes;

--- a/src/boxlite/src/runtime/query.rs
+++ b/src/boxlite/src/runtime/query.rs
@@ -1,0 +1,314 @@
+//! Read committed metadata without acquiring Runtime ownership.
+//!
+//! Each query uses a short SQLite read transaction. These results do not probe
+//! or repair live VM state, and may lag the owner's in-memory state. SQLite's
+//! normal WAL coordination remains enabled; the database is not immutable.
+
+use std::path::PathBuf;
+
+use boxlite_shared::errors::{BoxliteError, BoxliteResult};
+
+use crate::db::{BoxStore, Database, ImageIndexStore};
+use crate::runtime::layout::{FilesystemLayout, FsLayoutConfig};
+use crate::runtime::types::{BoxInfo, ImageInfo};
+
+/// Read-only view of an existing home's committed metadata.
+#[derive(Debug, Clone)]
+pub struct ReadOnlyRuntime {
+    db_path: PathBuf,
+}
+
+impl ReadOnlyRuntime {
+    pub fn new(home_dir: PathBuf) -> Self {
+        let layout = FilesystemLayout::new(home_dir, FsLayoutConfig::default());
+        Self {
+            db_path: layout.db_dir().join("boxlite.db"),
+        }
+    }
+
+    pub async fn list_info(&self) -> BoxliteResult<Vec<BoxInfo>> {
+        self.read(|db| {
+            Ok(BoxStore::new(db)
+                .list_all()?
+                .into_iter()
+                .map(|(config, state)| BoxInfo::new(&config, &state))
+                .collect())
+        })
+        .await
+    }
+
+    pub async fn list_images(&self) -> BoxliteResult<Vec<ImageInfo>> {
+        self.read(|db| {
+            Ok(ImageIndexStore::new(db)
+                .list_all()?
+                .into_iter()
+                .map(|(reference, cached)| ImageInfo::from_cached(reference, cached))
+                .collect())
+        })
+        .await
+    }
+
+    /// Box metadata and image count from the same committed snapshot.
+    pub async fn info(&self) -> BoxliteResult<(Vec<BoxInfo>, usize)> {
+        self.read(|db| {
+            let boxes = BoxStore::new(db.clone())
+                .list_all()?
+                .into_iter()
+                .map(|(config, state)| BoxInfo::new(&config, &state))
+                .collect();
+            Ok((boxes, ImageIndexStore::new(db).len()?))
+        })
+        .await
+    }
+
+    async fn read<T: Send + 'static>(
+        &self,
+        query: impl FnOnce(Database) -> BoxliteResult<T> + Send + 'static,
+    ) -> BoxliteResult<T> {
+        let path = self.db_path.clone();
+        tokio::task::spawn_blocking(move || query(Database::open_read_only_snapshot(&path)?))
+            .await
+            .map_err(|e| BoxliteError::Internal(format!("Read-only query task failed: {e}")))?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::CachedImage;
+    use crate::runtime::types::BoxStatus;
+    use crate::{
+        BoxliteRuntime,
+        runtime::options::{BoxOptions, BoxliteOptions, RootfsSpec},
+    };
+
+    fn database(home: &std::path::Path) -> Database {
+        Database::open(&home.join("db/boxlite.db")).unwrap()
+    }
+
+    fn cached_image() -> CachedImage {
+        CachedImage {
+            manifest_digest: "sha256:1234567890abcdef".into(),
+            config_digest: "sha256:config".into(),
+            layers: vec!["sha256:layer".into()],
+            cached_at: "2026-09-10T00:00:00Z".into(),
+            complete: true,
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_database_is_not_created() {
+        let home = tempfile::tempdir().unwrap();
+        let query = ReadOnlyRuntime::new(home.path().to_path_buf());
+        let error = query.list_info().await.unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("Failed to open read-only database")
+        );
+        assert!(!home.path().join("db").exists());
+    }
+
+    #[tokio::test]
+    async fn incompatible_schema_is_not_migrated() {
+        for version in [0, 4, 999] {
+            let home = tempfile::tempdir().unwrap();
+            let db = database(home.path());
+            db.conn()
+                .execute("UPDATE schema_version SET version = ?1", [version])
+                .unwrap();
+            let query = ReadOnlyRuntime::new(home.path().to_path_buf());
+            let before: String = db
+                .conn()
+                .query_row("SELECT group_concat(sql) FROM sqlite_master", [], |row| {
+                    row.get(0)
+                })
+                .unwrap();
+            let error = query.info().await.unwrap_err();
+            assert!(
+                error
+                    .to_string()
+                    .contains("Read-only schema version mismatch")
+            );
+            let actual: i32 = db
+                .conn()
+                .query_row("SELECT version FROM schema_version", [], |row| row.get(0))
+                .unwrap();
+            assert_eq!(actual, version);
+            let after: String = db
+                .conn()
+                .query_row("SELECT group_concat(sql) FROM sqlite_master", [], |row| {
+                    row.get(0)
+                })
+                .unwrap();
+            assert_eq!(before, after);
+        }
+    }
+
+    #[tokio::test]
+    async fn absent_schema_is_not_initialized() {
+        let home = tempfile::tempdir().unwrap();
+        let path = home.path().join("db/boxlite.db");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let writer = rusqlite::Connection::open(&path).unwrap();
+        let query = ReadOnlyRuntime::new(home.path().to_path_buf());
+        assert!(
+            query
+                .list_info()
+                .await
+                .unwrap_err()
+                .to_string()
+                .contains("schema_version")
+        );
+        let tables: i64 = writer
+            .query_row("SELECT count(*) FROM sqlite_master", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(tables, 0);
+    }
+
+    #[tokio::test]
+    async fn images_use_committed_index_and_shared_conversion() {
+        let home = tempfile::tempdir().unwrap();
+        let db = database(home.path());
+        let index = ImageIndexStore::new(db.clone());
+        let query = ReadOnlyRuntime::new(home.path().to_path_buf());
+        db.conn().execute_batch("BEGIN IMMEDIATE").unwrap();
+        index.upsert("alpine:3.21", &cached_image()).unwrap();
+        assert!(query.list_images().await.unwrap().is_empty());
+        db.conn().execute_batch("COMMIT").unwrap();
+        let images = query.list_images().await.unwrap();
+        assert_eq!(images.len(), 1);
+        assert_eq!(images[0].reference, "alpine:3.21");
+        assert_eq!(images[0].repository, "library/alpine");
+        assert_eq!(images[0].tag, "3.21");
+        assert_eq!(images[0].id, "sha256:1234567890abcdef");
+        assert_eq!(
+            images[0].cached_at.to_rfc3339(),
+            "2026-09-10T00:00:00+00:00"
+        );
+        assert_eq!(query.info().await.unwrap().1, 1);
+        assert!(!home.path().join("images").exists());
+        index.remove("alpine:3.21").unwrap();
+        assert!(query.list_images().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn actual_read_only_connection_rejects_writes_and_releases_snapshot() {
+        let home = tempfile::tempdir().unwrap();
+        let db = database(home.path());
+        let query = ReadOnlyRuntime::new(home.path().to_path_buf());
+        query
+            .read(|reader| {
+                let error = reader
+                    .conn()
+                    .execute("DELETE FROM image_index", [])
+                    .unwrap_err();
+                assert_eq!(
+                    error.sqlite_error_code(),
+                    Some(rusqlite::ErrorCode::ReadOnly)
+                );
+                Ok(())
+            })
+            .await
+            .unwrap();
+        ImageIndexStore::new(db.clone())
+            .upsert("alpine:latest", &cached_image())
+            .unwrap();
+        // TRUNCATE can complete only when the previous read transaction is gone.
+        let checkpoint: (i32, i32, i32) = db
+            .conn()
+            .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |r| {
+                Ok((r.get(0)?, r.get(1)?, r.get(2)?))
+            })
+            .unwrap();
+        assert_eq!(checkpoint, (0, 0, 0));
+    }
+
+    #[tokio::test]
+    async fn busy_database_has_a_bounded_wait() {
+        let home = tempfile::tempdir().unwrap();
+        let db = database(home.path());
+        db.conn()
+            .execute_batch("PRAGMA journal_mode=DELETE; BEGIN EXCLUSIVE;")
+            .unwrap();
+        let query = ReadOnlyRuntime::new(home.path().to_path_buf());
+        let start = std::time::Instant::now();
+        let error = query.list_info().await.unwrap_err();
+        assert!(error.to_string().contains("database is locked"), "{error}");
+        assert!(start.elapsed() < std::time::Duration::from_secs(5));
+        db.conn().execute_batch("ROLLBACK").unwrap();
+        assert!(query.list_info().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn schema_and_queries_share_one_snapshot() {
+        let home = tempfile::tempdir().unwrap();
+        let db = database(home.path());
+        let query = ReadOnlyRuntime::new(home.path().to_path_buf());
+        let writer = db.clone();
+        query.read(move |reader| {
+            // Simulate a competing schema commit after the reader checked its version.
+            writer.conn().execute_batch("BEGIN; UPDATE schema_version SET version=999; DROP TABLE image_index; COMMIT;").unwrap();
+            assert_eq!(ImageIndexStore::new(reader).len()?, 0);
+            Ok(())
+        }).await.unwrap();
+        assert!(
+            query
+                .list_images()
+                .await
+                .unwrap_err()
+                .to_string()
+                .contains("schema version mismatch")
+        );
+    }
+
+    #[tokio::test]
+    async fn runtime_query_contract_observes_commits_without_repairing_stored_state() {
+        let home = boxlite_test_utils::home::PerTestBoxHome::isolated();
+        let runtime = BoxliteRuntime::new(BoxliteOptions {
+            home_dir: home.path.clone(),
+            image_registries: vec![],
+        })
+        .unwrap();
+        let handle = runtime
+            .create(
+                BoxOptions {
+                    rootfs: RootfsSpec::Image("issue258:latest".into()),
+                    auto_delete: Some(0),
+                    ..Default::default()
+                },
+                Some("query-contract".into()),
+            )
+            .await
+            .unwrap();
+        let id = handle.id().to_string();
+        let query = ReadOnlyRuntime::new(home.path.clone());
+        assert_eq!(
+            query.list_info().await.unwrap()[0].status,
+            BoxStatus::Configured
+        );
+        // Fixture injection through the project store, not a live VM transition:
+        // the invalid PID deliberately makes liveness repair observable.
+        let writer = database(&home.path);
+        let store = BoxStore::new(writer);
+        let mut state = store.load_state(&id).unwrap().unwrap();
+        state.set_status(BoxStatus::Running);
+        state.set_pid(Some(u32::MAX));
+        store.update_state(&id, &state).unwrap();
+        assert_eq!(
+            query.list_info().await.unwrap()[0].status,
+            BoxStatus::Running
+        );
+        assert_eq!(store.load_state(&id).unwrap().unwrap().pid, Some(u32::MAX));
+        assert_eq!(
+            store.load_state(&id).unwrap().unwrap().status,
+            BoxStatus::Running
+        );
+        state.set_status(BoxStatus::Configured);
+        state.set_pid(None);
+        store.update_state(&id, &state).unwrap();
+        drop(handle);
+        runtime.remove(&id, false).await.unwrap();
+        assert!(query.list_info().await.unwrap().is_empty());
+    }
+}

--- a/src/boxlite/src/runtime/rt_impl.rs
+++ b/src/boxlite/src/runtime/rt_impl.rs
@@ -269,12 +269,13 @@ impl RuntimeImpl {
             ))
         })?;
 
-        let runtime_lock = RuntimeLock::acquire(layout.home_dir()).map_err(|e| {
-            BoxliteError::Internal(format!(
+        let runtime_lock = RuntimeLock::acquire(layout.home_dir()).map_err(|e| match e {
+            BoxliteError::RuntimeInUse { .. } => e,
+            e => BoxliteError::Internal(format!(
                 "Failed to acquire runtime lock at {}: {}",
                 layout.home_dir().display(),
                 e
-            ))
+            )),
         })?;
 
         // Clean temp dir contents to avoid stale files from previous runs

--- a/src/boxlite/src/runtime/types.rs
+++ b/src/boxlite/src/runtime/types.rs
@@ -660,6 +660,33 @@ pub struct ImageInfo {
     pub size: Option<Bytes>,
 }
 
+impl ImageInfo {
+    pub(crate) fn from_cached(reference: String, cached: crate::db::CachedImage) -> Self {
+        use std::str::FromStr;
+        let cached_at = DateTime::parse_from_rfc3339(&cached.cached_at)
+            .map(|dt| dt.with_timezone(&Utc))
+            .unwrap_or_else(|e| {
+                tracing::warn!("Invalid cached_at timestamp: {}, using epoch", e);
+                DateTime::<Utc>::from(std::time::SystemTime::UNIX_EPOCH)
+            });
+        let (repository, tag) = match oci_client::Reference::from_str(&reference) {
+            Ok(r) => (
+                r.repository().to_string(),
+                r.tag().unwrap_or("latest").to_string(),
+            ),
+            Err(_) => (reference.clone(), "<none>".to_string()),
+        };
+        Self {
+            reference,
+            repository,
+            tag,
+            id: cached.manifest_digest,
+            cached_at,
+            size: None,
+        }
+    }
+}
+
 // ============================================================================
 // BOX CONFIG (Podman-style separation)
 // ============================================================================

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -118,6 +118,12 @@ boxlite pull alpine:latest
 boxlite images
 ```
 
+When another local Runtime owns the same home, `list`, `images`, and `info`
+read its committed database metadata. Box status may lag live VM state; these
+queries do not probe VMs, recover boxes, clean temporary files, or migrate the
+database. An incompatible schema returns an error. Without lock contention,
+normal Runtime initialization and recovery still apply.
+
 ## Connecting to a remote server
 
 To target a remote BoxLite REST server instead of the local runtime, sign in

--- a/src/cli/src/commands/images.rs
+++ b/src/cli/src/commands/images.rs
@@ -1,5 +1,6 @@
 use crate::cli::GlobalFlags;
 use crate::formatter::{self, OutputFormat};
+use crate::query::QueryRuntime;
 use boxlite::runtime::types::ImageInfo;
 use clap::Args;
 use serde::Serialize;
@@ -51,9 +52,8 @@ impl From<&ImageInfo> for ImagePresenter {
 
 pub async fn execute(args: ImagesArgs, global: &GlobalFlags) -> anyhow::Result<()> {
     let options = global.resolve_runtime_options()?;
-    let rt = global.create_runtime_with_options(options)?;
-    let image_handle = rt.images()?;
-    let images = image_handle.list().await?;
+    let rt = QueryRuntime::from_runtime(global.create_runtime_with_options(options))?;
+    let images = rt.list_images().await?;
 
     if args.quiet {
         for info in images {

--- a/src/cli/src/commands/info.rs
+++ b/src/cli/src/commands/info.rs
@@ -1,5 +1,6 @@
 use crate::cli::GlobalFlags;
 use crate::formatter;
+use crate::query::QueryRuntime;
 use boxlite::BoxStatus;
 use clap::Args;
 use clap::ValueEnum;
@@ -40,7 +41,7 @@ pub async fn execute(args: InfoArgs, global: &GlobalFlags) -> anyhow::Result<()>
     let options = global.resolve_runtime_options()?;
     let home_dir = options.home_dir.to_string_lossy().to_string();
 
-    let rt = global.create_runtime_with_options(options)?;
+    let rt = QueryRuntime::from_runtime(global.create_runtime_with_options(options))?;
     let version = boxlite::VERSION.to_string();
     let virtualization = boxlite::system_check::SystemCheck::run()
         .map(|_| "available".to_string())
@@ -48,7 +49,7 @@ pub async fn execute(args: InfoArgs, global: &GlobalFlags) -> anyhow::Result<()>
     let os = std::env::consts::OS.to_string();
     let arch = std::env::consts::ARCH.to_string();
 
-    let boxes_list = rt.list_info().await?;
+    let (boxes_list, images_count) = rt.info().await?;
     let boxes_total = boxes_list.len() as u32;
     let boxes_running = boxes_list.iter().filter(|b| b.status.is_active()).count() as u32;
     let boxes_stopped = boxes_list
@@ -60,7 +61,7 @@ pub async fn execute(args: InfoArgs, global: &GlobalFlags) -> anyhow::Result<()>
         .filter(|b| b.status == BoxStatus::Configured)
         .count() as u32;
 
-    let images_count = rt.images()?.list().await?.len() as u32;
+    let images_count = images_count as u32;
 
     let info = SystemInfo {
         version,

--- a/src/cli/src/commands/list.rs
+++ b/src/cli/src/commands/list.rs
@@ -1,5 +1,6 @@
 use crate::cli::GlobalFlags;
 use crate::formatter::{self, OutputFormat};
+use crate::query::QueryRuntime;
 use boxlite::BoxInfo;
 use clap::Args;
 use serde::Serialize;
@@ -57,7 +58,7 @@ impl From<BoxInfo> for BoxPresenter {
 }
 
 pub async fn execute(args: ListArgs, global: &GlobalFlags) -> anyhow::Result<()> {
-    let rt = global.create_runtime()?;
+    let rt = QueryRuntime::from_runtime(global.create_runtime())?;
     let boxes = rt.list_info().await?;
 
     let boxes: Vec<BoxInfo> = boxes

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -4,6 +4,7 @@ mod config;
 mod credentials;
 mod defaults;
 mod formatter;
+mod query;
 pub mod terminal;
 pub mod util;
 mod volumespec;

--- a/src/cli/src/query.rs
+++ b/src/cli/src/query.rs
@@ -1,0 +1,67 @@
+//! Query routing keeps ordinary Runtime initialization first and falls back
+//! only for local home-lock contention, never for other startup errors.
+
+use boxlite::runtime::query::ReadOnlyRuntime;
+use boxlite::runtime::types::ImageInfo;
+use boxlite::{BoxInfo, BoxliteError, BoxliteRuntime};
+
+enum Backend {
+    Runtime(BoxliteRuntime),
+    ReadOnly(ReadOnlyRuntime),
+}
+
+pub(crate) struct QueryRuntime(Backend);
+
+impl QueryRuntime {
+    pub(crate) fn from_runtime(result: anyhow::Result<BoxliteRuntime>) -> anyhow::Result<Self> {
+        match result {
+            Ok(runtime) => Ok(Self(Backend::Runtime(runtime))),
+            Err(error) => match error.downcast_ref::<BoxliteError>() {
+                Some(BoxliteError::RuntimeInUse { home_dir }) => Ok(Self(Backend::ReadOnly(
+                    ReadOnlyRuntime::new(home_dir.clone()),
+                ))),
+                _ => Err(error),
+            },
+        }
+    }
+
+    pub(crate) async fn list_info(&self) -> anyhow::Result<Vec<BoxInfo>> {
+        Ok(match &self.0 {
+            Backend::Runtime(runtime) => runtime.list_info().await?,
+            Backend::ReadOnly(runtime) => runtime.list_info().await?,
+        })
+    }
+
+    pub(crate) async fn list_images(&self) -> anyhow::Result<Vec<ImageInfo>> {
+        Ok(match &self.0 {
+            Backend::Runtime(runtime) => runtime.images()?.list().await?,
+            Backend::ReadOnly(runtime) => runtime.list_images().await?,
+        })
+    }
+
+    pub(crate) async fn info(&self) -> anyhow::Result<(Vec<BoxInfo>, usize)> {
+        Ok(match &self.0 {
+            Backend::Runtime(runtime) => (
+                runtime.list_info().await?,
+                runtime.images()?.list().await?.len(),
+            ),
+            Backend::ReadOnly(runtime) => runtime.info().await?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unrelated_initialization_errors_propagate_even_with_lock_text() {
+        let error =
+            BoxliteError::Storage("Another BoxliteRuntime is already using directory".into());
+        let result = QueryRuntime::from_runtime(Err(error.into()));
+        assert!(matches!(
+            result.err().unwrap().downcast_ref::<BoxliteError>(),
+            Some(BoxliteError::Storage(_))
+        ));
+    }
+}

--- a/src/cli/tests/readonly_queries.rs
+++ b/src/cli/tests/readonly_queries.rs
@@ -1,0 +1,242 @@
+use assert_cmd::Command;
+use boxlite::BoxliteRuntime;
+use boxlite::runtime::options::{BoxOptions, BoxliteOptions, RootfsSpec};
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Output;
+use std::time::Duration;
+
+const BOX_NAME: &str = "issue-258-query-box";
+
+fn runtime_for(home: &Path) -> BoxliteRuntime {
+    BoxliteRuntime::new(BoxliteOptions {
+        home_dir: home.to_path_buf(),
+        image_registries: Vec::new(),
+    })
+    .expect("create the process-A runtime owner")
+}
+
+async fn create_configured_box(runtime: &BoxliteRuntime) -> String {
+    let handle = runtime
+        .create(
+            BoxOptions {
+                rootfs: RootfsSpec::Image("issue-258-fixture:latest".into()),
+                auto_delete: Some(0),
+                ..Default::default()
+            },
+            Some(BOX_NAME.to_string()),
+        )
+        .await
+        .expect("persist configured box through the public Runtime API");
+    let id = handle.id().to_string();
+    drop(handle);
+    id
+}
+
+fn cli_command(home: &Path) -> Command {
+    let mut command = Command::new(assert_cmd::cargo::cargo_bin!("boxlite"));
+    command.timeout(Duration::from_secs(30));
+    command
+        .env("BOXLITE_HOME", home)
+        .env_remove("BOXLITE_REST_URL")
+        .env_remove("BOXLITE_API_KEY")
+        .env_remove("BOXLITE_PROFILE");
+    command.arg("--home").arg(home);
+    command
+}
+
+fn run_cli(home: &Path, args: &[&str]) -> Output {
+    cli_command(home)
+        .args(args)
+        .output()
+        .expect("run boxlite CLI child process")
+}
+
+fn assert_query_succeeded(output: &Output, query: &str) {
+    assert!(
+        output.status.success(),
+        "`boxlite {query}` must query committed state while another process owns the Runtime lock\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+struct RecoverySentinels {
+    temp_file: PathBuf,
+    orphan_file: PathBuf,
+}
+
+impl RecoverySentinels {
+    fn create(home: &Path) -> Self {
+        let temp_file = home.join("tmp/issue-258-query-sentinel");
+        fs::write(&temp_file, "keep").expect("create temp cleanup sentinel");
+
+        // A normal Runtime startup treats an unrecorded box directory as an
+        // orphan during recovery. Read-only queries must leave it untouched.
+        let orphan_file = home.join("boxes/issue258keep/sentinel");
+        fs::create_dir_all(orphan_file.parent().unwrap()).expect("create recovery sentinel dir");
+        fs::write(&orphan_file, "keep").expect("create recovery sentinel file");
+
+        Self {
+            temp_file,
+            orphan_file,
+        }
+    }
+
+    fn assert_untouched(&self) {
+        assert_eq!(
+            fs::read_to_string(&self.temp_file).expect("read temp cleanup sentinel"),
+            "keep",
+            "read-only query must not clean the Runtime temp directory",
+        );
+        assert_eq!(
+            fs::read_to_string(&self.orphan_file).expect("read recovery sentinel"),
+            "keep",
+            "read-only query must not run orphan recovery",
+        );
+    }
+}
+
+#[tokio::test]
+async fn list_reads_committed_create_and_delete_while_another_process_owns_runtime() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated();
+    let runtime = runtime_for(&home.path);
+    let box_id = create_configured_box(&runtime).await;
+    let sentinels = RecoverySentinels::create(&home.path);
+
+    let created = run_cli(&home.path, &["list", "--all", "--format", "json"]);
+    sentinels.assert_untouched();
+    assert_query_succeeded(&created, "list --all --format json");
+    let rows: Value = serde_json::from_slice(&created.stdout).expect("list output is JSON");
+    let rows = rows.as_array().expect("list output is an array");
+    assert!(
+        rows.iter().any(|row| {
+            row.get("ID").and_then(Value::as_str) == Some(box_id.as_str())
+                && row.get("Names").and_then(Value::as_str) == Some(BOX_NAME)
+                && row.get("Status").and_then(Value::as_str) == Some("Configured")
+        }),
+        "CLI list did not observe the box committed by the Runtime owner: {rows:?}",
+    );
+
+    runtime
+        .remove(&box_id, false)
+        .await
+        .expect("delete box through the public Runtime API");
+    let deleted = run_cli(&home.path, &["list", "--all", "--format", "json"]);
+    sentinels.assert_untouched();
+    assert_query_succeeded(&deleted, "list --all --format json after delete");
+    let rows: Value = serde_json::from_slice(&deleted.stdout).expect("list output is JSON");
+    assert!(
+        rows.as_array()
+            .expect("list output is an array")
+            .iter()
+            .all(|row| row.get("ID").and_then(Value::as_str) != Some(box_id.as_str())),
+        "CLI list still showed a box after the Runtime owner committed its deletion",
+    );
+}
+
+#[tokio::test]
+async fn images_queries_while_another_process_owns_runtime() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated();
+    let runtime = runtime_for(&home.path);
+    let box_id = create_configured_box(&runtime).await;
+    let sentinels = RecoverySentinels::create(&home.path);
+
+    let output = run_cli(&home.path, &["images", "--format", "json"]);
+    sentinels.assert_untouched();
+    assert_query_succeeded(&output, "images --format json");
+    assert_eq!(
+        serde_json::from_slice::<Value>(&output.stdout).expect("images output is JSON"),
+        Value::Array(Vec::new()),
+        "creating a configured box must not invent an image-cache entry",
+    );
+    runtime
+        .remove(&box_id, false)
+        .await
+        .expect("delete test box through the public Runtime API");
+}
+
+#[tokio::test]
+async fn info_reads_committed_counts_while_another_process_owns_runtime() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated();
+    let runtime = runtime_for(&home.path);
+    let box_id = create_configured_box(&runtime).await;
+    let sentinels = RecoverySentinels::create(&home.path);
+
+    let output = run_cli(&home.path, &["info", "--format", "json"]);
+    sentinels.assert_untouched();
+    assert_query_succeeded(&output, "info --format json");
+    let info: Value = serde_json::from_slice(&output.stdout).expect("info output is JSON");
+    assert_eq!(info.get("boxesTotal").and_then(Value::as_u64), Some(1));
+    assert_eq!(info.get("boxesConfigured").and_then(Value::as_u64), Some(1));
+    assert_eq!(info.get("boxesRunning").and_then(Value::as_u64), Some(0));
+    assert_eq!(info.get("boxesStopped").and_then(Value::as_u64), Some(0));
+    assert_eq!(info.get("imagesCount").and_then(Value::as_u64), Some(0));
+    runtime
+        .remove(&box_id, false)
+        .await
+        .expect("delete test box through the public Runtime API");
+}
+
+#[test]
+fn queries_initialize_a_fresh_home_without_contention() {
+    for command in ["list", "images", "info"] {
+        let home = tempfile::tempdir().unwrap();
+        let output = run_cli(home.path(), &[command, "--format", "json"]);
+        assert_query_succeeded(&output, command);
+        assert!(home.path().join("db/boxlite.db").is_file());
+    }
+}
+
+#[tokio::test]
+async fn local_images_and_info_ignore_rest_url_during_contention() {
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated();
+    let _runtime = runtime_for(&home.path);
+    for command in ["images", "info"] {
+        // Explicit --url is rejected by these local-only commands; the
+        // existing routing contract ignores an ambient REST URL instead.
+        let output = cli_command(&home.path)
+            .env("BOXLITE_REST_URL", "http://127.0.0.1:1")
+            .args([command, "--format", "json"])
+            .output()
+            .unwrap();
+        assert_query_succeeded(&output, command);
+        let explicit = run_cli(&home.path, &["--url", "http://127.0.0.1:1", command]);
+        assert_eq!(explicit.status.code(), Some(2));
+        assert!(
+            String::from_utf8_lossy(&explicit.stderr)
+                .contains(&format!("--url is not valid for `boxlite {command}`"))
+        );
+    }
+}
+
+#[tokio::test]
+async fn list_keeps_rest_routing_during_local_contention() {
+    use std::io::{Read, Write};
+    let home = boxlite_test_utils::home::PerTestBoxHome::isolated();
+    let _runtime = runtime_for(&home.path);
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let url = format!("http://{}", listener.local_addr().unwrap());
+    let server = std::thread::spawn(move || {
+        // Bound even when a routing regression means no connection arrives.
+        socket2::SockRef::from(&listener)
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        let (mut stream, _) = listener.accept().expect("REST list must reach server");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        let mut request = [0; 8192];
+        let count = stream.read(&mut request).unwrap();
+        let request = String::from_utf8_lossy(&request[..count]);
+        assert!(request.starts_with("GET "), "{request}");
+        let body = r#"{"error":{"message":"issue258-rest-sentinel","type":"InternalError","code":"internal"}}"#;
+        write!(stream, "HTTP/1.1 500 Internal Server Error\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}", body.len(), body).unwrap();
+    });
+    let output = run_cli(&home.path, &["--url", &url, "list", "--format", "json"]);
+    server.join().unwrap();
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("issue258-rest-sentinel"));
+}

--- a/src/shared/src/errors.rs
+++ b/src/shared/src/errors.rs
@@ -34,6 +34,10 @@ pub enum BoxliteError {
     #[error("gRPC transport error: {0}")]
     RpcTransport(String),
 
+    /// Another local Runtime owns this home; queries may read committed state.
+    #[error("Another BoxliteRuntime is already using directory: {home_dir}\nOnly one runtime instance can use a BOXLITE_HOME directory at a time.", home_dir = .home_dir.display())]
+    RuntimeInUse { home_dir: std::path::PathBuf },
+
     #[error("internal error: {0}")]
     Internal(String),
 
@@ -188,7 +192,10 @@ impl BoxliteError {
             BoxliteError::Database(_) => (500, "DatabaseError", "database_error"),
             BoxliteError::MetadataError(_) => (500, "MetadataError", "metadata_error"),
             BoxliteError::Config(_) => (500, "ConfigError", "config_error"),
-            BoxliteError::Internal(_) => (500, "InternalError", "internal"),
+            // Keep the existing wire contract; RuntimeInUse is a local routing signal.
+            BoxliteError::Internal(_) | BoxliteError::RuntimeInUse { .. } => {
+                (500, "InternalError", "internal")
+            }
         }
     }
 }
@@ -343,6 +350,14 @@ mod tests {
                 500,
                 "ConfigError",
                 "config_error",
+            ),
+            (
+                BoxliteError::RuntimeInUse {
+                    home_dir: "/tmp/boxlite".into(),
+                },
+                500,
+                "InternalError",
+                "internal",
             ),
             (
                 BoxliteError::Internal("unreachable".into()),


### PR DESCRIPTION
## Summary
Allow local `list`, `images`, and `info` to query committed metadata while an SDK process owns the same runtime home. Fall back to a read-only database snapshot only on a structured home-lock conflict; preserve normal initialization, existing routing, and all other startup errors.

## Call graph

Before
```text
execute (CLI · src/cli/src/commands/list.rs:59, images.rs:53, info.rs:39)
  → create_runtime / create_runtime_with_options (GlobalFlags · src/cli/src/cli.rs:800,823)
    → acquire (RuntimeLock · src/boxlite/src/runtime/lock.rs:41)
      → exclusive home lock conflict ← BUG: read-only commands fail before querying
```

After
```text
execute (CLI · src/cli/src/commands/list.rs:60, images.rs:53, info.rs:40)
  → create_runtime / create_runtime_with_options (GlobalFlags · src/cli/src/cli.rs:800,823)
    → acquire (RuntimeLock · src/boxlite/src/runtime/lock.rs:41) — typed RuntimeInUse
  → from_runtime (QueryRuntime · src/cli/src/query.rs:16) — fall back only for this error
    → list_info / list_images / info (ReadOnlyRuntime · src/boxlite/src/runtime/query.rs:29,40,52)
      → open_read_only_snapshot (Database · src/boxlite/src/db/mod.rs:84)
        → existing metadata stores — schema check and reads in one short transaction
```

Fixes #258

## Changes
- Share a read-only query facade and cached-image conversion without constructing another Runtime or image storage manager.
- Reject incompatible schemas without migration; perform no fallback recovery, cleanup, or VM-state repair.
- Preserve existing C and HTTP error mappings for lock contention.

## How to verify
- `NEXTEST_FILTER_EXPR='binary(readonly_queries)' make test:integration:cli` — cross-process queries, committed create/delete visibility, cleanup sentinels, and routing compatibility.
- `make test:unit:rust FILTER=runtime::query` — snapshots, schema rejection, write rejection, and recorded-state semantics.
- Regression checked with all production changes reverted: original three queries fail at the home lock; restored implementation passes. Six CLI tests and focused core/query/error-mapping checks passed before rebase; `range-diff` confirms the feature patch is unchanged after rebase onto `801bc91f`.
- Pre-rebase non-REST CLI suite: 468 passed. Core baseline: 1109/1111 passed; two seccomp tests assume an initially unfiltered host. A local test-only correction is not included in this PR.
- After rebase and runtime rebuild, the network-grant test passes; `detached_box_force_remove_reaps_whole_tree` and `detached_box_stop_reaps_whole_tree_and_keeps_box` still fail (2 residual processes, expected 0). Related upstream tracking: #1239 / #1240. REST tests and the full pre-push matrix were not rerun because earlier REST runs destabilized WSL; full validation remains outstanding.

## Risks / rollout
Draft pending feedback on the query contract: fallback reports committed database state and does not guarantee real-time VM status. Stale-state behavior was tested with an explicitly injected record, not a real VM crash. Normal initialization may still prepare directories before encountering the lock; SQLite WAL/SHM coordination remains enabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `list`, `images`, and `info` remain available in read-only mode when another runtime uses the same home directory.
  - Read-only queries display committed box and image metadata without modifying or repairing runtime state.
  - Query results use a consistent snapshot for improved accuracy.

- **Bug Fixes**
  - Runtime contention now reports a clear, structured error.
  - Incompatible database schemas are reported instead of migrated during read-only queries.

- **Documentation**
  - Documented read-only query behavior and schema compatibility handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->