### PR TITLE
fix(test): ws_watchdog_fires_when_idleextend, WebSocket watchdog reco…

### DIFF
--- a/src/boxlite/src/rest/litebox.rs
+++ b/src/boxlite/src/rest/litebox.rs
@@ -1984,9 +1984,12 @@ mod tests {
             .await;
         });
 
-        let res = tokio::time::timeout(Duration::from_secs(3), result_rx.recv())
+        // This timeout covers the full watchdog recovery path, including the
+        // status probe and reconnect fallback. Expiration only means that no
+        // result reached the channel; it does not prove the watchdog failed.
+        let res = tokio::time::timeout(Duration::from_secs(4), result_rx.recv())
             .await
-            .expect("watchdog never fired")
+            .expect("timed out waiting for watchdog result")
             .expect("result channel closed without value");
         assert_eq!(res.exit_code, -1);
         let msg = res.error_message.expect("expected diagnostic message");


### PR DESCRIPTION
## Summary

Increase the timeout for the idle WebSocket watchdog test so it covers the
status-probe and reconnect fallback path. Clarify the timeout diagnostic.

## Call graph

Before

  ws_watchdog_fires_when_idle (unit test · src/boxlite/src/rest/litebox.rs:1958)
    └─ result_rx.recv (ExecResult channel · src/boxlite/src/rest/litebox.rs:1987)
         ← BUG: 3s timeout can expire while watchdog recovery is still running

After

  ws_watchdog_fires_when_idle (unit test · src/boxlite/src/rest/litebox.rs:1958)
    └─ result_rx.recv (ExecResult channel · src/boxlite/src/rest/litebox.rs:1990)
         — waits 4s for watchdog recovery and reports an accurate timeout

Fixes #1488

## Changes

- Increase the test timeout from 3 seconds to 4 seconds.
- Replace the misleading `watchdog never fired` message with
  `timed out waiting for watchdog result`.
- Document why the timeout covers the full recovery path.

## How to verify

```bash
make test:unit:rust FILTER=ws_watchdog_fires_when_idle


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the watchdog test timeout to improve reliability.
  * Clarified that the test covers status probing and reconnect fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->